### PR TITLE
Add support for EXISTS and NOT EXISTS

### DIFF
--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -165,6 +165,7 @@ fn check_expr<'a, T: 'static + Debug>(
 
             Ok(negated ^ (evaluate(low)? <= target && target <= evaluate(high)?))
         }
+        Expr::Exists(expr) => Ok(select(storage, expr, filter_context)?.count() > 0),
         _ => Err(FilterError::Unimplemented.into()),
     }
 }

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -165,7 +165,7 @@ fn check_expr<'a, T: 'static + Debug>(
 
             Ok(negated ^ (evaluate(low)? <= target && target <= evaluate(high)?))
         }
-        Expr::Exists(expr) => Ok(select(storage, expr, filter_context)?.next().is_some()),
+        Expr::Exists(query) => Ok(select(storage, query, filter_context)?.next().is_some()),
         _ => Err(FilterError::Unimplemented.into()),
     }
 }

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -165,7 +165,7 @@ fn check_expr<'a, T: 'static + Debug>(
 
             Ok(negated ^ (evaluate(low)? <= target && target <= evaluate(high)?))
         }
-        Expr::Exists(expr) => Ok(select(storage, expr, filter_context)?.count() > 0),
+        Expr::Exists(expr) => Ok(select(storage, expr, filter_context)?.next().is_some()),
         _ => Err(FilterError::Unimplemented.into()),
     }
 }

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -68,9 +68,9 @@ CREATE TABLE Boss (
     name TEXT
 )"#,
     );
