### PR TITLE
Implement UNIQUE constraint in CREATE TABLE

### DIFF
--- a/src/data/table.rs
+++ b/src/data/table.rs
@@ -45,7 +45,7 @@ impl<'a> Table<'a> {
     }
 }
 
-pub fn get_name<'a>(table_name: &'a ObjectName) -> Result<&'a String> {
+pub fn get_name(table_name: &ObjectName) -> Result<&String> {
     let ObjectName(idents) = table_name;
 
     idents

--- a/src/data/value.rs
+++ b/src/data/value.rs
@@ -472,7 +472,7 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
-    use super::Value;
+    use super::*;
 
     #[test]
     fn eq() {
@@ -495,5 +495,21 @@ mod tests {
         assert_eq!(Value::OptStr(None), Value::OptStr(None));
 
         assert_eq!(Value::Empty, Value::Empty);
+    }
+
+    #[test]
+    fn float_cannot_be_unique() {
+        assert_eq!(
+            TryInto::<UniqueKey>::try_into(Value::F64(1.0)),
+            Err(ValueError::FloatCannotBeUnique.into())
+        );
+        assert_eq!(
+            TryInto::<UniqueKey>::try_into(Value::OptF64(Some(1.0))),
+            Err(ValueError::FloatCannotBeUnique.into())
+        );
+        assert_eq!(
+            TryInto::<UniqueKey>::try_into(Value::OptF64(None)),
+            Err(ValueError::FloatCannotBeUnique.into())
+        );
     }
 }

--- a/src/data/value.rs
+++ b/src/data/value.rs
@@ -47,6 +47,9 @@ pub enum ValueError {
 
     #[error("unary minus operation for non numeric value")]
     UnaryMinusOnNonNumeric,
+
+    #[error("Duplicate entry '{0}' for unique column '{1}'")]
+    DuplicateEntryOnUniqueField(String, String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +129,10 @@ impl PartialEq<AstValue> for Value {
 impl PartialOrd<Value> for Value {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match (self, other) {
+            (Value::Bool(l), Value::Bool(r))
+            | (Value::OptBool(Some(l)), Value::Bool(r))
+            | (Value::Bool(l), Value::OptBool(Some(r)))
+            | (Value::OptBool(Some(l)), Value::OptBool(Some(r))) => Some(l.cmp(r)),
             (Value::I64(l), Value::I64(r))
             | (Value::OptI64(Some(l)), Value::I64(r))
             | (Value::I64(l), Value::OptI64(Some(r)))

--- a/src/executor/create_table.rs
+++ b/src/executor/create_table.rs
@@ -1,0 +1,58 @@
+use serde::Serialize;
+use sqlparser::ast::{ColumnDef, ColumnOption, DataType};
+use std::fmt::Debug;
+use thiserror::Error as ThisError;
+
+use crate::data::Schema;
+use crate::result::Result;
+use crate::store::Store;
+
+#[derive(Debug, PartialEq, Serialize, ThisError)]
+pub enum CreateTableError {
+    #[error("table already exists")]
+    TableAlreadyExists,
+
+    #[error("column '{0}' of data type '{1}' is unsupported for unique constraint")]
+    UnsupportedDataTypeForUniqueColumn(String, String),
+}
+
+pub async fn validate_table<T: 'static + Debug>(
+    storage: &impl Store<T>,
+    schema: &Schema,
+    if_not_exists: bool,
+) -> Result<()> {
+    validate_column_unique_option(&schema.column_defs)?;
+    validate_table_if_not_exists(storage, &schema.table_name, if_not_exists).await
+}
+
+fn validate_column_unique_option(column_defs: &[ColumnDef]) -> Result<()> {
+    let found = column_defs.iter().find(|col| match col.data_type {
+        DataType::Float(_) => col
+            .options
+            .iter()
+            .any(|opt| matches!(opt.option, ColumnOption::Unique { .. })),
+        _ => false,
+    });
+
+    if let Some(col) = found {
+        return Err(CreateTableError::UnsupportedDataTypeForUniqueColumn(
+            col.name.to_string(),
+            col.data_type.to_string(),
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn validate_table_if_not_exists<'a, T: 'static + Debug>(
+    storage: &impl Store<T>,
+    table_name: &str,
+    if_not_exists: bool,
+) -> Result<()> {
+    if if_not_exists || storage.fetch_schema(table_name).await?.is_none() {
+        return Ok(());
+    }
+
+    Err(CreateTableError::TableAlreadyExists.into())
+}

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -6,18 +6,19 @@ use thiserror::Error as ThisError;
 
 #[cfg(feature = "alter-table")]
 use sqlparser::ast::AlterTableOperation;
-use sqlparser::ast::{Ident, ObjectType, SetExpr, Statement, Values};
+use sqlparser::ast::{ColumnDef, Ident, ObjectType, SetExpr, Statement, Values};
 
 use crate::data::{get_name, Row, Schema};
 use crate::parse_sql::Query;
 use crate::result::{Error, MutResult, Result};
 use crate::store::{AlterTable, Store, StoreMut};
 
+use super::create_table::validate_table;
 use super::fetch::{fetch, fetch_columns};
 use super::filter::Filter;
 use super::select::{select, select_with_labels};
 use super::update::Update;
-use super::validate::{validate_rows, validate_table, ColumnValidation};
+use super::validate::{validate_rows, ColumnValidation};
 
 #[derive(ThisError, Serialize, Debug, PartialEq)]
 pub enum ExecuteError {
@@ -86,9 +87,15 @@ pub async fn execute<T: 'static + Debug, U: Store<T> + StoreMut<T> + AlterTable>
                 .await
                 .map(|(storage, _)| (storage, Payload::Create))
         }
-        Prepared::Insert(table_name, rows) => {
-            let validated =
-                validate_rows(&storage, &table_name, ColumnValidation::All, rows.iter()).await;
+        Prepared::Insert(table_name, column_defs, rows) => {
+            let column_defs = Rc::from(column_defs);
+            let validated = validate_rows(
+                &storage,
+                &table_name,
+                ColumnValidation::All(Rc::clone(&column_defs)),
+                rows.iter(),
+            )
+            .await;
             try_into!(storage, validated);
 
             let num_rows = rows.len();
@@ -106,11 +113,12 @@ pub async fn execute<T: 'static + Debug, U: Store<T> + StoreMut<T> + AlterTable>
                 .await
                 .map(|(storage, _)| (storage, Payload::Delete(num_rows)))
         }
-        Prepared::Update(table_name, columns_to_update, rows) => {
+        Prepared::Update(table_name, all_column_defs, columns_to_update, rows) => {
+            let all_column_defs = Rc::from(all_column_defs);
             let validated = validate_rows(
                 &storage,
                 &table_name,
-                ColumnValidation::SpecifiedColumns(columns_to_update),
+                ColumnValidation::SpecifiedColumns(Rc::clone(&all_column_defs), columns_to_update),
                 rows.iter().map(|r| &r.1),
             )
             .await;
@@ -189,9 +197,9 @@ enum Prepared<'a, T> {
         schema: Schema,
         if_not_exists: bool,
     },
-    Insert(&'a str, Vec<Row>),
+    Insert(&'a str, Vec<ColumnDef>, Vec<Row>),
     Delete(Vec<T>),
-    Update(&'a str, Vec<Ident>, Vec<(T, Row)>),
+    Update(&'a str, Vec<ColumnDef>, Vec<Ident>, Vec<(T, Row)>),
     Select {
         labels: Vec<String>,
         rows: Vec<Row>,
@@ -275,7 +283,7 @@ async fn prepare<'a, T: 'static + Debug>(
                 }
             };
 
-            Ok(Prepared::Insert(table_name, rows))
+            Ok(Prepared::Insert(table_name, column_defs, rows))
         }
         Statement::Update {
             table_name,
@@ -283,12 +291,16 @@ async fn prepare<'a, T: 'static + Debug>(
             assignments,
         } => {
             let table_name = get_name(table_name)?;
-            let columns = Rc::from(fetch_columns(storage, table_name).await?);
-            let update = Update::new(storage, table_name, assignments, Rc::clone(&columns))?;
+            let Schema { column_defs, .. } = storage
+                .fetch_schema(table_name)
+                .await?
+                .ok_or(ExecuteError::TableNotExists)?;
+            let update = Update::new(storage, table_name, assignments, &column_defs)?;
             let filter = Filter::new(storage, selection.as_ref(), None, None);
-            let columns_to_update = update.columns_to_update();
 
-            fetch(storage, table_name, columns, filter)
+            let all_columns = Rc::from(update.all_columns());
+            let columns_to_update = update.columns_to_update();
+            fetch(storage, table_name, Rc::clone(&all_columns), filter)
                 .await?
                 .and_then(|item| {
                     let update = &update;
@@ -302,7 +314,7 @@ async fn prepare<'a, T: 'static + Debug>(
                 })
                 .try_collect::<Vec<_>>()
                 .await
-                .map(|rows| Prepared::Update(table_name, columns_to_update, rows))
+                .map(|rows| Prepared::Update(table_name, column_defs, columns_to_update, rows))
         }
         Statement::Delete {
             table_name,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -9,6 +9,7 @@ mod join;
 mod limit;
 mod select;
 mod update;
+mod validate;
 
 pub use aggregate::{AggregateError, GroupKey};
 pub use blend::BlendError;

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,6 +1,7 @@
 mod aggregate;
 mod blend;
 mod context;
+mod create_table;
 mod evaluate;
 mod execute;
 mod fetch;
@@ -13,6 +14,7 @@ mod validate;
 
 pub use aggregate::{AggregateError, GroupKey};
 pub use blend::BlendError;
+pub use create_table::CreateTableError;
 pub use evaluate::EvaluateError;
 pub use execute::{execute, ExecuteError, Payload};
 pub use fetch::FetchError;

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -21,3 +21,4 @@ pub use join::JoinError;
 pub use limit::LimitError;
 pub use select::SelectError;
 pub use update::UpdateError;
+pub use validate::{UniqueKey, ValidateError};

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -116,4 +116,11 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
             .await
             .map(Row)
     }
+
+    pub fn columns_to_update(&self) -> Vec<Ident> {
+        self.fields
+            .iter()
+            .map(|assignment| assignment.id.clone())
+            .collect()
+    }
 }

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -1,0 +1,204 @@
+use futures::stream::{self, TryStreamExt};
+use sqlparser::ast::{ColumnDef, ColumnOption, Ident};
+use std::{cmp::Ordering, fmt::Debug, rc::Rc};
+
+use crate::data::{Row, Schema, Value, ValueError};
+use crate::result::Result;
+use crate::store::Store;
+
+use super::execute::ExecuteError;
+
+pub enum ColumnValidation {
+    All,
+    SpecifiedColumns(Vec<Ident>),
+}
+
+pub async fn validate_rows<'a, T: 'static + Debug>(
+    storage: &impl Store<T>,
+    table_name: &str,
+    column_validation: ColumnValidation,
+    rows: &'a [Row],
+) -> Result<()> {
+    validate_rows_by(storage, table_name, column_validation, rows, |r| r).await
+}
+
+pub async fn validate_rows_by<'a, T: 'static + Debug, U: 'static + Debug, F>(
+    storage: &impl Store<T>,
+    table_name: &str,
+    column_validation: ColumnValidation,
+    items: &'a [U],
+    item_to_row: F,
+) -> Result<()>
+where
+    F: Fn(&U) -> &Row,
+{
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    validate_unique_by(storage, table_name, column_validation, items, item_to_row).await
+}
+
+async fn validate_unique_by<'a, T: 'static + Debug, U: 'static + Debug, F>(
+    storage: &impl Store<T>,
+    table_name: &str,
+    column_validation: ColumnValidation,
+    items: &'a [U],
+    item_to_row: F,
+) -> Result<()>
+where
+    F: Fn(&U) -> &Row,
+{
+    let Schema { column_defs, .. } = storage
+        .fetch_schema(table_name)
+        .await?
+        .ok_or(ExecuteError::TableNotExists)?;
+    let column_indexes = match column_validation {
+        ColumnValidation::All => fetch_all_unique_column_indexes(&column_defs),
+        ColumnValidation::SpecifiedColumns(columns) => {
+            fetch_specified_unique_column_indexes(&column_defs, &columns)
+        }
+    };
+    let unique_checks = create_unique_checks(&column_defs, &column_indexes, items, item_to_row)?;
+    if unique_checks.is_empty() {
+        return Ok(());
+    }
+
+    let column_defs = Rc::new(column_defs);
+    let unique_checks = Rc::new(unique_checks);
+    storage
+        .scan_data(table_name)
+        .await
+        .map(stream::iter)?
+        .try_for_each(|(_, row)| {
+            let column_defs = Rc::clone(&column_defs);
+            let unique_checks = Rc::clone(&unique_checks);
+
+            async move {
+                for check in unique_checks.as_ref() {
+                    let column_index = check.column_index;
+                    let row_val = row.get_value(column_index).unwrap();
+                    if check
+                        .values
+                        .binary_search_by(|v| compare_values_for_sort(v, row_val).unwrap())
+                        .is_ok()
+                    {
+                        return Err(ValueError::DuplicateEntryOnUniqueField(
+                            format!("{:?}", row_val),
+                            column_defs[column_index].name.to_string(),
+                        )
+                        .into());
+                    }
+                }
+                Ok(())
+            }
+        })
+        .await
+}
+
+fn fetch_all_unique_column_indexes(column_defs: &[ColumnDef]) -> Vec<usize> {
+    let mut column_indexes = vec![];
+    for (i, col) in column_defs.iter().enumerate() {
+        if col
+            .options
+            .iter()
+            .any(|opt_def| matches!(opt_def.option, ColumnOption::Unique { .. }))
+        {
+            column_indexes.push(i);
+        }
+    }
+
+    column_indexes
+}
+
+fn fetch_specified_unique_column_indexes(
+    table_column_defs: &[ColumnDef],
+    specified_columns: &[Ident],
+) -> Vec<usize> {
+    let mut column_indexes = vec![];
+    for (i, table_col) in table_column_defs.iter().enumerate() {
+        if table_col
+            .options
+            .iter()
+            .any(|opt_def| match opt_def.option {
+                ColumnOption::Unique { .. } => specified_columns
+                    .iter()
+                    .any(|specified_col| specified_col.value == table_col.name.value),
+                _ => false,
+            })
+        {
+            column_indexes.push(i);
+        }
+    }
+
+    column_indexes
+}
+
+#[derive(Debug)]
+struct UniqueCheck<'a> {
+    column_index: usize,
+    values: Vec<&'a Value>,
+}
+
+fn create_unique_checks<'a, U: 'static + Debug, F>(
+    table_column_defs: &[ColumnDef],
+    unique_column_indexes: &[usize],
+    items: &'a [U],
+    item_to_row: F,
+) -> Result<Vec<UniqueCheck<'a>>>
+where
+    F: Fn(&U) -> &Row,
+{
+    let item_len = items.len();
+    let mut checks = Vec::with_capacity(unique_column_indexes.len());
+    for &column_index in unique_column_indexes {
+        let mut values: Vec<&'a Value> = Vec::with_capacity(item_len);
+        for item in items {
+            let new_val = item_to_row(item).get_value(column_index).unwrap();
+            match values.binary_search_by(|v| compare_values_for_sort(v, new_val).unwrap()) {
+                Ok(_) => {
+                    // The input values are duplicate.
+                    return Err(ValueError::DuplicateEntryOnUniqueField(
+                        format!("{:?}", new_val),
+                        table_column_defs[column_index].name.to_string(),
+                    )
+                    .into());
+                }
+                Err(idx) => values.insert(idx, new_val),
+            }
+        }
+
+        checks.push(UniqueCheck {
+            column_index,
+            values,
+        });
+    }
+
+    Ok(checks)
+}
+
+// This function tries to implement efficient value sort of the same column
+// (as same data type). The return ordering has no meaning for the value
+// comparison. It is only used to find the specified value efficiently
+// (for function `binary_search`). And it assumes no value is Float NAN.
+// This function should be updated when adding new Value.
+fn compare_values_for_sort(lhs: &Value, rhs: &Value) -> Option<Ordering> {
+    if let Some(ordering) = lhs.partial_cmp(rhs) {
+        return Some(ordering);
+    }
+
+    match (lhs, rhs) {
+        (Value::OptBool(Some(_)), Value::OptBool(None))
+        | (Value::OptI64(Some(_)), Value::OptI64(None))
+        | (Value::OptF64(Some(_)), Value::OptF64(None))
+        | (Value::OptStr(Some(_)), Value::OptStr(None)) => Some(Ordering::Greater),
+        (Value::OptBool(None), Value::OptBool(Some(_)))
+        | (Value::OptI64(None), Value::OptI64(Some(_)))
+        | (Value::OptF64(None), Value::OptF64(Some(_)))
+        | (Value::OptStr(None), Value::OptStr(Some(_))) => Some(Ordering::Less),
+        (Value::Empty, Value::Empty) => Some(Ordering::Equal),
+        (_, Value::Empty) => Some(Ordering::Greater),
+        (Value::Empty, _) => Some(Ordering::Less),
+        _ => None,
+    }
+}

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -125,8 +125,7 @@ fn create_unique_constraints<'a, 'b>(
     unique_columns
         .iter()
         .try_fold(Vector::new(), |constraints, &col| {
-            let col_idx = col.0;
-            let col_def = col.1;
+            let (col_idx, col_def) = col;
             let new_constraint = UniqueConstraint::new(col_idx, col_def);
             let new_constraint = row_iter
                 .clone()

--- a/src/result.rs
+++ b/src/result.rs
@@ -4,7 +4,7 @@ use thiserror::Error as ThisError;
 use crate::data::{RowError, TableError, ValueError};
 use crate::executor::{
     AggregateError, BlendError, EvaluateError, ExecuteError, FetchError, FilterError, JoinError,
-    LimitError, SelectError, UpdateError,
+    LimitError, SelectError, UpdateError, ValidateError,
 };
 
 #[cfg(feature = "alter-table")]
@@ -45,6 +45,8 @@ pub enum Error {
     #[error(transparent)]
     Table(#[from] TableError),
     #[error(transparent)]
+    Validate(#[from] ValidateError),
+    #[error(transparent)]
     Value(#[from] ValueError),
 }
 
@@ -70,6 +72,7 @@ impl PartialEq for Error {
             (Limit(e), Limit(e2)) => e == e2,
             (Row(e), Row(e2)) => e == e2,
             (Table(e), Table(e2)) => e == e2,
+            (Validate(e), Validate(e2)) => e == e2,
             (Value(e), Value(e2)) => e == e2,
             _ => false,
         }

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,8 +3,8 @@ use thiserror::Error as ThisError;
 
 use crate::data::{RowError, TableError, ValueError};
 use crate::executor::{
-    AggregateError, BlendError, EvaluateError, ExecuteError, FetchError, FilterError, JoinError,
-    LimitError, SelectError, UpdateError, ValidateError,
+    AggregateError, BlendError, CreateTableError, EvaluateError, ExecuteError, FetchError,
+    FilterError, JoinError, LimitError, SelectError, UpdateError, ValidateError,
 };
 
 #[cfg(feature = "alter-table")]
@@ -48,6 +48,8 @@ pub enum Error {
     Validate(#[from] ValidateError),
     #[error(transparent)]
     Value(#[from] ValueError),
+    #[error(transparent)]
+    CreateTable(#[from] CreateTableError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -74,6 +76,7 @@ impl PartialEq for Error {
             (Table(e), Table(e2)) => e == e2,
             (Validate(e), Validate(e2)) => e == e2,
             (Value(e), Value(e2)) => e == e2,
+            (CreateTable(e), CreateTable(e2)) => e == e2,
             _ => false,
         }
     }

--- a/src/tests/create_table.rs
+++ b/src/tests/create_table.rs
@@ -18,7 +18,7 @@ test_case!(create_table, async move {
             num INTEGER,
             name TEXT
         )"#,
-            Err(ExecuteError::TableAlreadyExists.into()),
+            Err(ValidateError::TableAlreadyExists.into()),
         ),
         (
             r#"

--- a/src/tests/create_table.rs
+++ b/src/tests/create_table.rs
@@ -13,15 +13,6 @@ test_case!(create_table, async move {
         ),
         (
             r#"
-        CREATE TABLE CreateTable1 (
-            id INTEGER NULL,
-            num INTEGER,
-            name TEXT
-        )"#,
-            Err(ValidateError::TableAlreadyExists.into()),
-        ),
-        (
-            r#"
         CREATE TABLE IF NOT EXISTS CreateTable2 (
             id INTEGER NULL,
             num INTEGER,

--- a/src/tests/create_table.rs
+++ b/src/tests/create_table.rs
@@ -13,6 +13,15 @@ test_case!(create_table, async move {
         ),
         (
             r#"
+        CREATE TABLE CreateTable1 (
+            id INTEGER NULL,
+            num INTEGER,
+            name TEXT
+        )"#,
+            Err(CreateTableError::TableAlreadyExists.into()),
+        ),
+        (
+            r#"
         CREATE TABLE IF NOT EXISTS CreateTable2 (
             id INTEGER NULL,
             num INTEGER,
@@ -28,6 +37,18 @@ test_case!(create_table, async move {
             name TEXT
         )"#,
             Ok(Payload::Create),
+        ),
+        (
+            r#"
+        CREATE TABLE CreateTable3 (
+            id INTEGER,
+            ratio FLOAT UNIQUE
+        )"#,
+            Err(CreateTableError::UnsupportedDataTypeForUniqueColumn(
+                "ratio".to_owned(),
+                "FLOAT".to_owned(),
+            )
+            .into()),
         ),
     ];
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,6 +17,7 @@ pub mod nullable;
 pub mod ordering;
 pub mod sql_types;
 pub mod synthesize;
+pub mod unique;
 
 mod tester;
 
@@ -75,6 +76,7 @@ macro_rules! generate_tests {
         glue!(ordering, ordering::ordering);
         glue!(sql_types, sql_types::sql_types);
         glue!(synthesize, synthesize::synthesize);
+        glue!(unique, unique::unique);
 
         generate_alter_table_tests!();
     };

--- a/src/tests/unique.rs
+++ b/src/tests/unique.rs
@@ -117,18 +117,6 @@ CREATE TABLE TestC (
             .into(),
             "UPDATE TestC SET id = 1",
         ),
-        (
-            ValidateError::TableAlreadyExists.into(),
-            "CREATE TABLE TestA (id INTEGER, num INTEGER, name TEXT)",
-        ),
-        (
-            ValidateError::UnsupportedDataTypeForUniqueColumn(
-                "ratio".to_owned(),
-                "FLOAT".to_owned(),
-            )
-            .into(),
-            "CREATE TABLE TestD (id INTEGER, ratio FLOAT UNIQUE)",
-        ),
     ];
 
     for (error, sql) in error_cases.into_iter() {

--- a/src/tests/unique.rs
+++ b/src/tests/unique.rs
@@ -117,6 +117,18 @@ CREATE TABLE TestC (
             .into(),
             "UPDATE TestC SET id = 1",
         ),
+        (
+            ValidateError::TableAlreadyExists.into(),
+            "CREATE TABLE TestA (id INTEGER, num INTEGER, name TEXT)",
+        ),
+        (
+            ValidateError::UnsupportedDataTypeForUniqueColumn(
+                "ratio".to_owned(),
+                "FLOAT".to_owned(),
+            )
+            .into(),
+            "CREATE TABLE TestD (id INTEGER, ratio FLOAT UNIQUE)",
+        ),
     ];
 
     for (error, sql) in error_cases.into_iter() {

--- a/src/tests/unique.rs
+++ b/src/tests/unique.rs
@@ -1,0 +1,88 @@
+use crate::*;
+
+test_case!(unique, async move {
+    run!(
+        r#"
+CREATE TABLE TestA (
+    id INTEGER UNIQUE,
+    num INT
+)"#
+    );
+
+    run!(
+        r#"
+CREATE TABLE TestB (
+    id INTEGER UNIQUE,
+    num INT UNIQUE
+)"#
+    );
+
+    run!("INSERT INTO TestA VALUES (1, 1)");
+    run!("INSERT INTO TestA VALUES (2, 1), (3, 1)");
+
+    run!("INSERT INTO TestB VALUES (1, 1)");
+    run!("INSERT INTO TestB VALUES (2, 2), (3, 3)");
+
+    let error_cases = vec![
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(2)),
+                "id".to_owned(),
+            )
+            .into(),
+            "INSERT INTO TestA VALUES (2, 2)",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(4)),
+                "id".to_owned(),
+            )
+            .into(),
+            "INSERT INTO TestA VALUES (4, 4), (4, 5)",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(2)),
+                "id".to_owned(),
+            )
+            .into(),
+            "UPDATE TestA SET id = 2 WHERE id = 1",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(1)),
+                "id".to_owned(),
+            )
+            .into(),
+            "INSERT INTO TestB VALUES (1, 3)",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(2)),
+                "num".to_owned(),
+            )
+            .into(),
+            "INSERT INTO TestB VALUES (4, 2)",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(5)),
+                "num".to_owned(),
+            )
+            .into(),
+            "INSERT INTO TestB VALUES (5, 5), (6, 5)",
+        ),
+        (
+            ValueError::DuplicateEntryOnUniqueField(
+                format!("{:?}", Value::I64(2)),
+                "num".to_owned(),
+            )
+            .into(),
+            "UPDATE TestB SET num = 2 WHERE id = 1",
+        ),
+    ];
+
+    for (error, sql) in error_cases.into_iter() {
+        test!(Err(error), sql);
+    }
+});


### PR DESCRIPTION
Closes #105 .

I add a new source file `validate.rs` which only contains the logic of unique validation for now.
The function `validate_unique_by` applies unique validation on both `insert` and `update` rows.