### PR TITLE
Remove Value::from_data_type, merge to TryFromLiteral trait for Value

### DIFF
--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -2,14 +2,8 @@ use {serde::Serialize, std::fmt::Debug, thiserror::Error};
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum ValueError {
-    #[error("sql type not supported yet")]
-    SqlTypeNotSupported,
-
-    #[error("literal not supported yet")]
-    LiteralNotSupported,
-
-    #[error("ast expr not supported: {0}")]
-    ExprNotSupported(String),
+    #[error("literal: {literal} is incompatible with data type: {data_type}")]
+    IncompatibleLiteralForDataType { data_type: String, literal: String },
 
     #[error("failed to parse number")]
     FailedToParseNumber,
@@ -37,6 +31,9 @@ pub enum ValueError {
 
     #[error("unary minus operation for non numeric value")]
     UnaryMinusOnNonNumeric,
+
+    #[error("unreachable failure on parsing number")]
+    UnreachableNumberParsing,
 
     #[error("floating columns cannot be set to unique constraint")]
     ConflictOnFloatWithUniqueConstraint,

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -109,7 +109,7 @@ impl<'a> Evaluated<'a> {
     }
 
     pub fn cast(self, data_type: &DataType) -> Result<Evaluated<'a>> {
-        let cast_literal = |literal: &Literal| Value::try_from_literal(data_type, literal);
+        let cast_literal = |literal: &Literal| Value::try_cast_from_literal(data_type, literal);
         let cast_value = |value: &Value| value.cast(data_type);
 
         match self {

--- a/src/tests/alter_table.rs
+++ b/src/tests/alter_table.rs
@@ -80,7 +80,7 @@ test_case!(add_drop, async move {
         ),
         (
             "ALTER TABLE Foo ADD COLUMN something INTEGER DEFAULT (SELECT id FROM Bar LIMIT 1)",
-            Err(ValueError::ExprNotSupported("(SELECT id FROM Bar LIMIT 1)".to_owned()).into()),
+            Err(LiteralError::UnsupportedExpr("(SELECT id FROM Bar LIMIT 1)".to_owned()).into()),
         ),
         (
             "ALTER TABLE Foo DROP COLUMN IF EXISTS something;",

--- a/src/tests/migrate.rs
+++ b/src/tests/migrate.rs
@@ -21,12 +21,12 @@ test_case!(migrate, async move {
 
     let error_cases = vec![
         (
-            ValueError::ExprNotSupported("3 * 2".to_owned()).into(),
+            LiteralError::UnsupportedExpr("3 * 2".to_owned()).into(),
             "INSERT INTO Test (id, num) VALUES (3 * 2, 1);",
         ),
         (
             ValueError::FailedToParseNumber.into(),
-            "INSERT INTO Test (id, num) VALUES (1.1, 1);",
+            r#"INSERT INTO Test (id, num, name) VALUES (1.1, 1, "good");"#,
         ),
         (
             EvaluateError::UnsupportedCompoundIdentifier("Here.User.id".to_owned()).into(),

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -230,7 +230,7 @@ CREATE TABLE Test (
             )),
         ),
         (
-            "INSERT INTO Test VALUES (1, NULL)",
+            r#"INSERT INTO Test VALUES (1, NULL, "ok")"#,
             Err(ValueError::NullValueOnNotNullField.into()),
         ),
     ];


### PR DESCRIPTION
Remove `Value::from_data_type` and merge to `TryFromLiteral` trait which has impl for `Value`.

However, this is still a temporal refactoring.
Once after we use `evaluate` to handle `expr`, then we can remove `Value::from_expr`.