### PR TITLE
Add DATE & TIMESTAMP data type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ sled-storage = ["sled", "bincode"]
 async-trait = "0.1.41"
 async-recursion = "0.3.1"
 boolinator = "2.4.0"
+chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 futures = "0.3"
 indexmap = "1.6.0"
 im-rc = "15.0.0"

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -14,6 +14,9 @@ pub enum ValueError {
     #[error("failed to parse number")]
     FailedToParseNumber,
 
+    #[error("failed to parse date: {0}")]
+    FailedToParseDate(String),
+
     #[error("add on non-numeric values: {0} + {1}")]
     AddOnNonNumeric(String, String),
 

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -17,6 +17,9 @@ pub enum ValueError {
     #[error("failed to parse date: {0}")]
     FailedToParseDate(String),
 
+    #[error("failed to parse timestamp: {0}")]
+    FailedToParseTimestamp(String),
+
     #[error("add on non-numeric values: {0} + {1}")]
     AddOnNonNumeric(String, String),
 

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -18,6 +18,7 @@ impl TryInto<GroupKey> for &Value {
             I64(v) => Ok(GroupKey::I64(*v)),
             Str(v) => Ok(GroupKey::Str(v.clone())),
             Date(v) => Ok(GroupKey::Date(*v)),
+            Timestamp(v) => Ok(GroupKey::Timestamp(*v)),
             Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
@@ -35,6 +36,7 @@ impl TryInto<GroupKey> for Value {
             I64(v) => Ok(GroupKey::I64(v)),
             Str(v) => Ok(GroupKey::Str(v)),
             Date(v) => Ok(GroupKey::Date(v)),
+            Timestamp(v) => Ok(GroupKey::Timestamp(v)),
             Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -17,6 +17,7 @@ impl TryInto<GroupKey> for &Value {
             Bool(v) => Ok(GroupKey::Bool(*v)),
             I64(v) => Ok(GroupKey::I64(*v)),
             Str(v) => Ok(GroupKey::Str(v.clone())),
+            Date(v) => Ok(GroupKey::Date(*v)),
             Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }
@@ -33,6 +34,7 @@ impl TryInto<GroupKey> for Value {
             Bool(v) => Ok(GroupKey::Bool(v)),
             I64(v) => Ok(GroupKey::I64(v)),
             Str(v) => Ok(GroupKey::Str(v)),
+            Date(v) => Ok(GroupKey::Date(v)),
             Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
         }

--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -1,6 +1,7 @@
 use {
     super::{Value, ValueError},
     crate::result::{Error, Result},
+    chrono::{NaiveDate, NaiveDateTime},
     std::convert::TryInto,
 };
 
@@ -12,6 +13,7 @@ impl From<&Value> for String {
             Value::I64(value) => value.to_string(),
             Value::F64(value) => value.to_string(),
             Value::Date(value) => value.to_string(),
+            Value::Timestamp(value) => value.to_string(),
             Value::Null => String::from("NULL"),
         }
     }
@@ -51,7 +53,9 @@ impl TryInto<bool> for &Value {
                 "FALSE" => false,
                 _ => return Err(ValueError::ImpossibleCast.into()),
             },
-            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Timestamp(_) | Value::Null => {
+                return Err(ValueError::ImpossibleCast.into())
+            }
         })
     }
 }
@@ -81,7 +85,9 @@ impl TryInto<i64> for &Value {
             Value::Str(value) => value
                 .parse::<i64>()
                 .map_err(|_| ValueError::ImpossibleCast)?,
-            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Timestamp(_) | Value::Null => {
+                return Err(ValueError::ImpossibleCast.into())
+            }
         })
     }
 }
