### PR TITLE
Support Plus(+) and Minus(-) signs in WHERE

### DIFF
--- a/src/data/value.rs
+++ b/src/data/value.rs
@@ -152,20 +152,6 @@ impl PartialOrd<AstValue> for Value {
     }
 }
 
-impl Neg for Value {
-    type Output = Value;
-
-    fn neg(self) -> Self::Output {
-        match self {
-            Value::I64(v) => Value::I64(-v),
-            Value::OptI64(Some(v)) => Value::OptI64(Some(-v)),
-            Value::F64(v) => Value::F64(-v),
-            Value::OptF64(Some(v)) => Value::OptF64(Some(-v)),
-            _ => Value::Empty,
-        }
-    }
-}
-
 impl TryFrom<&AstValue> for Value {
     type Error = Error;
 

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -146,7 +146,6 @@ fn literal_partial_cmp(a: &AstValue, b: &AstValue) -> Option<Ordering> {
     }
 }
 
-
 impl<'a> Evaluated<'a> {
     pub fn add(&self, other: &Evaluated<'a>) -> Result<Evaluated<'a>> {
         use Evaluated::*;

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -372,7 +372,7 @@ fn literal_positive(a: &AstValue) -> Result<AstValue> {
             Ok(a) => Ok(AstValue::Number(a.to_string())),
             _ => panic!(),
         }
-        AstValue::Null | AstValue::Number(_) => {
+        AstValue::Null => {
             Ok(AstValue::Null)
         }
         _ => Err(EvaluateError::UnreachableLiteralArithmetic.into()),
@@ -385,7 +385,7 @@ fn literal_negative(a: &AstValue) -> Result<AstValue> {
             Ok(a) => Ok(AstValue::Number((-a).to_string())),
             _ => panic!(),
         }
-        AstValue::Null | AstValue::Number(_) => {
+        AstValue::Null => {
             Ok(AstValue::Null)
         }
         _ => Err(EvaluateError::UnreachableLiteralArithmetic.into()),

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -5,7 +5,7 @@ use im_rc::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
 
-use sqlparser::ast::{BinaryOperator, Expr, Function, Value as AstValue};
+use sqlparser::ast::{BinaryOperator, UnaryOperator, Expr, Function, Value as AstValue};
 
 use super::context::FilterContext;
 use super::select::select;
@@ -87,6 +87,15 @@ pub fn evaluate<'a, T: 'static + Debug>(
                 BinaryOperator::Minus => l.subtract(&r),
                 BinaryOperator::Multiply => l.multiply(&r),
                 BinaryOperator::Divide => l.divide(&r),
+                _ => Err(EvaluateError::Unimplemented.into()),
+            }
+        }
+        Expr::UnaryOp { op, expr } => {
+            let v = eval(expr)?;
+
+            match op {
+                UnaryOperator::Plus => v.positive(),
+                UnaryOperator::Minus => v.negative(),
                 _ => Err(EvaluateError::Unimplemented.into()),
             }
         }

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -60,6 +60,8 @@ pub fn filter(mut tester: impl tests::Tester) {
                 SELECT * FROM Hunter WHERE Hunter.name = Boss.name
              )",
         ),
+        (5, "SELECT name FROM Boss WHERE +1 = 1"),
+        (3, "SELECT id FROM Hunter WHERE -1 = -1"),
     ];
 
     select_sqls


### PR DESCRIPTION
This pull request resolves issue #101 by supporting unary operations of Value. Specific modifications are the following.
- value.rs & evaluated.rs: Functions to evaluate unary operations of the expression were added.
- mod.rs: Expressions now handle unary operations.
- test.rs: Two test cases to check if WHERE supports plus(+) and minus(-) signs were added.