### PR TITLE
Change literal casting function to return from AstValue to Value,

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,7 +1,7 @@
 mod row;
 mod schema;
 mod table;
-mod value;
+pub mod value;
 
 pub use {
     row::{Row, RowError},

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -41,9 +41,26 @@ pub enum ValueError {
     #[error("floating columns cannot be set to unique constraint")]
     ConflictOnFloatWithUniqueConstraint,
 
+    // Cast errors from value to value
     #[error("impossible cast")]
     ImpossibleCast,
 
     #[error("unimplemented cast")]
     UnimplementedCast,
+
+    // Cast errors from literal to value
+    #[error("literal cast failed from text to integer: {0}")]
+    LiteralCastFromTextToIntegerFailed(String),
+
+    #[error("literal cast failed from text to float: {0}")]
+    LiteralCastToFloatFailed(String),
+
+    #[error("literal cast failed to boolean: {0}")]
+    LiteralCastToBooleanFailed(String),
+
+    #[error("unreachable literal cast from number to integer: {0}")]
+    UnreachableLiteralCastFromNumberToInteger(String),
+
+    #[error("unimplemented literal cast: {literal} as {data_type}")]
+    UnimplementedLiteralCast { data_type: String, literal: String },
 }

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -11,6 +11,7 @@ mod error;
 mod group_key;
 mod unique_key;
 
+pub use ast_value::TryFromLiteral;
 pub use error::ValueError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -45,15 +45,6 @@ pub enum EvaluateError {
     #[error("unimplemented")]
     Unimplemented,
 
-    #[error("impossible cast")]
-    ImpossibleCast,
-
-    #[error("unimplemented cast")]
-    UnimplementedCast,
-
-    #[error("unreachable impossible cast")]
-    UnreachableImpossibleCast,
-
     #[error("unreachable named function argument: {0}")]
     UnreachableFunctionArg(String),
 }

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -1,107 +1,118 @@
 use crate::*;
 
-test_case!(cast, async move {
-    use Value::{Bool, Str, F64, I64};
+test_case!(cast_literal, async move {
+    use Value::*;
+
     let test_cases = vec![
         ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
+        (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),
         (
-            r#"INSERT INTO Item VALUES ("1"), ("2"), ("3")"#,
-            Ok(Payload::Insert(3)),
+            r#"SELECT CAST("TRUE" AS BOOLEAN) AS cast FROM Item"#,
+            Ok(select!(cast Bool; true)),
         ),
         (
-            r#"SELECT CAST("1" AS INTEGER) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast I64;
-                1
-            )),
+            r#"SELECT CAST(1 AS BOOLEAN) AS cast FROM Item"#,
+            Ok(select!(cast Bool; true)),
         ),
         (
-            r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast F64;
-                1.1
-            )),
+            r#"SELECT CAST("asdf" AS BOOLEAN) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastToBooleanFailed("asdf".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(1 AS TEXT) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast Str;
-                "1".to_string()
-            )),
+            r#"SELECT CAST(3 AS BOOLEAN) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastToBooleanFailed("3".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(1.1 AS INTEGER) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast I64;
-                1
-            )),
+            r#"SELECT CAST(NULL AS BOOLEAN) AS cast FROM Item"#,
+            Ok(select!(cast OptBool; None)),
         ),
         (
-            r#"SELECT CAST(1.1 AS TEXT) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast Str;
-                "1.1".to_string()
-            )),
+            r#"SELECT CAST("1" AS INTEGER) AS cast FROM Item"#,
+            Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST(TRUE AS INTEGER) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast I64;
-                1
-            )),
+            r#"SELECT CAST("foo" AS INTEGER) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastFromTextToIntegerFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(TRUE AS TEXT) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast Str;
-                "TRUE".to_string()
-            )),
+            r#"SELECT CAST(1.1 AS INTEGER) AS cast FROM Item"#,
+            Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST(1 AS BOOLEAN) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast Bool;
-                true
-            )),
+            r#"SELECT CAST(TRUE AS INTEGER) AS cast FROM Item"#,
+            Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST("TRUE" AS BOOLEAN) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast Bool;
-                true
-            )),
+            r#"SELECT CAST(NULL AS INTEGER) AS cast FROM Item"#,
+            Ok(select!(cast OptI64; None)),
         ),
         (
-            r#"SELECT CAST(LOWER(number) AS INTEGER) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast I64;
-                1
-            )),
+            r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
+            Ok(select!(cast F64; 1.1)),
         ),
         (
-            r#"SELECT CAST(1 AS FLOAT) AS cast FROM Item LIMIT 1"#,
-            Ok(select!(
-                cast I64; // Ideally should be F64
-                1
-            )),
+            r#"SELECT CAST(1 AS FLOAT) AS cast FROM Item"#,
+            Ok(select!(cast F64; 1.0)),
         ),
         (
-            r#"SELECT CAST("ABC" AS INTEGER) FROM Item LIMIT 1"#,
-            Err(ValueError::FailedToParseNumber.into()),
+            r#"SELECT CAST("foo" AS FLOAT) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastToFloatFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST("$1" AS INTEGER) FROM Item LIMIT 1"#,
-            Err(ValueError::FailedToParseNumber.into()),
+            r#"SELECT CAST(TRUE AS FLOAT) AS cast FROM Item"#,
+            Ok(select!(cast F64; 1.0)),
         ),
         (
-            r#"SELECT CAST("BLEH" AS BOOLEAN) FROM Item LIMIT 1"#,
-            Err(EvaluateError::ImpossibleCast.into()),
+            r#"SELECT CAST(NULL AS FLOAT) AS cast FROM Item"#,
+            Ok(select!(cast OptF64; None)),
         ),
         (
-            r#"SELECT CAST(number AS BOOLEAN) FROM Item LIMIT 1"#,
+            r#"SELECT CAST(1 AS TEXT) AS cast FROM Item"#,
+            Ok(select!(cast Str; "1".to_string())),
+        ),
+        (
+            r#"SELECT CAST(1.1 AS TEXT) AS cast FROM Item"#,
+            Ok(select!(cast Str; "1.1".to_string())),
+        ),
+        (
+            r#"SELECT CAST(TRUE AS TEXT) AS cast FROM Item"#,
+            Ok(select!(cast Str; "TRUE".to_string())),
+        ),
+        (
+            r#"SELECT CAST(NULL AS TEXT) AS cast FROM Item"#,
+            Ok(select!(cast OptStr; None)),
+        ),
+        (
+            r#"SELECT CAST(NULL AS NULL) FROM Item"#,
+            Err(ValueError::UnimplementedLiteralCast {
+                data_type: "NULL".to_owned(),
+                literal: "NULL".to_owned(),
+            }
+            .into()),
+        ),
+    ];
+
+    for (sql, expected) in test_cases.into_iter() {
+        test!(expected, sql);
+    }
+});
+
+test_case!(cast_value, async move {
+    use Value::*;
+
+    let test_cases = vec![
+        ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
+        (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),
+        (
+            r#"SELECT CAST(LOWER(number) AS INTEGER) AS cast FROM Item"#,
+            Ok(select!(cast I64; 1)),
+        ),
+        (
+            r#"SELECT CAST(number AS BOOLEAN) FROM Item"#,
             Err(ValueError::ImpossibleCast.into()),
         ),
     ];
+
     for (sql, expected) in test_cases.into_iter() {
         test!(expected, sql);
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -67,7 +67,8 @@ macro_rules! generate_tests {
         glue!(error, error::error);
         glue!(filter, filter::filter);
         glue!(function, function::function);
-        glue!(function_cast, function::cast::cast);
+        glue!(function_cast_literal, function::cast::cast_literal);
+        glue!(function_cast_value, function::cast::cast_value);
         glue!(join, join::join);
         glue!(join_blend, join::blend);
         glue!(migrate, migrate::migrate);


### PR DESCRIPTION
Add `Value::TryFromLiteral` to replace `cast_ast_value` in `evaluated.rs`.
Now it can handle `CAST(1 AS FLOAT)`.
Test cases in `function::cast::cast_literal` reach all branches in `Value::TryFromLiteral` match.

@KyGost You even left a comment about `CAST(1 AS FLOAT)` issue but I missed to check it.
I just figured out and that was because of... function return value type.
Previous: `AstValue -> AstValue`
Current: `AstValue -> Value`
This was possible because `CAST` provides `DataType` information.

And I modified `cast_literal` test cases little bit to reach every branches in `match`
```rust
impl TryFromLiteral for Value {
    fn try_from_literal(data_type: &DataType, literal: &AstValue) -> Result<Value> {
       match ...
    }
}
```
Order of match branches (`try_from_literal`) and test cases (`function::cast::cast_literal`) is same, you will be able to check simply following the code lines.
`CAST` were too big task so my review was.... not sufficient, sorry for that. Writing test cases to reach every branches would be helpful for you to work on https://github.com/gluesql/gluesql/pull/157

I also found some issues on handling `cast_value`, I might work for casting value on Sunday, then I'll also share with you. :)
