### PR TITLE
Fix ALTER TABLE DROP COLUMN to remove related indexes

### DIFF
--- a/src/executor/alter/alter_table.rs
+++ b/src/executor/alter/alter_table.rs
@@ -6,9 +6,16 @@ use {
         ast::{AlterTableOperation, ObjectName},
         data::get_name,
         result::MutResult,
-        store::{AlterTable, Store, StoreMut},
+        store::{GStore, GStoreMut},
     },
     std::fmt::Debug,
+};
+
+#[cfg(feature = "index")]
+use {
+    super::AlterError,
+    crate::{ast::Expr, data::Schema},
+    futures::stream::{self, TryStreamExt},
 };
 
 macro_rules! try_into {
@@ -22,7 +29,7 @@ macro_rules! try_into {
     };
 }
 
-pub async fn alter_table<T: 'static + Debug, U: Store<T> + StoreMut<T> + AlterTable>(
+pub async fn alter_table<T: 'static + Debug, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     name: &ObjectName,
     operation: &AlterTableOperation,
@@ -54,9 +61,53 @@ pub async fn alter_table<T: 'static + Debug, U: Store<T> + StoreMut<T> + AlterTa
             column_name,
             if_exists,
         } => {
+            #[cfg(feature = "index")]
+            let storage = {
+                let indexes = match storage.fetch_schema(table_name).await {
+                    Ok(Some(Schema { indexes, .. })) => indexes,
+                    Ok(None) => {
+                        return Err((
+                            storage,
+                            AlterError::TableNotFound(table_name.to_owned()).into(),
+                        ));
+                    }
+                    Err(e) => {
+                        return Err((storage, e));
+                    }
+                };
+
+                let indexes = indexes
+                    .iter()
+                    .filter(|(_, expr)| find_column(expr, column_name))
+                    .map(Ok);
+
+                stream::iter(indexes)
+                    .try_fold(storage, |storage, (index_name, _)| async move {
+                        storage
+                            .drop_index(table_name, index_name)
+                            .await
+                            .map(|(storage, _)| storage)
+                    })
+                    .await?
+            };
+
             storage
                 .drop_column(table_name, column_name, *if_exists)
                 .await
         }
+    }
+}
+
+#[cfg(feature = "index")]
+fn find_column(expr: &Expr, column_name: &str) -> bool {
+    let find = |expr| find_column(expr, column_name);
+
+    match expr {
+        Expr::Identifier(ident) => ident == column_name,
+        Expr::Nested(expr) => find(expr),
+        Expr::BinaryOp { left, right, .. } => find(left) || find(right),
+        Expr::UnaryOp { expr, .. } => find(expr),
+        Expr::Cast { expr, .. } => find(expr),
+        _ => false,
     }
 }

--- a/src/tests/alter/drop_indexed_column.rs
+++ b/src/tests/alter/drop_indexed_column.rs
@@ -1,0 +1,136 @@
+#![cfg(all(feature = "alter-table", feature = "index"))]
+
+use crate::*;
+
+test_case!(drop_indexed_column, async move {
+    run!(
+        r#"
+CREATE TABLE Test (
+    id INTEGER,
+    num INTEGER,
+    name TEXT
+)"#
+    );
+
+    run!(
+        r#"
+        INSERT INTO Test
+            (id, num, name)
+        VALUES
+            (1, 2, "Hello");
+    "#
+    );
+
+    use {
+        ast::{AstLiteral, Expr, IndexOperator::*},
+        Value::*,
+    };
+
+    // create indexes
+    run!("CREATE INDEX idx_name ON Test (num + 1)");
+    run!("CREATE INDEX idx_id ON Test (id)");
+    run!("CREATE INDEX idx_typed_string ON Test ((id))");
+    run!("CREATE INDEX idx_binary_op ON Test (id || name);");
+    run!("CREATE INDEX idx_unary_op ON Test (-id);");
+    run!("CREATE INDEX idx_cast ON Test (CAST(id AS TEXT));");
+
+    // check indexes working
+    test!(
+        Err(AlterError::IdentifierNotFound(format!(
+            "{:#?}",
+            Expr::Literal(AstLiteral::Number("100".to_owned()))
+        ))
+        .into()),
+        "CREATE INDEX idx_literal ON Test (100)"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(),
+        "SELECT id, num, name FROM Test"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_id, LtEq, "1"),
+        "SELECT id, num, name FROM Test WHERE id <= 1"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_id, LtEq, "(1)"),
+        "SELECT id, num, name FROM Test WHERE id <= (1)"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_binary_op, Eq, r#""1Hello""#),
+        r#"SELECT id, num, name FROM Test WHERE id || name = "1Hello""#
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_unary_op, GtEq, "-7"),
+        "SELECT id, num, name FROM Test WHERE -id >= -7"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_unary_op, Gt, "-7"),
+        "SELECT id, num, name FROM Test WHERE -id > -7"
+    );
+
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
+        idx!(idx_cast, Eq, r#""1""#),
+        r#"SELECT id, num, name FROM Test WHERE CAST(id AS TEXT) = "1""#
+    );
+
+    test!(
+        Err(AlterError::TableNotFound("Noname".to_owned()).into()),
+        "ALTER TABLE Noname DROP COLUMN id"
+    );
+
+    run!("ALTER TABLE Test DROP COLUMN id");
+
+    test_idx!(
+        Ok(select!(
+            num | name
+            I64 | Str;
+            2     "Hello".to_owned()
+        )),
+        idx!(),
+        "SELECT * FROM Test"
+    );
+
+    // Only idx_name remains.
+    assert_eq!(1, schema!("Test").indexes.len());
+});

