### PR TITLE
Projection aliases support for SELECT queries

### DIFF
--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -41,15 +41,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
 
     pub fn apply(&self, context: Result<AggregateContext<'a>>) -> Result<Row> {
         let AggregateContext { aggregated, next } = context?;
-
-        let values = self
-            .blend(aggregated, next)?
-            .into_iter()
-            .map(|value| match Rc::try_unwrap(value) {
-                Ok(value) => value,
-                Err(value) => (*value).clone(),
-            })
-            .collect();
+        let values = self.blend(aggregated, next)?;
 
         Ok(Row(values))
     }
@@ -58,7 +50,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
         &self,
         aggregated: Option<HashMap<&'a Function, Value>>,
         context: Rc<BlendContext<'a>>,
-    ) -> Result<Vec<Rc<Value>>> {
+    ) -> Result<Vec<Value>> {
         macro_rules! err {
             ($err: expr) => {
                 Blended::Err(once(Err($err.into())))
@@ -71,7 +63,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
             .iter()
             .flat_map(|item| match item {
                 SelectItem::Wildcard => {
-                    let values = context.get_all_values().into_iter().map(Rc::new).map(Ok);
+                    let values = context.get_all_values().into_iter().map(Ok);
 
                     Blended::All(values)
                 }
@@ -84,9 +76,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
                     };
 
                     match context.get_alias_values(table_alias) {
-                        Some(values) => {
-                            Blended::AllInTable(values.into_iter().map(Rc::new).map(Ok))
-                        }
+                        Some(values) => Blended::AllInTable(values.into_iter().map(Ok)),
                         None => err!(BlendError::TableNotFound(table_alias.to_string())),
                     }
                 }
@@ -107,8 +97,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
                         Evaluated::StringRef(v) => Ok(Value::Str(v.to_string())),
                         Evaluated::ValueRef(v) => Ok(v.clone()),
                         Evaluated::Value(v) => Ok(v),
-                    }
-                    .map(Rc::new);
+                    };
 
                     Blended::Single(once(value))
                 }

--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -17,8 +17,8 @@ use crate::store::Store;
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum BlendError {
-    #[error("table not found: {0}")]
-    TableNotFound(String),
+    #[error("table alias not found: {0}")]
+    TableAliasNotFound(String),
 }
 
 pub struct Blend<'a, T: 'static + Debug> {
@@ -77,7 +77,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
 
                     match context.get_alias_values(table_alias) {
                         Some(values) => Blended::AllInTable(values.into_iter().map(Ok)),
-                        None => err!(BlendError::TableNotFound(table_alias.to_string())),
+                        None => err!(BlendError::TableAliasNotFound(table_alias.to_string())),
                     }
                 }
                 SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,10 +1,12 @@
 use boolinator::Boolinator;
+use iter_enum::Iterator;
 use serde::Serialize;
 use std::fmt::Debug;
+use std::iter::once;
 use std::rc::Rc;
 use thiserror::Error;
 
-use sqlparser::ast::{Ident, Query, SetExpr, TableWithJoins};
+use sqlparser::ast::{Expr, Ident, Query, SelectItem, SetExpr, TableWithJoins};
 
 use super::aggregate::Aggregate;
 use super::blend::Blend;
@@ -13,7 +15,7 @@ use super::fetch::fetch_columns;
 use super::filter::Filter;
 use super::join::Join;
 use super::limit::Limit;
-use crate::data::{Row, Table};
+use crate::data::{get_name, Row, Table};
 use crate::result::Result;
 use crate::store::Store;
 
