### PR TITLE
Migrate sqlparser dep version from v0.6.1 to v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ iter-enum = "0.2.4"
 itertools = "0.9.0"
 pin-project = "1.0.1"
 serde = { version = "1.0.117", features = ["derive"] }
-sqlparser = { version = "0.6.1", features = ["serde"] }
+sqlparser = { version = "0.8.0", features = ["serde"] }
 thiserror = "1.0.21"
 
 # dependencies for sled-storage

--- a/src/data/value/ast_value.rs
+++ b/src/data/value/ast_value.rs
@@ -10,16 +10,16 @@ impl PartialEq<AstValue> for Value {
         match (self, other) {
             (Value::Bool(l), AstValue::Boolean(r))
             | (Value::OptBool(Some(l)), AstValue::Boolean(r)) => l == r,
-            (Value::I64(l), AstValue::Number(r))
-            | (Value::OptI64(Some(l)), AstValue::Number(r)) => match r.parse::<i64>() {
+            (Value::I64(l), AstValue::Number(r, false))
+            | (Value::OptI64(Some(l)), AstValue::Number(r, false)) => match r.parse::<i64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64) == r,
                     Err(_) => false,
                 },
             },
-            (Value::F64(l), AstValue::Number(r))
-            | (Value::OptF64(Some(l)), AstValue::Number(r)) => match r.parse::<f64>() {
+            (Value::F64(l), AstValue::Number(r, false))
+            | (Value::OptF64(Some(l)), AstValue::Number(r, false)) => match r.parse::<f64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => *l == (r as f64),
@@ -40,16 +40,16 @@ impl PartialEq<AstValue> for Value {
 impl PartialOrd<AstValue> for Value {
     fn partial_cmp(&self, other: &AstValue) -> Option<Ordering> {
         match (self, other) {
-            (Value::I64(l), AstValue::Number(r))
-            | (Value::OptI64(Some(l)), AstValue::Number(r)) => match r.parse::<i64>() {
+            (Value::I64(l), AstValue::Number(r, false))
+            | (Value::OptI64(Some(l)), AstValue::Number(r, false)) => match r.parse::<i64>() {
                 Ok(r) => Some(l.cmp(&r)),
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64).partial_cmp(&r),
                     Err(_) => None,
                 },
             },
-            (Value::F64(l), AstValue::Number(r))
-            | (Value::OptF64(Some(l)), AstValue::Number(r)) => match r.parse::<f64>() {
+            (Value::F64(l), AstValue::Number(r, false))
+            | (Value::OptF64(Some(l)), AstValue::Number(r, false)) => match r.parse::<f64>() {
                 Ok(r) => l.partial_cmp(&r),
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => l.partial_cmp(&(r as f64)),
@@ -68,7 +68,7 @@ impl TryFrom<&AstValue> for Value {
 
     fn try_from(literal: &AstValue) -> Result<Self> {
         match literal {
-            AstValue::Number(v) => v
+            AstValue::Number(v, false) => v
                 .parse::<i64>()
                 .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -135,11 +135,11 @@ impl Value {
         literal: &AstValue,
     ) -> Result<Self> {
         match (data_type, literal) {
-            (DataType::Int, AstValue::Number(v)) => v
+            (DataType::Int, AstValue::Number(v, false)) => v
                 .parse()
                 .map(|v| nullable.into_value(Value::OptI64(Some(v)), Value::I64(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (DataType::Float(_), AstValue::Number(v)) => v
+            (DataType::Float(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(|v| nullable.into_value(Value::OptF64(Some(v)), Value::F64(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
@@ -226,20 +226,20 @@ impl Value {
 
     pub fn clone_by(&self, literal: &AstValue) -> Result<Self> {
         match (self, literal) {
-            (Value::I64(_), AstValue::Number(v)) => v
+            (Value::I64(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(Value::I64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptI64(_), AstValue::Number(v)) => v
+            (Value::OptI64(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(|v| Value::OptI64(Some(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
             (Value::OptI64(_), AstValue::Null) => Ok(Value::OptI64(None)),
-            (Value::F64(_), AstValue::Number(v)) => v
+            (Value::F64(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(Value::F64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptF64(_), AstValue::Number(v)) => v
+            (Value::OptF64(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(|v| Value::OptF64(Some(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),

--- a/src/executor/aggregate/error.rs
+++ b/src/executor/aggregate/error.rs
@@ -18,4 +18,7 @@ pub enum AggregateError {
 
     #[error("unreachable")]
     Unreachable,
+
+    #[error("unreachable named function arg: {0}")]
+    UnreachableNamedFunctionArg(String),
 }

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -53,4 +53,7 @@ pub enum EvaluateError {
 
     #[error("unreachable impossible cast")]
     UnreachableImpossibleCast,
+
+    #[error("unreachable named function argument: {0}")]
+    UnreachableFunctionArg(String),
 }

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -11,7 +11,9 @@ use {
     async_recursion::async_recursion,
     futures::stream::{StreamExt, TryStreamExt},
     im_rc::HashMap,
-    sqlparser::ast::{BinaryOperator, Expr, Function, UnaryOperator, Value as AstValue},
+    sqlparser::ast::{
+        BinaryOperator, Expr, Function, FunctionArg, UnaryOperator, Value as AstValue,
+    },
     std::{convert::TryInto, fmt::Debug, rc::Rc},
 };
 
@@ -34,7 +36,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
 
     match expr {
         Expr::Value(value) => match value {
-            AstValue::Number(_)
+            AstValue::Number(_, false)
             | AstValue::Boolean(_)
             | AstValue::SingleQuotedString(_)
             | AstValue::Null => Ok(Evaluated::LiteralRef(value)),
@@ -130,6 +132,15 @@ async fn evaluate_function<'a, T: 'static + Debug>(
         evaluate(storage, context, aggregated, expr, use_empty)
     };
 
+    let get_arg_expr = |arg: &'a FunctionArg| -> Result<&'a Expr> {
+        match arg {
+            FunctionArg::Unnamed(expr) => Ok(expr),
+            FunctionArg::Named { name, .. } => {
+                Err(EvaluateError::UnreachableFunctionArg(name.to_string()).into())
+            }
+        }
+    };
+
     let Function { name, args, .. } = func;
 
     match get_name(name)?.to_uppercase().as_str() {
@@ -142,15 +153,18 @@ async fn evaluate_function<'a, T: 'static + Debug>(
                 }
             };
 
-            if args.len() != 1 {
-                return Err(EvaluateError::NumberOfFunctionParamsNotMatching {
-                    expected: 1,
-                    found: args.len(),
+            let arg = match args.len() {
+                1 => &args[0],
+                found => {
+                    return Err(EvaluateError::NumberOfFunctionParamsNotMatching {
+                        expected: 1,
+                        found,
+                    }
+                    .into());
                 }
-                .into());
-            }
+            };
 
-            let expr = &args[0];
+            let expr = get_arg_expr(arg)?;
             let value: Value = match eval(expr).await?.try_into()? {
                 Value::Str(s) => Value::Str(convert(s)),
                 Value::OptStr(s) => Value::OptStr(s.map(convert)),

--- a/src/executor/join.rs
+++ b/src/executor/join.rs
@@ -165,6 +165,7 @@ async fn fetch_joined<'a, T: 'static + Debug>(
         JoinConstraint::Natural => {
             return Err(JoinError::NaturalOnJoinNotSupported.into());
         }
+        JoinConstraint::None => None,
     };
 
     let rows = storage

--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -21,7 +21,7 @@ impl Limit {
     pub fn new(limit: Option<&Expr>, offset: Option<&Offset>) -> Result<Self> {
         let parse = |expr: &Expr| -> Result<usize> {
             match expr {
-                Expr::Value(AstValue::Number(v)) => {
+                Expr::Value(AstValue::Number(v, false)) => {
                     v.parse().map_err(|_| LimitError::Unreachable.into())
                 }
                 _ => Err(LimitError::Unreachable.into()),

--- a/src/tests/join.rs
+++ b/src/tests/join.rs
@@ -61,6 +61,7 @@ test_case!(join, async move {
     }
 
     let select_sqls = [
+        (75, "SELECT * FROM Item JOIN Player"),
         (
             15,
             "SELECT * FROM Item LEFT JOIN Player ON Player.id = Item.player_id;",


### PR DESCRIPTION
There were lots of small changes.

Now due to this upgrade, join query without any constraint is now supported.

e.g.
```sql
SELECT * FROM Item JOIN Player
```