-    tester.run_and_print("INSERT INTO Boss (id, name, strength) VALUES (1, \"Amelia\")");
-    tester.run_and_print("INSERT INTO Boss (id, name, strength) VALUES (4, \"Gehrman\")");
-    tester.run_and_print("INSERT INTO Boss (id, name, strength) VALUES (5, \"Maria\")");
+    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (1, \"Amelia\")");
+    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (4, \"Gehrman\")");
+    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (5, \"Maria\")");
 
     tester.run_and_print(
         r#"

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -1,117 +1,68 @@
 use crate::*;
 
-pub fn between(mut tester: impl tests::Tester) {
-    tester.run_and_print(
-        r#"
-CREATE TABLE Test (
-    id INTEGER,
-    name TEXT,
-    strength FLOAT
-)"#,
-    );
-    tester.run_and_print("INSERT INTO Test (id, name, strength) VALUES (1, \"Amelia\", 10.10)");
-    tester.run_and_print("INSERT INTO Test (id, name, strength) VALUES (2, \"Doll\", 20.20)");
-    tester.run_and_print("INSERT INTO Test (id, name, strength) VALUES (3, \"Gascoigne\", 30.30)");
-    tester.run_and_print("INSERT INTO Test (id, name, strength) VALUES (4, \"Gehrman\", 40.40)");
-    tester.run_and_print("INSERT INTO Test (id, name, strength) VALUES (5, \"Maria\", 50.50)");
+pub fn filter(mut tester: impl tests::Tester) {
+    let create_sqls = [
+        "
+        CREATE TABLE Boss (
+            id INTEGER,
+            name TEXT,
+            strength FLOAT
+        );",
+        "
+        CREATE TABLE Hunter (
+            id INTEGER,
+            name TEXT
+        );",
+    ];
 
-    use Value::*;
+    create_sqls.iter().for_each(|sql| tester.run_and_print(sql));
 
-    let found = tester
-        .run("SELECT id, name FROM Test WHERE id BETWEEN 2 AND 4")
-        .expect("select");
-    let expected = select!(
-        I64 Str;
-        2   "Doll".to_owned();
-        3   "Gascoigne".to_owned();
-        4   "Gehrman".to_owned()
-    );
-    assert_eq!(expected, found);
+    let insert_sqls = [
+        "INSERT INTO Boss (id, name, strength) VALUES (1, \"Amelia\", 10.10);",
+        "INSERT INTO Boss (id, name, strength) VALUES (2, \"Doll\", 20.20);",
+        "INSERT INTO Boss (id, name, strength) VALUES (3, \"Gascoigne\", 30.30);",
+        "INSERT INTO Boss (id, name, strength) VALUES (4, \"Gehrman\", 40.40);",
+        "INSERT INTO Boss (id, name, strength) VALUES (5, \"Maria\", 50.50);",
+        "INSERT INTO Hunter (id, name) VALUES (1, \"Gascoigne\");",
+        "INSERT INTO Hunter (id, name) VALUES (2, \"Gehrman\");",
+        "INSERT INTO Hunter (id, name) VALUES (3, \"Maria\");",
+    ];
 
-    let found = tester
-        .run("SELECT id, name FROM Test WHERE name BETWEEN 'Doll' AND 'Gehrman'")
-        .expect("select");
-    let expected = select!(
-        I64 Str;
-        2   "Doll".to_owned();
-        3   "Gascoigne".to_owned();
-        4   "Gehrman".to_owned()
-    );
-    assert_eq!(expected, found);
+    insert_sqls.iter().for_each(|sql| tester.run_and_print(sql));
 
-    let found = tester
-        .run("SELECT name FROM Test WHERE name NOT BETWEEN 'Doll' AND 'Gehrman'")
-        .expect("select");
-    let expected = select!(
-        Str;
-        "Amelia".to_owned();
-        "Maria".to_owned()
-    );
-    assert_eq!(expected, found);
+    let select_sqls = [
+        (3, "SELECT id, name FROM Boss WHERE id BETWEEN 2 AND 4"),
+        (
+            3,
+            "SELECT id, name FROM Boss WHERE name BETWEEN 'Doll' AND 'Gehrman'",
+        ),
+        (
+            2,
+            "SELECT name FROM Boss WHERE name NOT BETWEEN 'Doll' AND 'Gehrman'",
+        ),
+        (
+            2,
+            "SELECT strength, name FROM Boss WHERE name NOT BETWEEN 'Doll' AND 'Gehrman'",
+        ),
+        (
+            3,
+            "SELECT name 
+             FROM Boss 
+             WHERE EXISTS (
+                SELECT * FROM Hunter WHERE Hunter.name = Boss.name
+             )",
+        ),
+        (
+            2,
+            "SELECT name 
+             FROM Boss 
+             WHERE NOT EXISTS (
+                SELECT * FROM Hunter WHERE Hunter.name = Boss.name
+             )",
+        ),
+    ];
 
-    let found = tester
-        .run("SELECT strength, name FROM Test WHERE name NOT BETWEEN 'Doll' AND 'Gehrman'")
-        .expect("select");
-    let expected = select!(
-        F64   Str;
-        10.10 "Amelia".to_owned();
-        50.50 "Maria".to_owned()
-    );
-    assert_eq!(expected, found);
-}
-
-pub fn exists(mut tester: impl tests::Tester) {
-    tester.run_and_print(
-        r#"
-CREATE TABLE Boss (
-    id INTEGER,
-    name TEXT
-)"#,
-    );
-    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (1, \"Amelia\")");
-    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (4, \"Gehrman\")");
-    tester.run_and_print("INSERT INTO Boss (id, name) VALUES (5, \"Maria\")");
-
-    tester.run_and_print(
-        r#"
-CREATE TABLE Hunter (
-    id INTEGER,
-    name TEXT
-)"#,
-    );
-    tester.run_and_print("INSERT INTO Hunter (id, name) VALUES (2, \"Gehrman\")");
-    tester.run_and_print("INSERT INTO Hunter (id, name) VALUES (3, \"Maria\")");
-
-    use Value::*;
-
-    let found = tester
-        .run(
-            r#"SELECT name 
-                     FROM Boss 
-                     WHERE EXISTS (
-                         SELECT * FROM Hunter WHERE Hunter.name = Boss.name
-                     )"#,
-        )
-        .expect("select");
-    let expected = select!(
-        Str;
-        "Gehrman".to_owned();
-        "Maria".to_owned()
-    );
-    assert_eq!(expected, found);
-
-    let found = tester
-        .run(
-            r#"SELECT name 
-                     FROM Boss 
-                     WHERE NOT EXISTS (
-                         SELECT * FROM Hunter WHERE Hunter.name = Boss.name
-                     )"#,
-        )
-        .expect("select");
-    let expected = select!(
-        Str;
-        "Amelia".to_owned()
-    );
-    assert_eq!(expected, found);
+    select_sqls
+        .iter()
+        .for_each(|(num, sql)| tester.test_rows(sql, *num));
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -50,5 +50,6 @@ macro_rules! generate_tests {
         glue!(sql_types, sql_types::sql_types);
         glue!(synthesize, synthesize::synthesize);
         glue!(between, filter::between);
+        glue!(exists, filter::exists);
     };
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -49,7 +49,6 @@ macro_rules! generate_tests {
         glue!(ordering, ordering::ordering);
         glue!(sql_types, sql_types::sql_types);
         glue!(synthesize, synthesize::synthesize);
-        glue!(between, filter::between);
-        glue!(exists, filter::exists);
+        glue!(filter, filter::filter);
     };
 }


### PR DESCRIPTION
SELECT foo FROM TableA `WHERE EXISTS`(
  SELECT * FROM TableB WHERE(TableA.foo = TableB.bar)
)

SELECT foo FROM TableA `WHERE NOT EXISTS`(
  SELECT * FROM TableB WHERE(TableA.foo = TableB.bar)
)