@@ -103,7 +109,33 @@ impl TryInto<f64> for &Value {
             Value::Str(value) => value
                 .parse::<f64>()
                 .map_err(|_| ValueError::ImpossibleCast)?,
-            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Timestamp(_) | Value::Null => {
+                return Err(ValueError::ImpossibleCast.into())
+            }
+        })
+    }
+}
+
+impl TryInto<NaiveDate> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<NaiveDate> {
+        Ok(match self {
+            Value::Date(value) => *value,
+            Value::Timestamp(value) => value.date(),
+            _ => return Err(ValueError::ImpossibleCast.into()),
+        })
+    }
+}
+
+impl TryInto<NaiveDateTime> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<NaiveDateTime> {
+        Ok(match self {
+            Value::Date(value) => value.and_hms(0, 0, 0),
+            Value::Timestamp(value) => *value,
+            _ => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }

--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -11,6 +11,7 @@ impl From<&Value> for String {
             Value::Bool(value) => (if *value { "TRUE" } else { "FALSE" }).to_string(),
             Value::I64(value) => value.to_string(),
             Value::F64(value) => value.to_string(),
+            Value::Date(value) => value.to_string(),
             Value::Null => String::from("NULL"),
         }
     }
@@ -50,7 +51,7 @@ impl TryInto<bool> for &Value {
                 "FALSE" => false,
                 _ => return Err(ValueError::ImpossibleCast.into()),
             },
-            Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -80,7 +81,7 @@ impl TryInto<i64> for &Value {
             Value::Str(value) => value
                 .parse::<i64>()
                 .map_err(|_| ValueError::ImpossibleCast)?,
-            Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -102,7 +103,7 @@ impl TryInto<f64> for &Value {
             Value::Str(value) => value
                 .parse::<f64>()
                 .map_err(|_| ValueError::ImpossibleCast)?,
-            Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            Value::Date(_) | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -17,6 +17,7 @@ impl TryInto<Option<UniqueKey>> for &Value {
             Bool(v) => Some(UniqueKey::Bool(*v)),
             I64(v) => Some(UniqueKey::I64(*v)),
             Str(v) => Some(UniqueKey::Str(v.clone())),
+            Date(v) => Some(UniqueKey::Date(*v)),
             Null => None,
             F64(_) => {
                 return Err(ValueError::ConflictOnFloatWithUniqueConstraint.into());

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -18,6 +18,7 @@ impl TryInto<Option<UniqueKey>> for &Value {
             I64(v) => Some(UniqueKey::I64(*v)),
             Str(v) => Some(UniqueKey::Str(v.clone())),
             Date(v) => Some(UniqueKey::Date(*v)),
+            Timestamp(v) => Some(UniqueKey::Timestamp(*v)),
             Null => None,
             F64(_) => {
                 return Err(ValueError::ConflictOnFloatWithUniqueConstraint.into());

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -4,7 +4,7 @@ use {
         executor::evaluate::Evaluated,
         result::{Error, Result},
     },
-    chrono::NaiveDate,
+    chrono::{NaiveDate, NaiveDateTime},
     std::convert::{TryFrom, TryInto},
 };
 
@@ -14,6 +14,7 @@ pub enum GroupKey {
     Bool(bool),
     Str(String),
     Date(NaiveDate),
+    Timestamp(NaiveDateTime),
     None,
 }
 

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -1,14 +1,19 @@
-use std::convert::{TryFrom, TryInto};
-
-use crate::data::Value;
-use crate::executor::evaluate::Evaluated;
-use crate::result::{Error, Result};
+use {
+    crate::{
+        data::Value,
+        executor::evaluate::Evaluated,
+        result::{Error, Result},
+    },
+    chrono::NaiveDate,
+    std::convert::{TryFrom, TryInto},
+};
 
 #[derive(PartialEq, Eq, Hash, Clone, std::fmt::Debug)]
 pub enum GroupKey {
     I64(i64),
     Bool(bool),
     Str(String),
+    Date(NaiveDate),
     None,
 }
 

--- a/src/executor/alter/validate.rs
+++ b/src/executor/alter/validate.rs
@@ -15,7 +15,7 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
     // data type
     if !matches!(
         data_type,
-        DataType::Boolean | DataType::Int | DataType::Float(_) | DataType::Text
+        DataType::Boolean | DataType::Int | DataType::Float(_) | DataType::Text | DataType::Date
     ) {
         return Err(AlterError::UnsupportedDataType(data_type.to_string()).into());
     }

--- a/src/executor/alter/validate.rs
+++ b/src/executor/alter/validate.rs
@@ -15,7 +15,12 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
     // data type
     if !matches!(
         data_type,
-        DataType::Boolean | DataType::Int | DataType::Float(_) | DataType::Text | DataType::Date
+        DataType::Boolean
+            | DataType::Int
+            | DataType::Float(_)
+            | DataType::Text
+            | DataType::Date
+            | DataType::Timestamp
     ) {
         return Err(AlterError::UnsupportedDataType(data_type.to_string()).into());
     }

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -12,7 +12,7 @@ use {
     boolinator::Boolinator,
     futures::stream::{self, StreamExt, TryStreamExt},
     im_rc::HashMap,
-    sqlparser::ast::{BinaryOperator, DataType, Expr, Function, FunctionArg, UnaryOperator},
+    sqlparser::ast::{BinaryOperator, Expr, Function, FunctionArg, UnaryOperator},
     std::{
         borrow::Cow,
         convert::{TryFrom, TryInto},
@@ -40,13 +40,10 @@ pub async fn evaluate<'a, T: 'static + Debug>(
 
     match expr {
         Expr::Value(ast_value) => Literal::try_from(ast_value).map(Evaluated::Literal),
-        Expr::TypedString {
-            data_type: DataType::Date,
-            value,
-        } => {
+        Expr::TypedString { data_type, value } => {
             let literal = Literal::Text(Cow::Borrowed(value));
 
-            Value::try_from_literal(&DataType::Date, &literal).map(Evaluated::from)
+            Value::try_from_literal(&data_type, &literal).map(Evaluated::from)
         }
         Expr::Identifier(ident) => match ident.quote_style {
             Some(_) => Ok(Literal::Text(Cow::Borrowed(&ident.value))).map(Evaluated::Literal),

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -6,7 +6,7 @@ use {
         utils::Vector,
     },
     boolinator::Boolinator,
-    chrono::NaiveDate,
+    chrono::{NaiveDate, NaiveDateTime},
     im_rc::HashSet,
     serde::Serialize,
     sqlparser::ast::{ColumnDef, ColumnOption, Ident},
@@ -34,6 +34,7 @@ pub enum UniqueKey {
     I64(i64),
     Str(String),
     Date(NaiveDate),
+    Timestamp(NaiveDateTime),
 }
 
 #[derive(Debug)]

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -6,6 +6,7 @@ use {
         utils::Vector,
     },
     boolinator::Boolinator,
+    chrono::NaiveDate,
     im_rc::HashSet,
     serde::Serialize,
     sqlparser::ast::{ColumnDef, ColumnOption, Ident},
@@ -32,6 +33,7 @@ pub enum UniqueKey {
     Bool(bool),
     I64(i64),
     Str(String),
+    Date(NaiveDate),
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
 //! After you implement `Tester` trait, the only thing you need to do is calling `generate_tests!` macro.
 
 // re-export
+pub use chrono;
 pub use sqlparser as parser;
 
 mod executor;

--- a/src/tests/date.rs
+++ b/src/tests/date.rs
@@ -1,0 +1,93 @@
+use crate::*;
+
+test_case!(date, async move {
+    run!(
+        r#"
+CREATE TABLE DateLog (
+    id INTEGER,
+    date1 DATE,
+    date2 DATE,
+)"#
+    );
+
+    run!(
+        r#"
+INSERT INTO DateLog VALUES
+    (1, "2020-06-11", "2021-03-01"),
+    (2, "2020-09-30", "1989-01-01"),
+    (3, "2021-05-01", "2021-05-01");
+"#
+    );
+
+    use Value::*;
+
+    macro_rules! date {
+        ($date: expr) => {
+            $date.parse().unwrap()
+        };
+    }
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            1     date!("2020-06-11")   date!("2021-03-01");
+            2     date!("2020-09-30")   date!("1989-01-01");
+            3     date!("2021-05-01")   date!("2021-05-01")
+        )),
+        "SELECT id, date1, date2 FROM DateLog"
+    );
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            2     date!("2020-09-30")   date!("1989-01-01")
+        )),
+        "SELECT * FROM DateLog WHERE date1 > date2"
+    );
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            1     date!("2020-06-11")   date!("2021-03-01");
+            3     date!("2021-05-01")   date!("2021-05-01")
+        )),
+        "SELECT * FROM DateLog WHERE date1 <= date2"
+    );
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            1     date!("2020-06-11")   date!("2021-03-01")
+        )),
+        r#"SELECT * FROM DateLog WHERE date1 = DATE "2020-06-11";"#
+    );
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            2     date!("2020-09-30")   date!("1989-01-01")
+        )),
+        r#"SELECT * FROM DateLog WHERE date2 < "2000-01-01";"#
+    );
+
+    test!(
+        Ok(select!(
+            id  | date1               | date2
+            I64 | Date                | Date;
+            1     date!("2020-06-11")   date!("2021-03-01");
+            2     date!("2020-09-30")   date!("1989-01-01");
+            3     date!("2021-05-01")   date!("2021-05-01")
+        )),
+        r#"SELECT * FROM DateLog WHERE "1999-01-03" < DATE "2000-01-01";"#
+    );
+
+    test!(
+        Err(ValueError::FailedToParseDate("12345-678".to_owned()).into()),
+        r#"INSERT INTO DateLog VALUES (1, "12345-678", "2021-05-01")"#
+    );
+});

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,6 +6,7 @@ pub mod basic;
 pub mod blend;
 pub mod concat;
 pub mod create_table;
