### PR TITLE
Remove Evaluated::StringRef,

### DIFF
--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -107,7 +107,8 @@ impl TryFromLiteral for Value {
 
                 Ok(Value::F64(v))
             }
-            (DataType::Text, Literal::Number(v, false)) => Ok(Value::Str(v.to_string())),
+            (DataType::Text, Literal::Number(v, false))
+            | (DataType::Text, Literal::SingleQuotedString(v)) => Ok(Value::Str(v.to_string())),
             (DataType::Text, Literal::Boolean(v)) => {
                 let v = if *v { "TRUE" } else { "FALSE" };
 

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -21,7 +21,6 @@ impl TryFrom<&Evaluated<'_>> for GroupKey {
             Evaluated::Literal(l) => Value::try_from(l)?.try_into(),
             Evaluated::ValueRef(v) => (*v).try_into(),
             Evaluated::Value(v) => v.try_into(),
-            Evaluated::StringRef(s) => Ok(GroupKey::Str(s.to_string())),
         }
     }
 }

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -39,12 +39,6 @@ pub enum EvaluateError {
     #[error("unsupported literal binary arithmetic between {0} and {1}")]
     UnsupportedLiteralBinaryArithmetic(String, String),
 
-    #[error("unsupported evaluated binary arithmetic between {0} and {1}")]
-    UnsupportedEvaluatedBinaryArithmetic(String, String),
-
-    #[error("unsupported evaluated unary arithmetic of {0}")]
-    UnsupportedEvaluatedUnaryArithmetic(String),
-
     #[error("unimplemented")]
     Unimplemented,
 

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -47,7 +47,9 @@ pub async fn evaluate<'a, T: 'static + Debug>(
             _ => Err(EvaluateError::Unimplemented.into()),
         },
         Expr::Identifier(ident) => match ident.quote_style {
-            Some(_) => Ok(Evaluated::StringRef(&ident.value)),
+            Some(_) => Ok(Evaluated::Literal(Literal::SingleQuotedString(
+                ident.value.to_string(),
+            ))),
             None => {
                 let context = context.ok_or(EvaluateError::UnreachableEmptyContext)?;
 

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -73,7 +73,6 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
                 match evaluate(self.storage, context, None, value, false).await? {
                     Evaluated::LiteralRef(v) => Value::try_from_literal(data_type, v),
                     Evaluated::Literal(v) => Value::try_from_literal(data_type, &v),
-                    Evaluated::StringRef(v) => Ok(Value::Str(v.to_string())),
                     Evaluated::ValueRef(v) => Ok(v.clone()),
                     Evaluated::Value(v) => Ok(v),
                 }

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -85,19 +85,6 @@ test_case!(arithmetic, async move {
                 .into(),
             "SELECT * FROM Arith WHERE TRUE + 1 = 1",
         ),
-        (
-            EvaluateError::UnsupportedEvaluatedBinaryArithmetic(
-                r#"StringRef("asdf")"#.to_owned(),
-                r#"LiteralRef(Number("1", false))"#.to_owned(),
-            )
-            .into(),
-            r#"SELECT * FROM Arith WHERE "asdf" + 1 > 1"#,
-        ),
-        (
-            EvaluateError::UnsupportedEvaluatedUnaryArithmetic(r#"StringRef("asdf")"#.to_owned())
-                .into(),
-            r#"SELECT * FROM Arith WHERE -"asdf" = TRUE;"#,
-        ),
     ];
 
     for (error, sql) in test_cases.into_iter() {


### PR DESCRIPTION
Replace to Evaluated::Literal by cloning string value

`Evaluated::StringRef` was only for storing borrowed string value from `sqlparser::ast::Ident`.
Once it is converted into `Evaluated`, the role was totally same with `Evaluated::Literal`, but it used different enum type.

The only reason of this design was avoiding unnecessary string clone from `Ident` to `Evaluated`.
However, the side effect was huge, it reduced the code quality quite a lot.

Now when `Ident` is provided for evaluate, it simply clone and convert into `Evaluated::Literal`, everything is now simple.

@KyGost Thanks for the suggestion!