### PR TITLE
Remove fake unreachable errors in EvaluateError

### DIFF
--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -36,20 +36,23 @@ pub enum EvaluateError {
     #[error("unsupported compound identifier {0}")]
     UnsupportedCompoundIdentifier(String),
 
-    #[error("unreachable condition base")]
-    UnreachableConditionBase,
+    #[error("unsupported literal binary arithmetic between {0} and {1}")]
+    UnsupportedLiteralBinaryArithmetic(String, String),
 
-    #[error("unreachable evaluated arithmetic")]
-    UnreachableEvaluatedArithmetic,
+    #[error("unsupported evaluated binary arithmetic between {0} and {1}")]
+    UnsupportedEvaluatedBinaryArithmetic(String, String),
+
+    #[error("unsupported evaluated unary arithmetic of {0}")]
+    UnsupportedEvaluatedUnaryArithmetic(String),
+
+    #[error("unimplemented")]
+    Unimplemented,
 
     #[error("unreachable literal arithmetic")]
     UnreachableLiteralArithmetic,
 
     #[error("unreachable empty context")]
     UnreachableEmptyContext,
-
-    #[error("unimplemented")]
-    Unimplemented,
 
     #[error("unreachable named function argument: {0}")]
     UnreachableFunctionArg(String),

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -80,6 +80,24 @@ test_case!(arithmetic, async move {
             UpdateError::ColumnNotFound("aaa".to_owned()).into(),
             "UPDATE Arith SET aaa = 1",
         ),
+        (
+            EvaluateError::UnsupportedLiteralBinaryArithmetic("true".to_owned(), "1".to_owned())
+                .into(),
+            "SELECT * FROM Arith WHERE TRUE + 1 = 1",
+        ),
+        (
+            EvaluateError::UnsupportedEvaluatedBinaryArithmetic(
+                r#"StringRef("asdf")"#.to_owned(),
+                r#"LiteralRef(Number("1", false))"#.to_owned(),
+            )
+            .into(),
+            r#"SELECT * FROM Arith WHERE "asdf" + 1 > 1"#,
+        ),
+        (
+            EvaluateError::UnsupportedEvaluatedUnaryArithmetic(r#"StringRef("asdf")"#.to_owned())
+                .into(),
+            r#"SELECT * FROM Arith WHERE -"asdf" = TRUE;"#,
+        ),
     ];
 
     for (error, sql) in test_cases.into_iter() {

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -116,6 +116,15 @@ CREATE TABLE Test (
             ),
         ),
         (
+            "SELECT id, num FROM Test WHERE (NULL + NULL) IS NULL;",
+            select_with_null!(
+                id   | num;
+                Null   I64(2);
+                I64(1)   I64(9);
+                I64(3)   I64(4)
+            ),
+        ),
+        (
             "SELECT id, num FROM Test WHERE \"NULL\" IS NULL",
             select!(id | num),
         ),


### PR DESCRIPTION
There were some reachable errors in `evaluate.rs` but marked as `Unreachable-`.
Remove some fake unreachable errors, and replace to reachable named errors.