### PR TITLE
Indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # GlueSQL project files
-data/
+/data/
 
 # Vim
 *.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ default = ["sled-storage", "alter-table"]
 # You can include whether ALTER TABLE support or not for your custom database implementation.
 alter-table = []
 
+# INDEXes are optionnal.
+# You can choose to import INDEXes or not for your custom implementation.
+index = []
+
 # Who wants to make a custom storage engine,
 # default storage engine sled-storage is not required.
 sled-storage = ["sled", "bincode"]

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -2,8 +2,10 @@
 //! TODO: Add more documentation about how each comparison works.
 
 use crate::Value;
+use sqlparser::ast::{Expr, Query};
+
 /// The conditions are the base type of condition, and are used to describe all WHERE closes supported.
-enum Condition {
+pub enum Condition {
     /// Represents an expression of the type `column_name = value`
     /// For example: `country = "France"`
     Equals { column_name: String, value: Value },
@@ -29,9 +31,40 @@ enum Condition {
         min: Value,
         max: Value,
     },
+    /// Represents an expression of the type `column_name IS NULL`
+    /// For example: `price IS NULL`
+    IsNull {
+        column_name: String
+    },
+    /// Represents an expression of the type `column_name IS NOT NULL`
+    /// For example: `price IS NOT NULL`
+    /// It's better to keep it as a condition instead of a `Not(Null(column_name))` as it allows for specific optimizations in the backend.
+    IsNotNull {
+        column_name: String
+    },
+    /// Represents an expression of the type `column_name IS IN (values...)`
+    /// For example: `country IS IN ("France", "Switzerland")`
+    InList {
+        column_name: String,
+        list_elem: Vec<Value>
+    },
+    CompareColumns {
+        column_left: String
+    },
+    /// Represents an expression of a Subquery, following this pattern: `(SELECT ...)`
+    ExistsSubquery {
+        query: Box<Query>
+    },
+    /// An condition that always return true.
+    /// For example `1 = 1`
+    True,
+    /// An expression that always return false.
+    /// For example `1 = 2`
+    False,
 }
+
 /// The links are the links between the different conditions in place.
-enum Link {
+pub enum Link {
     /// Condition is a special kind of link, that allows to convert a condition to a link
     /// This is mandatory, because if this link were not there,
     /// it would not be possible to chain conditions without difficulty.
@@ -39,13 +72,13 @@ enum Link {
     /// Represents the combination of two conditions.
     /// It is true only if **both** internal conditions are true.
     /// For example: `country = "France" AND price < 30`
-    And(Link, Link),
+    And(Box<Link>, Box<Link>),
     /// Represents the logical disjunction of the two internal conditions.
     /// It is true if **at least one** internal condition is true.
     /// For example: `country = "France" OR price < 30`
-    Or(Link, Link),
+    Or(Box<Link>, Box<Link>),
     /// Represents the negation of the internal condition.
     /// It is true if the internal condition is false.
     /// For example: `NOT country = "France"`
-    Not(Link),
+    Not(Box<Link>),
 }

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -6,47 +6,29 @@ use crate::Value;
 enum Condition {
     /// Represents an expression of the type `column_name = value`
     /// For example: `country = "France"`
-    Equals {
-        column_name: String,
-        value: Value
-    },
+    Equals { column_name: String, value: Value },
     /// Represents an expression of the type `column_name != value` or `column_name <> value`
     /// For example: `stock != 0` or `stock <> 0`
-    NotEquals {
-        column_name: String,
-        value: Value
-    },
+    NotEquals { column_name: String, value: Value },
     /// Represents an expression of the type `column_name > value`
     /// For example: `price > 50`
-    GreaterThan {
-        column_name: String,
-        value: Value
-    },
+    GreaterThan { column_name: String, value: Value },
     /// Represents an expression of the type `column_name >= value`
     /// For example: `price >= 40`
-    GreaterThanOrEquals {
-        column_name: String,
-        value: Value
-    },
+    GreaterThanOrEquals { column_name: String, value: Value },
     /// Represents an expression of the type `column_name < value`
     /// For example: `price < 60`
-    LessThan {
-        column_name: String,
-        value: Value
-    },
+    LessThan { column_name: String, value: Value },
     /// Represents an expression of the type `column_name <= value`
     /// For example: `price <= 35`
-    LessThanOrEquals {
-        column_name: String,
-        value: Value
-    },
+    LessThanOrEquals { column_name: String, value: Value },
     /// Represents an expression of the type `column_name BETWEEN min AND max`
     /// For example: `price BETWEEN 20 AND 30`
     Between {
         column_name: String,
         min: Value,
-        max: Value
-    }
+        max: Value,
+    },
 }
 /// The links are the links between the different conditions in place.
 enum Link {

--- a/src/data/conditions.rs
+++ b/src/data/conditions.rs
@@ -1,0 +1,69 @@
+//! This file contains all the types of comparison that can be created in a WHERE clause.
+//! TODO: Add more documentation about how each comparison works.
+
+use crate::Value;
+/// The conditions are the base type of condition, and are used to describe all WHERE closes supported.
+enum Condition {
+    /// Represents an expression of the type `column_name = value`
+    /// For example: `country = "France"`
+    Equals {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name != value` or `column_name <> value`
+    /// For example: `stock != 0` or `stock <> 0`
+    NotEquals {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name > value`
+    /// For example: `price > 50`
+    GreaterThan {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name >= value`
+    /// For example: `price >= 40`
+    GreaterThanOrEquals {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name < value`
+    /// For example: `price < 60`
+    LessThan {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name <= value`
+    /// For example: `price <= 35`
+    LessThanOrEquals {
+        column_name: String,
+        value: Value
+    },
+    /// Represents an expression of the type `column_name BETWEEN min AND max`
+    /// For example: `price BETWEEN 20 AND 30`
+    Between {
+        column_name: String,
+        min: Value,
+        max: Value
+    }
+}
+/// The links are the links between the different conditions in place.
+enum Link {
+    /// Condition is a special kind of link, that allows to convert a condition to a link
+    /// This is mandatory, because if this link were not there,
+    /// it would not be possible to chain conditions without difficulty.
+    Condition(Condition),
+    /// Represents the combination of two conditions.
+    /// It is true only if **both** internal conditions are true.
+    /// For example: `country = "France" AND price < 30`
+    And(Link, Link),
+    /// Represents the logical disjunction of the two internal conditions.
+    /// It is true if **at least one** internal condition is true.
+    /// For example: `country = "France" OR price < 30`
+    Or(Link, Link),
+    /// Represents the negation of the internal condition.
+    /// It is true if the internal condition is false.
+    /// For example: `NOT country = "France"`
+    Not(Link),
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,3 +8,4 @@ pub use row::{Row, RowError};
 pub use schema::Schema;
 pub use table::{get_name, Table, TableError};
 pub use value::{Value, ValueError};
+pub use conditions::{Condition, Link};

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,9 +1,8 @@
+mod conditions;
 mod row;
 mod schema;
 mod table;
 mod value;
-mod conditions;
-
 
 pub use row::{Row, RowError};
 pub use schema::Schema;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,8 @@ mod row;
 mod schema;
 mod table;
 mod value;
+mod conditions;
+
 
 pub use row::{Row, RowError};
 pub use schema::Schema;

--- a/src/executor/converter/mod.rs
+++ b/src/executor/converter/mod.rs
@@ -1,0 +1,3 @@
+mod where_converter;
+
+pub use where_converter::*;

--- a/src/executor/converter/where_converter.rs
+++ b/src/executor/converter/where_converter.rs
@@ -1,0 +1,93 @@
+use sqlparser::ast::Expr;
+use crate::{Link, Condition, Value, Error, ValueError};
+use crate::Result;
+use sqlparser::ast::Expr::Case;
+use std::convert::TryFrom;
+use std::fs::read;
+use sqlparser::ast::BinaryOperator;
+
+/// Converts the SQL AST directly to a [crate::data::conditions::Link] type.
+pub fn convert_where_query(where_expression: &Expr) -> Result<Link> {
+    match where_expression {
+        Expr::Value(_) | Expr::Wildcard => {
+            // A where without any value is weird.
+            unreachable!()
+        },
+        Expr::BinaryOp { left, op, right } => {
+            match *left.clone() {
+                Expr::Identifier(value) => {
+                    let column = value.value.clone();
+                    let value;
+                    match *right.clone() {
+                        Expr::Identifier(_) => unimplemented!("Comparing two rows is not implemented yet."),
+                        Expr::Value(val) => value = val,
+                        // The subquery will need some more work
+                        Expr::Subquery(_) => {
+                            unimplemented!("Subqueries are not supported yet.")
+                        },
+                        _ => {
+                            eprintln!("Expression: {:?}", where_expression);
+                            unimplemented!("Unsupported expression.")
+                        }
+                    }
+                    match *op.clone() {
+
+                    }
+                },
+                Expr::Value(value) => {
+                    let column;
+                    let value = Value::try_from(&value)?;
+                    match *right.clone() {
+                        Expr::Identifier(col) => column = col,
+                        Expr::Value(value_2) => {
+                            let value_2 = Value::try_from(&value_2)?;
+                            // Do operations
+                            match op.clone() {
+                                BinaryOperator::Eq => {
+                                    if value == value_2 {
+                                        return Ok(Link::Condition(Condition::True));
+                                    }
+                                    return Ok(Link::Condition(Condition::False));
+                                },
+                                BinaryOperator::NotEq => {
+                                    if value != value_2 {
+                                        return Ok(Link::Condition(Condition::True));
+                                    }
+                                    return Ok(Link::Condition(Condition::False));
+                                }
+                                BinaryOperator::Plus => {
+
+                                },
+                                _ => {
+                                    eprintln!("Expression: {:?}", where_expression);
+                                    unimplemented!("Unsupported expression.")
+                                }
+                            }
+                        },
+                        Expr::Subquery(_) => {
+                            unimplemented!("Subqueries are not implemented yet")
+                        },
+                        _ => {
+                            eprintln!("Expression: {:?}", where_expression);
+                            unimplemented!("Unsupported expression.")
+                        }
+                    }
+                }
+                _ => {
+                    eprintln!("Expression: {:?}", where_expression);
+                    unimplemented!("Unsupported expression.")
+                }
+            };
+        }
+        Expr::Exists(query) => {
+            return Ok(Link::Condition(Condition::ExistsSubquery { query: Box::from(*query.clone()) }))
+        }
+
+        _ => {
+            eprintln!("Expression: {:?}", where_expression);
+            unimplemented!("Unsupported expression.");
+        }
+    }
+    eprintln!("Expression: {:?}", where_expression);
+    unimplemented!("Unsupported expression.");
+}

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -15,6 +15,7 @@ use super::select::select;
 use crate::data::Value;
 use crate::result::Result;
 use crate::store::Store;
+use crate::convert_where_query;
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum FilterError {
@@ -52,6 +53,7 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
                 let context = Some(context).map(Rc::new);
                 let aggregated = self.aggregated.as_ref().map(Rc::clone);
 
+
                 check_expr(self.storage, context, aggregated, expr).await
             }
             None => Ok(true),
@@ -59,6 +61,23 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
     }
 }
 
+//Doing thid for the sake of testing
+//TODO: Replace this with a proper wa to deal with feature flags.
+#[cfg(feature = "index")]
+#[async_recursion(?Send)]
+pub async fn check_expr<T: 'static + Debug>(
+    storage: &dyn Store<T>,
+    filter_context: Option<Rc<FilterContext<'async_recursion>>>,
+    aggregated: Option<Rc<HashMap<&'async_recursion Function, Value>>>,
+    expr: &Expr,
+) -> Result<bool> {
+    eprintln!("Calling testing function !");
+    convert_where_query(expr);
+    Ok(true)
+}
+
+
+#[cfg(not(feature = "index"))]
 #[async_recursion(?Send)]
 pub async fn check_expr<T: 'static + Debug>(
     storage: &dyn Store<T>,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -9,6 +9,7 @@ mod join;
 mod limit;
 mod select;
 mod update;
+mod converter;
 
 pub use aggregate::{AggregateError, GroupKey};
 pub use blend::BlendError;
@@ -20,3 +21,4 @@ pub use join::JoinError;
 pub use limit::LimitError;
 pub use select::SelectError;
 pub use update::UpdateError;
+pub use converter::convert_where_query;

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -19,6 +19,7 @@ use super::limit::Limit;
 use crate::data::{get_name, Row, Table};
 use crate::result::{Error, Result};
 use crate::store::Store;
+use crate::convert_where_query;
 
 #[derive(ThisError, Serialize, Debug, PartialEq)]
 pub enum SelectError {
@@ -157,6 +158,13 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
         }
         _ => err!(SelectError::Unreachable),
     };
+
+    //Doing this for the sake of resting
+    //TODO: Remove this horror
+    if let Some(where_query) = where_clause {
+        convert_where_query(where_query);
+    }
+
 
     let TableWithJoins { relation, joins } = &table_with_joins;
     let table = Table::new(relation)?;

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,12 +9,18 @@ use crate::executor::{
 
 #[cfg(feature = "alter-table")]
 use crate::store::AlterTableError;
+#[cfg(feature = "index")]
+use crate::IndexError;
 
 #[derive(ThisError, Serialize, Debug)]
 pub enum Error {
     #[cfg(feature = "alter-table")]
     #[error(transparent)]
     AlterTable(#[from] AlterTableError),
+
+    #[cfg(feature = "index")]
+    #[error(transparent)]
+    Index(#[from] IndexError),
 
     #[error(transparent)]
     #[serde(with = "stringify")]

--- a/src/store/index.rs
+++ b/src/store/index.rs
@@ -19,7 +19,7 @@ pub enum IndexError {
 }
 
 #[async_trait]
-pub trait AlterTable
+pub trait Index
 where
     Self: Sized,
 {

--- a/src/store/index.rs
+++ b/src/store/index.rs
@@ -34,11 +34,5 @@ where
     ) -> MutResult<Self, ()>;
 
     /// Drops one or more already created index(es)
-    async fn drop(
-        self,
-        table_name: &str,
-        row_names: Vec<&str>,
-    ) -> MutResult<Self, ()>;
-
-    /// Scans the database for documents matching an array of requirements.
+    async fn drop(self, table_name: &str, row_names: Vec<&str>) -> MutResult<Self, ()>;
 }

--- a/src/store/index.rs
+++ b/src/store/index.rs
@@ -1,0 +1,44 @@
+use crate::MutResult;
+use async_trait::async_trait;
+use serde::Serialize;
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Error, Serialize, Debug, PartialEq)]
+pub enum IndexError {
+    #[error("Table not found: {0}")]
+    TableNotFound(String),
+    #[error("The index {0} already exists")]
+    IndexAlreadyExists(String),
+    #[error("The index {0} does not exists")]
+    IndexNotFound(String),
+    #[error("Duplicates are not allowed on an UNIQUE index, some were found in {0}.")]
+    UniqueIndexContainsDuplicates(String),
+    #[error("The row {0} was not found")]
+    RowNotFound(String),
+}
+
+#[async_trait]
+pub trait AlterTable
+where
+    Self: Sized,
+{
+    /// Creates one or more index(es)
+    /// Please not that if unique is set to true and there is a duplicate row,
+    /// you have to return [crate::store::index::IndexError::UniqueIndexContainsDuplicates].
+    async fn create(
+        self,
+        table_name: &str,
+        row_names: Vec<&str>,
+        unique: bool,
+    ) -> MutResult<Self, ()>;
+
+    /// Drops one or more already created index(es)
+    async fn drop(
+        self,
+        table_name: &str,
+        row_names: Vec<&str>,
+    ) -> MutResult<Self, ()>;
+
+    /// Scans the database for documents matching an array of requirements.
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,6 +5,13 @@ pub use alter_table::*;
 #[cfg(not(feature = "alter-table"))]
 pub trait AlterTable {}
 
+#[cfg(feature = "index")]
+mod index;
+#[cfg(feature = "index")]
+pub use index::*;
+#[cfg(not(feature = "index"))]
+pub trait Index {}
+
 use async_trait::async_trait;
 use std::fmt::Debug;
 use std::marker::Sized;


### PR DESCRIPTION
This is the draft PR for the indexing.

Just to justify some of my choices:
- Implementing directly the operator functions makes it impossible to combine multiple conditions on the same array of elements. Let's take an example:
```sql
CREATE TABLE Testing (id INTEGER, field_one INTEGER, field_two TEXT);
CREATE INDEX field_one;
-- Skipped the insertion of the actual elements
SELECT * FROM Testing WHERE `field_one` > 5 OR `field_one` < 2;
```
In that specific case, if the Storage only implements the basic operators, it means that the index has to be crawled twice, and the cost of doing that can be significant on big tables.

The actual objective is to have a simplified condition system, that can easily be expanded afterwards to create a custom Query Builder for GlueSQL, and being read by the Storage backend.