### PR TITLE
Small cleanups - reduce unwrap(), etc

### DIFF
--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -30,8 +30,8 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
         Self { storage, fields }
     }
 
-    pub async fn apply(&self, context: Result<AggregateContext<'a>>) -> Result<Row> {
-        let AggregateContext { aggregated, next } = context?;
+    pub async fn apply(&self, context: AggregateContext<'a>) -> Result<Row> {
+        let AggregateContext { aggregated, next } = context;
         let values = self.blend(aggregated, next).await?;
 
         Ok(Row(values))

--- a/src/executor/context/blend_context.rs
+++ b/src/executor/context/blend_context.rs
@@ -8,8 +8,8 @@ use crate::data::{Row, Value};
 #[derive(Debug)]
 pub struct BlendContext<'a> {
     table_alias: &'a str,
-    pub columns: Rc<[Ident]>,
-    pub row: Option<Row>,
+    columns: Rc<[Ident]>,
+    row: Option<Row>,
     next: Option<Rc<BlendContext<'a>>>,
 }
 

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -243,7 +243,7 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
         .and_then(move |aggregate_context| {
             let blend = Rc::clone(&blend);
 
-            async move { blend.apply(Ok(aggregate_context)).await }
+            async move { blend.apply(aggregate_context).await }
         });
 
     Ok((labels, rows))


### PR DESCRIPTION
In the `fetch.rs` fetch function, it was unnecessarily using `BlendContext`.
Removed `BlendContext` uses in `fetch.rs` and made member variables in `BlendContext` to private.