### PR TITLE
More expression support in blend

### DIFF
--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -177,7 +177,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
                                 ))),
                             }
                         }
-                        Expr::BinaryOp { .. } | Expr::Function(_) => {
+                        _ => {
                             let value = evaluate_blended(
                                 self.storage,
                                 None,
@@ -189,12 +189,6 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
 
                             Blended::Single(once(value))
                         }
-                        Expr::Value(literal) => {
-                            let value = Value::try_from(literal).map(Rc::new);
-
-                            Blended::Single(once(value))
-                        }
-                        _ => err!(BlendError::FieldDefinitionNotSupported),
                     }
                 }
             })

--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -17,8 +17,8 @@ use crate::store::Store;
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum BlendError {
-    #[error("this field definition is not supported yet")]
-    FieldDefinitionNotSupported,
+    #[error("Not supported compound identifier: {0}")]
+    NotSupportedCompoundIdentifier(String),
 
     #[error("column not found: {0}")]
     ColumnNotFound(String),
@@ -163,7 +163,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
                         },
                         Expr::CompoundIdentifier(idents) => {
                             if idents.len() != 2 {
-                                return err!(BlendError::FieldDefinitionNotSupported);
+                                return err!(BlendError::NotSupportedCompoundIdentifier(expr.to_string()));
                             }
 
                             let table_alias = &idents[0].value;

--- a/src/tests/blend.rs
+++ b/src/tests/blend.rs
@@ -122,7 +122,7 @@ pub fn blend(mut tester: impl tests::Tester) {
 
     let error_cases = vec![
         (
-            BlendError::FieldDefinitionNotSupported,
+            BlendError::NotSupportedCompoundIdentifier("a.b.c.d".to_owned()),
             "SELECT a.b.c.d as a FROM BlendItem;",
         ),
         (

--- a/src/tests/blend.rs
+++ b/src/tests/blend.rs
@@ -106,12 +106,12 @@ pub fn blend(mut tester: impl tests::Tester) {
             ),
         ),
         (
-            "SELECT 2+id+2*100-1 as Ident, name FROM BlendUser",
+            "SELECT (1 + 2) as foo, 2+id+2*100-1 as Ident, name FROM BlendUser",
             select!(
-                I64 Str;
-                202   "Taehoon".to_owned();
-                203   "Mike".to_owned();
-                204   "Jorno".to_owned()
+                I64 I64 Str;
+                3   202   "Taehoon".to_owned();
+                3   203   "Mike".to_owned();
+                3   204   "Jorno".to_owned()
             ),
         ),
     ];
@@ -123,7 +123,7 @@ pub fn blend(mut tester: impl tests::Tester) {
     let error_cases = vec![
         (
             BlendError::FieldDefinitionNotSupported,
-            "SELECT (1 * 2) as a FROM BlendItem;",
+            "SELECT a.b.c.d as a FROM BlendItem;",
         ),
         (
             BlendError::ColumnNotFound("a".to_owned()),


### PR DESCRIPTION
```sql
SELECT (1 + 2) AS foo FROM Table1;
...
```

Except for a few expressions which is specially handled by `blend.rs` itself, all other expressions are now handled by 'evaluate' module.