+pub mod date;
 pub mod default;
 pub mod drop_table;
 pub mod error;
@@ -80,6 +81,7 @@ macro_rules! generate_tests {
         glue!(nullable_text, nullable::nullable_text);
         glue!(ordering, ordering::ordering);
         glue!(sql_types, sql_types::sql_types);
+        glue!(date, date::date);
         glue!(synthesize, synthesize::synthesize);
         glue!(validate_unique, validate::unique::unique);
         glue!(validate_types, validate::types::types);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,6 +19,7 @@ pub mod nullable;
 pub mod ordering;
 pub mod sql_types;
 pub mod synthesize;
+pub mod timestamp;
 pub mod validate;
 
 mod tester;
@@ -82,6 +83,7 @@ macro_rules! generate_tests {
         glue!(ordering, ordering::ordering);
         glue!(sql_types, sql_types::sql_types);
         glue!(date, date::date);
+        glue!(timestamp, timestamp::timestamp);
         glue!(synthesize, synthesize::synthesize);
         glue!(validate_unique, validate::unique::unique);
         glue!(validate_types, validate::types::types);

--- a/src/tests/timestamp.rs
+++ b/src/tests/timestamp.rs
@@ -1,0 +1,93 @@
+use crate::*;
+
+test_case!(timestamp, async move {
+    run!(
+        r#"
+CREATE TABLE TimestampLog (
+    id INTEGER,
+    t1 TIMESTAMP,
+    t2 TIMESTAMP,
+)"#
+    );
+
+    run!(
+        r#"
+INSERT INTO TimestampLog VALUES
+    (1, "2020-06-11 11:23:11Z",           "2021-03-01"),
+    (2, "2020-09-30 12:00:00 -07:00",     "1989-01-01T00:01:00+09:00"),
+    (3, "2021-04-30T07:00:00.1234-17:00", "2021-05-01T09:00:00.1234+09:00");
+"#
+    );
+
+    macro_rules! t {
+        ($timestamp: expr) => {
+            $timestamp.parse().unwrap()
+        };
+    }
+
+    use Value::*;
+
+    test!(
+        Ok(select!(
+            id  | t1                             | t2
+            I64 | Timestamp                      | Timestamp;
+            1     t!("2020-06-11T11:23:11")        t!("2021-03-01T00:00:00");
+            2     t!("2020-09-30T19:00:00")        t!("1988-12-31T15:01:00");
+            3     t!("2021-05-01T00:00:00.1234")   t!("2021-05-01T00:00:00.1234")
+        )),
+        "SELECT id, t1, t2 FROM TimestampLog"
+    );
+
+    test!(
+        Ok(select!(
+            id  | t1                        | t2
+            I64 | Timestamp                 | Timestamp;
+            2     t!("2020-09-30T19:00:00")   t!("1988-12-31T15:01:00")
+        )),
+        "SELECT * FROM TimestampLog WHERE t1 > t2"
+    );
+
+    test!(
+        Ok(select!(
+            id  | t1                             | t2
+            I64 | Timestamp                      | Timestamp;
+            3     t!("2021-05-01T00:00:00.1234")   t!("2021-05-01T00:00:00.1234")
+        )),
+        "SELECT * FROM TimestampLog WHERE t1 = t2"
+    );
+
+    test!(
+        Ok(select!(
+            id  | t1                        | t2
+            I64 | Timestamp                 | Timestamp;
+            1     t!("2020-06-11T11:23:11")   t!("2021-03-01T00:00:00")
+
+        )),
+        r#"SELECT * FROM TimestampLog WHERE t1 = "2020-06-11T14:23:11+0300";"#
+    );
+
+    test!(
+        Ok(select!(
+            id  | t1                        | t2
+            I64 | Timestamp                 | Timestamp;
+            2     t!("2020-09-30T19:00:00")   t!("1988-12-31T15:01:00")
+        )),
+        r#"SELECT * FROM TimestampLog WHERE t2 < TIMESTAMP "2000-01-01";"#
+    );
+
+    test!(
+        Ok(select!(
+            id  | t1                             | t2
+            I64 | Timestamp                      | Timestamp;
+            1     t!("2020-06-11T11:23:11")        t!("2021-03-01T00:00:00");
+            2     t!("2020-09-30T19:00:00")        t!("1988-12-31T15:01:00");
+            3     t!("2021-05-01T00:00:00.1234")   t!("2021-05-01T00:00:00.1234")
+        )),
+        r#"SELECT * FROM TimestampLog WHERE TIMESTAMP "1999-01-03" < "2000-01-01";"#
+    );
+
+    test!(
+        Err(ValueError::FailedToParseTimestamp("12345-678".to_owned()).into()),
+        r#"INSERT INTO TimestampLog VALUES (1, "12345-678", "2021-05-01")"#
+    );
+});


### PR DESCRIPTION
Implement `DATE` and `TIMESTAMP` data type!

`DATE` does not have time zone info.
`TIMESTAMP` stores values by converting into UTC time zone.
e.g. `2021-05-01T11:00:00+0900` -> `2021-05-01T02:00:00Z`

Though `INTERVAL` type is not implemented yet, comparison between `DATE and DATE`, `TIMESTAMP and TIMESTAMP` and `DATE and TIMESTAMP` are supported.