### PR TITLE
Update StoreMut mutating data functions to accept multiple items

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ pub trait Store<T: Debug> {
 }
 
 pub trait StoreMut<T: Debug> where Self: Sized {
-    async fn generate_id(..) -> ..;
     async fn insert_schema(..) -> ..;
     async fn delete_schema(..) -> ..;
     async fn insert_data(..) -> ..;
+    async fn update_data(..) -> ..;
     async fn delete_data(..) -> ..;
 }
 ```

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -100,14 +100,14 @@ pub async fn execute<T: 'static + Debug, U: Store<T> + StoreMut<T> + AlterTable>
                 .await
                 .map(|(storage, _)| (storage, Payload::Insert(num_rows)))
         }
-        Prepared::Delete(keys) => stream::iter(keys.into_iter().map(Ok::<T, (U, Error)>))
-            .try_fold((storage, 0), |(storage, num), key| async move {
-                let (storage, _) = storage.delete_data(&key).await?;
+        Prepared::Delete(keys) => {
+            let num_rows = keys.len();
 
-                Ok((storage, num + 1))
-            })
-            .await
-            .map(|(storage, num_rows)| (storage, Payload::Delete(num_rows))),
+            storage
+                .delete_data(keys)
+                .await
+                .map(|(storage, _)| (storage, Payload::Delete(num_rows)))
+        }
         Prepared::Update(rows) => {
             let num_rows = rows.len();
 

--- a/src/storages/sled_storage/store_mut.rs
+++ b/src/storages/sled_storage/store_mut.rs
@@ -74,8 +74,10 @@ impl StoreMut<IVec> for SledStorage {
         Ok((self, ()))
     }
 
-    async fn delete_data(self, key: &IVec) -> MutResult<Self, ()> {
-        try_into!(self, self.tree.remove(key));
+    async fn delete_data(self, keys: Vec<IVec>) -> MutResult<Self, ()> {
+        for key in keys.into_iter() {
+            try_into!(self, self.tree.remove(key));
+        }
 
         Ok((self, ()))
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -37,5 +37,5 @@ where
 
     async fn update_data(self, rows: Vec<(T, Row)>) -> MutResult<Self, ()>;
 
-    async fn delete_data(self, key: &T) -> MutResult<Self, ()>;
+    async fn delete_data(self, keys: Vec<T>) -> MutResult<Self, ()>;
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -29,13 +29,13 @@ pub trait StoreMut<T: Debug>
 where
     Self: Sized,
 {
-    async fn generate_id(self, table_name: &str) -> MutResult<Self, T>;
-
     async fn insert_schema(self, schema: &Schema) -> MutResult<Self, ()>;
 
     async fn delete_schema(self, table_name: &str) -> MutResult<Self, ()>;
 
-    async fn insert_data(self, key: &T, row: Row) -> MutResult<Self, ()>;
+    async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()>;
+
+    async fn update_data(self, rows: Vec<(T, Row)>) -> MutResult<Self, ()>;
 
     async fn delete_data(self, key: &T) -> MutResult<Self, ()>;
 }


### PR DESCRIPTION
## Summary
### Changes - `StoreMut` trait
* `insert_data` now takes `Vec<Row>`
* `delete_data` now taks `Vec<(T, ROW)>`
* Add `update_data`
* Remove `generate_id`

## Details
Previous `insert_data` and `delete_data` only took a single item to mutate.
However, GlueSQL's execution layer only uses mutating `Vec<_>` of data.
So, it's certainly better to accept `Vec<_>` rather than a single item.

Considering making a custom storage based on remote kv store. (redis, ..)
Due to the network overhead, it is better to request by bundling multiple items in to a single request.

`generate_id` was only for `insert_data` so it is not necessary to have it as a `StoreMut` trait function, so removed.
