### PR TITLE
Replace Value::Opt- and Empty to Value::Null!

### DIFF
--- a/src/data/value/ast_value.rs
+++ b/src/data/value/ast_value.rs
@@ -24,7 +24,6 @@ impl PartialEq<AstValue> for Value {
                 },
             },
             (Value::Str(l), AstValue::SingleQuotedString(r)) => l == r,
-            (Value::Null, AstValue::Null) => true,
             _ => false,
         }
     }

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -17,7 +17,7 @@ impl TryInto<GroupKey> for &Value {
             Bool(v) | OptBool(Some(v)) => Ok(GroupKey::Bool(*v)),
             I64(v) | OptI64(Some(v)) => Ok(GroupKey::I64(*v)),
             Str(v) | OptStr(Some(v)) => Ok(GroupKey::Str(v.clone())),
-            Empty | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
+            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
             F64(_) | OptF64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }
@@ -33,7 +33,7 @@ impl TryInto<GroupKey> for Value {
             Bool(v) | OptBool(Some(v)) => Ok(GroupKey::Bool(v)),
             I64(v) | OptI64(Some(v)) => Ok(GroupKey::I64(v)),
             Str(v) | OptStr(Some(v)) => Ok(GroupKey::Str(v)),
-            Empty | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
+            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
             F64(_) | OptF64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -17,7 +17,7 @@ impl TryInto<GroupKey> for &Value {
             Bool(v) => Ok(GroupKey::Bool(*v)),
             I64(v) => Ok(GroupKey::I64(*v)),
             Str(v) => Ok(GroupKey::Str(v.clone())),
-            Null => Ok(GroupKey::Null),
+            Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }
@@ -33,7 +33,7 @@ impl TryInto<GroupKey> for Value {
             Bool(v) => Ok(GroupKey::Bool(v)),
             I64(v) => Ok(GroupKey::I64(v)),
             Str(v) => Ok(GroupKey::Str(v)),
-            Null => Ok(GroupKey::Null),
+            Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -14,11 +14,11 @@ impl TryInto<GroupKey> for &Value {
         use Value::*;
 
         match self {
-            Bool(v) | OptBool(Some(v)) => Ok(GroupKey::Bool(*v)),
-            I64(v) | OptI64(Some(v)) => Ok(GroupKey::I64(*v)),
-            Str(v) | OptStr(Some(v)) => Ok(GroupKey::Str(v.clone())),
-            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
-            F64(_) | OptF64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
+            Bool(v) => Ok(GroupKey::Bool(*v)),
+            I64(v) => Ok(GroupKey::I64(*v)),
+            Str(v) => Ok(GroupKey::Str(v.clone())),
+            Null => Ok(GroupKey::Null),
+            F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }
 }
@@ -30,11 +30,11 @@ impl TryInto<GroupKey> for Value {
         use Value::*;
 
         match self {
-            Bool(v) | OptBool(Some(v)) => Ok(GroupKey::Bool(v)),
-            I64(v) | OptI64(Some(v)) => Ok(GroupKey::I64(v)),
-            Str(v) | OptStr(Some(v)) => Ok(GroupKey::Str(v)),
-            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(GroupKey::Null),
-            F64(_) | OptF64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
+            Bool(v) => Ok(GroupKey::Bool(v)),
+            I64(v) => Ok(GroupKey::I64(v)),
+            Str(v) => Ok(GroupKey::Str(v)),
+            Null => Ok(GroupKey::Null),
+            F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
     }
 }

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -24,7 +24,7 @@ pub enum Value {
     OptI64(Option<i64>),
     OptF64(Option<f64>),
     OptStr(Option<String>),
-    Empty,
+    Null,
 }
 
 impl PartialEq<Value> for Value {
@@ -50,7 +50,7 @@ impl PartialEq<Value> for Value {
             | (Value::OptI64(None), Value::OptI64(None))
             | (Value::OptF64(None), Value::OptF64(None))
             | (Value::OptStr(None), Value::OptStr(None))
-            | (Value::Empty, Value::Empty) => true,
+            | (Value::Null, Value::Null) => true,
             _ => false,
         }
     }
@@ -414,7 +414,7 @@ impl Value {
 
         !matches!(
             self,
-            Empty | OptBool(None) | OptI64(None) | OptF64(None) | OptStr(None)
+            Null | OptBool(None) | OptI64(None) | OptF64(None) | OptStr(None)
         )
     }
 
@@ -466,7 +466,7 @@ mod tests {
         assert_eq!(Value::OptStr(Some(glue())), Value::Str(glue()));
         assert_eq!(Value::OptStr(None), Value::OptStr(None));
 
-        assert_eq!(Value::Empty, Value::Empty);
+        assert_eq!(Value::Null, Value::Null);
     }
 
     #[test]

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -20,37 +20,16 @@ pub enum Value {
     I64(i64),
     F64(f64),
     Str(String),
-    OptBool(Option<bool>),
-    OptI64(Option<i64>),
-    OptF64(Option<f64>),
-    OptStr(Option<String>),
     Null,
 }
 
 impl PartialEq<Value> for Value {
     fn eq(&self, other: &Value) -> bool {
         match (self, other) {
-            (Value::Bool(l), Value::Bool(r))
-            | (Value::OptBool(Some(l)), Value::Bool(r))
-            | (Value::Bool(l), Value::OptBool(Some(r)))
-            | (Value::OptBool(Some(l)), Value::OptBool(Some(r))) => l == r,
-            (Value::I64(l), Value::I64(r))
-            | (Value::OptI64(Some(l)), Value::I64(r))
-            | (Value::I64(l), Value::OptI64(Some(r)))
-            | (Value::OptI64(Some(l)), Value::OptI64(Some(r))) => l == r,
-            (Value::F64(l), Value::F64(r))
-            | (Value::OptF64(Some(l)), Value::F64(r))
-            | (Value::F64(l), Value::OptF64(Some(r)))
-            | (Value::OptF64(Some(l)), Value::OptF64(Some(r))) => l == r,
-            (Value::Str(l), Value::Str(r))
-            | (Value::OptStr(Some(l)), Value::Str(r))
-            | (Value::Str(l), Value::OptStr(Some(r)))
-            | (Value::OptStr(Some(l)), Value::OptStr(Some(r))) => l == r,
-            (Value::OptBool(None), Value::OptBool(None))
-            | (Value::OptI64(None), Value::OptI64(None))
-            | (Value::OptF64(None), Value::OptF64(None))
-            | (Value::OptStr(None), Value::OptStr(None))
-            | (Value::Null, Value::Null) => true,
+            (Value::Bool(l), Value::Bool(r)) => l == r,
+            (Value::I64(l), Value::I64(r)) => l == r,
+            (Value::F64(l), Value::F64(r)) => l == r,
+            (Value::Str(l), Value::Str(r)) => l == r,
             _ => false,
         }
     }
@@ -59,30 +38,12 @@ impl PartialEq<Value> for Value {
 impl PartialOrd<Value> for Value {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match (self, other) {
-            (Value::Bool(l), Value::Bool(r))
-            | (Value::OptBool(Some(l)), Value::Bool(r))
-            | (Value::Bool(l), Value::OptBool(Some(r)))
-            | (Value::OptBool(Some(l)), Value::OptBool(Some(r))) => Some(l.cmp(r)),
-            (Value::I64(l), Value::I64(r))
-            | (Value::OptI64(Some(l)), Value::I64(r))
-            | (Value::I64(l), Value::OptI64(Some(r)))
-            | (Value::OptI64(Some(l)), Value::OptI64(Some(r))) => Some(l.cmp(r)),
-            (Value::I64(l), Value::F64(r))
-            | (Value::OptI64(Some(l)), Value::F64(r))
-            | (Value::I64(l), Value::OptF64(Some(r)))
-            | (Value::OptI64(Some(l)), Value::OptF64(Some(r))) => (*l as f64).partial_cmp(r),
-            (Value::F64(l), Value::F64(r))
-            | (Value::OptF64(Some(l)), Value::F64(r))
-            | (Value::F64(l), Value::OptF64(Some(r)))
-            | (Value::OptF64(Some(l)), Value::OptF64(Some(r))) => l.partial_cmp(r),
-            (Value::F64(l), Value::I64(r))
-            | (Value::OptF64(Some(l)), Value::I64(r))
-            | (Value::F64(l), Value::OptI64(Some(r)))
-            | (Value::OptF64(Some(l)), Value::OptI64(Some(r))) => l.partial_cmp(&(*r as f64)),
-            (Value::Str(l), Value::Str(r))
-            | (Value::OptStr(Some(l)), Value::Str(r))
-            | (Value::Str(l), Value::OptStr(Some(r)))
-            | (Value::OptStr(Some(l)), Value::OptStr(Some(r))) => Some(l.cmp(r)),
+            (Value::Bool(l), Value::Bool(r)) => Some(l.cmp(r)),
+            (Value::I64(l), Value::I64(r)) => Some(l.cmp(r)),
+            (Value::I64(l), Value::F64(r)) => (*l as f64).partial_cmp(r),
+            (Value::F64(l), Value::I64(r)) => l.partial_cmp(&(*r as f64)),
+            (Value::F64(l), Value::F64(r)) => l.partial_cmp(r),
+            (Value::Str(l), Value::Str(r)) => Some(l.cmp(r)),
             _ => None,
         }
     }
@@ -116,17 +77,13 @@ impl Value {
         matches!(
             (data_type, self),
             (DataType::Boolean, Value::Bool(_))
-                | (DataType::Boolean, Value::OptBool(Some(_)))
-                | (DataType::Text, Value::Str(_))
-                | (DataType::Text, Value::OptStr(Some(_)))
                 | (DataType::Int, Value::I64(_))
-                | (DataType::Int, Value::OptI64(Some(_)))
                 | (DataType::Float(_), Value::F64(_))
-                | (DataType::Float(_), Value::OptF64(Some(_)))
-                | (_, Value::OptBool(None))
-                | (_, Value::OptStr(None))
-                | (_, Value::OptI64(None))
-                | (_, Value::OptF64(None))
+                | (DataType::Text, Value::Str(_))
+                | (DataType::Boolean, Value::Null)
+                | (DataType::Int, Value::Null)
+                | (DataType::Float(_), Value::Null)
+                | (DataType::Text, Value::Null)
         )
     }
 
@@ -138,34 +95,20 @@ impl Value {
         match (data_type, literal) {
             (DataType::Int, AstValue::Number(v, false)) => v
                 .parse()
-                .map(|v| nullable.into_value(Value::OptI64(Some(v)), Value::I64(v)))
+                .map(Value::I64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
             (DataType::Float(_), AstValue::Number(v, false)) => v
                 .parse()
-                .map(|v| nullable.into_value(Value::OptF64(Some(v)), Value::F64(v)))
+                .map(Value::F64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (DataType::Boolean, AstValue::Boolean(v)) => {
-                Ok(nullable.into_value(Value::OptBool(Some(*v)), Value::Bool(*v)))
+            (DataType::Boolean, AstValue::Boolean(v)) => Ok(Value::Bool(*v)),
+            (DataType::Text, AstValue::SingleQuotedString(v)) => Ok(Value::Str(v.clone())),
+            (DataType::Int, AstValue::Null)
+            | (DataType::Float(_), AstValue::Null)
+            | (DataType::Boolean, AstValue::Null)
+            | (DataType::Text, AstValue::Null) => {
+                nullable.as_result(Value::Null, ValueError::NullValueOnNotNullField.into())
             }
-            (DataType::Text, AstValue::SingleQuotedString(v)) => {
-                Ok(nullable.into_value(Value::OptStr(Some(v.clone())), Value::Str(v.clone())))
-            }
-            (DataType::Int, AstValue::Null) => nullable.as_result(
-                Value::OptI64(None),
-                ValueError::NullValueOnNotNullField.into(),
-            ),
-            (DataType::Float(_), AstValue::Null) => nullable.as_result(
-                Value::OptF64(None),
-                ValueError::NullValueOnNotNullField.into(),
-            ),
-            (DataType::Boolean, AstValue::Null) => nullable.as_result(
-                Value::OptBool(None),
-                ValueError::NullValueOnNotNullField.into(),
-            ),
-            (DataType::Text, AstValue::Null) => nullable.as_result(
-                Value::OptStr(None),
-                ValueError::NullValueOnNotNullField.into(),
-            ),
             _ => Err(ValueError::SqlTypeNotSupported.into()),
         }
     }
@@ -174,13 +117,15 @@ impl Value {
         match (data_type, self) {
             // Same as
             (DataType::Boolean, Value::Bool(_))
-            | (DataType::Boolean, Value::OptBool(_))
-            | (DataType::Text, Value::Str(_))
-            | (DataType::Text, Value::OptStr(_))
             | (DataType::Int, Value::I64(_))
-            | (DataType::Int, Value::OptI64(_))
             | (DataType::Float(_), Value::F64(_))
-            | (DataType::Float(_), Value::OptF64(_)) => Ok(self.clone()),
+            | (DataType::Text, Value::Str(_)) => Ok(self.clone()),
+
+            // Null
+            (DataType::Boolean, Value::Null)
+            | (DataType::Int, Value::Null)
+            | (DataType::Float(_), Value::Null)
+            | (DataType::Text, Value::Null) => Ok(Value::Null),
 
             // Boolean
             (DataType::Boolean, Value::Str(value)) => match value.to_uppercase().as_str() {
@@ -188,21 +133,9 @@ impl Value {
                 "FALSE" => Ok(Value::Bool(false)),
                 _ => Err(ValueError::ImpossibleCast.into()),
             },
-            (DataType::Boolean, Value::OptStr(Some(value))) => {
-                match value.to_uppercase().as_str() {
-                    "TRUE" => Ok(Value::OptBool(Some(true))),
-                    "FALSE" => Ok(Value::OptBool(Some(false))),
-                    _ => Err(ValueError::ImpossibleCast.into()),
-                }
-            }
             (DataType::Boolean, Value::I64(value)) => match value {
                 1 => Ok(Value::Bool(true)),
                 0 => Ok(Value::Bool(false)),
-                _ => Err(ValueError::ImpossibleCast.into()),
-            },
-            (DataType::Boolean, Value::OptI64(Some(value))) => match value {
-                1 => Ok(Value::OptBool(Some(true))),
-                0 => Ok(Value::OptBool(Some(false))),
                 _ => Err(ValueError::ImpossibleCast.into()),
             },
             (DataType::Boolean, Value::F64(value)) => {
@@ -214,83 +147,31 @@ impl Value {
                     Err(ValueError::ImpossibleCast.into())
                 }
             }
-            (DataType::Boolean, Value::OptF64(Some(value))) => {
-                if value.eq(&1.0) {
-                    Ok(Value::OptBool(Some(true)))
-                } else if value.eq(&0.0) {
-                    Ok(Value::OptBool(Some(false)))
-                } else {
-                    Err(ValueError::ImpossibleCast.into())
-                }
-            }
-            (DataType::Boolean, Value::OptI64(None))
-            | (DataType::Boolean, Value::OptF64(None))
-            | (DataType::Boolean, Value::OptStr(None)) => Ok(Value::OptBool(None)),
 
             // Integer
             (DataType::Int, Value::Bool(value)) => Ok(Value::I64(if *value { 1 } else { 0 })),
-            (DataType::Int, Value::OptBool(Some(value))) => {
-                Ok(Value::OptI64(Some(if *value { 1 } else { 0 })))
-            }
             (DataType::Int, Value::F64(value)) => Ok(Value::I64(value.trunc() as i64)),
-            (DataType::Int, Value::OptF64(Some(value))) => {
-                Ok(Value::OptI64(Some(value.trunc() as i64)))
-            }
             (DataType::Int, Value::Str(value)) => value
                 .parse::<i64>()
                 .map(Value::I64)
                 .map_err(|_| ValueError::ImpossibleCast.into()),
-            (DataType::Int, Value::OptStr(Some(value))) => value
-                .parse::<i64>()
-                .map(Some)
-                .map(Value::OptI64)
-                .map_err(|_| ValueError::ImpossibleCast.into()),
-            (DataType::Int, Value::OptBool(None))
-            | (DataType::Int, Value::OptF64(None))
-            | (DataType::Int, Value::OptStr(None)) => Ok(Value::OptI64(None)),
 
             // Float
             (DataType::Float(_), Value::Bool(value)) => {
                 Ok(Value::F64(if *value { 1.0 } else { 0.0 }))
             }
-            (DataType::Float(_), Value::OptBool(Some(value))) => {
-                Ok(Value::OptF64(Some(if *value { 1.0 } else { 0.0 })))
-            }
             (DataType::Float(_), Value::I64(value)) => Ok(Value::F64((*value as f64).trunc())),
-            (DataType::Float(_), Value::OptI64(Some(value))) => {
-                Ok(Value::OptF64(Some((*value as f64).trunc())))
-            }
             (DataType::Float(_), Value::Str(value)) => value
                 .parse::<f64>()
                 .map(Value::F64)
                 .map_err(|_| ValueError::ImpossibleCast.into()),
-            (DataType::Float(_), Value::OptStr(Some(value))) => value
-                .parse::<f64>()
-                .map(Some)
-                .map(Value::OptF64)
-                .map_err(|_| ValueError::ImpossibleCast.into()),
-            (DataType::Float(_), Value::OptBool(None))
-            | (DataType::Float(_), Value::OptI64(None))
-            | (DataType::Float(_), Value::OptStr(None)) => Ok(Value::OptF64(None)),
 
             // Text
             (DataType::Text, Value::Bool(value)) => Ok(Value::Str(
                 (if *value { "TRUE" } else { "FALSE" }).to_string(),
             )),
-            (DataType::Text, Value::OptBool(Some(value))) => Ok(Value::OptStr(Some(
-                (if *value { "TRUE" } else { "FALSE" }).to_string(),
-            ))),
             (DataType::Text, Value::I64(value)) => Ok(Value::Str(value.to_string())),
-            (DataType::Text, Value::OptI64(Some(value))) => {
-                Ok(Value::OptStr(Some(value.to_string())))
-            }
             (DataType::Text, Value::F64(value)) => Ok(Value::Str(value.to_string())),
-            (DataType::Text, Value::OptF64(Some(value))) => {
-                Ok(Value::OptStr(Some(value.to_string())))
-            }
-            (DataType::Text, Value::OptBool(None))
-            | (DataType::Text, Value::OptI64(None))
-            | (DataType::Text, Value::OptF64(None)) => Ok(Value::OptStr(None)),
 
             _ => Err(ValueError::UnimplementedCast.into()),
         }
@@ -302,28 +183,20 @@ impl Value {
                 .parse()
                 .map(Value::I64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptI64(_), AstValue::Number(v, false)) => v
-                .parse()
-                .map(|v| Value::OptI64(Some(v)))
-                .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptI64(_), AstValue::Null) => Ok(Value::OptI64(None)),
             (Value::F64(_), AstValue::Number(v, false)) => v
                 .parse()
                 .map(Value::F64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptF64(_), AstValue::Number(v, false)) => v
-                .parse()
-                .map(|v| Value::OptF64(Some(v)))
-                .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::OptF64(_), AstValue::Null) => Ok(Value::OptF64(None)),
-            (Value::Str(_), AstValue::SingleQuotedString(v)) => Ok(Value::Str(v.clone())),
-            (Value::OptStr(_), AstValue::SingleQuotedString(v)) => {
-                Ok(Value::OptStr(Some(v.clone())))
+            (Value::Str(_), AstValue::SingleQuotedString(v))
+            | (Value::Null, AstValue::SingleQuotedString(v)) => Ok(Value::Str(v.clone())),
+            (Value::Bool(_), AstValue::Boolean(v)) | (Value::Null, AstValue::Boolean(v)) => {
+                Ok(Value::Bool(*v))
             }
-            (Value::OptStr(_), AstValue::Null) => Ok(Value::OptStr(None)),
-            (Value::Bool(_), AstValue::Boolean(v)) => Ok(Value::Bool(*v)),
-            (Value::OptBool(_), AstValue::Boolean(v)) => Ok(Value::OptBool(Some(*v))),
-            (Value::OptBool(_), AstValue::Null) => Ok(Value::OptBool(None)),
+            (Value::Null, AstValue::Number(v, false)) => v
+                .parse::<i64>()
+                .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
+                .map_err(|_| ValueError::FailedToParseNumber.into()),
+            (_, AstValue::Null) => Ok(Value::Null),
             _ => Err(ValueError::LiteralNotSupported.into()),
         }
     }
@@ -333,18 +206,8 @@ impl Value {
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a + b)),
-            (I64(a), OptI64(Some(b))) | (OptI64(Some(a)), I64(b)) => Ok(OptI64(Some(a + b))),
-            (OptI64(Some(a)), OptI64(Some(b))) => Ok(OptI64(Some(a + b))),
             (F64(a), F64(b)) => Ok(F64(a + b)),
-            (F64(a), OptF64(Some(b))) | (OptF64(Some(a)), F64(b)) => Ok(OptF64(Some(a + b))),
-            (OptI64(None), OptI64(_))
-            | (OptI64(_), OptI64(None))
-            | (OptI64(None), I64(_))
-            | (I64(_), OptI64(None)) => Ok(OptI64(None)),
-            (OptF64(_), OptF64(None))
-            | (OptF64(None), OptF64(_))
-            | (F64(_), OptF64(None))
-            | (OptF64(None), F64(_)) => Ok(OptF64(None)),
+            (Null, _) | (_, Null) => Ok(Null),
             _ => Err(ValueError::AddOnNonNumeric.into()),
         }
     }
@@ -354,17 +217,8 @@ impl Value {
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a - b)),
-            (I64(a), OptI64(Some(b))) | (OptI64(Some(a)), I64(b)) => Ok(OptI64(Some(a - b))),
             (F64(a), F64(b)) => Ok(F64(a - b)),
-            (F64(a), OptF64(Some(b))) | (OptF64(Some(a)), F64(b)) => Ok(OptF64(Some(a - b))),
-            (OptI64(None), OptI64(_))
-            | (OptI64(_), OptI64(None))
-            | (OptI64(None), I64(_))
-            | (I64(_), OptI64(None)) => Ok(OptI64(None)),
-            (OptF64(_), OptF64(None))
-            | (OptF64(None), OptF64(_))
-            | (F64(_), OptF64(None))
-            | (OptF64(None), F64(_)) => Ok(OptF64(None)),
+            (Null, _) | (_, Null) => Ok(Null),
             _ => Err(ValueError::SubtractOnNonNumeric.into()),
         }
     }
@@ -374,17 +228,8 @@ impl Value {
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a * b)),
-            (I64(a), OptI64(Some(b))) | (OptI64(Some(a)), I64(b)) => Ok(OptI64(Some(a * b))),
             (F64(a), F64(b)) => Ok(F64(a * b)),
