### PR TITLE
Rename AstValue to Literal,

### DIFF
--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -1,121 +1,121 @@
 use {
     super::{error::ValueError, Value},
     crate::result::{Error, Result},
-    sqlparser::ast::{DataType, Value as AstValue},
+    sqlparser::ast::{DataType, Value as Literal},
     std::{cmp::Ordering, convert::TryFrom},
 };
 
-impl PartialEq<AstValue> for Value {
-    fn eq(&self, other: &AstValue) -> bool {
+impl PartialEq<Literal> for Value {
+    fn eq(&self, other: &Literal) -> bool {
         match (self, other) {
-            (Value::Bool(l), AstValue::Boolean(r)) => l == r,
-            (Value::I64(l), AstValue::Number(r, false)) => match r.parse::<i64>() {
+            (Value::Bool(l), Literal::Boolean(r)) => l == r,
+            (Value::I64(l), Literal::Number(r, false)) => match r.parse::<i64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64) == r,
                     Err(_) => false,
                 },
             },
-            (Value::F64(l), AstValue::Number(r, false)) => match r.parse::<f64>() {
+            (Value::F64(l), Literal::Number(r, false)) => match r.parse::<f64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => *l == (r as f64),
                     Err(_) => false,
                 },
             },
-            (Value::Str(l), AstValue::SingleQuotedString(r)) => l == r,
+            (Value::Str(l), Literal::SingleQuotedString(r)) => l == r,
             _ => false,
         }
     }
 }
 
