### PR TITLE
Fix AlterTable to support custom storage implementation properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@
 //!
 //! After you implement `Tester` trait, the only thing you need to do is calling `generate_tests!` macro.
 
+// re-export
+pub use sqlparser as parser;
+
 mod executor;
 mod glue;
 mod parse;

--- a/src/tests/alter_table.rs
+++ b/src/tests/alter_table.rs
@@ -26,7 +26,6 @@ pub fn rename(tester: impl tests::Tester) {
             Ok(Payload::AlterTable),
         ),
         ("SELECT new_id FROM Bar", Ok(select!(I64; 1; 2; 3))),
-        ("SELECT new_id FROM Bar", Ok(select!(I64; 1; 2; 3))),
         (
             "ALTER TABLE Bar RENAME COLUMN hello TO idid",
             Err(AlterTableError::RenamingColumnNotFound.into()),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,6 +21,21 @@ pub mod macros;
 
 pub use tester::*;
 
+#[cfg(feature = "alter-table")]
+#[macro_export]
+macro_rules! generate_alter_table_tests {
+    () => {
+        glue!(alter_table_rename, alter_table::rename);
+        glue!(alter_table_add_drop, alter_table::add_drop);
+    };
+}
+
+#[cfg(not(feature = "alter-table"))]
+#[macro_export]
+macro_rules! generate_alter_table_tests {
+    () => {};
+}
+
 #[macro_export]
 macro_rules! generate_tests {
     ($test: meta, $storage: ident) => {
@@ -56,9 +71,6 @@ macro_rules! generate_tests {
         glue!(synthesize, synthesize::synthesize);
         glue!(filter, filter::filter);
 
-        #[cfg(feature = "alter-table")]
-        glue!(alter_table_rename, alter_table::rename);
-        #[cfg(feature = "alter-table")]
-        glue!(alter_table_add_drop, alter_table::add_drop);
+        generate_alter_table_tests!();
     };
 }

--- a/tests/sled_storage.rs
+++ b/tests/sled_storage.rs
@@ -2,7 +2,10 @@
 use std::convert::TryFrom;
 
 #[cfg(feature = "sled-storage")]
-use gluesql::{execute, generate_tests, sled, tests::*, Payload, Query, Result, SledStorage};
+use gluesql::{
+    execute, generate_alter_table_tests, generate_tests, sled, tests::*, Payload, Query, Result,
+    SledStorage,
+};
 
 #[cfg(feature = "sled-storage")]
 struct SledTester {


### PR DESCRIPTION
When I was implementing `sled` storage engine, the codes are inside of this project so there wasn't any issue.

But for implementing custom storage by using gluesql as an external library, I found some issues.

* Re-exporting `sqlparser-rs` is required.
* Fix `cfg` in here not to be exposed to outside.