--- a/src/tests/alter/mod.rs
+++ b/src/tests/alter/mod.rs
@@ -1,8 +1,11 @@
 mod alter_table;
 mod create_table;
+mod drop_indexed_column;
 mod drop_table;
 
 #[cfg(feature = "alter-table")]
 pub use alter_table::{alter_table_add_drop, alter_table_rename};
 pub use create_table::create_table;
+#[cfg(all(feature = "alter-table", feature = "index"))]
+pub use drop_indexed_column::drop_indexed_column;
 pub use drop_table::drop_table;

--- a/src/tests/index/and.rs
+++ b/src/tests/index/and.rs
@@ -106,12 +106,13 @@ CREATE TABLE NullIdx (
         "#
     );
 
-    test!(
+    test_idx!(
         Ok(select!(
             id  | date                | flag
             I64 | Date                | Bool;
             5     date!("2030-03-01")   false
         )),
+        idx!(),
         r#"
         SELECT * FROM NullIdx
         WHERE

--- a/src/tests/index/basic.rs
+++ b/src/tests/index/basic.rs
@@ -35,7 +35,7 @@ CREATE TABLE Test (
     use ast::IndexOperator::*;
     use Value::*;
 
-    test!(
+    test_idx!(
         Ok(select!(
             id  | num | name
             I64 | I64 | Str;
@@ -44,6 +44,7 @@ CREATE TABLE Test (
             11    7     "Great".to_owned();
             4     7     "Job".to_owned()
         )),
+        idx!(),
         "SELECT id, num, name FROM Test"
     );
 
@@ -244,20 +245,22 @@ CREATE TABLE Test (
     );
 
     test!(Ok(Payload::DropIndex), "DROP INDEX Test.idx_id2;");
-    test!(
+    test_idx!(
         Ok(select!(
             id  | num | name
             I64 | I64 | Str;
             2     17    "World".to_owned()
         )),
+        idx!(),
         "SELECT * FROM Test WHERE id + num = 19"
     );
 
-    test!(
+    test_idx!(
         Ok(Payload::Select {
             labels: vec!["id".to_owned()],
             rows: vec![],
         }),
+        idx!(),
         "SELECT id FROM Test WHERE id + num = id"
     );
 

--- a/src/tests/index/basic.rs
+++ b/src/tests/index/basic.rs
@@ -124,10 +124,13 @@ CREATE TABLE Test (
         Ok(select!(
             id  | num | name
             I64 | I64 | Str;
+            1     2     "Hello".to_owned();
+            1     17    "World".to_owned();
+            4     7     "Job".to_owned();
             11    7     "Great".to_owned()
         )),
-        idx!(idx_id, Gt, "4"),
-        "SELECT id, num, name FROM Test WHERE id > 4"
+        idx!(idx_id, Gt, "0"),
+        "SELECT id, num, name FROM Test WHERE id > 0"
     );
 
     test_idx!(

--- a/src/tests/index/null.rs
+++ b/src/tests/index/null.rs
@@ -109,11 +109,12 @@ CREATE TABLE NullIdx (
         "SELECT id, date, flag FROM NullIdx WHERE date IS NOT NULL"
     );
 
-    test!(
+    test_idx!(
         Ok(Payload::Select {
             labels: vec!["id".to_owned(), "date".to_owned(), "flag".to_owned()],
             rows: vec![],
         }),
+        idx!(),
         "SELECT * FROM NullIdx WHERE id = NULL"
     );
 });

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -7,6 +7,9 @@ macro_rules! row {
 
 #[macro_export]
 macro_rules! idx {
+    () => {
+        vec![]
+    };
     ($name: path, $op: path, $sql_expr: literal) => {
         vec![ast::IndexItem {
             name: stringify!($name).to_owned(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -90,6 +90,9 @@ macro_rules! generate_tests {
             };
         }
 
+        #[cfg(all(feature = "alter-table", feature = "index"))]
+        glue!(alter_table_drop_indexed_column, alter::drop_indexed_column);
+
         #[cfg(feature = "index")]
         glue_index!();
         #[cfg(feature = "alter-table")]

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -32,6 +32,7 @@ pub async fn run<T: 'static + Debug, U: GStore<T> + GStoreMut<T>>(
         };
     }
 
+    println!("[SQL] {}", sql);
     let parsed = try_run!(parse(sql));
     let statement = try_run!(translate(&parsed[0]));
     let statement = try_run!(plan(&storage, statement).await);
@@ -124,6 +125,19 @@ macro_rules! test_case {
             use std::rc::Rc;
 
             let cell = tester.get_cell();
+
+            #[allow(unused_macros)]
+            macro_rules! schema {
+                ($table_name: literal) => {
+                    cell.borrow()
+                        .as_ref()
+                        .expect("cell is empty")
+                        .fetch_schema($table_name)
+                        .await
+                        .expect("error fetching schema")
+                        .expect("table not found")
+                };
+            }
 
             #[allow(unused_macros)]
             macro_rules! run {


### PR DESCRIPTION
When DROP COLUMN is executed, if there exists related indexes which refer the dropping column, those indexes must be removed, too.

Fix `executor/alter/alter_table.rs` to handle it and add tests to `src/tests/alter/drop_indexed_column.rs`.