-            (F64(a), OptF64(Some(b))) | (OptF64(Some(a)), F64(b)) => Ok(OptF64(Some(a * b))),
-            (OptI64(None), OptI64(_))
-            | (OptI64(_), OptI64(None))
-            | (OptI64(None), I64(_))
-            | (I64(_), OptI64(None)) => Ok(OptI64(None)),
-            (OptF64(_), OptF64(None))
-            | (OptF64(None), OptF64(_))
-            | (F64(_), OptF64(None))
-            | (OptF64(None), F64(_)) => Ok(OptF64(None)),
+            (Null, _) | (_, Null) => Ok(Null),
             _ => Err(ValueError::MultiplyOnNonNumeric.into()),
         }
     }
@@ -394,17 +239,8 @@ impl Value {
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a / b)),
-            (I64(a), OptI64(Some(b))) | (OptI64(Some(a)), I64(b)) => Ok(OptI64(Some(a / b))),
             (F64(a), F64(b)) => Ok(F64(a / b)),
-            (F64(a), OptF64(Some(b))) | (OptF64(Some(a)), F64(b)) => Ok(OptF64(Some(a / b))),
-            (OptI64(None), OptI64(_))
-            | (OptI64(_), OptI64(None))
-            | (OptI64(None), I64(_))
-            | (I64(_), OptI64(None)) => Ok(OptI64(None)),
-            (OptF64(_), OptF64(None))
-            | (OptF64(None), OptF64(_))
-            | (F64(_), OptF64(None))
-            | (OptF64(None), F64(_)) => Ok(OptF64(None)),
+            (Null, _) | (_, Null) => Ok(Null),
             _ => Err(ValueError::DivideOnNonNumeric.into()),
         }
     }
