### PR TITLE
Support binary arithmetic operations between Value::I64 and Value::F64

### DIFF
--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -14,17 +14,17 @@ pub enum ValueError {
     #[error("failed to parse number")]
     FailedToParseNumber,
 
-    #[error("add on non numeric value")]
-    AddOnNonNumeric,
+    #[error("add on non-numeric values: {0} + {1}")]
+    AddOnNonNumeric(String, String),
 
-    #[error("subtract on non numeric value")]
-    SubtractOnNonNumeric,
+    #[error("subtract on non-numeric values: {0} - {1}")]
+    SubtractOnNonNumeric(String, String),
 
-    #[error("multiply on non numeric value")]
-    MultiplyOnNonNumeric,
+    #[error("multiply on non-numeric values: {0} * {1}")]
+    MultiplyOnNonNumeric(String, String),
 
-    #[error("divide on non numeric value")]
-    DivideOnNonNumeric,
+    #[error("divide on non-numeric values: {0} / {1}")]
+    DivideOnNonNumeric(String, String),
 
     #[error("floating numbers cannot be grouped by")]
     FloatCannotBeGroupedBy,

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -144,7 +144,9 @@ impl Value {
             (Null, I64(_)) | (Null, F64(_)) | (I64(_), Null) | (F64(_), Null) | (Null, Null) => {
                 Ok(Null)
             }
-            _ => Err(ValueError::AddOnNonNumeric.into()),
+            _ => Err(
+                ValueError::AddOnNonNumeric(format!("{:?}", self), format!("{:?}", other)).into(),
+            ),
         }
     }
 
@@ -159,7 +161,11 @@ impl Value {
             (Null, I64(_)) | (Null, F64(_)) | (I64(_), Null) | (F64(_), Null) | (Null, Null) => {
                 Ok(Null)
             }
-            _ => Err(ValueError::SubtractOnNonNumeric.into()),
+            _ => Err(ValueError::SubtractOnNonNumeric(
+                format!("{:?}", self),
+                format!("{:?}", other),
+            )
+            .into()),
         }
     }
 
@@ -173,7 +179,11 @@ impl Value {
             (Null, I64(_)) | (Null, F64(_)) | (I64(_), Null) | (F64(_), Null) | (Null, Null) => {
                 Ok(Null)
             }
-            _ => Err(ValueError::MultiplyOnNonNumeric.into()),
+            _ => Err(ValueError::MultiplyOnNonNumeric(
+                format!("{:?}", self),
+                format!("{:?}", other),
+            )
+            .into()),
         }
     }
 
@@ -188,7 +198,10 @@ impl Value {
             (Null, I64(_)) | (Null, F64(_)) | (I64(_), Null) | (F64(_), Null) | (Null, Null) => {
                 Ok(Null)
             }
-            _ => Err(ValueError::DivideOnNonNumeric.into()),
+            _ => Err(
+                ValueError::DivideOnNonNumeric(format!("{:?}", self), format!("{:?}", other))
+                    .into(),
+            ),
         }
     }
 

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -61,19 +61,35 @@ test_case!(arithmetic, async move {
 
     let test_cases = vec![
         (
-            ValueError::AddOnNonNumeric.into(),
+            ValueError::AddOnNonNumeric(
+                format!("{:?}", Value::Str("A".to_owned())),
+                format!("{:?}", Value::I64(1)),
+            )
+            .into(),
             "SELECT * FROM Arith WHERE name + id < 1",
         ),
         (
-            ValueError::SubtractOnNonNumeric.into(),
+            ValueError::SubtractOnNonNumeric(
+                format!("{:?}", Value::Str("A".to_owned())),
+                format!("{:?}", Value::I64(1)),
+            )
+            .into(),
             "SELECT * FROM Arith WHERE name - id < 1",
         ),
         (
-            ValueError::MultiplyOnNonNumeric.into(),
+            ValueError::MultiplyOnNonNumeric(
+                format!("{:?}", Value::Str("A".to_owned())),
+                format!("{:?}", Value::I64(1)),
+            )
+            .into(),
             "SELECT * FROM Arith WHERE name * id < 1",
         ),
         (
-            ValueError::DivideOnNonNumeric.into(),
+            ValueError::DivideOnNonNumeric(
+                format!("{:?}", Value::Str("A".to_owned())),
+                format!("{:?}", Value::I64(1)),
+            )
+            .into(),
             "SELECT * FROM Arith WHERE name / id < 1",
         ),
         (


### PR DESCRIPTION
Arithmetic operation between Value and Literal or Literal and Literal are supported properly.
However, between `Value::I64` and `Value::F64`, it wasn't.

Now it supports `I64(1) + F64(2.0)` like arithmetic operations between `I64` and `F64`.