### PR TITLE
Change Store->fetch_schema interface return type to Option<_>,

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -15,6 +15,7 @@ pub use blend::BlendError;
 pub use context::{BlendContextError, FilterContextError};
 pub use evaluate::EvaluateError;
 pub use execute::{execute, ExecuteError, Payload};
+pub use fetch::FetchError;
 pub use filter::FilterError;
 pub use join::JoinError;
 pub use limit::LimitError;

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,19 +3,15 @@ use thiserror::Error as ThisError;
 
 use crate::data::{RowError, TableError, ValueError};
 use crate::executor::{
-    AggregateError, BlendContextError, BlendError, EvaluateError, ExecuteError, FilterContextError,
-    FilterError, JoinError, LimitError, SelectError, UpdateError,
+    AggregateError, BlendContextError, BlendError, EvaluateError, ExecuteError, FetchError,
+    FilterContextError, FilterError, JoinError, LimitError, SelectError, UpdateError,
 };
 
 #[cfg(feature = "alter-table")]
 use crate::store::AlterTableError;
-use crate::store::StoreError;
 
 #[derive(ThisError, Serialize, Debug)]
 pub enum Error {
-    #[error(transparent)]
-    Store(#[from] StoreError),
-
     #[cfg(feature = "alter-table")]
     #[error(transparent)]
     AlterTable(#[from] AlterTableError),
@@ -26,6 +22,8 @@ pub enum Error {
 
     #[error(transparent)]
     Execute(#[from] ExecuteError),
+    #[error(transparent)]
+    Fetch(#[from] FetchError),
     #[error(transparent)]
     Evaluate(#[from] EvaluateError),
     #[error(transparent)]
@@ -62,10 +60,10 @@ impl PartialEq for Error {
         use Error::*;
 
         match (self, other) {
-            (Store(e), Store(e2)) => e == e2,
             #[cfg(feature = "alter-table")]
             (AlterTable(e), AlterTable(e2)) => e == e2,
             (Execute(e), Execute(e2)) => e == e2,
+            (Fetch(e), Fetch(e2)) => e == e2,
             (Evaluate(e), Evaluate(e2)) => e == e2,
             (Select(e), Select(e2)) => e == e2,
             (Join(e), Join(e2)) => e == e2,

--- a/src/storages/sled_storage/store.rs
+++ b/src/storages/sled_storage/store.rs
@@ -54,7 +54,7 @@ impl StoreMut<IVec> for SledStorage {
 }
 
 impl Store<IVec> for SledStorage {
-    fn fetch_schema(&self, table_name: &str) -> Result<Schema> {
+    fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
         fetch_schema(&self.tree, table_name).map(|(_, schema)| schema)
     }
 

--- a/src/store/alter_table.rs
+++ b/src/store/alter_table.rs
@@ -8,6 +8,9 @@ use crate::result::MutResult;
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum AlterTableError {
+    #[error("Table not found: {0}")]
+    TableNotFound(String),
+
     #[error("Renaming column not found")]
     RenamingColumnNotFound,
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,25 +5,17 @@ pub use alter_table::*;
 #[cfg(not(feature = "alter-table"))]
 pub trait AlterTable {}
 
-use serde::Serialize;
 use std::fmt::Debug;
 use std::marker::Sized;
-use thiserror::Error;
 
 use crate::data::{Row, Schema};
 use crate::result::{MutResult, Result};
-
-#[derive(Error, Serialize, Debug, PartialEq)]
-pub enum StoreError {
-    #[error("Schema not found")]
-    SchemaNotFound,
-}
 
 pub type RowIter<T> = Box<dyn Iterator<Item = Result<(T, Row)>>>;
 
 /// By implementing `Store` trait, you can run `SELECT` queries.
 pub trait Store<T: Debug> {
-    fn fetch_schema(&self, table_name: &str) -> Result<Schema>;
+    fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>>;
 
     fn scan_data(&self, table_name: &str) -> Result<RowIter<T>>;
 }

--- a/src/tests/alter_table.rs
+++ b/src/tests/alter_table.rs
@@ -19,6 +19,10 @@ pub fn rename(tester: impl tests::Tester) {
             Ok(Payload::Insert(3)),
         ),
         ("SELECT id FROM Foo", Ok(select!(id; I64; 1; 2; 3))),
+        (
+            "ALTER TABLE Foo2 RENAME TO Bar;",
+            Err(AlterTableError::TableNotFound("Foo2".to_owned()).into()),
+        ),
         ("ALTER TABLE Foo RENAME TO Bar;", Ok(Payload::AlterTable)),
         ("SELECT id FROM Bar", Ok(select!(id; I64; 1; 2; 3))),
         (

--- a/src/tests/drop_table.rs
+++ b/src/tests/drop_table.rs
@@ -45,7 +45,7 @@ CREATE TABLE DropTable (
         ("DROP TABLE IF EXISTS DropTable;", Ok(Payload::DropTable)),
         (
             "SELECT id, num, name FROM DropTable;",
-            Err(StoreError::SchemaNotFound.into()),
+            Err(FetchError::TableNotFound("DropTable".to_owned()).into()),
         ),
         (create_sql, Ok(Payload::Create)),
         (

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -6,7 +6,10 @@ pub fn error(mut tester: impl tests::Tester) {
 
     let test_cases = vec![
         (ExecuteError::QueryNotSupported.into(), "COMMIT;"),
-        (StoreError::SchemaNotFound.into(), "SELECT * FROM Nothing;"),
+        (
+            FetchError::TableNotFound("Nothing".to_owned()).into(),
+            "SELECT * FROM Nothing;",
+        ),
         (
             SelectError::TooManyTables.into(),
             "SELECT * FROM TableA, TableB",


### PR DESCRIPTION
Remove StoreError, now fetch_schema returns Result<Option<Schema>>.
StoreError::SchemaNotFound was error, but now it simply returns "None".
This error handling is up to execution layer, not for store layer.

---

@leoppro Your previous PR became a good motivation. (https://github.com/gluesql/gluesql/pull/68)
`StoreError::SchemaNotFound` was something... not consistent with other interfaces.

Other mutating functions like insert and delete don't return error no matter there already exists data or not.
But only `fetch_schema` returns error when data not found case.

