### PR TITLE
Update Cargo.toml default to have all features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: rustup component add clippy rustfmt
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --no-default-features -- -D warnings
     - name: Clippy (alter-table)
       run: cargo clippy --features alter-table -- -D warnings
     - name: Clippy (sled-storage)
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: cargo build --all-features --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --no-default-features --verbose
     - name: Run tests with features (sled-storage)
       run: cargo test --features sled-storage --verbose
     - name: Run tests with all features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,14 @@ keywords = ["sql-database", "sql", "functional", "no-mut-in-the-middle", "webass
 all-features = true
 
 [features]
+default = ["sled-storage", "alter-table"]
+
+# ALTER TABLE is optional.
+# You can include whether ALTER TABLE support or not for your custom database implementation.
 alter-table = []
+
+# Who wants to make a custom storage engine,
+# default storage engine sled-storage is not required.
 sled-storage = ["sled", "bincode"]
 
 [dependencies]


### PR DESCRIPTION
Users who wants to use GlueSQL as an embedded SQL database, now they can simply add 
```toml
[dependencies]
gluesql = "0.1.16"
```

Who wants to implement a custom storage engine, they can choose what to include
```toml
[dependencies]
gluesql = { version = "0.1.16", features = ["alter-table"], default-features = false }

# or
gluesql = { version = "0.1.16", default-features = false }
```