### PR TITLE
Remove `cargo bench` from GitHub Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,5 +35,3 @@ jobs:
       run: cargo test --features sled-storage --verbose
     - name: Run tests with all features
       run: cargo test --all-features --verbose
-    - name: Run benchmarks
-      run: cargo bench

--- a/benches/sled_benchmark.rs
+++ b/benches/sled_benchmark.rs
@@ -2,6 +2,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use gluesql::{parse, Glue, SledStorage};
 use std::convert::TryFrom;
 
+const ITEM_SIZE: u32 = 5000;
+
 // Generate benchmark tests
 pub fn bench_insert(c: &mut Criterion) {
     // Generate a new database
@@ -79,8 +81,8 @@ pub fn bench_select(c: &mut Criterion) {
             field_three TEXT
         );"
         .to_string();
-        // Insert 100k elements
-        for i in 0..100000 {
+
+        for i in 0..ITEM_SIZE {
             sqls += &*format!(
                 "INSERT INTO Testing \
             VALUES ({:#}, \"Testing 1\", \"Testing 2\", \"Testing 3\");",
@@ -100,7 +102,7 @@ pub fn bench_select(c: &mut Criterion) {
         b.iter(|| {
             let query_str = format!("SELECT * FROM Testing WHERE id = {}", id);
             id += 1;
-            if id >= 10000 {
+            if id >= ITEM_SIZE {
                 id = 1;
             }
             for query in parse(&query_str).unwrap() {
@@ -116,7 +118,7 @@ pub fn bench_select(c: &mut Criterion) {
                 id + 50
             );
             id += 1;
-            if id >= 10000 {
+            if id >= ITEM_SIZE {
                 id = 1;
             }
             for query in parse(&query_str).unwrap() {
@@ -160,8 +162,8 @@ pub fn bench_select_tainted(c: &mut Criterion) {
         );
         "
         .to_string();
-        // Insert 100k elements
-        for i in 0..100000 {
+
+        for i in 0..ITEM_SIZE {
             sqls += &*format!(
                 "INSERT INTO Testing \
             VALUES ({0:#}, \"Testing 1\", \"Testing 2\", \"Testing 3\");\
@@ -183,7 +185,7 @@ pub fn bench_select_tainted(c: &mut Criterion) {
         b.iter(|| {
             let query_str = format!("SELECT * FROM Testing WHERE id = {}", id);
             id += 1;
-            if id >= 10000 {
+            if id >= ITEM_SIZE {
                 id = 1;
             }
             for query in parse(&query_str).unwrap() {
@@ -199,7 +201,7 @@ pub fn bench_select_tainted(c: &mut Criterion) {
                 id + 50
             );
             id += 1;
-            if id >= 10000 {
+            if id >= ITEM_SIZE {
                 id = 1;
             }
             for query in parse(&query_str).unwrap() {


### PR DESCRIPTION
Previous item size was unnecessary too big and bench library itself also warned about it.

Now reduce the size to 5k and someone who wants to increase can easily do it by changing the `ITEM_SIZE` constant.

@KyGost Thanks :)