@@ -412,17 +248,15 @@ impl Value {
     pub fn is_some(&self) -> bool {
         use Value::*;
 
-        !matches!(
-            self,
-            Null | OptBool(None) | OptI64(None) | OptF64(None) | OptStr(None)
-        )
+        !matches!(self, Null)
     }
 
     pub fn unary_plus(&self) -> Result<Value> {
         use Value::*;
 
         match self {
-            I64(_) | OptI64(_) | F64(_) | OptF64(_) => Ok(self.clone()),
+            I64(_) | F64(_) => Ok(self.clone()),
+            Null => Ok(Null),
             _ => Err(ValueError::UnaryPlusOnNonNumeric.into()),
         }
     }
@@ -432,11 +266,8 @@ impl Value {
 
         match self {
             I64(a) => Ok(I64(-a)),
-            OptI64(Some(a)) => Ok(OptI64(Some(-a))),
             F64(a) => Ok(F64(-a)),
-            OptF64(Some(a)) => Ok(OptF64(Some(-a))),
-            OptI64(None) => Ok(OptI64(None)),
-            OptF64(None) => Ok(OptF64(None)),
+            Null => Ok(Null),
             _ => Err(ValueError::UnaryMinusOnNonNumeric.into()),
         }
     }
@@ -444,105 +275,68 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
-    use super::Value;
+    use super::Value::*;
 
     #[test]
     fn eq() {
-        assert_eq!(Value::Bool(true), Value::OptBool(Some(true)));
-        assert_eq!(Value::OptBool(Some(false)), Value::Bool(false));
-        assert_eq!(Value::OptBool(None), Value::OptBool(None));
-
-        assert_eq!(Value::I64(1), Value::OptI64(Some(1)));
-        assert_eq!(Value::OptI64(Some(1)), Value::I64(1));
-        assert_eq!(Value::OptI64(None), Value::OptI64(None));
-
-        assert_eq!(Value::F64(6.11), Value::OptF64(Some(6.11)));
-        assert_eq!(Value::OptF64(Some(6.11)), Value::F64(6.11));
-        assert_eq!(Value::OptF64(None), Value::OptF64(None));
-
-        let glue = || "Glue".to_owned();
-
-        assert_eq!(Value::Str(glue()), Value::OptStr(Some(glue())));
-        assert_eq!(Value::OptStr(Some(glue())), Value::Str(glue()));
-        assert_eq!(Value::OptStr(None), Value::OptStr(None));
-
-        assert_eq!(Value::Null, Value::Null);
+        assert_ne!(Null, Null);
+        assert_eq!(Bool(true), Bool(true));
+        assert_eq!(I64(1), I64(1));
+        assert_eq!(F64(6.11), F64(6.11));
+        assert_eq!(Str("Glue".to_owned()), Str("Glue".to_owned()));
     }
 
     #[test]
     fn cast() {
-        use {sqlparser::ast::DataType::*, Value::*};
+        use sqlparser::ast::DataType::*;
 
         macro_rules! cast {
-            ($input: expr => $data_type: expr, $output: expr) => {
-                assert_eq!($input.cast(&$data_type), Ok($output));
+            ($input: expr => $data_type: expr, $expected: expr) => {
+                let found = $input.cast(&$data_type).unwrap();
+
+                match ($expected, found) {
+                    (Null, Null) => {}
+                    (expected, found) => {
+                        assert_eq!(expected, found);
+                    }
+                }
             };
         }
 
         // Same as
-        cast!(Bool(true)                    => Boolean      , Bool(true));
-        cast!(OptBool(Some(true))           => Boolean      , OptBool(Some(true)));
-        cast!(Str("a".to_owned())           => Text         , Str("a".to_owned()));
-        cast!(OptStr(Some("a".to_owned()))  => Text         , OptStr(Some("a".to_owned())));
-        cast!(I64(1)                        => Int          , I64(1));
-        cast!(OptI64(Some(1))               => Int          , OptI64(Some(1)));
-        cast!(F64(1.0)                      => Float(None)  , F64(1.0));
-        cast!(OptF64(Some(1.0))             => Float(None)  , OptF64(Some(1.0)));
+        cast!(Bool(true)            => Boolean      , Bool(true));
+        cast!(Str("a".to_owned())   => Text         , Str("a".to_owned()));
+        cast!(I64(1)                => Int          , I64(1));
+        cast!(F64(1.0)              => Float(None)  , F64(1.0));
 
         // Boolean
-        cast!(Str("TRUE".to_owned())            => Boolean, Bool(true));
-        cast!(Str("FALSE".to_owned())           => Boolean, Bool(false));
-        cast!(OptStr(Some("TRUE".to_owned()))   => Boolean, OptBool(Some(true)));
-        cast!(OptStr(Some("FALSE".to_owned()))  => Boolean, OptBool(Some(false)));
-        cast!(I64(1)                            => Boolean, Bool(true));
-        cast!(I64(0)                            => Boolean, Bool(false));
-        cast!(OptI64(Some(1))                   => Boolean, OptBool(Some(true)));
-        cast!(OptI64(Some(0))                   => Boolean, OptBool(Some(false)));
-        cast!(F64(1.0)                          => Boolean, Bool(true));
-        cast!(F64(0.0)                          => Boolean, Bool(false));
-        cast!(OptF64(Some(1.0))                 => Boolean, OptBool(Some(true)));
-        cast!(OptF64(Some(0.0))                 => Boolean, OptBool(Some(false)));
-        cast!(OptI64(None)                      => Boolean, OptBool(None));
-        cast!(OptF64(None)                      => Boolean, OptBool(None));
-        cast!(OptStr(None)                      => Boolean, OptBool(None));
+        cast!(Str("TRUE".to_owned())    => Boolean, Bool(true));
+        cast!(Str("FALSE".to_owned())   => Boolean, Bool(false));
+        cast!(I64(1)                    => Boolean, Bool(true));
+        cast!(I64(0)                    => Boolean, Bool(false));
+        cast!(F64(1.0)                  => Boolean, Bool(true));
+        cast!(F64(0.0)                  => Boolean, Bool(false));
+        cast!(Null                      => Boolean, Null);
 
         // Integer
-        cast!(Bool(true)                    => Int, I64(1));
-        cast!(Bool(false)                   => Int, I64(0));
-        cast!(OptBool(Some(true))           => Int, OptI64(Some(1)));
-        cast!(OptBool(Some(false))          => Int, OptI64(Some(0)));
-        cast!(F64(1.1)                      => Int, I64(1));
-        cast!(OptF64(Some(1.1))             => Int, OptI64(Some(1)));
-        cast!(Str("11".to_owned())          => Int, I64(11));
-        cast!(OptStr(Some("11".to_owned())) => Int, OptI64(Some(11)));
-        cast!(OptBool(None)                 => Int, OptI64(None));
-        cast!(OptF64(None)                  => Int, OptI64(None));
-        cast!(OptStr(None)                  => Int, OptI64(None));
+        cast!(Bool(true)            => Int, I64(1));
+        cast!(Bool(false)           => Int, I64(0));
+        cast!(F64(1.1)              => Int, I64(1));
+        cast!(Str("11".to_owned())  => Int, I64(11));
+        cast!(Null                  => Int, Null);
 
         // Float
-        cast!(Bool(true)                    => Float(None), F64(1.0));
-        cast!(Bool(false)                   => Float(None), F64(0.0));
-        cast!(OptBool(Some(true))           => Float(None), OptF64(Some(1.0)));
-        cast!(OptBool(Some(false))          => Float(None), OptF64(Some(0.0)));
-        cast!(I64(1)                        => Float(None), F64(1.0));
-        cast!(OptI64(Some(1))               => Float(None), OptF64(Some(1.0)));
-        cast!(Str("11".to_owned())          => Float(None), F64(11.0));
-        cast!(OptStr(Some("11".to_owned())) => Float(None), OptF64(Some(11.0)));
-        cast!(OptBool(None)                 => Float(None), OptF64(None));
-        cast!(OptI64(None)                  => Float(None), OptF64(None));
-        cast!(OptStr(None)                  => Float(None), OptF64(None));
+        cast!(Bool(true)            => Float(None), F64(1.0));
+        cast!(Bool(false)           => Float(None), F64(0.0));
+        cast!(I64(1)                => Float(None), F64(1.0));
+        cast!(Str("11".to_owned())  => Float(None), F64(11.0));
+        cast!(Null                  => Float(None), Null);
 
         // Text
-        cast!(Bool(true)            => Text, Str("TRUE".to_owned()));
-        cast!(Bool(false)           => Text, Str("FALSE".to_owned()));
-        cast!(OptBool(Some(true))   => Text, OptStr(Some("TRUE".to_owned())));
-        cast!(OptBool(Some(false))  => Text, OptStr(Some("FALSE".to_owned())));
-        cast!(I64(11)               => Text, Str("11".to_owned()));
-        cast!(OptI64(Some(11))      => Text, OptStr(Some("11".to_owned())));
-        cast!(F64(1.0)              => Text, Str("1".to_owned()));
-        cast!(OptF64(Some(1.0))     => Text, OptStr(Some("1".to_owned())));
-        cast!(OptBool(None)         => Text, OptStr(None));
-        cast!(OptI64(None)          => Text, OptStr(None));
-        cast!(OptF64(None)          => Text, OptStr(None));
+        cast!(Bool(true)    => Text, Str("TRUE".to_owned()));
+        cast!(Bool(false)   => Text, Str("FALSE".to_owned()));
+        cast!(I64(11)       => Text, Str("11".to_owned()));
+        cast!(F64(1.0)      => Text, Str("1".to_owned()));
+        cast!(Null          => Text, Null);
     }
 }

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -14,11 +14,11 @@ impl TryInto<UniqueKey> for &Value {
         use Value::*;
 
         match self {
-            Bool(v) | OptBool(Some(v)) => Ok(UniqueKey::Bool(*v)),
-            I64(v) | OptI64(Some(v)) => Ok(UniqueKey::I64(*v)),
-            Str(v) | OptStr(Some(v)) => Ok(UniqueKey::Str(v.clone())),
-            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(UniqueKey::Null),
-            F64(_) | OptF64(_) => Err(ValueError::ConflictOnFloatWithUniqueConstraint.into()),
+            Bool(v) => Ok(UniqueKey::Bool(*v)),
+            I64(v) => Ok(UniqueKey::I64(*v)),
+            Str(v) => Ok(UniqueKey::Str(v.clone())),
+            Null => Ok(UniqueKey::Null),
+            F64(_) => Err(ValueError::ConflictOnFloatWithUniqueConstraint.into()),
         }
     }
 }

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -7,18 +7,22 @@ use {
     std::convert::TryInto,
 };
 