@@ -22,14 +24,11 @@ pub enum SelectError {
     #[error("unimplemented! select on two or more than tables are not supported")]
     TooManyTables,
 
+    #[error("table alias not found: {0}")]
+    TableAliasNotFound(String),
+
     #[error("unreachable!")]
     Unreachable,
-}
-
-macro_rules! err {
-    ($err: expr) => {{
-        return Err($err.into());
-    }};
 }
 
 fn fetch_blended<'a, T: 'static + Debug>(
@@ -48,11 +47,95 @@ fn fetch_blended<'a, T: 'static + Debug>(
     Ok(rows)
 }
 
-pub fn select<'a, T: 'static + Debug>(
+fn get_aliases<'a>(
+    projection: &[SelectItem],
+    table_alias: &str,
+    columns: &'a [Ident],
+    join_columns: &'a [(&String, Vec<Ident>)],
+) -> Result<Vec<String>> {
+    #[derive(Iterator)]
+    enum Aliased<I1, I2, I3, I4> {
+        Err(I1),
+        Wildcard(I2),
+        QualifiedWildcard(I3),
+        Once(I4),
+    };
+
+    let err = |e| Aliased::Err(once(Err(e)));
+
+    macro_rules! try_into {
+        ($v: expr) => {
+            match $v {
+                Ok(v) => v,
+                Err(e) => {
+                    return err(e);
+                }
+            }
+        };
+    }
+
+    let to_aliases = |columns: &'a [Ident]| columns.iter().map(|ident| ident.value.to_string());
+
+    projection
+        .iter()
+        .flat_map(|item| match item {
+            SelectItem::Wildcard => {
+                let columns = to_aliases(columns);
+                let join_columns = join_columns
+                    .iter()
+                    .flat_map(|(_, columns)| to_aliases(columns));
+                let columns = columns.chain(join_columns).map(Ok);
+
+                Aliased::Wildcard(columns)
+            }
+            SelectItem::QualifiedWildcard(target) => {
+                let target_table_alias = try_into!(get_name(target));
+
+                if table_alias == target_table_alias {
+                    return Aliased::QualifiedWildcard(to_aliases(columns).map(Ok));
+                }
+
+                let columns = join_columns
+                    .iter()
+                    .find(|(table_alias, _)| table_alias == &target_table_alias)
+                    .map(|(_, columns)| columns)
+                    .ok_or_else(|| {
+                        SelectError::TableAliasNotFound(target_table_alias.to_string()).into()
+                    });
+                let columns = try_into!(columns);
+
+                Aliased::QualifiedWildcard(to_aliases(columns).map(Ok))
+            }
+            SelectItem::UnnamedExpr(expr) => {
+                let alias = match expr {
+                    Expr::CompoundIdentifier(idents) => try_into!(idents
+                        .last()
+                        .map(|ident| ident.value.to_string())
+                        .ok_or_else(|| SelectError::Unreachable.into())),
+                    _ => expr.to_string(),
+                };
+
+                Aliased::Once(once(Ok(alias)))
+            }
+            SelectItem::ExprWithAlias { alias, .. } => {
+                Aliased::Once(once(Ok(alias.value.to_string())))
+            }
+        })
+        .collect::<Result<_>>()
+}
+
+pub fn select_with_aliases<'a, T: 'static + Debug>(
     storage: &'a dyn Store<T>,
     query: &'a Query,
     filter_context: Option<Rc<FilterContext<'a>>>,
-) -> Result<impl Iterator<Item = Result<Row>> + 'a> {
+    with_aliases: bool,
+) -> Result<(Vec<String>, impl Iterator<Item = Result<Row>> + 'a)> {
+    macro_rules! err {
+        ($err: expr) => {{
+            return Err($err.into());
+        }};
+    }
+
     let (table_with_joins, where_clause, projection, group_by, having) = match &query.body {
         SetExpr::Select(statement) => {
             let tables = &statement.from;
@@ -77,16 +160,30 @@ pub fn select<'a, T: 'static + Debug>(
     let table = Table::new(relation)?;
 
     let columns = fetch_columns(storage, table.get_name())?;
-    let columns = Rc::new(columns);
     let join_columns = joins
         .iter()
         .map(|join| {
-            let table_name = Table::new(&join.relation)?.get_name();
+            let table = Table::new(&join.relation)?;
+            let table_alias = table.get_alias();
+            let table_name = table.get_name();
             let columns = fetch_columns(storage, table_name)?;
 
-            Ok(Rc::new(columns))
+            Ok((table_alias, columns))
         })
-        .collect::<Result<_>>()?;
+        .collect::<Result<Vec<_>>>()?;
+
+    let aliases = if with_aliases {
+        get_aliases(&projection, table.get_alias(), &columns, &join_columns)?
+    } else {
+        vec![]
+    };
+
+    let columns = Rc::new(columns);
+    let join_columns = join_columns
+        .into_iter()
+        .map(|(_, columns)| columns)
+        .map(Rc::new)
+        .collect::<Vec<_>>();
     let join_columns = Rc::new(join_columns);
 
     let join = Join::new(storage, joins, filter_context.as_ref().map(Rc::clone));
@@ -127,6 +224,16 @@ pub fn select<'a, T: 'static + Debug>(
 
         rows.map(move |blend_context| blend.apply(blend_context))
     };
+
+    Ok((aliases, rows))
+}
+
+pub fn select<'a, T: 'static + Debug>(
+    storage: &'a dyn Store<T>,
+    query: &'a Query,
+    filter_context: Option<Rc<FilterContext<'a>>>,
+) -> Result<impl Iterator<Item = Result<Row>> + 'a> {
+    let (_, rows) = select_with_aliases(storage, query, filter_context, false)?;
 
     Ok(rows)
 }

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -28,31 +28,39 @@ pub fn aggregate(mut tester: impl tests::Tester) {
     let mut run = |sql| tester.run(sql).expect("select");
 
     let test_cases = vec![
-        ("SELECT COUNT(*) FROM Item", select!(I64; 5)),
-        ("SELECT count(*) FROM Item", select!(I64; 5)),
-        ("SELECT COUNT(*), COUNT(*) FROM Item", select!(I64 I64; 5 5)),
+        ("SELECT COUNT(*) FROM Item", select!("COUNT(*)"; I64; 5)),
+        ("SELECT count(*) FROM Item", select!("count(*)"; I64; 5)),
+        (
+            "SELECT COUNT(*), COUNT(*) FROM Item",
+            select!("COUNT(*)" | "COUNT(*)"; I64 | I64; 5 5),
+        ),
         (
             "SELECT SUM(quantity), MAX(quantity), MIN(quantity) FROM Item",
-            select!(I64 I64 I64; 47 25 0),
+            select!(
+                "SUM(quantity)" | "MAX(quantity)" | "MIN(quantity)"
+                I64             | I64             | I64;
+                47                25                0
+            ),
         ),
         (
             "SELECT SUM(quantity) * 2 + MAX(quantity) - 3 / 1 FROM Item",
-            select!(I64; 116),
+            select!("SUM(quantity) * 2 + MAX(quantity) - 3 / 1"; I64; 116),
         ),
         (
             "SELECT SUM(age), MAX(age), MIN(age) FROM Item",
             select!(
-                OptI64 OptI64   OptI64;
-                None   Some(90) Some(3)
+                "SUM(age)" | "MAX(age)" | "MIN(age)"
+                OptI64     | OptI64     | OptI64;
+                None         Some(90)     Some(3)
             ),
         ),
         (
             "SELECT SUM(age) + SUM(quantity) FROM Item",
-            select!(OptI64; None),
+            select!("SUM(age) + SUM(quantity)"; OptI64; None),
         ),
         (
             "SELECT COUNT(age), COUNT(quantity) FROM Item",
-            select!(I64 I64; 3 5),
+            select!("COUNT(age)" | "COUNT(quantity)"; I64 | I64; 3 5),
         ),
     ];
 
@@ -116,47 +124,50 @@ pub fn group_by(mut tester: impl tests::Tester) {
     let test_cases = vec![
         (
             "SELECT id, COUNT(*) FROM Item GROUP BY id",
-            select!(I64 I64; 1 1; 2 1; 3 2; 4 1; 5 1),
+            select!(id | "COUNT(*)"; I64 | I64; 1 1; 2 1; 3 2; 4 1; 5 1),
         ),
         (
             "SELECT id FROM Item GROUP BY id",
-            select!(I64; 1; 2; 3; 4; 5),
+            select!(id; I64; 1; 2; 3; 4; 5),
         ),
         (
             "SELECT SUM(quantity), COUNT(*), city FROM Item GROUP BY city",
             select!(
-                 OptI64   I64 Str;
-                 Some(21) 2 "Seoul".to_owned();
-                 Some(0)  1 "Dhaka".to_owned();
-                 None     1 "Beijing".to_owned();
-                 Some(30) 1 "Daejeon".to_owned();
-                 Some(24) 1 "Seattle".to_owned()
+                "SUM(quantity)" | "COUNT(*)" | city
+                OptI64          | I64        | Str;
+                Some(21)          2            "Seoul".to_owned();
+                Some(0)           1            "Dhaka".to_owned();
+                None              1            "Beijing".to_owned();
+                Some(30)          1            "Daejeon".to_owned();
+                Some(24)          1            "Seattle".to_owned()
             ),
         ),
         (
             "SELECT id, city FROM Item GROUP BY city",
             select!(
-                 I64 Str;
-                 1 "Seoul".to_owned();
-                 2 "Dhaka".to_owned();
-                 3 "Beijing".to_owned();
-                 3 "Daejeon".to_owned();
-                 5 "Seattle".to_owned()
+                id  | city
+                I64 | Str;
+                1     "Seoul".to_owned();
+                2     "Dhaka".to_owned();
+                3     "Beijing".to_owned();
+                3     "Daejeon".to_owned();
+                5     "Seattle".to_owned()
             ),
         ),
         (
             "SELECT ratio FROM Item GROUP BY id, city",
-            select!(F64; 0.2; 0.9; 1.1; 3.2; 11.1; 6.11),
+            select!(ratio; F64; 0.2; 0.9; 1.1; 3.2; 11.1; 6.11),
         ),
         (
             "SELECT ratio FROM Item GROUP BY id, city HAVING ratio > 10",
-            select!(F64; 11.1),
+            select!(ratio; F64; 11.1),
         ),
         (
             "SELECT SUM(quantity), COUNT(*), city FROM Item GROUP BY city HAVING COUNT(*) > 1",
             select!(
-                 OptI64   I64 Str;
-                 Some(21) 2 "Seoul".to_owned()
+                "SUM(quantity)" | "COUNT(*)" | city
+                OptI64          | I64        | Str;
+                Some(21)          2            "Seoul".to_owned()
             ),
         ),
     ];

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -120,19 +120,20 @@ pub fn blend(mut tester: impl tests::Tester) {
 
     let sql = "SELECT 1 * 2 + 1 - 3 / 1 FROM Arith LIMIT 1;";
     let found = tester.run(sql).expect("select");
-    let expected = select!(I64; 0);
+    let expected = select!("1 * 2 + 1 - 3 / 1"; I64; 0);
     assert_eq!(expected, found);
 
     let found = tester
         .run("SELECT id, id + 1, id + num, 1 + 1 FROM Arith")
         .expect("select");
     let expected = select!(
-        I64 I64 I64 I64;
-        1   2   7   2;
-        2   3   10  2;
-        3   4   7   2;
-        4   5   6   2;
-        5   6   8   2
+        id  | "id + 1" | "id + num" | "1 + 1"
+        I64 | I64      | I64        | I64;
+        1     2          7            2;
+        2     3          10           2;
+        3     4          7            2;
+        4     5          6            2;
+        5     6          8            2
     );
     assert_eq!(expected, found);
 
@@ -142,6 +143,6 @@ pub fn blend(mut tester: impl tests::Tester) {
       JOIN Arith b ON a.id = b.id + 1
     ";
     let found = tester.run(sql).expect("select");
-    let expected = select!(I64; 3; 5; 7; 9);
+    let expected = select!("a.id + b.id"; I64; 3; 5; 7; 9);
     assert_eq!(expected, found);
 }

--- a/src/tests/basic.rs
+++ b/src/tests/basic.rs
@@ -21,21 +21,22 @@ CREATE TABLE Test (
         .run("SELECT id, num, name FROM Test")
         .expect("select");
     let expected = select!(
-        I64 I64 Str;
-        1   2   "Hello".to_owned();
-        1   9   "World".to_owned();
-        3   4   "Great".to_owned();
-        4   7   "Job".to_owned()
+        id  | num | name
+        I64 | I64 | Str;
+        1     2     "Hello".to_owned();
+        1     9     "World".to_owned();
+        3     4     "Great".to_owned();
+        4     7     "Job".to_owned()
     );
     assert_eq!(expected, found);
 
     tester.run_and_print("UPDATE Test SET id = 2");
 
     let found = tester.run("SELECT id FROM Test").expect("select");
-    let expected = select!(I64; 2; 2; 2; 2);
+    let expected = select!(id; I64; 2; 2; 2; 2);
     assert_eq!(expected, found);
 
     let found = tester.run("SELECT id, num FROM Test").expect("select");
-    let expected = select!(I64 I64; 2 2; 2 9; 2 4; 2 7);
+    let expected = select!(id | num; I64 | I64; 2 2; 2 9; 2 4; 2 7);
     assert_eq!(expected, found);
 }

--- a/src/tests/default.rs
+++ b/src/tests/default.rs
@@ -25,12 +25,13 @@ pub fn default(mut tester: impl tests::Tester) {
         (
             "SELECT * FROM Test;",
             select!(
-                I64 I64 OptBool;
-                8   80  Some(true);
-                1   10  Some(false);
-                2   20  Some(false);
-                1   30  None;
-                1   40  Some(true)
+                id  | num | flag
+                I64 | I64 | OptBool;
+                8     80    Some(true);
+                1     10    Some(false);
+                2     20    Some(false);
+                1     30    None;
+                1     40    Some(true)
             ),
         ),
     ];

--- a/src/tests/drop_table.rs
+++ b/src/tests/drop_table.rs
@@ -22,8 +22,9 @@ CREATE TABLE DropTable (
         (
             "SELECT id, num, name FROM DropTable;",
             Ok(select!(
-                I64 I64 Str;
-                1   2   "Hello".to_owned()
+                id  | num | name
+                I64 | I64 | Str;
+                1     2     "Hello".to_owned()
             )),
         ),
         ("DROP TABLE DropTable;", Ok(Payload::DropTable)),
@@ -34,7 +35,7 @@ CREATE TABLE DropTable (
         (create_sql, Ok(Payload::Create)),
         (
             "SELECT id, num, name FROM DropTable;",
-            Ok(Payload::Select(vec![])),
+            Ok(select!(id | num | name)),
         ),
         (
             "DROP VIEW DropTable;",

--- a/src/tests/join.rs
+++ b/src/tests/join.rs
@@ -172,11 +172,12 @@ pub fn blend(mut tester: impl tests::Tester) {
     ";
     let found = tester.run(sql).expect("select");
     let expected = select_with_empty!(
-        I64(1) I64(101);
-        I64(2) I64(102);
-        I64(3) Empty;
-        I64(4) I64(103);
-        I64(5) Empty
+        id     | id;
+        I64(1)   I64(101);
+        I64(2)   I64(102);
+        I64(3)   Empty;
+        I64(4)   I64(103);
+        I64(5)   Empty
     );
     assert_eq!(expected, found);
 
@@ -188,11 +189,12 @@ pub fn blend(mut tester: impl tests::Tester) {
     ";
     let found = tester.run(sql).expect("select");
     let expected = select_with_empty!(
-        I64(1) I64(1);
-        I64(2) I64(2);
-        I64(3) Empty;
-        I64(4) I64(4);
-        I64(5) Empty
+        id     | player_id;
+        I64(1)   I64(1);
+        I64(2)   I64(2);
+        I64(3)   Empty;
+        I64(4)   I64(4);
+        I64(5)   Empty
     );
     assert_eq!(expected, found);
 
@@ -204,11 +206,12 @@ pub fn blend(mut tester: impl tests::Tester) {
     ";
     let found = tester.run(sql).expect("select");
     let expected = select_with_empty!(
-        I64(101) I64(1) I64(1);
-        I64(102) I64(4) I64(2);
-        Empty    Empty  Empty;
-        I64(103) I64(9) I64(4);
-        Empty    Empty  Empty
+        id       | quantity | player_id;
+        I64(101)   I64(1)     I64(1);
+        I64(102)   I64(4)     I64(2);
+        Empty      Empty      Empty;
+        I64(103)   I64(9)     I64(4);
+        Empty      Empty      Empty
     );
     assert_eq!(expected, found);
 
@@ -220,11 +223,12 @@ pub fn blend(mut tester: impl tests::Tester) {
     ";
     let found = tester.run(sql).expect("select");
     let expected = select_with_empty!(
-        I64(1) Str("Taehoon".to_owned()) I64(101) I64(1) I64(1);
-        I64(2) Str("Mike".to_owned())    I64(102) I64(4) I64(2);
-        I64(3) Str("Jorno".to_owned())   Empty    Empty  Empty;
-        I64(4) Str("Berry".to_owned())   I64(103) I64(9) I64(4);
-        I64(5) Str("Hwan".to_owned())    Empty    Empty  Empty
+        id     | name                      | id       | quantity | player_id;
+        I64(1)   Str("Taehoon".to_owned())   I64(101)   I64(1)     I64(1);
+        I64(2)   Str("Mike".to_owned())      I64(102)   I64(4)     I64(2);
+        I64(3)   Str("Jorno".to_owned())     Empty      Empty      Empty;
+        I64(4)   Str("Berry".to_owned())     I64(103)   I64(9)     I64(4);
+        I64(5)   Str("Hwan".to_owned())      Empty      Empty      Empty
     );
     assert_eq!(expected, found);
 }

--- a/src/tests/migrate.rs
+++ b/src/tests/migrate.rs
@@ -55,10 +55,11 @@ CREATE TABLE Test (
         .run("SELECT id, num, name FROM Test")
         .expect("select");
     let expected = select!(
-        I64 I64 Str;
-        1   2   "Hello".to_owned();
-        1   9   "World".to_owned();
-        3   4   "Great".to_owned()
+        id  | num | name
+        I64 | I64 | Str;
+        1     2     "Hello".to_owned();
+        1     9     "World".to_owned();
+        3     4     "Great".to_owned()
     );
     assert_eq!(expected, found);
 
@@ -66,9 +67,10 @@ CREATE TABLE Test (
         .run("SELECT id, num, name FROM Test WHERE id = 1")
         .expect("select");
     let expected = select!(
-        I64 I64 Str;
-        1   2   "Hello".to_owned();
-        1   9   "World".to_owned()
+        id  | num | name
+        I64 | I64 | Str;
+        1     2     "Hello".to_owned();
+        1     9     "World".to_owned()
     );
     assert_eq!(expected, found);
 
@@ -78,24 +80,25 @@ CREATE TABLE Test (
         .run("SELECT id, num, name FROM Test")
         .expect("select");
     let expected = select!(
-        I64 I64 Str;
-        2   2   "Hello".to_owned();
-        2   9   "World".to_owned();
-        2   4   "Great".to_owned()
+        id  | num | name;
+        I64 | I64 | Str;
+        2     2     "Hello".to_owned();
+        2     9     "World".to_owned();
+        2     4     "Great".to_owned()
     );
     assert_eq!(expected, found);
 
     let found = tester.run("SELECT id FROM Test").expect("select");
-    let expected = select!(I64; 2; 2; 2);
+    let expected = select!(id; I64; 2; 2; 2);
     assert_eq!(expected, found);
 
     let found = tester.run("SELECT id, num FROM Test").expect("select");
-    let expected = select!(I64 I64; 2 2; 2 9; 2 4);
+    let expected = select!(id | num; I64 | I64; 2 2; 2 9; 2 4);
     assert_eq!(expected, found);
 
     let found = tester
         .run("SELECT id, num FROM Test LIMIT 1 OFFSET 1")
         .expect("select");
-    let expected = select!(I64 I64; 2 9);
+    let expected = select!(id | num; I64 | I64; 2 9);
     assert_eq!(expected, found);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,6 +15,7 @@ pub mod nullable;
 pub mod ordering;
 pub mod sql_types;
 pub mod synthesize;
+
 mod tester;
 
 pub mod macros;

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -21,162 +21,181 @@ CREATE TABLE Test (
         (
             "SELECT id, num, name FROM Test",
             select!(
-                OptI64  I64 Str;
-                None    2   "Hello".to_owned();
-                Some(1) 9   "World".to_owned();
-                Some(3) 4   "Great".to_owned()
+                id      | num | name
+                OptI64  | I64 | Str;
+                None      2     "Hello".to_owned();
+                Some(1)   9     "World".to_owned();
+                Some(3)   4     "Great".to_owned()
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL AND name = \'Hello\'",
             select!(
-                OptI64 I64;
-                None   2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NULL",
             select!(
-                OptI64 I64;
-                None   2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NOT NULL",
             select!(
-                OptI64  I64;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NULL",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NOT NULL",
             select!(
-                OptI64  I64;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE 100 IS NULL",
-            select!(OptI64 I64),
+            select!(id | num),
         ),
         (
             "SELECT id, num FROM Test WHERE 100 IS NOT NULL",
             select!(
-                OptI64  I64;
-                None    2;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                None      2;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE 8 + 3 IS NULL",
-            select!(OptI64 I64),
+            select!(id | num),
         ),
         (
             "SELECT id, num FROM Test WHERE 8 + 3 IS NOT NULL",
             select!(
-                OptI64  I64;
-                None    2;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                None      2;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE NULL IS NULL",
             select!(
-                OptI64  I64;
-                None    2;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                None      2;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE NULL IS NOT NULL",
-            select!(OptI64 I64),
+            select!(id | num),
         ),
         (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NULL",
-            select!(OptI64 I64),
+            select!(id | num),
         ),
         (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NOT NULL",
             select!(
-                OptI64  I64;
-                None    2;
-                Some(1) 9;
-                Some(3) 4
+                id      | num
+                OptI64  | I64;
+                None      2;
+                Some(1)   9;
+                Some(3)   4
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL + 1;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 + NULL;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL - 1;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 - NULL;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL * 1;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 * NULL;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL / 1;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 / NULL;",
             select!(
-                OptI64  I64;
-                None    2
+                id     | num
+                OptI64 | I64;
+                None     2
             ),
         ),
         (
             "SELECT id + 1, 1 + id, id - 1, 1 - id, id * 1, 1 * id, id / 1, 1 / id FROM Test WHERE id = NULL;",
             select!(
-                OptI64 OptI64 OptI64 OptI64 OptI64 OptI64 OptI64 OptI64;
-                None   None   None   None   None   None   None   None
+                "id + 1" | "1 + id" | "id - 1" | "1 - id" | "id * 1" | "1 * id" | "id / 1" | "1 / id";
+                OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64;
+                None       None       None       None       None       None       None       None
             ),
         ),
     ];
@@ -192,6 +211,7 @@ CREATE TABLE Test (
         (
             "SELECT id FROM Test",
             Ok(select!(
+                id
                 OptI64;
                 Some(2);
                 Some(2);
@@ -201,7 +221,8 @@ CREATE TABLE Test (
         (
             "SELECT id, num FROM Test",
             Ok(select!(
-                OptI64  I64;
+                id      | num
+                OptI64  | I64;
                 Some(2) 2;
                 Some(2) 9;
                 Some(2) 4

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -31,7 +31,7 @@ pub trait Tester {
         let result = self.run(sql);
 
         match result.unwrap() {
-            Payload::Select(rows) => println!("[Ok ]\n{:#?}\n", rows),
+            Payload::Select { rows, .. } => println!("[Ok ]\n{:#?}\n", rows),
             Payload::Insert(num) => println!("[Ok ] {} rows inserted.\n", num),
             Payload::Delete(num) => println!("[Ok ] {} rows deleted.\n", num),
             Payload::Update(num) => println!("[Ok ] {} rows updated.\n", num),
@@ -46,7 +46,7 @@ pub trait Tester {
         let result = self.run(sql);
 
         match result.unwrap() {
-            Payload::Select(rows) => assert_eq!(count, rows.len()),
+            Payload::Select { rows, .. } => assert_eq!(count, rows.len()),
             Payload::Delete(num) => assert_eq!(count, num),
             Payload::Update(num) => assert_eq!(count, num),
             _ => panic!("compare is only for Select, Delete and Update"),
@@ -57,7 +57,7 @@ pub trait Tester {
         let result = self.run(sql);
 
         match result.unwrap() {
-            Payload::Select(rows) => {
+            Payload::Select { rows, .. } => {
                 let Row(items) = rows.into_iter().next().unwrap();
 
                 assert_eq!(count, items.len())


### PR DESCRIPTION
Now the result of SELECT query returns both aliases and rows.
Implement support for fetching aliases.

e.g.
```sql
SELECT id, name as foo FROM TableA;
```

The query above provides not only fetched rows, but also it serve aliases like `["id", "foo"]`.

Change `Payload::SELECT` from
```rust
Payload::SELECT(Vec<Row>)
```
to
```rust
Payload::SELECT {
  aliases: Vec<String>,
  rows: Vec<Row>,
}
```

resolve #83 