### PR TITLE
Report an error for inserting more values than table columns

### DIFF
--- a/src/data/row.rs
+++ b/src/data/row.rs
@@ -17,6 +17,9 @@ pub enum RowError {
     #[error("literals does not fit to columns")]
     LackOfRequiredValue(String),
 
+    #[error("literals have more values than target columns")]
+    TooManyValues,
+
     #[error("unsupported ast value type")]
     UnsupportedAstValueType,
 
@@ -61,6 +64,10 @@ impl Row {
         values
             .iter()
             .map(|values| {
+                if values.len() > column_defs.len() {
+                    return Err(RowError::TooManyValues.into());
+                }
+
                 (&column_defs)
                     .iter()
                     .enumerate()

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -39,6 +39,10 @@ pub fn error(mut tester: impl tests::Tester) {
             RowError::LackOfRequiredValue("id".to_owned()).into(),
             "INSERT INTO TableA (id2, id) VALUES (100);",
         ),
+        (
+            RowError::TooManyValues.into(),
+            "INSERT INTO TableA VALUES (100), (100, 200);",
+        ),
     ];
 
     test_cases


### PR DESCRIPTION
Closes #62 .

Fixes to report an error `TooManyValues` if inserting more values than target columns of the specified table.