### PR TITLE
Remove Value::clone_by, replace to Value::TryFrom

### DIFF
--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -63,6 +63,7 @@ impl TryFrom<&Literal> for Value {
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
             Literal::Boolean(v) => Ok(Value::Bool(*v)),
             Literal::SingleQuotedString(v) => Ok(Value::Str(v.to_string())),
+            Literal::Null => Ok(Value::Null),
             _ => Err(ValueError::SqlTypeNotSupported.into()),
         }
     }

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -173,30 +173,6 @@ impl Value {
         }
     }
 
-    pub fn clone_by(&self, literal: &Literal) -> Result<Self> {
-        match (self, literal) {
-            (Value::I64(_), Literal::Number(v, false)) => v
-                .parse()
-                .map(Value::I64)
-                .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::F64(_), Literal::Number(v, false)) => v
-                .parse()
-                .map(Value::F64)
-                .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (Value::Str(_), Literal::SingleQuotedString(v))
-            | (Value::Null, Literal::SingleQuotedString(v)) => Ok(Value::Str(v.clone())),
-            (Value::Bool(_), Literal::Boolean(v)) | (Value::Null, Literal::Boolean(v)) => {
-                Ok(Value::Bool(*v))
-            }
-            (Value::Null, Literal::Number(v, false)) => v
-                .parse::<i64>()
-                .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
-                .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (_, Literal::Null) => Ok(Value::Null),
-            _ => Err(ValueError::LiteralNotSupported.into()),
-        }
-    }
-
     pub fn add(&self, other: &Value) -> Result<Value> {
         use Value::*;
 

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -107,6 +107,15 @@ CREATE TABLE Test (
             select!(id | num),
         ),
         (
+            "SELECT id, num FROM Test WHERE (NULL + id) IS NULL;",
+            select_with_null!(
+                id   | num;
+                Null   I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
+            ),
+        ),
+        (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NULL",
             select!(id | num),
         ),
@@ -115,6 +124,15 @@ CREATE TABLE Test (
             select_with_null!(
                 id     | num;
                 Null     I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
+            ),
+        ),
+        (
+            "SELECT id, num FROM Test WHERE (NULL + id) IS NULL;",
+            select_with_null!(
+                id   | num;
+                Null   I64(2);
                 I64(1)   I64(9);
                 I64(3)   I64(4)
             ),


### PR DESCRIPTION
`clone_by` is not necessary enough to keep, `Value::TryFrom` can take an exact same role.
Remove `Value clone_by` and now `Value::TryFrom` handles all conversion from literal to value.
Also add some more tests to `tests/nullable.rs` which can test other null cases like `NULL + 1 -> Literal`, `NULL + id -> Value`.