### PR TITLE
[Revised] Support Plus(+) and Minus(-) signs in WHERE

### DIFF
--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -10,6 +10,12 @@ pub enum EvaluateError {
     #[error("literal add on non-numeric")]
     LiteralAddOnNonNumeric,
 
+    #[error("unary plus operation on non-numeric")]
+    LiteralUnaryPlusOnNonNumeric,
+
+    #[error("unary minus operation on non-numeric")]
+    LiteralUnaryMinusOnNonNumeric,
+
     #[error("function is not supported: {0}")]
     FunctionNotSupported(String),
 

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 use std::rc::Rc;
 
-use sqlparser::ast::{BinaryOperator, Expr, Function, Value as AstValue};
+use sqlparser::ast::{BinaryOperator, Expr, Function, UnaryOperator, Value as AstValue};
 
 use super::context::FilterContext;
 use super::select::select;
@@ -91,6 +91,16 @@ pub fn evaluate<'a, T: 'static + Debug>(
                 _ => Err(EvaluateError::Unimplemented.into()),
             }
         }
+        Expr::UnaryOp { op, expr } => {
+            let v = eval(expr)?;
+
+            match op {
+                UnaryOperator::Plus => v.unary_plus(),
+                UnaryOperator::Minus => v.unary_minus(),
+                _ => Err(EvaluateError::Unimplemented.into()),
+            }
+        }
+
         Expr::Function(func) => aggregated
             .as_ref()
             .map(|aggr| aggr.get(func))

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -60,9 +60,38 @@ pub fn filter(mut tester: impl tests::Tester) {
                 SELECT * FROM Hunter WHERE Hunter.name = Boss.name
              )",
         ),
+        (5, "SELECT name FROM Boss WHERE +1 = 1"),
+        (3, "SELECT id FROM Hunter WHERE -1 = -1"),
+        (5, "SELECT name FROM Boss WHERE -2.0 < -1.0"),
+        (3, "SELECT id FROM Hunter WHERE +2 > +1.0"),
+        (2, "SELECT name FROM Boss WHERE id <= +2"),
+        (2, "SELECT name FROM Boss WHERE +id <= 2"),
     ];
 
     select_sqls
         .iter()
         .for_each(|(num, sql)| tester.test_rows(sql, *num));
+
+    let select_sqls_err = vec![
+        (
+            EvaluateError::LiteralUnaryPlusOnNonNumeric.into(),
+            "SELECT id FROM Hunter WHERE +'abcd' > 1.0",
+        ),
+        (
+            EvaluateError::LiteralUnaryMinusOnNonNumeric.into(),
+            "SELECT id FROM Hunter WHERE -'abcd' < 1.0",
+        ),
+        (
+            ValueError::UnaryPlusOnNonNumeric.into(),
+            "SELECT id FROM Hunter WHERE +name > 1.0",
+        ),
+        (
+            ValueError::UnaryMinusOnNonNumeric.into(),
+            "SELECT id FROM Hunter WHERE -name < 1.0",
+        ),
+    ];
+
+    select_sqls_err
+        .into_iter()
+        .for_each(|(error, sql)| tester.test_error(sql, error));
 }


### PR DESCRIPTION
This pull request resolves issue #101 by supporting unary operations of Value. Specific modifications are the following.
- value.rs & evaluated.rs: Functions to evaluate unary operations of the expression were added.
- mod.rs: Expressions now handle unary operations.
- test.rs: Two test cases to check if WHERE supports plus(+) and minus(-) signs were added.