### PR TITLE
Add more expr support to DEFAULT & INSERT VALUES,

### DIFF
--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        ast::{AstLiteral, Expr},
+        ast::AstLiteral,
         result::{Error, Result},
     },
     serde::Serialize,
@@ -11,9 +11,6 @@ use {
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum LiteralError {
-    #[error("unsupported expr: {0}")]
-    UnsupportedExpr(String),
-
     #[error("unsupported literal binary arithmetic between {0} and {1}")]
     UnsupportedBinaryArithmetic(String, String),
 
@@ -58,19 +55,6 @@ impl<'a> TryFrom<&'a AstLiteral> for Literal<'a> {
         };
 
         Ok(literal)
-    }
-}
-
-impl<'a> TryFrom<&'a Expr> for Literal<'a> {
-    type Error = Error;
-
-    fn try_from(expr: &'a Expr) -> Result<Self> {
-        match expr {
-            Expr::Literal(literal) => Literal::try_from(literal),
-            // TODO: Expr::TypedString support
-            Expr::Identifier(value) => Ok(Literal::Text(Cow::Borrowed(value))),
-            _ => Err(LiteralError::UnsupportedExpr(format!("{:?}", expr)).into()),
-        }
     }
 }
 

--- a/src/data/row.rs
+++ b/src/data/row.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         ast::{ColumnDef, Expr},
         data::{schema::ColumnDefExt, Value},
+        executor::evaluate_stateless,
         result::Result,
     },
     serde::{Deserialize, Serialize},
@@ -68,7 +69,7 @@ impl Row {
                 }?;
                 let nullable = column_def.is_nullable();
 
-                Value::from_expr(&data_type, nullable, expr)
+                evaluate_stateless(None, expr)?.try_into_value(&data_type, nullable)
             })
             .collect::<Result<_>>()
             .map(Self)

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -1,17 +1,10 @@
 use {
-    super::{Interval, Literal},
-    crate::{
-        ast::{DataType, Expr},
-        result::Result,
-    },
+    super::Interval,
+    crate::{ast::DataType, result::Result},
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
     core::ops::Sub,
     serde::{Deserialize, Serialize},
-    std::{
-        cmp::Ordering,
-        convert::{TryFrom, TryInto},
-        fmt::Debug,
-    },
+    std::{cmp::Ordering, convert::TryInto, fmt::Debug},
 };
 
 mod big_edian;
@@ -77,15 +70,6 @@ impl PartialOrd<Value> for Value {
 }
 
 impl Value {
-    pub fn from_expr(data_type: &DataType, nullable: bool, expr: &Expr) -> Result<Self> {
-        let literal = Literal::try_from(expr)?;
-        let value = Value::try_from_literal(data_type, &literal)?;
-
-        value.validate_null(nullable)?;
-
-        Ok(value)
-    }
-
     pub fn validate_type(&self, data_type: &DataType) -> Result<()> {
         let valid = matches!(
             (data_type, self),

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -160,4 +160,15 @@ impl<'a> Evaluated<'a> {
             Evaluated::Literal(v) => matches!(v, &Literal::Null),
         }
     }
+
+    pub fn try_into_value(self, data_type: &DataType, nullable: bool) -> Result<Value> {
+        let value = match self {
+            Evaluated::Value(v) => v.into_owned(),
+            Evaluated::Literal(v) => Value::try_from_literal(data_type, &v)?,
+        };
+
+        value.validate_null(nullable)?;
+
+        Ok(value)
+    }
 }

--- a/src/executor/evaluate/stateless.rs
+++ b/src/executor/evaluate/stateless.rs
@@ -105,7 +105,6 @@ pub fn evaluate_stateless<'a>(
         Expr::Wildcard | Expr::QualifiedWildcard(_) => {
             Err(EvaluateError::UnreachableWildcardExpr.into())
         }
-        // TODO: Add test - UnsupportedStatelessExpr error
         _ => Err(EvaluateError::UnsupportedStatelessExpr(format!("{:#?}", expr)).into()),
     }
 }

--- a/src/tests/alter/alter_table.rs
+++ b/src/tests/alter/alter_table.rs
@@ -89,8 +89,8 @@ test_case!(alter_table_add_drop, async move {
         ),
         (
             "ALTER TABLE Foo ADD COLUMN something INTEGER DEFAULT (SELECT id FROM Bar LIMIT 1)",
-            Err(LiteralError::UnsupportedExpr(format!(
-                "{:?}",
+            Err(EvaluateError::UnsupportedStatelessExpr(format!(
+                "{:#?}",
                 Expr::Subquery(Box::new(ast::Query {
                     body: SetExpr::Select(Box::new(Select {
                         projection: vec![SelectItem::Expr {

--- a/src/tests/default.rs
+++ b/src/tests/default.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use chrono::NaiveDate;
 
 test_case!(default, async move {
     use Value::*;
@@ -38,4 +39,31 @@ test_case!(default, async move {
     for (sql, expected) in test_cases.into_iter() {
         test!(Ok(expected), sql);
     }
+
+    test!(
+        Ok(Payload::Create),
+        r#"
+        CREATE TABLE TestExpr (
+            id INTEGER,
+            date DATE DEFAULT DATE "2020-01-01",
+            num INTEGER DEFAULT -(-1 * +2),
+            flag BOOLEAN DEFAULT CAST("TRUE" AS BOOLEAN),
+            flag2 BOOLEAN DEFAULT 1 IN (1, 2, 3),
+            flag3 BOOLEAN DEFAULT 10 BETWEEN 1 AND 2,
+            flag4 BOOLEAN DEFAULT (1 IS NULL OR NULL IS NOT NULL)
+        )"#
+    );
+
+    run!("INSERT INTO TestExpr (id) VALUES (1);");
+
+    let d = |y, m, d| NaiveDate::from_ymd(y, m, d);
+
+    test!(
+        Ok(select!(
+            id  | date          | num | flag | flag2 | flag3 | flag4;
+            I64 | Date          | I64 | Bool | Bool  | Bool  | Bool;
+            1     d(2020, 1, 1)   2     true   true    false   false
+        )),
+        "SELECT * FROM TestExpr"
+    );
 });


### PR DESCRIPTION
DEFAULT and INSERT VALUES now support exprs like (1 + 1), (CAST "TRUE" AS BOOLEAN)..
It uses "evaluate_stateless" function, remove Value::from_expr.