### PR TITLE
Remove evaluate use_empty param, replace to handle in BlendContext

### DIFF
--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -68,21 +68,18 @@ impl<'a, T: 'static + Debug> Aggregate<'a, T> {
             .enumerate()
             .map(|(i, row)| row.map(|row| (i, row)))
             .try_fold(State::new(), |state, (index, blend_context)| async move {
-                let evaluated: Vec<Evaluated<'_>> =
-                    stream::iter(self.group_by.iter())
-                        .then(|expr| {
-                            let filter_context = FilterContext::concat(
-                                self.filter_context.as_ref().map(Rc::clone),
-                                Some(&blend_context).map(Rc::clone),
-                            );
-                            let filter_context = Some(filter_context).map(Rc::new);
+                let evaluated: Vec<Evaluated<'_>> = stream::iter(self.group_by.iter())
+                    .then(|expr| {
+                        let filter_context = FilterContext::concat(
+                            self.filter_context.as_ref().map(Rc::clone),
+                            Some(&blend_context).map(Rc::clone),
+                        );
+                        let filter_context = Some(filter_context).map(Rc::new);
 
-                            async move {
-                                evaluate(self.storage, filter_context, None, expr, false).await
-                            }
-                        })
-                        .try_collect::<Vec<_>>()
-                        .await?;
+                        async move { evaluate(self.storage, filter_context, None, expr).await }
+                    })
+                    .try_collect::<Vec<_>>()
+                    .await?;
                 let group = evaluated
                     .iter()
                     .map(GroupKey::try_from)

--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -72,7 +72,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
                             }
                         }
                         SelectItem::Expr { expr, .. } => {
-                            evaluate(self.storage, filter_context, aggregated, expr, true)
+                            evaluate(self.storage, filter_context, aggregated, expr)
                                 .await
                                 .map(|evaluated| evaluated.try_into())?
                                 .map(|v| vec![v])

--- a/src/executor/context/blend_context.rs
+++ b/src/executor/context/blend_context.rs
@@ -31,7 +31,10 @@ impl<'a> BlendContext<'a> {
             self.columns
                 .iter()
                 .position(|column| column == target)
-                .map(|index| self.row.as_ref().and_then(|row| row.get_value(index)))
+                .map(|index| match &self.row {
+                    Some(row) => row.get_value(index),
+                    None => Some(&Value::Null),
+                })
         };
 
         match get_value() {
@@ -52,7 +55,10 @@ impl<'a> BlendContext<'a> {
             self.columns
                 .iter()
                 .position(|column| column == target)
-                .map(|index| self.row.as_ref().and_then(|row| row.get_value(index)))
+                .map(|index| match &self.row {
+                    Some(row) => row.get_value(index),
+                    None => Some(&Value::Null),
+                })
         };
 
         match get_value() {

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -56,7 +56,7 @@ pub async fn check_expr<'a, T: 'static + Debug>(
     aggregated: Option<Rc<HashMap<&'a Function, Value>>>,
     expr: &'a Expr,
 ) -> Result<bool> {
-    evaluate(storage, context, aggregated, expr, false)
+    evaluate(storage, context, aggregated, expr)
         .await
         .map(|evaluated| evaluated.try_into())?
 }

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -59,7 +59,7 @@ async fn fetch_blended<'a, T: 'static + Debug>(
                 op: index_op,
                 value_expr,
             }) => {
-                let evaluated = evaluate(storage, None, None, value_expr, false).await?;
+                let evaluated = evaluate(storage, None, None, value_expr).await?;
                 let index_value: Value = evaluated.try_into()?;
 
                 storage

--- a/src/executor/update.rs
+++ b/src/executor/update.rs
@@ -70,7 +70,7 @@ impl<'a, T: 'static + Debug> Update<'a, T> {
                 let ColumnDef { data_type, .. } = column_def;
                 let nullable = column_def.is_nullable();
 
-                let value = match evaluate(self.storage, context, None, value, false).await? {
+                let value = match evaluate(self.storage, context, None, value).await? {
                     Evaluated::Literal(v) => Value::try_from_literal(data_type, &v)?,
                     Evaluated::Value(v) => {
                         v.validate_type(data_type)?;

--- a/src/tests/blend.rs
+++ b/src/tests/blend.rs
@@ -142,6 +142,10 @@ test_case!(blend, async move {
             BlendError::TableAliasNotFound("Whatever".to_owned()).into(),
             "SELECT * FROM BlendUser WHERE id IN (SELECT Whatever.* FROM BlendUser)",
         ),
+        (
+            EvaluateError::ValueNotFound("noname".to_owned()).into(),
+            "SELECT noname FROM BlendUser",
+        ),
     ];
 
     for (error, sql) in error_cases.into_iter() {


### PR DESCRIPTION
`use_empty` param in `evaluate` was unnecessary.
Now `BlendContext` takes this and it returns `Value::Null` when column exists && empty row.