-impl TryInto<UniqueKey> for &Value {
+impl TryInto<Option<UniqueKey>> for &Value {
     type Error = Error;
 
-    fn try_into(self) -> Result<UniqueKey> {
+    fn try_into(self) -> Result<Option<UniqueKey>> {
         use Value::*;
 
-        match self {
-            Bool(v) => Ok(UniqueKey::Bool(*v)),
-            I64(v) => Ok(UniqueKey::I64(*v)),
-            Str(v) => Ok(UniqueKey::Str(v.clone())),
-            Null => Ok(UniqueKey::Null),
-            F64(_) => Err(ValueError::ConflictOnFloatWithUniqueConstraint.into()),
-        }
+        let unique_key = match self {
+            Bool(v) => Some(UniqueKey::Bool(*v)),
+            I64(v) => Some(UniqueKey::I64(*v)),
+            Str(v) => Some(UniqueKey::Str(v.clone())),
+            Null => None,
+            F64(_) => {
+                return Err(ValueError::ConflictOnFloatWithUniqueConstraint.into());
+            }
+        };
+
+        Ok(unique_key)
     }
 }

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -17,7 +17,7 @@ impl TryInto<UniqueKey> for &Value {
             Bool(v) | OptBool(Some(v)) => Ok(UniqueKey::Bool(*v)),
             I64(v) | OptI64(Some(v)) => Ok(UniqueKey::I64(*v)),
             Str(v) | OptStr(Some(v)) => Ok(UniqueKey::Str(v.clone())),
-            Empty | OptBool(None) | OptI64(None) | OptStr(None) => Ok(UniqueKey::Null),
+            Null | OptBool(None) | OptI64(None) | OptStr(None) => Ok(UniqueKey::Null),
             F64(_) | OptF64(_) => Err(ValueError::ConflictOnFloatWithUniqueConstraint.into()),
         }
     }

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -9,7 +9,7 @@ pub enum GroupKey {
     I64(i64),
     Bool(bool),
     Str(String),
-    Null,
+    None,
 }
 
 impl TryFrom<&Evaluated<'_>> for GroupKey {

--- a/src/executor/aggregate/state.rs
+++ b/src/executor/aggregate/state.rs
@@ -27,7 +27,7 @@ impl<'a> State<'a> {
     pub fn new() -> Self {
         State {
             index: 0,
-            group: Rc::new(vec![GroupKey::Null]),
+            group: Rc::new(vec![GroupKey::None]),
             values: IndexMap::new(),
             groups: HashSet::new(),
             contexts: Vector::new(),

--- a/src/executor/context/blend_context.rs
+++ b/src/executor/context/blend_context.rs
@@ -70,7 +70,7 @@ impl<'a> BlendContext<'a> {
         if self.table_alias == alias {
             let values = match &self.row {
                 Some(Row(values)) => values.clone(),
-                None => self.columns.iter().map(|_| Value::Empty).collect(),
+                None => self.columns.iter().map(|_| Value::Null).collect(),
             };
 
             Some(values)
@@ -84,7 +84,7 @@ impl<'a> BlendContext<'a> {
     pub fn get_all_values(&'a self) -> Vec<Value> {
         let values: Vec<Value> = match &self.row {
             Some(Row(values)) => values.clone(),
-            None => self.columns.iter().map(|_| Value::Empty).collect(),
+            None => self.columns.iter().map(|_| Value::Null).collect(),
         };
 
         match &self.next {

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -53,7 +53,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
 
                 match (context.get_value(&ident.value), use_empty) {
                     (Some(value), _) => Ok(value.clone()),
-                    (None, true) => Ok(Value::Empty),
+                    (None, true) => Ok(Value::Null),
                     (None, false) => {
                         Err(EvaluateError::ValueNotFound(ident.value.to_string()).into())
                     }
@@ -73,7 +73,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
 
             match (context.get_alias_value(table_alias, column), use_empty) {
                 (Some(value), _) => Ok(value.clone()),
-                (None, true) => Ok(Value::Empty),
+                (None, true) => Ok(Value::Null),
                 (None, false) => Err(EvaluateError::ValueNotFound(column.to_string()).into()),
             }
             .map(Evaluated::Value)

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -44,15 +44,14 @@ test_case!(aggregate, async move {
         ),
         (
             "SELECT SUM(age), MAX(age), MIN(age) FROM Item",
-            select!(
-                "SUM(age)" | "MAX(age)" | "MIN(age)"
-                OptI64     | OptI64     | OptI64;
-                None         Some(90)     Some(3)
+            select_with_empty!(
+                "SUM(age)" | "MAX(age)" | "MIN(age)";
+                Null         I64(90)     I64(3)
             ),
         ),
         (
             "SELECT SUM(age) + SUM(quantity) FROM Item",
-            select!("SUM(age) + SUM(quantity)"; OptI64; None),
+            select_with_empty!("SUM(age) + SUM(quantity)"; Null),
         ),
         (
             "SELECT COUNT(age), COUNT(quantity) FROM Item",
@@ -124,14 +123,13 @@ test_case!(group_by, async move {
         ),
         (
             "SELECT SUM(quantity), COUNT(*), city FROM Item GROUP BY city",
-            select!(
-                "SUM(quantity)" | "COUNT(*)" | city
-                OptI64          | I64        | Str;
-                Some(21)          2            "Seoul".to_owned();
-                Some(0)           1            "Dhaka".to_owned();
-                None              1            "Beijing".to_owned();
-                Some(30)          1            "Daejeon".to_owned();
-                Some(24)          1            "Seattle".to_owned()
+            select_with_empty!(
+                "SUM(quantity)" | "COUNT(*)" | city;
+                I64(21)           I64(2)       Str("Seoul".to_owned());
+                I64(0)            I64(1)       Str("Dhaka".to_owned());
+                Null              I64(1)       Str("Beijing".to_owned());
+                I64(30)           I64(1)       Str("Daejeon".to_owned());
+                I64(24)           I64(1)       Str("Seattle".to_owned())
             ),
         ),
         (
@@ -158,8 +156,8 @@ test_case!(group_by, async move {
             "SELECT SUM(quantity), COUNT(*), city FROM Item GROUP BY city HAVING COUNT(*) > 1",
             select!(
                 "SUM(quantity)" | "COUNT(*)" | city
-                OptI64          | I64        | Str;
-                Some(21)          2            "Seoul".to_owned()
+                I64          | I64        | Str;
+                21             2            "Seoul".to_owned()
             ),
         ),
     ];

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -44,14 +44,14 @@ test_case!(aggregate, async move {
         ),
         (
             "SELECT SUM(age), MAX(age), MIN(age) FROM Item",
-            select_with_empty!(
+            select_with_null!(
                 "SUM(age)" | "MAX(age)" | "MIN(age)";
                 Null         I64(90)     I64(3)
             ),
         ),
         (
             "SELECT SUM(age) + SUM(quantity) FROM Item",
-            select_with_empty!("SUM(age) + SUM(quantity)"; Null),
+            select_with_null!("SUM(age) + SUM(quantity)"; Null),
         ),
         (
             "SELECT COUNT(age), COUNT(quantity) FROM Item",
@@ -123,7 +123,7 @@ test_case!(group_by, async move {
         ),
         (
             "SELECT SUM(quantity), COUNT(*), city FROM Item GROUP BY city",
-            select_with_empty!(
+            select_with_null!(
                 "SUM(quantity)" | "COUNT(*)" | city;
                 I64(21)           I64(2)       Str("Seoul".to_owned());
                 I64(0)            I64(1)       Str("Dhaka".to_owned());

--- a/src/tests/alter_table.rs
+++ b/src/tests/alter_table.rs
@@ -60,11 +60,10 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select!(
-                id  | amount | opt
-                I64 | I64    | OptBool;
-                1     10       None;
-                2     10       None
+            Ok(select_with_empty!(
+                id     | amount  | opt;
+                I64(1)   I64(10)   Null;
+                I64(2)   I64(10)   Null
             )),
         ),
         (
@@ -73,11 +72,10 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select!(
-                id  | amount | opt     | opt2
-                I64 | I64    | OptBool | OptBool;
-                1     10       None      Some(true);
-                2     10       None      Some(true)
+            Ok(select_with_empty!(
+                id     | amount  | opt  | opt2;
+                I64(1)   I64(10)   Null   Bool(true);
+                I64(2)   I64(10)   Null   Bool(true)
             )),
         ),
         (
@@ -98,11 +96,10 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select!(
-                id  | opt     | opt2
-                I64 | OptBool | OptBool;
-                1     None      Some(true);
-                2     None      Some(true)
+            Ok(select_with_empty!(
+                id     | opt  | opt2;
+                I64(1)   Null   Bool(true);
+                I64(2)   Null   Bool(true)
             )),
         ),
         (
@@ -111,11 +108,10 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select!(
-                id  | opt
-                I64 | OptBool;
-                1     None;
-                2     None
+            Ok(select_with_empty!(
+                id     | opt;
+                I64(1)   Null;
+                I64(2)   Null
             )),
         ),
     ];

--- a/src/tests/alter_table.rs
+++ b/src/tests/alter_table.rs
@@ -60,7 +60,7 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select_with_empty!(
+            Ok(select_with_null!(
                 id     | amount  | opt;
                 I64(1)   I64(10)   Null;
                 I64(2)   I64(10)   Null
@@ -72,7 +72,7 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select_with_empty!(
+            Ok(select_with_null!(
                 id     | amount  | opt  | opt2;
                 I64(1)   I64(10)   Null   Bool(true);
                 I64(2)   I64(10)   Null   Bool(true)
@@ -96,7 +96,7 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select_with_empty!(
+            Ok(select_with_null!(
                 id     | opt  | opt2;
                 I64(1)   Null   Bool(true);
                 I64(2)   Null   Bool(true)
@@ -108,7 +108,7 @@ test_case!(add_drop, async move {
         ),
         (
             "SELECT * FROM Foo;",
-            Ok(select_with_empty!(
+            Ok(select_with_null!(
                 id     | opt;
                 I64(1)   Null;
                 I64(2)   Null

--- a/src/tests/default.rs
+++ b/src/tests/default.rs
@@ -24,14 +24,13 @@ test_case!(default, async move {
         ),
         (
             "SELECT * FROM Test;",
-            select!(
-                id  | num | flag
-                I64 | I64 | OptBool;
-                8     80    Some(true);
-                1     10    Some(false);
-                2     20    Some(false);
-                1     30    None;
-                1     40    Some(true)
+            select_with_empty!(
+                id     | num     | flag;
+                I64(8)   I64(80)   Bool(true);
+                I64(1)   I64(10)   Bool(false);
+                I64(2)   I64(20)   Bool(false);
+                I64(1)   I64(30)   Null;
+                I64(1)   I64(40)   Bool(true)
             ),
         ),
     ];

--- a/src/tests/default.rs
+++ b/src/tests/default.rs
@@ -24,7 +24,7 @@ test_case!(default, async move {
         ),
         (
             "SELECT * FROM Test;",
-            select_with_empty!(
+            select_with_null!(
                 id     | num     | flag;
                 I64(8)   I64(80)   Bool(true);
                 I64(1)   I64(10)   Bool(false);

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -24,7 +24,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS BOOLEAN) AS cast FROM Item"#,
-            Ok(select_with_empty!(cast; Null)),
+            Ok(select_with_null!(cast; Null)),
         ),
         (
             r#"SELECT CAST("1" AS INTEGER) AS cast FROM Item"#,
@@ -44,7 +44,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS INTEGER) AS cast FROM Item"#,
-            Ok(select_with_empty!(cast; Null)),
+            Ok(select_with_null!(cast; Null)),
         ),
         (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
@@ -64,7 +64,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS FLOAT) AS cast FROM Item"#,
-            Ok(select_with_empty!(cast; Null)),
+            Ok(select_with_null!(cast; Null)),
         ),
         (
             r#"SELECT CAST(1 AS TEXT) AS cast FROM Item"#,
@@ -80,7 +80,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS TEXT) AS cast FROM Item"#,
-            Ok(select_with_empty!(cast; Null)),
+            Ok(select_with_null!(cast; Null)),
         ),
         (
             r#"SELECT CAST(NULL AS NULL) FROM Item"#,
@@ -131,7 +131,7 @@ test_case!(cast_value, async move {
         ),
         (
             r#"SELECT CAST(ratio AS INTEGER) AS cast FROM Item"#,
-            Ok(select_with_empty!(cast; Null)),
+            Ok(select_with_null!(cast; Null)),
         ),
         (
             r#"SELECT CAST(number AS BOOLEAN) FROM Item"#,

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -24,7 +24,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS BOOLEAN) AS cast FROM Item"#,
-            Ok(select!(cast OptBool; None)),
+            Ok(select_with_empty!(cast; Null)),
         ),
         (
             r#"SELECT CAST("1" AS INTEGER) AS cast FROM Item"#,
@@ -44,7 +44,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS INTEGER) AS cast FROM Item"#,
-            Ok(select!(cast OptI64; None)),
+            Ok(select_with_empty!(cast; Null)),
         ),
         (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
@@ -64,7 +64,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS FLOAT) AS cast FROM Item"#,
-            Ok(select!(cast OptF64; None)),
+            Ok(select_with_empty!(cast; Null)),
         ),
         (
             r#"SELECT CAST(1 AS TEXT) AS cast FROM Item"#,
@@ -80,7 +80,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(NULL AS TEXT) AS cast FROM Item"#,
-            Ok(select!(cast OptStr; None)),
+            Ok(select_with_empty!(cast; Null)),
         ),
         (
             r#"SELECT CAST(NULL AS NULL) FROM Item"#,
@@ -123,7 +123,7 @@ test_case!(cast_value, async move {
         ),
         (
             r#"SELECT CAST(id AS BOOLEAN) AS cast FROM Item"#,
-            Ok(select!(cast OptBool; Some(false))),
+            Ok(select!(cast Bool; false)),
         ),
         (
             r#"SELECT CAST(flag AS TEXT) AS cast FROM Item"#,
@@ -131,7 +131,7 @@ test_case!(cast_value, async move {
         ),
         (
             r#"SELECT CAST(ratio AS INTEGER) AS cast FROM Item"#,
-            Ok(select!(cast OptI64; None)),
+            Ok(select_with_empty!(cast; Null)),
         ),
         (
             r#"SELECT CAST(number AS BOOLEAN) FROM Item"#,

--- a/src/tests/function/left_right.rs
+++ b/src/tests/function/left_right.rs
@@ -1,7 +1,8 @@
 use crate::*;
 
 test_case!(left_right, async move {
-    use Value::OptStr;
+    use Value::{Null, Str};
+
     let test_cases = vec![
         ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
         (
@@ -44,20 +45,20 @@ test_case!(left_right, async move {
             r#"SELECT LEFT(name, 3) AS test FROM Item"#,
             Ok(select!(
                 "test"
-                OptStr;
-                Some("Blo".to_owned());
-                Some("B".to_owned());
-                Some("Ste".to_owned())
+                Str;
+                "Blo".to_owned();
+                "B".to_owned();
+                "Ste".to_owned()
             )),
         ),
         (
             r#"SELECT RIGHT(name, 10) AS test FROM Item"#,
             Ok(select!(
                 "test"
-                OptStr;
-                Some("op mc blee".to_owned());
-                Some("B".to_owned());
-                Some("d$ folken!".to_owned())
+                Str;
+                "op mc blee".to_owned();
+                "B".to_owned();
+                "d$ folken!".to_owned()
             )),
         ),
         // TODO Concatenation
@@ -75,48 +76,36 @@ test_case!(left_right, async move {
             r#"SELECT LEFT('blue', 10) AS test FROM SingleItem"#,
             Ok(select!(
                 "test"
-                OptStr;
-                Some("blue".to_owned())
+                Str;
+                "blue".to_owned()
             )),
         ),
         (
             r#"SELECT LEFT("blunder", 3) AS test FROM SingleItem"#,
             Ok(select!(
                 "test"
-                OptStr;
-                Some("blu".to_owned())
+                Str;
+                "blu".to_owned()
             )),
         ),
         (
             r#"SELECT LEFT(name, 3) AS test FROM NullName"#,
-            Ok(select!(
-                "test"
-                OptStr;
-                None
-            )),
+            Ok(select_with_empty!(test; Null)),
         ),
         (
             r#"SELECT LEFT('Words', number) AS test FROM NullNumber"#,
-            Ok(select!(
-                "test"
-                OptStr;
-                None
-            )),
+            Ok(select_with_empty!(test; Null)),
         ),
         (
             r#"SELECT LEFT(name, number) AS test FROM NullNumber INNER JOIN NullName ON 1 = 1"#,
-            Ok(select!(
-                "test"
-                OptStr;
-                None
-            )),
+            Ok(select_with_empty!(test; Null)),
         ),
         (
             r#"SELECT LEFT(name, 1) AS test FROM NullableName"#,
             Ok(select!(
                 "test"
-                OptStr;
-                Some("n".to_owned())
+                Str;
+                "n".to_owned()
             )),
         ),
         // TODO: Cast cannot handle

--- a/src/tests/function/left_right.rs
+++ b/src/tests/function/left_right.rs
@@ -90,15 +90,15 @@ test_case!(left_right, async move {
         ),
         (
             r#"SELECT LEFT(name, 3) AS test FROM NullName"#,
-            Ok(select_with_empty!(test; Null)),
+            Ok(select_with_null!(test; Null)),
         ),
         (
             r#"SELECT LEFT('Words', number) AS test FROM NullNumber"#,
-            Ok(select_with_empty!(test; Null)),
+            Ok(select_with_null!(test; Null)),
         ),
         (
             r#"SELECT LEFT(name, number) AS test FROM NullNumber INNER JOIN NullName ON 1 = 1"#,
-            Ok(select_with_empty!(test; Null)),
+            Ok(select_with_null!(test; Null)),
         ),
         (
             r#"SELECT LEFT(name, 1) AS test FROM NullableName"#,

--- a/src/tests/function/upper_lower.rs
+++ b/src/tests/function/upper_lower.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 test_case!(upper_lower, async move {
-    use Value::{OptStr, Str};
+    use Value::{Null, Str};
 
     let test_cases = vec![
         (
@@ -46,12 +46,11 @@ test_case!(upper_lower, async move {
         ),
         (
             "SELECT LOWER(opt_name), UPPER(opt_name) FROM Item;",
-            Ok(select!(
-                "LOWER(opt_name)"       | "UPPER(opt_name)"
-                OptStr                  | OptStr;
-                Some("efgi".to_owned())   Some("EFGI".to_owned());
-                None                      None;
-                Some("efgi".to_owned())   Some("EFGI".to_owned())
+            Ok(select_with_empty!(
+                "LOWER(opt_name)"      | "UPPER(opt_name)";
+                Str("efgi".to_owned())   Str("EFGI".to_owned());
+                Null                     Null;
+                Str("efgi".to_owned())   Str("EFGI".to_owned())
             )),
         ),
         (

--- a/src/tests/function/upper_lower.rs
+++ b/src/tests/function/upper_lower.rs
@@ -46,7 +46,7 @@ test_case!(upper_lower, async move {
         ),
         (
             "SELECT LOWER(opt_name), UPPER(opt_name) FROM Item;",
-            Ok(select_with_empty!(
+            Ok(select_with_null!(
                 "LOWER(opt_name)"      | "UPPER(opt_name)";
                 Str("efgi".to_owned())   Str("EFGI".to_owned());
                 Null                     Null;

--- a/src/tests/join.rs
+++ b/src/tests/join.rs
@@ -191,7 +191,7 @@ test_case!(blend, async move {
         LEFT JOIN Item i
         ON p.id = i.player_id
     ";
-    let expected = select_with_empty!(
+    let expected = select_with_null!(
         id     | id;
         I64(1)   I64(101);
         I64(2)   I64(102);
@@ -207,7 +207,7 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let expected = select_with_empty!(
+    let expected = select_with_null!(
         id     | player_id;
         I64(1)   I64(1);
         I64(2)   I64(2);
@@ -223,7 +223,7 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let expected = select_with_empty!(
+    let expected = select_with_null!(
         id       | quantity | player_id;
         I64(101)   I64(1)     I64(1);
         I64(102)   I64(4)     I64(2);
@@ -239,7 +239,7 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let expected = select_with_empty!(
+    let expected = select_with_null!(
         id     | name                      | id       | quantity | player_id;
         I64(1)   Str("Taehoon".to_owned())   I64(101)   I64(1)     I64(1);
         I64(2)   Str("Mike".to_owned())      I64(102)   I64(4)     I64(2);

--- a/src/tests/join.rs
+++ b/src/tests/join.rs
@@ -183,7 +183,7 @@ test_case!(blend, async move {
         run!(insert_sql);
     }
 
-    use Value::{Empty, Str, I64};
+    use Value::{Null, Str, I64};
 
     let sql = "
         SELECT p.id, i.id
@@ -196,9 +196,9 @@ test_case!(blend, async move {
         id     | id;
         I64(1)   I64(101);
         I64(2)   I64(102);
-        I64(3)   Empty;
+        I64(3)   Null;
         I64(4)   I64(103);
-        I64(5)   Empty
+        I64(5)   Null
     );
     assert_eq!(expected, found);
 
@@ -213,9 +213,9 @@ test_case!(blend, async move {
         id     | player_id;
         I64(1)   I64(1);
         I64(2)   I64(2);
-        I64(3)   Empty;
+        I64(3)   Null;
         I64(4)   I64(4);
-        I64(5)   Empty
+        I64(5)   Null
     );
     assert_eq!(expected, found);
 
@@ -230,9 +230,9 @@ test_case!(blend, async move {
         id       | quantity | player_id;
         I64(101)   I64(1)     I64(1);
         I64(102)   I64(4)     I64(2);
-        Empty      Empty      Empty;
+        Null       Null       Null;
         I64(103)   I64(9)     I64(4);
-        Empty      Empty      Empty
+        Null       Null       Null
     );
     assert_eq!(expected, found);
 
@@ -247,9 +247,9 @@ test_case!(blend, async move {
         id     | name                      | id       | quantity | player_id;
         I64(1)   Str("Taehoon".to_owned())   I64(101)   I64(1)     I64(1);
         I64(2)   Str("Mike".to_owned())      I64(102)   I64(4)     I64(2);
-        I64(3)   Str("Jorno".to_owned())     Empty      Empty      Empty;
+        I64(3)   Str("Jorno".to_owned())     Null       Null       Null;
         I64(4)   Str("Berry".to_owned())     I64(103)   I64(9)     I64(4);
-        I64(5)   Str("Hwan".to_owned())      Empty      Empty      Empty
+        I64(5)   Str("Hwan".to_owned())      Null       Null       Null
     );
     assert_eq!(expected, found);
 });

--- a/src/tests/join.rs
+++ b/src/tests/join.rs
@@ -191,7 +191,6 @@ test_case!(blend, async move {
         LEFT JOIN Item i
         ON p.id = i.player_id
     ";
-    let found = run!(sql);
     let expected = select_with_empty!(
         id     | id;
         I64(1)   I64(101);
@@ -200,7 +199,7 @@ test_case!(blend, async move {
         I64(4)   I64(103);
         I64(5)   Null
     );
-    assert_eq!(expected, found);
+    test!(Ok(expected), sql);
 
     let sql = "
         SELECT p.id, player_id
@@ -208,7 +207,6 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let found = run!(sql);
     let expected = select_with_empty!(
         id     | player_id;
         I64(1)   I64(1);
@@ -217,7 +215,7 @@ test_case!(blend, async move {
         I64(4)   I64(4);
         I64(5)   Null
     );
-    assert_eq!(expected, found);
+    test!(Ok(expected), sql);
 
     let sql = "
         SELECT Item.*
@@ -225,7 +223,6 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let found = run!(sql);
     let expected = select_with_empty!(
         id       | quantity | player_id;
         I64(101)   I64(1)     I64(1);
@@ -234,7 +231,7 @@ test_case!(blend, async move {
         I64(103)   I64(9)     I64(4);
         Null       Null       Null
     );
-    assert_eq!(expected, found);
+    test!(Ok(expected), sql);
 
     let sql = "
         SELECT *
@@ -242,7 +239,6 @@ test_case!(blend, async move {
         LEFT JOIN Item
         ON p.id = player_id
     ";
-    let found = run!(sql);
     let expected = select_with_empty!(
         id     | name                      | id       | quantity | player_id;
         I64(1)   Str("Taehoon".to_owned())   I64(101)   I64(1)     I64(1);
@@ -251,5 +247,5 @@ test_case!(blend, async move {
         I64(4)   Str("Berry".to_owned())     I64(103)   I64(9)     I64(4);
         I64(5)   Str("Hwan".to_owned())      Null       Null       Null
     );
-    assert_eq!(expected, found);
+    test!(Ok(expected), sql);
 });

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -46,7 +46,7 @@ macro_rules! concat_with {
 }
 
 #[macro_export]
-macro_rules! select_with_empty {
+macro_rules! select_with_null {
     ( $( $c: tt )|* ; $( $v: expr )* ) => (
         Payload::Select {
             labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
@@ -60,13 +60,13 @@ macro_rules! select_with_empty {
 
         Payload::Select {
             labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
-            rows: concat_with_empty!(rows ; $( $( $v2 )* );*),
+            rows: concat_with_null!(rows ; $( $( $v2 )* );*),
         }
     });
 }
 
 #[macro_export]
-macro_rules! concat_with_empty {
+macro_rules! concat_with_null {
     ( $rows: ident ; $( $v: expr )* ) => ({
         $rows.push(Row(vec![$( $v ),*]));
 
@@ -75,6 +75,6 @@ macro_rules! concat_with_empty {
     ( $rows: ident ; $( $v: expr )* ; $( $( $v2: expr )* );* ) => ({
         $rows.push(Row(vec![$( $v ),*]));
 
-        concat_with_empty!($rows ; $( $( $v2 )* );* )
+        concat_with_null!($rows ; $( $( $v2 )* );* )
     });
 }

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -31,7 +31,7 @@ CREATE TABLE Test (
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = NULL AND name = \'Hello\'",
+            "SELECT id, num FROM Test WHERE id IS NULL AND name = \'Hello\'",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
@@ -120,63 +120,63 @@ CREATE TABLE Test (
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = NULL + 1;",
+            "SELECT id, num FROM Test WHERE id + 1 IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = 1 + NULL;",
+            "SELECT id, num FROM Test WHERE 1 + id IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = NULL - 1;",
+            "SELECT id, num FROM Test WHERE id - 1 IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = 1 - NULL;",
+            "SELECT id, num FROM Test WHERE 1 - id IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = NULL * 1;",
+            "SELECT id, num FROM Test WHERE id * 1 IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = 1 * NULL;",
+            "SELECT id, num FROM Test WHERE 1 * id IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = NULL / 1;",
+            "SELECT id, num FROM Test WHERE id / 1 IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id = 1 / NULL;",
+            "SELECT id, num FROM Test WHERE 1 / id IS NULL;",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
-            "SELECT id + 1, 1 + id, id - 1, 1 - id, id * 1, 1 * id, id / 1, 1 / id FROM Test WHERE id = NULL;",
+            "SELECT id + 1, 1 + id, id - 1, 1 - id, id * 1, 1 * id, id / 1, 1 / id FROM Test WHERE id IS NULL;",
             select_with_null!(
                 "id + 1" | "1 + id" | "id - 1" | "1 - id" | "id * 1" | "1 * id" | "id / 1" | "1 / id";
                 Null       Null       Null       Null       Null       Null       Null       Null

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -23,54 +23,48 @@ CREATE TABLE Test (
     let test_cases = vec![
         (
             "SELECT id, num, name FROM Test",
-            select!(
-                id      | num | name
-                OptI64  | I64 | Str;
-                None      2     "Hello".to_owned();
-                Some(1)   9     "World".to_owned();
-                Some(3)   4     "Great".to_owned()
+            select_with_empty!(
+                id     | num    | name;
+                Null     I64(2)   Str("Hello".to_owned());
+                I64(1)   I64(9)   Str("World".to_owned());
+                I64(3)   I64(4)   Str("Great".to_owned())
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL AND name = \'Hello\'",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NULL",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NOT NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NULL",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NOT NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
@@ -79,12 +73,11 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE 100 IS NOT NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                None      2;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                Null     I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
@@ -93,22 +86,20 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE 8 + 3 IS NOT NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                None      2;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                Null     I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE NULL IS NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                None      2;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                Null     I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
@@ -121,84 +112,74 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NOT NULL",
-            select!(
-                id      | num
-                OptI64  | I64;
-                None      2;
-                Some(1)   9;
-                Some(3)   4
+            select_with_empty!(
+                id     | num;
+                Null     I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL + 1;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 + NULL;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL - 1;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 - NULL;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL * 1;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 * NULL;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL / 1;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 / NULL;",
-            select!(
-                id     | num
-                OptI64 | I64;
-                None     2
+            select_with_empty!(
+                id   | num;
+                Null   I64(2)
             ),
         ),
         (
             "SELECT id + 1, 1 + id, id - 1, 1 - id, id * 1, 1 * id, id / 1, 1 / id FROM Test WHERE id = NULL;",
-            select!(
+            select_with_empty!(
                 "id + 1" | "1 + id" | "id - 1" | "1 - id" | "id * 1" | "1 * id" | "id / 1" | "1 / id";
-                OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64   | OptI64;
-                None       None       None       None       None       None       None       None
+                Null       Null       Null       Null       Null       Null       Null       Null
             ),
         ),
     ];
@@ -210,24 +191,15 @@ CREATE TABLE Test (
     run!("UPDATE Test SET id = 2");
 
     let test_cases = vec![
-        (
-            "SELECT id FROM Test",
-            Ok(select!(
-                id
-                OptI64;
-                Some(2);
-                Some(2);
-                Some(2)
-            )),
-        ),
+        ("SELECT id FROM Test", Ok(select!(id I64; 2; 2; 2))),
         (
             "SELECT id, num FROM Test",
             Ok(select!(
-                id      | num
-                OptI64  | I64;
-                Some(2) 2;
-                Some(2) 9;
-                Some(2) 4
+                id  | num
+                I64 | I64;
+                2     2;
+                2     9;
+                2     4
             )),
         ),
         (

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -23,7 +23,7 @@ CREATE TABLE Test (
     let test_cases = vec![
         (
             "SELECT id, num, name FROM Test",
-            select_with_empty!(
+            select_with_null!(
                 id     | num    | name;
                 Null     I64(2)   Str("Hello".to_owned());
                 I64(1)   I64(9)   Str("World".to_owned());
@@ -32,21 +32,21 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL AND name = \'Hello\'",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NULL",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id IS NOT NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 I64(1)   I64(9);
                 I64(3)   I64(4)
@@ -54,14 +54,14 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NULL",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id + 1 IS NOT NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 I64(1)   I64(9);
                 I64(3)   I64(4)
@@ -73,7 +73,7 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE 100 IS NOT NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 Null     I64(2);
                 I64(1)   I64(9);
@@ -86,7 +86,7 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE 8 + 3 IS NOT NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 Null     I64(2);
                 I64(1)   I64(9);
@@ -95,7 +95,7 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE NULL IS NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 Null     I64(2);
                 I64(1)   I64(9);
@@ -112,7 +112,7 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NOT NULL",
-            select_with_empty!(
+            select_with_null!(
                 id     | num;
                 Null     I64(2);
                 I64(1)   I64(9);
@@ -121,63 +121,63 @@ CREATE TABLE Test (
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL + 1;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 + NULL;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL - 1;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 - NULL;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL * 1;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 * NULL;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = NULL / 1;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id, num FROM Test WHERE id = 1 / NULL;",
-            select_with_empty!(
+            select_with_null!(
                 id   | num;
                 Null   I64(2)
             ),
         ),
         (
             "SELECT id + 1, 1 + id, id - 1, 1 - id, id * 1, 1 * id, id / 1, 1 / id FROM Test WHERE id = NULL;",
-            select_with_empty!(
+            select_with_null!(
                 "id + 1" | "1 + id" | "id - 1" | "1 - id" | "id * 1" | "1 * id" | "id / 1" | "1 / id";
                 Null       Null       Null       Null       Null       Null       Null       Null
             ),

--- a/src/tests/validate/unique.rs
+++ b/src/tests/validate/unique.rs
@@ -95,7 +95,7 @@ CREATE TABLE TestC (
         ),
         (
             ValidateError::DuplicateEntryOnUniqueField(
-                format!("{:?}", Value::OptI64(Some(2))),
+                format!("{:?}", Value::I64(2)),
                 "id".to_owned(),
             )
             .into(),
@@ -103,7 +103,7 @@ CREATE TABLE TestC (
         ),
         (
             ValidateError::DuplicateEntryOnUniqueField(
-                format!("{:?}", Value::OptI64(Some(3))),
+                format!("{:?}", Value::I64(3)),
                 "id".to_owned(),
             )
             .into(),
@@ -111,7 +111,7 @@ CREATE TABLE TestC (
         ),
         (
             ValidateError::DuplicateEntryOnUniqueField(
-                format!("{:?}", Value::OptI64(Some(1))),
+                format!("{:?}", Value::I64(1)),
                 "id".to_owned(),
             )
             .into(),


### PR DESCRIPTION
Remove `Value::OptBool`, `OptI64`, `OptF64`, `OptStr` and `Empty`.
Now all nullable values are changed to use `Value::Null`.


- **Fix null comparison - now `Value::Null != Value::Null`.**
Due to this change, I need to change `test!` macro to compare `Null` properly.
https://github.com/gluesql/gluesql/compare/add-null-value?expand=1#diff-0332555274be05c9e038aa9524f43b29f55c1b112aea18edcea3a1dbffb4c8cdR94-R165

- **Fix `update.rs` to use `TryFromLiteral` rather than `value.clone_by`.**
It was unavoidable because `Value::Null` cannot provide original type info.

resolve https://github.com/gluesql/gluesql/issues/166

@KyGost yeaaaaah 🚀🚀🚀🚀🚀

