### PR TITLE
Replace Rc<Vec<_>> to Rc<[_]>, make codes clippy clean

### DIFF
--- a/src/executor/context/blend_context.rs
+++ b/src/executor/context/blend_context.rs
@@ -8,7 +8,7 @@ use crate::data::{Row, Value};
 #[derive(Debug)]
 pub struct BlendContext<'a> {
     table_alias: &'a str,
-    pub columns: Rc<Vec<Ident>>,
+    pub columns: Rc<[Ident]>,
     pub row: Option<Row>,
     next: Option<Rc<BlendContext<'a>>>,
 }
@@ -16,7 +16,7 @@ pub struct BlendContext<'a> {
 impl<'a> BlendContext<'a> {
     pub fn new(
         table_alias: &'a str,
-        columns: Rc<Vec<Ident>>,
+        columns: Rc<[Ident]>,
         row: Option<Row>,
         next: Option<Rc<BlendContext<'a>>>,
     ) -> Self {

--- a/src/executor/context/filter_context.rs
+++ b/src/executor/context/filter_context.rs
@@ -10,7 +10,7 @@ use crate::data::{Row, Value};
 enum Content<'a> {
     Some {
         table_alias: &'a str,
-        columns: Rc<Vec<Ident>>,
+        columns: Rc<[Ident]>,
         row: Option<&'a Row>,
     },
     None,
@@ -26,7 +26,7 @@ pub struct FilterContext<'a> {
 impl<'a> FilterContext<'a> {
     pub fn new(
         table_alias: &'a str,
-        columns: Rc<Vec<Ident>>,
+        columns: Rc<[Ident]>,
         row: Option<&'a Row>,
         next: Option<Rc<FilterContext<'a>>>,
     ) -> Self {

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -279,7 +279,7 @@ async fn prepare<'a, T: 'static + Debug>(
             assignments,
         } => {
             let table_name = get_name(table_name)?;
-            let columns = Rc::new(fetch_columns(storage, table_name).await?);
+            let columns = Rc::from(fetch_columns(storage, table_name).await?);
             let update = Update::new(storage, table_name, assignments, Rc::clone(&columns))?;
             let filter = Filter::new(storage, selection.as_ref(), None, None);
 
@@ -304,7 +304,7 @@ async fn prepare<'a, T: 'static + Debug>(
             selection,
         } => {
             let table_name = get_name(table_name)?;
-            let columns = Rc::new(fetch_columns(storage, table_name).await?);
+            let columns = Rc::from(fetch_columns(storage, table_name).await?);
             let filter = Filter::new(storage, selection.as_ref(), None, None);
 
             fetch(storage, table_name, columns, filter)

--- a/src/executor/fetch.rs
+++ b/src/executor/fetch.rs
@@ -36,9 +36,9 @@ pub async fn fetch_columns<T: 'static + Debug>(
 pub async fn fetch<'a, T: 'static + Debug>(
     storage: &dyn Store<T>,
     table_name: &'a str,
-    columns: Rc<Vec<Ident>>,
+    columns: Rc<[Ident]>,
     filter: Filter<'a, T>,
-) -> Result<impl TryStream<Ok = (Rc<Vec<Ident>>, T, Row), Error = Error> + 'a> {
+) -> Result<impl TryStream<Ok = (Rc<[Ident]>, T, Row), Error = Error> + 'a> {
     let filter = Rc::new(filter);
 
     let rows = storage

--- a/src/executor/join.rs
+++ b/src/executor/join.rs
@@ -56,7 +56,7 @@ impl<'a, T: 'static + Debug> Join<'a, T> {
     pub async fn apply(
         &self,
         init_context: Result<BlendContext<'a>>,
-        join_columns: Rc<Vec<Rc<Vec<Ident>>>>,
+        join_columns: Rc<[Rc<[Ident]>]>,
     ) -> Result<Joined<'a>> {
         let init_context = init_context.map(Rc::new);
         let init_rows: Joined<'a> = Box::pin(stream::once(async { init_context }));
@@ -101,7 +101,7 @@ async fn join<'a, T: 'static + Debug>(
     storage: &'a dyn Store<T>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     ast_join: &'a AstJoin,
-    columns: Rc<Vec<Ident>>,
+    columns: Rc<[Ident]>,
     blend_context: Result<Rc<BlendContext<'a>>>,
 ) -> Result<Joined<'a>> {
     let AstJoin {
@@ -152,7 +152,7 @@ async fn fetch_joined<'a, T: 'static + Debug>(
     storage: &'a dyn Store<T>,
     table_name: &'a str,
     table_alias: &'a str,
-    columns: Rc<Vec<Ident>>,
+    columns: Rc<[Ident]>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     blend_context: Rc<BlendContext<'a>>,
     constraint: &'a JoinConstraint,

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -35,7 +35,7 @@ pub enum SelectError {
 async fn fetch_blended<'a, T: 'static + Debug>(
     storage: &dyn Store<T>,
     table: Table<'a>,
-    columns: Rc<Vec<Ident>>,
+    columns: Rc<[Ident]>,
 ) -> Result<impl Stream<Item = Result<BlendContext<'a>>> + 'a> {
     let rows = storage.scan_data(table.get_name()).await?.map(move |data| {
         let (_, row) = data?;
@@ -186,13 +186,13 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
         vec![]
     };
 
-    let columns = Rc::new(columns);
+    let columns = Rc::from(columns);
     let join_columns = join_columns
         .into_iter()
         .map(|(_, columns)| columns)
-        .map(Rc::new)
+        .map(Rc::from)
         .collect::<Vec<_>>();
-    let join_columns = Rc::new(join_columns);
+    let join_columns = Rc::from(join_columns);
 
     let join = Rc::new(Join::new(
         storage,

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -28,7 +28,7 @@ pub struct Update<'a, T: 'static + Debug> {
     storage: &'a dyn Store<T>,
     table_name: &'a str,
     fields: &'a [Assignment],
-    columns: Rc<Vec<Ident>>,
+    columns: Rc<[Ident]>,
 }
 
 impl<'a, T: 'static + Debug> Update<'a, T> {
@@ -36,7 +36,7 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
         storage: &'a dyn Store<T>,
         table_name: &'a str,
         fields: &'a [Assignment],
-        columns: Rc<Vec<Ident>>,
+        columns: Rc<[Ident]>,
     ) -> Result<Self> {
         for assignment in fields.iter() {
             let Assignment { id, .. } = assignment;
@@ -72,7 +72,7 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
                     .columns
                     .iter()
                     .position(|column| column.value == id.value)
-                    .ok_or_else(|| UpdateError::Unreachable)?;
+                    .ok_or(UpdateError::Unreachable)?;
 
                 let evaluated = evaluate(self.storage, context, None, value, false).await?;
 


### PR DESCRIPTION
cargo clippy recently updated and it became smarter.

`clippy 0.0.212 (7eac88a 2020-11-16)`

* Replace all `Rc<Vec<_>>` to `Rc<[_]>`
* Remove unnecessary lazy evaluation  `.ok_or_else(|| UpdateError::Unreachable)?;`


