### PR TITLE
Merge filter->check_expr function into evaluate

### DIFF
--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -27,6 +27,7 @@ impl From<Value> for String {
 
 impl TryInto<bool> for &Value {
     type Error = Error;
+
     fn try_into(self) -> Result<bool> {
         Ok(match self {
             Value::Bool(value) => *value,
@@ -53,8 +54,18 @@ impl TryInto<bool> for &Value {
         })
     }
 }
+
+impl TryInto<bool> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<bool> {
+        (&self).try_into()
+    }
+}
+
 impl TryInto<i64> for &Value {
     type Error = Error;
+
     fn try_into(self) -> Result<i64> {
         Ok(match self {
             Value::Bool(value) => {
@@ -73,8 +84,10 @@ impl TryInto<i64> for &Value {
         })
     }
 }
+
 impl TryInto<f64> for &Value {
     type Error = Error;
+
     fn try_into(self) -> Result<f64> {
         Ok(match self {
             Value::Bool(value) => {

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -205,10 +205,8 @@ impl Value {
         }
     }
 
-    pub fn is_some(&self) -> bool {
-        use Value::*;
-
-        !matches!(self, Null)
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
     }
 
     pub fn unary_plus(&self) -> Result<Value> {

--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -224,10 +224,10 @@ fn aggregate<'a>(
                     let value = Value::I64(match expr {
                         Expr::Wildcard => 1,
                         _ => {
-                            if get_value(expr)?.is_some() {
-                                1
-                            } else {
+                            if get_value(expr)?.is_null() {
                                 0
+                            } else {
+                                1
                             }
                         }
                     });

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -146,10 +146,10 @@ impl<'a> Evaluated<'a> {
         Ok(evaluated)
     }
 
-    pub fn is_some(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         match self {
-            Evaluated::Value(v) => v.is_some(),
-            Evaluated::Literal(v) => !matches!(v, &Literal::Null),
+            Evaluated::Value(v) => v.is_null(),
+            Evaluated::Literal(v) => matches!(v, &Literal::Null),
         }
     }
 }

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -41,6 +41,16 @@ impl TryInto<Value> for Evaluated<'_> {
     }
 }
 
+impl TryInto<bool> for Evaluated<'_> {
+    type Error = Error;
+
+    fn try_into(self) -> Result<bool> {
+        let value: Value = self.try_into()?;
+
+        value.try_into()
+    }
+}
+
 impl<'a> PartialEq for Evaluated<'a> {
     fn eq(&self, other: &Evaluated<'a>) -> bool {
         match (self, other) {

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -222,14 +222,14 @@ pub async fn evaluate<'a, T: 'static + Debug>(
             Ok(Evaluated::from(Value::Bool(v)))
         }
         Expr::IsNull(expr) => {
-            let v = !eval(expr).await?.is_some();
+            let v = eval(expr).await?.is_null();
 
             Ok(Evaluated::from(Value::Bool(v)))
         }
         Expr::IsNotNull(expr) => {
-            let v = eval(expr).await?.is_some();
+            let v = eval(expr).await?.is_null();
 
-            Ok(Evaluated::from(Value::Bool(v)))
+            Ok(Evaluated::from(Value::Bool(!v)))
         }
         _ => Err(EvaluateError::Unimplemented.into()),
     }

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -1,26 +1,13 @@
-use async_recursion::async_recursion;
-use boolinator::Boolinator;
-use futures::stream::{self, StreamExt, TryStreamExt};
-use im_rc::HashMap;
-use serde::Serialize;
-use std::fmt::Debug;
-use std::rc::Rc;
-use thiserror::Error;
-
-use sqlparser::ast::{BinaryOperator, Expr, Function, UnaryOperator};
-
-use super::context::{BlendContext, FilterContext};
-use super::evaluate::{evaluate, Evaluated};
-use super::select::select;
-use crate::data::Value;
-use crate::result::Result;
-use crate::store::Store;
-
-#[derive(Error, Serialize, Debug, PartialEq)]
-pub enum FilterError {
-    #[error("unimplemented")]
-    Unimplemented,
-}
+use {
+    super::{
+        context::{BlendContext, FilterContext},
+        evaluate::evaluate,
+    },
+    crate::{data::Value, result::Result, store::Store},
+    im_rc::HashMap,
+    sqlparser::ast::{Expr, Function},
+    std::{convert::TryInto, fmt::Debug, rc::Rc},
+};
 
 pub struct Filter<'a, T: 'static + Debug> {
     storage: &'a dyn Store<T>,
@@ -59,132 +46,13 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
     }
 }
 
-#[async_recursion(?Send)]
-pub async fn check_expr<T: 'static + Debug>(
-    storage: &dyn Store<T>,
-    filter_context: Option<Rc<FilterContext<'async_recursion>>>,
-    aggregated: Option<Rc<HashMap<&'async_recursion Function, Value>>>,
-    expr: &Expr,
+pub async fn check_expr<'a, T: 'static + Debug>(
+    storage: &'a dyn Store<T>,
+    context: Option<Rc<FilterContext<'a>>>,
+    aggregated: Option<Rc<HashMap<&'a Function, Value>>>,
+    expr: &'a Expr,
 ) -> Result<bool> {
-    let evaluate = |expr: &'async_recursion Expr| {
-        let filter_context = filter_context.as_ref().map(Rc::clone);
-        let aggregated = aggregated.as_ref().map(Rc::clone);
-
-        evaluate(storage, filter_context, aggregated, expr, false)
-    };
-    let check = |expr| {
-        let filter_context = filter_context.as_ref().map(Rc::clone);
-        let aggregated = aggregated.as_ref().map(Rc::clone);
-
-        check_expr(storage, filter_context, aggregated, expr)
-    };
-
-    match expr {
-        Expr::BinaryOp { op, left, right } => {
-            let zip_evaluate = || async move {
-                let l = evaluate(left).await?;
-                let r = evaluate(right).await?;
-
-                Ok((l, r))
-            };
-            let zip_check = || async move {
-                let l = check(left).await?;
-                let r = check(right).await?;
-
-                Ok((l, r))
-            };
-
-            match op {
-                BinaryOperator::Eq => zip_evaluate().await.map(|(l, r)| l == r),
-                BinaryOperator::NotEq => zip_evaluate().await.map(|(l, r)| l != r),
-                BinaryOperator::And => zip_check().await.map(|(l, r)| l && r),
-                BinaryOperator::Or => zip_check().await.map(|(l, r)| l || r),
-                BinaryOperator::Lt => zip_evaluate().await.map(|(l, r)| l < r),
-                BinaryOperator::LtEq => zip_evaluate().await.map(|(l, r)| l <= r),
-                BinaryOperator::Gt => zip_evaluate().await.map(|(l, r)| l > r),
-                BinaryOperator::GtEq => zip_evaluate().await.map(|(l, r)| l >= r),
-                _ => Err(FilterError::Unimplemented.into()),
-            }
-        }
-        Expr::UnaryOp {
-            op: UnaryOperator::Not,
-            expr,
-        } => check(&expr).await.map(|v| !v),
-        Expr::Nested(expr) => check(&expr).await,
-        Expr::InList {
-            expr,
-            list,
-            negated,
-        } => {
-            let negated = *negated;
-            let target = evaluate(expr).await?;
-
-            stream::iter(list.iter())
-                .filter_map(|expr| {
-                    let target = &target;
-
-                    async move {
-                        evaluate(expr).await.map_or_else(
-                            |error| Some(Err(error)),
-                            |evaluated| (target == &evaluated).as_some(Ok(!negated)),
-                        )
-                    }
-                })
-                .take(1)
-                .collect::<Vec<_>>()
-                .await
-                .into_iter()
-                .next()
-                .unwrap_or(Ok(negated))
-        }
-        Expr::InSubquery {
-            expr,
-            subquery,
-            negated,
-        } => {
-            let target = evaluate(expr).await?;
-
-            select(storage, &subquery, filter_context)
-                .await?
-                .try_filter_map(|row| {
-                    let target = &target;
-
-                    async move {
-                        let value = row.take_first_value()?;
-
-                        (target == &Evaluated::from(&value))
-                            .as_some(Ok(!negated))
-                            .transpose()
-                    }
-                })
-                .take(1)
-                .collect::<Vec<_>>()
-                .await
-                .into_iter()
-                .next()
-                .unwrap_or(Ok(*negated))
-        }
-        Expr::Between {
-            expr,
-            negated,
-            low,
-            high,
-        } => {
-            let negated = *negated;
-            let target = evaluate(expr).await?;
-
-            Ok(negated ^ (evaluate(low).await? <= target && target <= evaluate(high).await?))
-        }
-        Expr::Exists(query) => Ok(select(storage, query, filter_context)
-            .await?
-            .into_stream()
-            .take(1)
-            .try_collect::<Vec<_>>()
-            .await?
-            .get(0)
-            .is_some()),
-        Expr::IsNull(expr) => Ok(!evaluate(expr).await?.is_some()),
-        Expr::IsNotNull(expr) => Ok(evaluate(expr).await?.is_some()),
-        _ => Err(FilterError::Unimplemented.into()),
-    }
+    evaluate(storage, context, aggregated, expr, false)
+        .await
+        .map(|evaluated| evaluated.try_into())?
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -18,7 +18,6 @@ pub use blend::BlendError;
 pub use evaluate::EvaluateError;
 pub use execute::{execute, ExecuteError, Payload};
 pub use fetch::FetchError;
-pub use filter::FilterError;
 pub use join::JoinError;
 pub use limit::LimitError;
 pub use select::SelectError;

--- a/src/glue/value/mod.rs
+++ b/src/glue/value/mod.rs
@@ -6,12 +6,6 @@ use {
     std::convert::TryInto,
 };
 
-impl TryInto<bool> for Value {
-    type Error = Error;
-    fn try_into(self) -> Result<bool> {
-        (&self).try_into()
-    }
-}
 impl TryInto<i64> for Value {
     type Error = Error;
     fn try_into(self) -> Result<i64> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,7 +3,7 @@ use {
         data::{LiteralError, RowError, TableError, ValueError},
         executor::{
             AggregateError, AlterError, BlendError, EvaluateError, ExecuteError, FetchError,
-            FilterError, JoinError, LimitError, SelectError, UpdateError, ValidateError,
+            JoinError, LimitError, SelectError, UpdateError, ValidateError,
         },
     },
     serde::Serialize,
@@ -42,8 +42,6 @@ pub enum Error {
     #[error(transparent)]
     Update(#[from] UpdateError),
     #[error(transparent)]
-    Filter(#[from] FilterError),
-    #[error(transparent)]
     Limit(#[from] LimitError),
     #[error(transparent)]
     Row(#[from] RowError),
@@ -76,7 +74,6 @@ impl PartialEq for Error {
             (Blend(e), Blend(e2)) => e == e2,
             (Aggregate(e), Aggregate(e2)) => e == e2,
             (Update(e), Update(e2)) => e == e2,
-            (Filter(e), Filter(e2)) => e == e2,
             (Limit(e), Limit(e2)) => e == e2,
             (Row(e), Row(e2)) => e == e2,
             (Table(e), Table(e2)) => e == e2,


### PR DESCRIPTION
Now evaluate can run every `Expr` evaluation which was only supported by `check_expr` function.

e.g.
```sql
SELECT 1 > 2 FROM TableA;
```

Now `check_expr` simply runs `evaluate` and converts the `Evaluated` result into `bool`.
Then it can return `Result<bool>`.

@yejihan-dev  I forgot to do merging work on `check_expr` and `evaluate`. Thanks so much for mentioning this!
