### PR TITLE
Clean up sled_storage implementation codes

### DIFF
--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -5,9 +5,9 @@ use std::str;
 
 use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident, Value as AstValue};
 
-use super::{fetch_schema, AlterTableError, SledStorage, StorageError};
+use super::{err_into, fetch_schema, AlterTableError, SledStorage};
 use crate::utils::Vector;
-use crate::{try_into, AlterTable, Error, MutResult, Row, Schema, Value};
+use crate::{AlterTable, MutResult, Row, Schema, Value};
 
 macro_rules! try_self {
     ($self: expr, $expr: expr) => {
@@ -17,6 +17,12 @@ macro_rules! try_self {
             }
             Ok(v) => v,
         }
+    };
+}
+
+macro_rules! try_into {
+    ($self: expr, $expr: expr) => {
+        try_self!($self, $expr.map_err(err_into))
     };
 }
 

--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alter-table")]
+
 use async_trait::async_trait;
 use boolinator::Boolinator;
 use std::iter::once;
@@ -5,9 +7,9 @@ use std::str;
 
 use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident, Value as AstValue};
 
-use super::{err_into, fetch_schema, AlterTableError, SledStorage};
+use super::{error::err_into, fetch_schema, SledStorage};
 use crate::utils::Vector;
-use crate::{AlterTable, MutResult, Row, Schema, Value};
+use crate::{AlterTable, AlterTableError, MutResult, Row, Schema, Value};
 
 macro_rules! try_self {
     ($self: expr, $expr: expr) => {

--- a/src/storages/sled_storage/error.rs
+++ b/src/storages/sled_storage/error.rs
@@ -1,0 +1,45 @@
+use std::str;
+use thiserror::Error as ThisError;
+
+#[cfg(feature = "alter-table")]
+use crate::AlterTableError;
+use crate::Error;
+
+#[derive(ThisError, Debug)]
+pub enum StorageError {
+    #[cfg(feature = "alter-table")]
+    #[error(transparent)]
+    AlterTable(#[from] AlterTableError),
+
+    #[error(transparent)]
+    Sled(#[from] sled::Error),
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    Str(#[from] str::Utf8Error),
+}
+
+impl Into<Error> for StorageError {
+    fn into(self) -> Error {
+        use StorageError::*;
+
+        match self {
+            Sled(e) => Error::Storage(Box::new(e)),
+            Bincode(e) => Error::Storage(e),
+            Str(e) => Error::Storage(Box::new(e)),
+
+            #[cfg(feature = "alter-table")]
+            AlterTable(e) => e.into(),
+        }
+    }
+}
+
+pub fn err_into<E>(e: E) -> Error
+where
+    E: Into<StorageError>,
+{
+    let e: StorageError = e.into();
+    let e: Error = e.into();
+
+    e
+}

--- a/src/storages/sled_storage/mod.rs
+++ b/src/storages/sled_storage/mod.rs
@@ -1,59 +1,15 @@
+mod alter_table;
+mod error;
+mod store;
+mod store_mut;
+#[cfg(not(feature = "alter-table"))]
+impl crate::AlterTable for SledStorage {}
+
 use sled::{self, Config, Db};
 use std::convert::TryFrom;
-use std::str;
-use thiserror::Error as ThisError;
 
-#[cfg(not(feature = "alter-table"))]
-use crate::AlterTable;
-#[cfg(feature = "alter-table")]
-use crate::AlterTableError;
 use crate::{Error, Result, Schema};
-
-#[cfg(feature = "alter-table")]
-mod alter_table;
-#[cfg(not(feature = "alter-table"))]
-impl AlterTable for SledStorage {}
-
-mod store;
-
-#[derive(ThisError, Debug)]
-enum StorageError {
-    #[cfg(feature = "alter-table")]
-    #[error(transparent)]
-    AlterTable(#[from] AlterTableError),
-
-    #[error(transparent)]
-    Sled(#[from] sled::Error),
-    #[error(transparent)]
-    Bincode(#[from] bincode::Error),
-    #[error(transparent)]
-    Str(#[from] str::Utf8Error),
-}
-
-impl Into<Error> for StorageError {
-    fn into(self) -> Error {
-        use StorageError::*;
-
-        match self {
-            Sled(e) => Error::Storage(Box::new(e)),
-            Bincode(e) => Error::Storage(e),
-            Str(e) => Error::Storage(Box::new(e)),
-
-            #[cfg(feature = "alter-table")]
-            AlterTable(e) => e.into(),
-        }
-    }
-}
-
-fn err_into<E>(e: E) -> Error
-where
-    E: Into<StorageError>,
-{
-    let e: StorageError = e.into();
-    let e: Error = e.into();
-
-    e
-}
+use error::err_into;
 
 #[derive(Debug, Clone)]
 pub struct SledStorage {

--- a/src/storages/sled_storage/store.rs
+++ b/src/storages/sled_storage/store.rs
@@ -2,75 +2,7 @@ use async_trait::async_trait;
 use sled::IVec;
 
 use super::{err_into, fetch_schema, SledStorage};
-use crate::{MutResult, Result, Row, RowIter, Schema, Store, StoreMut};
-
-macro_rules! try_into {
-    ($self: expr, $expr: expr) => {
-        match $expr.map_err(err_into) {
-            Err(e) => {
-                return Err(($self, e));
-            }
-            Ok(v) => v,
-        }
-    };
-}
-
-#[async_trait(?Send)]
-impl StoreMut<IVec> for SledStorage {
-    async fn generate_id(self, table_name: &str) -> MutResult<Self, IVec> {
-        let id = try_into!(self, self.tree.generate_id());
-        let id = id.to_be_bytes();
-        let prefix = format!("data/{}/", table_name);
-
-        let bytes = prefix
-            .into_bytes()
-            .into_iter()
-            .chain(id.iter().copied())
-            .collect::<Vec<_>>();
-
-        Ok((self, IVec::from(bytes.as_slice())))
-    }
-
-    async fn insert_schema(self, schema: &Schema) -> MutResult<Self, ()> {
-        let key = format!("schema/{}", schema.table_name);
-        let key = key.as_bytes();
-        let value = try_into!(self, bincode::serialize(schema));
-
-        try_into!(self, self.tree.insert(key, value));
-
-        Ok((self, ()))
-    }
-
-    async fn delete_schema(self, table_name: &str) -> MutResult<Self, ()> {
-        let prefix = format!("data/{}/", table_name);
-        let tree = &self.tree;
-
-        for item in tree.scan_prefix(prefix.as_bytes()) {
-            let (key, _) = try_into!(self, item);
-
-            try_into!(self, tree.remove(key));
-        }
-
-        let key = format!("schema/{}", table_name);
-        try_into!(self, tree.remove(key));
-
-        Ok((self, ()))
-    }
-
-    async fn insert_data(self, key: &IVec, row: Row) -> MutResult<Self, ()> {
-        let value = try_into!(self, bincode::serialize(&row));
-
-        try_into!(self, self.tree.insert(key, value));
-
-        Ok((self, ()))
-    }
-
-    async fn delete_data(self, key: &IVec) -> MutResult<Self, ()> {
-        try_into!(self, self.tree.remove(key));
-
-        Ok((self, ()))
-    }
-}
+use crate::{Result, RowIter, Schema, Store};
 
 #[async_trait(?Send)]
 impl Store<IVec> for SledStorage {

--- a/src/storages/sled_storage/store_mut.rs
+++ b/src/storages/sled_storage/store_mut.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use sled::IVec;
+
+use super::{err_into, SledStorage};
+use crate::{MutResult, Row, Schema, StoreMut};
+
+macro_rules! try_into {
+    ($self: expr, $expr: expr) => {
+        match $expr.map_err(err_into) {
+            Err(e) => {
+                return Err(($self, e));
+            }
+            Ok(v) => v,
+        }
+    };
+}
+
+#[async_trait(?Send)]
+impl StoreMut<IVec> for SledStorage {
+    async fn generate_id(self, table_name: &str) -> MutResult<Self, IVec> {
+        let id = try_into!(self, self.tree.generate_id());
+        let id = id.to_be_bytes();
+        let prefix = format!("data/{}/", table_name);
+
+        let bytes = prefix
+            .into_bytes()
+            .into_iter()
+            .chain(id.iter().copied())
+            .collect::<Vec<_>>();
+
+        Ok((self, IVec::from(bytes.as_slice())))
+    }
+
+    async fn insert_schema(self, schema: &Schema) -> MutResult<Self, ()> {
+        let key = format!("schema/{}", schema.table_name);
+        let key = key.as_bytes();
+        let value = try_into!(self, bincode::serialize(schema));
+
+        try_into!(self, self.tree.insert(key, value));
+
+        Ok((self, ()))
+    }
+
+    async fn delete_schema(self, table_name: &str) -> MutResult<Self, ()> {
+        let prefix = format!("data/{}/", table_name);
+        let tree = &self.tree;
+
+        for item in tree.scan_prefix(prefix.as_bytes()) {
+            let (key, _) = try_into!(self, item);
+
+            try_into!(self, tree.remove(key));
+        }
+
+        let key = format!("schema/{}", table_name);
+        try_into!(self, tree.remove(key));
+
+        Ok((self, ()))
+    }
+
+    async fn insert_data(self, key: &IVec, row: Row) -> MutResult<Self, ()> {
+        let value = try_into!(self, bincode::serialize(&row));
+
+        try_into!(self, self.tree.insert(key, value));
+
+        Ok((self, ()))
+    }
+
+    async fn delete_data(self, key: &IVec) -> MutResult<Self, ()> {
+        try_into!(self, self.tree.remove(key));
+
+        Ok((self, ()))
+    }
+}


### PR DESCRIPTION
This is only clean-up code pr, it does not have any functional changes.

* Reduce macro uses: `try_into`

Add `fn err_into`, it cleans redundant code used in `try_into!` macro.
```rust
let e: StorageError = e.into();	
let e: Error = e.into();	

return Err(($self, e));
```

* Split into more modules

Detach `error.rs` from `mod.rs` to make `mod.rs` easier to figure out.

`Store` and `StoreMut` implementation codes were in the same file, `store.rs`.
Now those splits into `store.rs` and `store_mut.rs`.