### PR TITLE
Fix glue.rs test code to DROP TABLE at first,

### DIFF
--- a/src/glue.rs
+++ b/src/glue.rs
@@ -53,6 +53,10 @@ mod tests {
         let mut glue = Glue::new(sled);
 
         assert_eq!(
+            glue.execute("DROP TABLE IF EXISTS api_test"),
+            Ok(Payload::DropTable)
+        );
+        assert_eq!(
             glue.execute("CREATE TABLE api_test (id INTEGER PRIMARY KEY, name TEXT, nullable TEXT NULL, is BOOLEAN)"),
             Ok(Payload::Create)
         );


### PR DESCRIPTION
test in glue.rs often fails in GitHub Action.
add DROP TABLE statement to prevent this