-impl PartialOrd<AstValue> for Value {
-    fn partial_cmp(&self, other: &AstValue) -> Option<Ordering> {
+impl PartialOrd<Literal> for Value {
+    fn partial_cmp(&self, other: &Literal) -> Option<Ordering> {
         match (self, other) {
-            (Value::I64(l), AstValue::Number(r, false)) => match r.parse::<i64>() {
+            (Value::I64(l), Literal::Number(r, false)) => match r.parse::<i64>() {
                 Ok(r) => Some(l.cmp(&r)),
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64).partial_cmp(&r),
                     Err(_) => None,
                 },
             },
-            (Value::F64(l), AstValue::Number(r, false)) => match r.parse::<f64>() {
+            (Value::F64(l), Literal::Number(r, false)) => match r.parse::<f64>() {
                 Ok(r) => l.partial_cmp(&r),
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => l.partial_cmp(&(r as f64)),
                     Err(_) => None,
                 },
             },
-            (Value::Str(l), AstValue::SingleQuotedString(r)) => Some(l.cmp(r)),
+            (Value::Str(l), Literal::SingleQuotedString(r)) => Some(l.cmp(r)),
             _ => None,
         }
     }
 }
 
-impl TryFrom<&AstValue> for Value {
+impl TryFrom<&Literal> for Value {
     type Error = Error;
 
-    fn try_from(literal: &AstValue) -> Result<Self> {
+    fn try_from(literal: &Literal) -> Result<Self> {
         match literal {
-            AstValue::Number(v, false) => v
+            Literal::Number(v, false) => v
                 .parse::<i64>()
                 .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            AstValue::Boolean(v) => Ok(Value::Bool(*v)),
-            AstValue::SingleQuotedString(v) => Ok(Value::Str(v.to_string())),
+            Literal::Boolean(v) => Ok(Value::Bool(*v)),
+            Literal::SingleQuotedString(v) => Ok(Value::Str(v.to_string())),
             _ => Err(ValueError::SqlTypeNotSupported.into()),
         }
     }
 }
 
 pub trait TryFromLiteral {
-    fn try_from_literal(data_type: &DataType, literal: &AstValue) -> Result<Value>;
+    fn try_from_literal(data_type: &DataType, literal: &Literal) -> Result<Value>;
 }
 
 impl TryFromLiteral for Value {
-    fn try_from_literal(data_type: &DataType, literal: &AstValue) -> Result<Value> {
+    fn try_from_literal(data_type: &DataType, literal: &Literal) -> Result<Value> {
         match (data_type, literal) {
-            (DataType::Boolean, AstValue::SingleQuotedString(v))
-            | (DataType::Boolean, AstValue::Number(v, false)) => match v.to_uppercase().as_str() {
+            (DataType::Boolean, Literal::SingleQuotedString(v))
+            | (DataType::Boolean, Literal::Number(v, false)) => match v.to_uppercase().as_str() {
                 "TRUE" | "1" => Ok(Value::Bool(true)),
                 "FALSE" | "0" => Ok(Value::Bool(false)),
                 _ => Err(ValueError::LiteralCastToBooleanFailed(v.to_string()).into()),
             },
-            (DataType::Int, AstValue::SingleQuotedString(v)) => v
+            (DataType::Int, Literal::SingleQuotedString(v)) => v
                 .parse::<i64>()
                 .map(Value::I64)
                 .map_err(|_| ValueError::LiteralCastFromTextToIntegerFailed(v.to_string()).into()),
-            (DataType::Int, AstValue::Number(v, false)) => v
+            (DataType::Int, Literal::Number(v, false)) => v
                 .parse::<f64>()
                 .map_err(|_| {
                     ValueError::UnreachableLiteralCastFromNumberToInteger(v.to_string()).into()
                 })
                 .map(|v| Value::I64(v.trunc() as i64)),
-            (DataType::Int, AstValue::Boolean(v)) => {
+            (DataType::Int, Literal::Boolean(v)) => {
                 let v = if *v { 1 } else { 0 };
 
                 Ok(Value::I64(v))
             }
-            (DataType::Float(_), AstValue::SingleQuotedString(v))
-            | (DataType::Float(_), AstValue::Number(v, false)) => v
+            (DataType::Float(_), Literal::SingleQuotedString(v))
+            | (DataType::Float(_), Literal::Number(v, false)) => v
                 .parse::<f64>()
                 .map(Value::F64)
                 .map_err(|_| ValueError::LiteralCastToFloatFailed(v.to_string()).into()),
-            (DataType::Float(_), AstValue::Boolean(v)) => {
+            (DataType::Float(_), Literal::Boolean(v)) => {
                 let v = if *v { 1.0 } else { 0.0 };
 
                 Ok(Value::F64(v))
             }
-            (DataType::Text, AstValue::Number(v, false)) => Ok(Value::Str(v.to_string())),
-            (DataType::Text, AstValue::Boolean(v)) => {
+            (DataType::Text, Literal::Number(v, false)) => Ok(Value::Str(v.to_string())),
+            (DataType::Text, Literal::Boolean(v)) => {
                 let v = if *v { "TRUE" } else { "FALSE" };
 
                 Ok(Value::Str(v.to_owned()))
             }
-            (DataType::Boolean, AstValue::Null)
-            | (DataType::Int, AstValue::Null)
-            | (DataType::Float(_), AstValue::Null)
-            | (DataType::Text, AstValue::Null) => Ok(Value::Null),
+            (DataType::Boolean, Literal::Null)
+            | (DataType::Int, Literal::Null)
+            | (DataType::Float(_), Literal::Null)
+            | (DataType::Text, Literal::Null) => Ok(Value::Null),
             _ => Err(ValueError::UnimplementedLiteralCast {
                 data_type: data_type.to_string(),
                 literal: literal.to_string(),

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -12,7 +12,7 @@ use {
     futures::stream::{StreamExt, TryStreamExt},
     im_rc::HashMap,
     sqlparser::ast::{
-        BinaryOperator, Expr, Function, FunctionArg, UnaryOperator, Value as AstValue,
+        BinaryOperator, Expr, Function, FunctionArg, UnaryOperator, Value as Literal,
     },
     std::{
         convert::{TryFrom, TryInto},
@@ -40,10 +40,10 @@ pub async fn evaluate<'a, T: 'static + Debug>(
 
     match expr {
         Expr::Value(value) => match value {
-            AstValue::Number(_, false)
-            | AstValue::Boolean(_)
-            | AstValue::SingleQuotedString(_)
-            | AstValue::Null => Ok(Evaluated::LiteralRef(value)),
+            Literal::Number(_, false)
+            | Literal::Boolean(_)
+            | Literal::SingleQuotedString(_)
+            | Literal::Null => Ok(Evaluated::LiteralRef(value)),
             _ => Err(EvaluateError::Unimplemented.into()),
         },
         Expr::Identifier(ident) => match ident.quote_style {

--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use std::fmt::Debug;
 use thiserror::Error;
 
-use sqlparser::ast::{Expr, Offset, Value as AstValue};
+use sqlparser::ast::{Expr, Offset, Value as Literal};
 
 use crate::result::Result;
 
@@ -21,7 +21,7 @@ impl Limit {
     pub fn new(limit: Option<&Expr>, offset: Option<&Offset>) -> Result<Self> {
         let parse = |expr: &Expr| -> Result<usize> {
             match expr {
-                Expr::Value(AstValue::Number(v, false)) => {
+                Expr::Value(Literal::Number(v, false)) => {
                     v.parse().map_err(|_| LimitError::Unreachable.into())
                 }
                 _ => Err(LimitError::Unreachable.into()),

--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -5,7 +5,7 @@ use boolinator::Boolinator;
 use std::iter::once;
 use std::str;
 
-use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident, Value as AstValue};
+use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident, Value as Literal};
 
 use super::{error::err_into, fetch_schema, SledStorage};
 use crate::utils::Vector;
@@ -160,7 +160,7 @@ impl AlterTable for SledStorage {
             (Some(value), _) => try_self!(self, value),
             (None, true) => try_self!(
                 self,
-                Value::from_data_type(&data_type, nullable, &AstValue::Null)
+                Value::from_data_type(&data_type, nullable, &Literal::Null)
             ),
             (None, false) => {
                 return Err((


### PR DESCRIPTION
Two keywords AstValue and literal were used together, but now unify to only use Literal