### PR TITLE
Remove Unreachable error in Row, replace to controllable error.

### DIFF
--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -21,8 +21,8 @@ pub enum ExecuteError {
     #[error("drop type not supported")]
     DropTypeNotSupported,
 
-    #[error("unreachable")]
-    Unreachable,
+    #[error("unsupported insert value type: {0}")]
+    UnsupportedInsertValueType(String),
 }
 
 #[derive(Serialize, Debug, PartialEq)]
@@ -135,8 +135,10 @@ fn prepare<'a, T: 'static + Debug>(
             let Schema { column_defs, .. } = storage.fetch_schema(table_name)?;
             let values_list = match &source.body {
                 SetExpr::Values(Values(values_list)) => values_list,
-                _ => {
-                    return Err(ExecuteError::Unreachable.into());
+                set_expr => {
+                    return Err(
+                        ExecuteError::UnsupportedInsertValueType(set_expr.to_string()).into(),
+                    );
                 }
             };
 

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -43,6 +43,10 @@ pub fn error(mut tester: impl tests::Tester) {
             RowError::TooManyValues.into(),
             "INSERT INTO TableA VALUES (100), (100, 200);",
         ),
+        (
+            ExecuteError::UnsupportedInsertValueType("SELECT id FROM TableA".to_owned()).into(),
+            "INSERT INTO TableA SELECT id FROM TableA",
+        ),
     ];
 
     test_cases


### PR DESCRIPTION
Remove `RowError::Unreachable` and replace to `ExecuteError::UnsupportedInsertValueType(String)`.
`Unreachable` use in this case was not correct because it was reachable.
```sql
INSERT INTO TableA SELECT id FROM TableA
```
This sql query above can trigger `Unreachable` error.
Now it is replaced by `ExecuteError::UnsupportedInsertValueType(_)`