### PR TITLE
Return row count instead of rows on Insert

### DIFF
--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -32,7 +32,7 @@ pub trait Tester {
 
         match result.unwrap() {
             Payload::Select(rows) => println!("[Ok ]\n{:#?}\n", rows),
-            Payload::Insert(rows) => println!("[Ok ]\n{:#?}\n", rows),
+            Payload::Insert(num) => println!("[Ok ] {} rows inserted.\n", num),
             Payload::Delete(num) => println!("[Ok ] {} rows deleted.\n", num),
             Payload::Update(num) => println!("[Ok ] {} rows updated.\n", num),
             Payload::DropTable => println!("[Ok ] :)\n"),


### PR DESCRIPTION
Return number of successfully inserted rows instead of the entire rows on INSERT queries
resolves #70