### PR TITLE
Update Store traits not to require std::marker::Send

### DIFF
--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -32,7 +32,7 @@ macro_rules! fetch_schema {
     }};
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl AlterTable for SledStorage {
     async fn rename_schema(self, table_name: &str, new_table_name: &str) -> MutResult<Self, ()> {
         let (_, Schema { column_defs, .. }) = fetch_schema!(self, &self.tree, table_name);

--- a/src/storages/sled_storage/store.rs
+++ b/src/storages/sled_storage/store.rs
@@ -5,7 +5,7 @@ use super::{fetch_schema, SledStorage, StorageError};
 use crate::try_into;
 use crate::{Error, MutResult, Result, Row, RowIter, Schema, Store, StoreMut};
 
-#[async_trait]
+#[async_trait(?Send)]
 impl StoreMut<IVec> for SledStorage {
     async fn generate_id(self, table_name: &str) -> MutResult<Self, IVec> {
         let id = try_into!(self, self.tree.generate_id());
@@ -62,7 +62,7 @@ impl StoreMut<IVec> for SledStorage {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl Store<IVec> for SledStorage {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
         fetch_schema(&self.tree, table_name).map(|(_, schema)| schema)

--- a/src/store/alter_table.rs
+++ b/src/store/alter_table.rs
@@ -25,7 +25,7 @@ pub enum AlterTableError {
     DroppingColumnNotFound(String),
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait AlterTable
 where
     Self: Sized,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,7 +15,7 @@ use crate::result::{MutResult, Result};
 pub type RowIter<T> = Box<dyn Iterator<Item = Result<(T, Row)>>>;
 
 /// By implementing `Store` trait, you can run `SELECT` queries.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait Store<T: Debug> {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>>;
 
@@ -24,7 +24,7 @@ pub trait Store<T: Debug> {
 
 /// `StoreMut` takes role of mutation, related to `INSERT`, `CREATE`, `DELETE`, `DROP` and
 /// `UPDATE`.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait StoreMut<T: Debug>
 where
     Self: Sized,


### PR DESCRIPTION
For supporting `await` on `JsFuture`, Store traits (`Store`, `StoreMut` and `AlterTable`) should not require `Send` trait which is for supporting threads safety.

So change `#[async_trait]` to `#[async_trait(?Send)]`.