### PR TITLE
Add custom enum Literal, it replaces ast::Value

### DIFF
--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -1,0 +1,156 @@
+use {
+    crate::result::{Error, Result},
+    sqlparser::ast::Value as AstValue,
+    std::{borrow::Cow, cmp::Ordering, convert::TryFrom, fmt::Debug},
+    Literal::*,
+};
+
+use {serde::Serialize, thiserror::Error};
+
+#[derive(Error, Serialize, Debug, PartialEq)]
+pub enum LiteralError {
+    #[error("Unsupported literal type: {0}")]
+    UnsupportedLiteralType(String),
+
+    #[error("unsupported literal binary arithmetic between {0} and {1}")]
+    UnsupportedBinaryArithmetic(String, String),
+
+    #[error("literal unary operation on non-numeric")]
+    UnaryOperationOnNonNumeric,
+
+    #[error("unreachable literal binary arithmetic")]
+    UnreachableBinaryArithmetic,
+
+    #[error("unreachable literal unary operation")]
+    UnreachableUnaryOperation,
+}
+
+#[derive(Clone, Debug)]
+pub enum Literal<'a> {
+    Boolean(bool),
+    Number(Cow<'a, String>),
+    Text(Cow<'a, String>),
+    Null,
+}
+
+impl<'a> TryFrom<&'a AstValue> for Literal<'a> {
+    type Error = Error;
+
+    fn try_from(ast_value: &'a AstValue) -> Result<Self> {
+        let literal = match ast_value {
+            AstValue::Boolean(v) => Boolean(*v),
+            AstValue::Number(v, false) => Number(Cow::Borrowed(v)),
+            AstValue::SingleQuotedString(v) => Text(Cow::Borrowed(v)),
+            AstValue::Null => Null,
+            _ => {
+                return Err(LiteralError::UnsupportedLiteralType(ast_value.to_string()).into());
+            }
+        };
+
+        Ok(literal)
+    }
+}
+
+impl PartialEq<Literal<'_>> for Literal<'_> {
+    fn eq(&self, other: &Literal) -> bool {
+        match (self, other) {
+            (Boolean(l), Boolean(r)) => l == r,
+            (Number(l), Number(r)) | (Text(l), Text(r)) => l == r,
+            _ => false,
+        }
+    }
+}
+
+impl PartialOrd<Literal<'_>> for Literal<'_> {
+    fn partial_cmp(&self, other: &Literal) -> Option<Ordering> {
+        match (self, other) {
+            (Boolean(l), Boolean(r)) => Some(l.cmp(r)),
+            (Number(l), Number(r)) => match (l.parse::<i64>(), r.parse::<i64>()) {
+                (Ok(l), Ok(r)) => Some(l.cmp(&r)),
+                (_, Ok(r)) => match l.parse::<f64>() {
+                    Ok(l) => l.partial_cmp(&(r as f64)),
+                    _ => None,
+                },
+                (Ok(l), _) => match r.parse::<f64>() {
+                    Ok(r) => (l as f64).partial_cmp(&r),
+                    _ => None,
+                },
+                _ => match (l.parse::<f64>(), r.parse::<f64>()) {
+                    (Ok(l), Ok(r)) => l.partial_cmp(&r),
+                    _ => None,
+                },
+            },
+            (Text(l), Text(r)) => Some(l.cmp(r)),
+            _ => None,
+        }
+    }
+}
+
+macro_rules! binary_op {
+    ($name:ident, $op:tt) => {
+        pub fn $name<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+            match (self, other) {
+                (Number(l), Number(r)) => {
+                    match (l.parse::<i64>(), r.parse::<i64>()) {
+                        (Ok(l), Ok(r)) => Ok((l $op r).to_string()),
+                        (Ok(l), _) => match r.parse::<f64>() {
+                            Ok(r) => Ok(((l as f64) $op r).to_string()),
+                            _ => Err(LiteralError::UnreachableBinaryArithmetic.into()),
+                        },
+                        (_, Ok(r)) => match l.parse::<f64>() {
+                            Ok(l) => Ok((l $op (r as f64)).to_string()),
+                            _ => Err(LiteralError::UnreachableBinaryArithmetic.into()),
+                        },
+                        (_, _) => match (l.parse::<f64>(), r.parse::<f64>()) {
+                            (Ok(l), Ok(r)) => Ok((l $op r).to_string()),
+                            _ => Err(LiteralError::UnreachableBinaryArithmetic.into()),
+                        },
+                    }.map(|v| Number(Cow::Owned(v)))
+                }
+                (Null, Number(_))
+                | (Number(_), Null)
+                | (Null, Null) => {
+                    Ok(Literal::Null)
+                }
+                _ => Err(
+                    LiteralError::UnsupportedBinaryArithmetic(
+                        format!("{:?}", self),
+                        format!("{:?}", other),
+                    ).into()
+                ),
+            }
+        }
+    }
+}
+
+impl<'a> Literal<'a> {
+    pub fn unary_plus(&self) -> Result<Self> {
+        match self {
+            Number(v) => v
+                .parse::<i64>()
+                .map(|_| self.to_owned())
+                .or_else(|_| v.parse::<f64>().map(|_| self.to_owned()))
+                .map_err(|_| LiteralError::UnreachableUnaryOperation.into()),
+            Null => Ok(Null),
+            _ => Err(LiteralError::UnaryOperationOnNonNumeric.into()),
+        }
+    }
+
+    pub fn unary_minus(&self) -> Result<Self> {
+        match self {
+            Number(v) => v
+                .parse::<i64>()
+                .map(|v| (-v).to_string())
+                .or_else(|_| v.parse::<f64>().map(|v| (-v).to_string()))
+                .map(|v| Number(Cow::Owned(v)))
+                .map_err(|_| LiteralError::UnreachableUnaryOperation.into()),
+            Null => Ok(Null),
+            _ => Err(LiteralError::UnaryOperationOnNonNumeric.into()),
+        }
+    }
+
+    binary_op!(add, +);
+    binary_op!(subtract, -);
+    binary_op!(multiply, *);
+    binary_op!(divide, /);
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,9 +1,11 @@
+mod literal;
 mod row;
 mod schema;
 mod table;
 pub mod value;
 
 pub use {
+    literal::{Literal, LiteralError},
     row::{Row, RowError},
     schema::Schema,
     table::{get_name, Table, TableError},

--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -1,92 +1,111 @@
 use {
     super::{error::ValueError, Value},
-    crate::result::{Error, Result},
-    sqlparser::ast::{DataType, Value as Literal},
+    crate::{
+        data::Literal,
+        result::{Error, Result},
+    },
+    sqlparser::ast::DataType,
     std::{cmp::Ordering, convert::TryFrom},
 };
 
-impl PartialEq<Literal> for Value {
-    fn eq(&self, other: &Literal) -> bool {
+impl PartialEq<Literal<'_>> for Value {
+    fn eq(&self, other: &Literal<'_>) -> bool {
         match (self, other) {
             (Value::Bool(l), Literal::Boolean(r)) => l == r,
-            (Value::I64(l), Literal::Number(r, false)) => match r.parse::<i64>() {
+            (Value::I64(l), Literal::Number(r)) => match r.parse::<i64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64) == r,
                     Err(_) => false,
                 },
             },
-            (Value::F64(l), Literal::Number(r, false)) => match r.parse::<f64>() {
+            (Value::F64(l), Literal::Number(r)) => match r.parse::<f64>() {
                 Ok(r) => l == &r,
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => *l == (r as f64),
                     Err(_) => false,
                 },
             },
-            (Value::Str(l), Literal::SingleQuotedString(r)) => l == r,
+            (Value::Str(l), Literal::Text(r)) => l == r.as_ref(),
             _ => false,
         }
     }
 }
 
-impl PartialOrd<Literal> for Value {
-    fn partial_cmp(&self, other: &Literal) -> Option<Ordering> {
+impl PartialOrd<Literal<'_>> for Value {
+    fn partial_cmp(&self, other: &Literal<'_>) -> Option<Ordering> {
         match (self, other) {
-            (Value::I64(l), Literal::Number(r, false)) => match r.parse::<i64>() {
+            (Value::I64(l), Literal::Number(r)) => match r.parse::<i64>() {
                 Ok(r) => Some(l.cmp(&r)),
                 Err(_) => match r.parse::<f64>() {
                     Ok(r) => (*l as f64).partial_cmp(&r),
                     Err(_) => None,
                 },
             },
-            (Value::F64(l), Literal::Number(r, false)) => match r.parse::<f64>() {
+            (Value::F64(l), Literal::Number(r)) => match r.parse::<f64>() {
                 Ok(r) => l.partial_cmp(&r),
                 Err(_) => match r.parse::<i64>() {
                     Ok(r) => l.partial_cmp(&(r as f64)),
                     Err(_) => None,
                 },
             },
-            (Value::Str(l), Literal::SingleQuotedString(r)) => Some(l.cmp(r)),
+            (Value::Str(l), Literal::Text(r)) => Some(l.cmp(r.as_ref())),
             _ => None,
         }
     }
 }
 
-impl TryFrom<&Literal> for Value {
+impl TryFrom<&Literal<'_>> for Value {
     type Error = Error;
 
-    fn try_from(literal: &Literal) -> Result<Self> {
+    fn try_from(literal: &Literal<'_>) -> Result<Self> {
         match literal {
-            Literal::Number(v, false) => v
+            Literal::Number(v) => v
                 .parse::<i64>()
                 .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
             Literal::Boolean(v) => Ok(Value::Bool(*v)),
-            Literal::SingleQuotedString(v) => Ok(Value::Str(v.to_string())),
+            Literal::Text(v) => Ok(Value::Str(v.as_ref().to_owned())),
             Literal::Null => Ok(Value::Null),
-            _ => Err(ValueError::SqlTypeNotSupported.into()),
+        }
+    }
+}
+
+impl TryFrom<Literal<'_>> for Value {
+    type Error = Error;
+
+    fn try_from(literal: Literal<'_>) -> Result<Self> {
+        match literal {
+            Literal::Number(v) => v
+                .parse::<i64>()
+                .map_or_else(|_| v.parse::<f64>().map(Value::F64), |v| Ok(Value::I64(v)))
+                .map_err(|_| ValueError::FailedToParseNumber.into()),
+            Literal::Boolean(v) => Ok(Value::Bool(v)),
+            Literal::Text(v) => Ok(Value::Str(v.into_owned())),
+            Literal::Null => Ok(Value::Null),
         }
     }
 }
 
 pub trait TryFromLiteral {
-    fn try_from_literal(data_type: &DataType, literal: &Literal) -> Result<Value>;
+    fn try_from_literal(data_type: &DataType, literal: &Literal<'_>) -> Result<Value>;
 }
 
 impl TryFromLiteral for Value {
-    fn try_from_literal(data_type: &DataType, literal: &Literal) -> Result<Value> {
+    fn try_from_literal(data_type: &DataType, literal: &Literal<'_>) -> Result<Value> {
         match (data_type, literal) {
-            (DataType::Boolean, Literal::SingleQuotedString(v))
-            | (DataType::Boolean, Literal::Number(v, false)) => match v.to_uppercase().as_str() {
-                "TRUE" | "1" => Ok(Value::Bool(true)),
-                "FALSE" | "0" => Ok(Value::Bool(false)),
-                _ => Err(ValueError::LiteralCastToBooleanFailed(v.to_string()).into()),
-            },
-            (DataType::Int, Literal::SingleQuotedString(v)) => v
+            (DataType::Boolean, Literal::Text(v)) | (DataType::Boolean, Literal::Number(v)) => {
+                match v.to_uppercase().as_str() {
+                    "TRUE" | "1" => Ok(Value::Bool(true)),
+                    "FALSE" | "0" => Ok(Value::Bool(false)),
+                    _ => Err(ValueError::LiteralCastToBooleanFailed(v.to_string()).into()),
+                }
+            }
+            (DataType::Int, Literal::Text(v)) => v
                 .parse::<i64>()
                 .map(Value::I64)
                 .map_err(|_| ValueError::LiteralCastFromTextToIntegerFailed(v.to_string()).into()),
-            (DataType::Int, Literal::Number(v, false)) => v
+            (DataType::Int, Literal::Number(v)) => v
                 .parse::<f64>()
                 .map_err(|_| {
                     ValueError::UnreachableLiteralCastFromNumberToInteger(v.to_string()).into()
@@ -97,8 +116,7 @@ impl TryFromLiteral for Value {
 
                 Ok(Value::I64(v))
             }
-            (DataType::Float(_), Literal::SingleQuotedString(v))
-            | (DataType::Float(_), Literal::Number(v, false)) => v
+            (DataType::Float(_), Literal::Text(v)) | (DataType::Float(_), Literal::Number(v)) => v
                 .parse::<f64>()
                 .map(Value::F64)
                 .map_err(|_| ValueError::LiteralCastToFloatFailed(v.to_string()).into()),
@@ -107,8 +125,9 @@ impl TryFromLiteral for Value {
 
                 Ok(Value::F64(v))
             }
-            (DataType::Text, Literal::Number(v, false))
-            | (DataType::Text, Literal::SingleQuotedString(v)) => Ok(Value::Str(v.to_string())),
+            (DataType::Text, Literal::Number(v)) | (DataType::Text, Literal::Text(v)) => {
+                Ok(Value::Str(v.to_string()))
+            }
             (DataType::Text, Literal::Boolean(v)) => {
                 let v = if *v { "TRUE" } else { "FALSE" };
 
@@ -120,7 +139,7 @@ impl TryFromLiteral for Value {
             | (DataType::Text, Literal::Null) => Ok(Value::Null),
             _ => Err(ValueError::UnimplementedLiteralCast {
                 data_type: data_type.to_string(),
-                literal: literal.to_string(),
+                literal: format!("{:?}", literal),
             }
             .into()),
         }

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -1,9 +1,10 @@
 use {
+    super::Literal,
     crate::result::Result,
     boolinator::Boolinator,
     serde::{Deserialize, Serialize},
-    sqlparser::ast::{DataType, Expr, Ident, Value as Literal},
-    std::{cmp::Ordering, fmt::Debug},
+    sqlparser::ast::{DataType, Expr, Ident},
+    std::{cmp::Ordering, convert::TryFrom, fmt::Debug},
 };
 
 mod error;
@@ -67,7 +68,9 @@ impl BoolToValue for bool {
 impl Value {
     pub fn from_expr(data_type: &DataType, nullable: bool, expr: &Expr) -> Result<Self> {
         match expr {
-            Expr::Value(literal) => Value::from_data_type(&data_type, nullable, literal),
+            Expr::Value(literal) => {
+                Value::from_data_type(&data_type, nullable, Literal::try_from(literal)?)
+            }
             Expr::Identifier(Ident { value, .. }) => Ok(Value::Str(value.clone())),
             _ => Err(ValueError::ExprNotSupported(expr.to_string()).into()),
         }
@@ -87,18 +90,22 @@ impl Value {
         )
     }
 
-    pub fn from_data_type(data_type: &DataType, nullable: bool, literal: &Literal) -> Result<Self> {
+    pub fn from_data_type(
+        data_type: &DataType,
+        nullable: bool,
+        literal: Literal<'_>,
+    ) -> Result<Self> {
         match (data_type, literal) {
-            (DataType::Int, Literal::Number(v, false)) => v
+            (DataType::Int, Literal::Number(v)) => v
                 .parse()
                 .map(Value::I64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (DataType::Float(_), Literal::Number(v, false)) => v
+            (DataType::Float(_), Literal::Number(v)) => v
                 .parse()
                 .map(Value::F64)
                 .map_err(|_| ValueError::FailedToParseNumber.into()),
-            (DataType::Boolean, Literal::Boolean(v)) => Ok(Value::Bool(*v)),
-            (DataType::Text, Literal::SingleQuotedString(v)) => Ok(Value::Str(v.clone())),
+            (DataType::Boolean, Literal::Boolean(v)) => Ok(Value::Bool(v)),
+            (DataType::Text, Literal::Text(v)) => Ok(Value::Str(v.into_owned())),
             (DataType::Int, Literal::Null)
             | (DataType::Float(_), Literal::Null)
             | (DataType::Boolean, Literal::Null)

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -17,7 +17,7 @@ impl TryFrom<&Evaluated<'_>> for GroupKey {
 
     fn try_from(evaluated: &Evaluated<'_>) -> Result<Self> {
         match evaluated {
-            Evaluated::Literal(l) => Value::try_from(l.as_ref())?.try_into(),
+            Evaluated::Literal(l) => Value::try_from(l)?.try_into(),
             Evaluated::Value(v) => v.as_ref().try_into(),
         }
     }

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -10,9 +10,6 @@ pub enum EvaluateError {
     #[error("literal add on non-numeric")]
     LiteralAddOnNonNumeric,
 
-    #[error("unary operation on non-numeric")]
-    LiteralUnaryOperationOnNonNumeric,
-
     #[error("function is not supported: {0}")]
     FunctionNotSupported(String),
 
@@ -36,14 +33,8 @@ pub enum EvaluateError {
     #[error("unsupported compound identifier {0}")]
     UnsupportedCompoundIdentifier(String),
 
-    #[error("unsupported literal binary arithmetic between {0} and {1}")]
-    UnsupportedLiteralBinaryArithmetic(String, String),
-
     #[error("unimplemented")]
     Unimplemented,
-
-    #[error("unreachable literal arithmetic")]
-    UnreachableLiteralArithmetic,
 
     #[error("unreachable empty context")]
     UnreachableEmptyContext,

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -71,7 +71,7 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
                 let ColumnDef { data_type, .. } = column_def;
 
                 match evaluate(self.storage, context, None, value, false).await? {
-                    Evaluated::Literal(v) => Value::try_from_literal(data_type, v.as_ref()),
+                    Evaluated::Literal(v) => Value::try_from_literal(data_type, &v),
                     Evaluated::Value(v) => Ok(v.into_owned()),
                 }
                 .map(Some)

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        data::{RowError, TableError, ValueError},
+        data::{LiteralError, RowError, TableError, ValueError},
         executor::{
             AggregateError, BlendError, CreateTableError, EvaluateError, ExecuteError, FetchError,
             FilterError, JoinError, LimitError, SelectError, UpdateError, ValidateError,
@@ -52,6 +52,8 @@ pub enum Error {
     #[error(transparent)]
     Value(#[from] ValueError),
     #[error(transparent)]
+    Literal(#[from] LiteralError),
+    #[error(transparent)]
     CreateTable(#[from] CreateTableError),
 }
 
@@ -79,6 +81,7 @@ impl PartialEq for Error {
             (Table(e), Table(e2)) => e == e2,
             (Validate(e), Validate(e2)) => e == e2,
             (Value(e), Value(e2)) => e == e2,
+            (Literal(e), Literal(e2)) => e == e2,
             (CreateTable(e), CreateTable(e2)) => e == e2,
             _ => false,
         }

--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -5,7 +5,7 @@ use boolinator::Boolinator;
 use std::iter::once;
 use std::str;
 
-use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident, Value as Literal};
+use sqlparser::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Ident};
 
 use super::{error::err_into, fetch_schema, SledStorage};
 use crate::utils::Vector;
@@ -158,10 +158,7 @@ impl AlterTable for SledStorage {
 
         let value = match (default, nullable) {
             (Some(value), _) => try_self!(self, value),
-            (None, true) => try_self!(
-                self,
-                Value::from_data_type(&data_type, nullable, &Literal::Null)
-            ),
+            (None, true) => Value::Null,
             (None, false) => {
                 return Err((
                     self,

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use {crate::*, std::borrow::Cow};
 
 test_case!(arithmetic, async move {
     run!(
@@ -81,8 +81,11 @@ test_case!(arithmetic, async move {
             "UPDATE Arith SET aaa = 1",
         ),
         (
-            EvaluateError::UnsupportedLiteralBinaryArithmetic("true".to_owned(), "1".to_owned())
-                .into(),
+            LiteralError::UnsupportedBinaryArithmetic(
+                format!("{:?}", data::Literal::Boolean(true)),
+                format!("{:?}", data::Literal::Number(Cow::Owned("1".to_owned()))),
+            )
+            .into(),
             "SELECT * FROM Arith WHERE TRUE + 1 = 1",
         ),
     ];

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -46,6 +46,10 @@ test_case!(error, async move {
             RowError::TooManyValues.into(),
             "INSERT INTO TableA VALUES (100), (100, 200);",
         ),
+        (
+            LiteralError::UnsupportedLiteralType(r#"X'123'"#.to_owned()).into(),
+            "SELECT * FROM TableA Where id = X'123';",
+        ),
         #[cfg(feature = "alter-table")]
         (
             ExecuteError::UnsupportedAlterTableOperation(

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -95,11 +95,11 @@ test_case!(filter, async move {
 
     let error_sqls = vec![
         (
-            EvaluateError::LiteralUnaryOperationOnNonNumeric.into(),
+            LiteralError::UnaryOperationOnNonNumeric.into(),
             "SELECT id FROM Hunter WHERE +'abcd' > 1.0",
         ),
         (
-            EvaluateError::LiteralUnaryOperationOnNonNumeric.into(),
+            LiteralError::UnaryOperationOnNonNumeric.into(),
             "SELECT id FROM Hunter WHERE -'abcd' < 1.0",
         ),
         (

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -86,7 +86,7 @@ test_case!(cast_literal, async move {
             r#"SELECT CAST(NULL AS NULL) FROM Item"#,
             Err(ValueError::UnimplementedLiteralCast {
                 data_type: "NULL".to_owned(),
-                literal: "NULL".to_owned(),
+                literal: format!("{:?}", data::Literal::Null),
             }
             .into()),
         ),


### PR DESCRIPTION
Now Literal means crate::data::Literal, no more sqlparser::ast::Value.

`sqlparser::ast::Value as Literal` was superset of literals what GlueSQL needs.
By using `enum Literal`, we can define `Literal` more clearly.

resolve https://github.com/gluesql/gluesql/issues/178

@KyGost it was quite a tough work, yeah! 🚀
