### PR TITLE
Update executor/limit to use evaluate,

### DIFF
--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -98,6 +98,14 @@ impl TryInto<i64> for &Value {
     }
 }
 
+impl TryInto<i64> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<i64> {
+        (&self).try_into()
+    }
+}
+
 impl TryInto<f64> for &Value {
     type Error = Error;
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -18,7 +18,6 @@ pub use blend::BlendError;
 pub use evaluate::{evaluate_stateless, EvaluateError};
 pub use execute::{execute, ExecuteError, Payload};
 pub use fetch::FetchError;
-pub use limit::LimitError;
 pub use select::SelectError;
 pub use update::UpdateError;
 pub use validate::{UniqueKey, ValidateError};

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,7 +3,7 @@ use {
         data::{IntervalError, LiteralError, RowError, TableError, ValueError},
         executor::{
             AggregateError, AlterError, BlendError, EvaluateError, ExecuteError, FetchError,
-            LimitError, SelectError, UpdateError, ValidateError,
+            SelectError, UpdateError, ValidateError,
         },
         translate::TranslateError,
     },
@@ -54,8 +54,6 @@ pub enum Error {
     #[error(transparent)]
     Update(#[from] UpdateError),
     #[error(transparent)]
-    Limit(#[from] LimitError),
-    #[error(transparent)]
     Row(#[from] RowError),
     #[error(transparent)]
     Table(#[from] TableError),
@@ -91,7 +89,6 @@ impl PartialEq for Error {
             (Blend(e), Blend(e2)) => e == e2,
             (Aggregate(e), Aggregate(e2)) => e == e2,
             (Update(e), Update(e2)) => e == e2,
-            (Limit(e), Limit(e2)) => e == e2,
             (Row(e), Row(e2)) => e == e2,
             (Table(e), Table(e2)) => e == e2,
             (Validate(e), Validate(e2)) => e == e2,

--- a/src/tests/limit.rs
+++ b/src/tests/limit.rs
@@ -1,0 +1,46 @@
+use crate::*;
+
+test_case!(limit, async move {
+    use Value::I64;
+
+    let test_cases = vec![
+        (
+            "CREATE TABLE Test (
+                id INTEGER
+            )",
+            Payload::Create,
+        ),
+        (
+            "INSERT INTO Test VALUES (1), (2), (3), (4), (5), (6), (7), (8);",
+            Payload::Insert(8),
+        ),
+        (
+            "SELECT * FROM Test LIMIT 10;",
+            select!(id; I64; 1; 2; 3; 4; 5; 6; 7; 8),
+        ),
+        (
+            "SELECT * FROM Test LIMIT 10 OFFSET 1;",
+            select!(id; I64; 2; 3; 4; 5; 6; 7; 8),
+        ),
+        (
+            "SELECT * FROM Test OFFSET 2;",
+            select!(id; I64; 3; 4; 5; 6; 7; 8),
+        ),
+        (
+            "SELECT * FROM Test OFFSET 10;",
+            Payload::Select {
+                labels: vec!["id".to_owned()],
+                rows: vec![],
+            },
+        ),
+        (r#"SELECT * FROM Test LIMIT 3;"#, select!(id; I64; 1; 2; 3)),
+        (
+            r#"SELECT * FROM Test LIMIT 4 OFFSET 3;"#,
+            select!(id; I64; 4; 5; 6; 7),
+        ),
+    ];
+
+    for (sql, expected) in test_cases.into_iter() {
+        test!(Ok(expected), sql);
+    }
+});

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,6 +11,7 @@ pub mod filter;
 pub mod function;
 pub mod index;
 pub mod join;
+pub mod limit;
 pub mod migrate;
 pub mod nested_select;
 pub mod nullable;
@@ -49,6 +50,7 @@ macro_rules! generate_tests {
         glue!(create_table, alter::create_table);
         glue!(drop_table, alter::drop_table);
         glue!(default, default::default);
+        glue!(limit, limit::limit);
         glue!(error, error::error);
         glue!(filter, filter::filter);
         glue!(function_upper_lower, function::upper_lower::upper_lower);


### PR DESCRIPTION
* Remove LimitError, replace to use evaluate_stateless.
* Add limit & offset integration test case

sqlparser only accepts number literal but it provides `Expr` for limit and offset values.
so, limit & offset test case only covers number value limit and offset values.