### PR TITLE
Split ast::Function into Function & Aggregate,

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,5 +1,5 @@
 use {
-    super::{AstLiteral, BinaryOperator, DataType, Function, Query, UnaryOperator},
+    super::{Aggregate, AstLiteral, BinaryOperator, DataType, Function, Query, UnaryOperator},
     serde::{Deserialize, Serialize},
 };
 
@@ -47,6 +47,7 @@ pub enum Expr {
         value: String,
     },
     Function(Function),
+    Aggregate(Aggregate),
     Exists(Box<Query>),
     Subquery(Box<Query>),
 }

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -1,16 +1,20 @@
 use {
-    super::{Expr, ObjectName},
+    super::Expr,
     serde::{Deserialize, Serialize},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum FunctionArg {
-    Named { name: String, arg: Expr },
-    Unnamed(Expr),
+pub enum Function {
+    Lower(Box<Expr>),
+    Upper(Box<Expr>),
+    Left { expr: Box<Expr>, size: Box<Expr> },
+    Right { expr: Box<Expr>, size: Box<Expr> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Function {
-    pub name: ObjectName,
-    pub args: Vec<FunctionArg>,
+pub enum Aggregate {
+    Count(Box<Expr>),
+    Sum(Box<Expr>),
+    Max(Box<Expr>),
+    Min(Box<Expr>),
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -10,7 +10,7 @@ pub use ast_literal::{AstLiteral, DateTimeField};
 pub use data_type::DataType;
 pub use ddl::*;
 pub use expr::Expr;
-pub use function::{Function, FunctionArg};
+pub use function::{Aggregate, Function};
 pub use operator::*;
 pub use query::*;
 

--- a/src/executor/aggregate/error.rs
+++ b/src/executor/aggregate/error.rs
@@ -5,18 +5,9 @@ pub enum AggregateError {
     #[error("unsupported compound identifier: {0:#?}")]
     UnsupportedCompoundIdentifier(Expr),
 
-    #[error("unsupported aggregation: {0}")]
-    UnsupportedAggregation(String),
-
     #[error("only identifier is allowed in aggregation")]
     OnlyIdentifierAllowed,
 
     #[error("value not found: {0}")]
     ValueNotFound(String),
-
-    #[error("unreachable")]
-    Unreachable,
-
-    #[error("unreachable named function arg: {0}")]
-    UnreachableNamedFunctionArg(String),
 }

--- a/src/executor/blend.rs
+++ b/src/executor/blend.rs
@@ -4,7 +4,7 @@ use {
         evaluate::evaluate,
     },
     crate::{
-        ast::{Function, SelectItem},
+        ast::{Aggregate, SelectItem},
         data::{get_name, Row, Value},
         result::{Error, Result},
         store::GStore,
@@ -42,7 +42,7 @@ impl<'a, T: 'static + Debug> Blend<'a, T> {
 
     async fn blend(
         &self,
-        aggregated: Option<HashMap<&'a Function, Value>>,
+        aggregated: Option<HashMap<&'a Aggregate, Value>>,
         context: Rc<BlendContext<'a>>,
     ) -> Result<Vec<Value>> {
         let filter_context = FilterContext::concat(None, Some(Rc::clone(&context)));

--- a/src/executor/context/aggregate_context.rs
+++ b/src/executor/context/aggregate_context.rs
@@ -1,12 +1,12 @@
 use {
     super::BlendContext,
-    crate::{ast::Function, data::Value},
+    crate::{ast::Aggregate, data::Value},
     im_rc::HashMap,
     std::{fmt::Debug, rc::Rc},
 };
 
 #[derive(Debug)]
 pub struct AggregateContext<'a> {
-    pub aggregated: Option<HashMap<&'a Function, Value>>,
+    pub aggregated: Option<HashMap<&'a Aggregate, Value>>,
     pub next: Rc<BlendContext<'a>>,
 }

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -1,4 +1,9 @@
-use {crate::ast::Expr, serde::Serialize, std::fmt::Debug, thiserror::Error};
+use {
+    crate::ast::{Aggregate, Expr},
+    serde::Serialize,
+    std::fmt::Debug,
+    thiserror::Error,
+};
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum EvaluateError {
@@ -7,9 +12,6 @@ pub enum EvaluateError {
 
     #[error("literal add on non-numeric")]
     LiteralAddOnNonNumeric,
-
-    #[error("function is not supported: {0}")]
-    FunctionNotSupported(String),
 
     #[error("function requires string value: {0}")]
     FunctionRequiresStringValue(String),
@@ -20,11 +22,6 @@ pub enum EvaluateError {
     #[error("function requires usize value: {0}")]
     FunctionRequiresUSizeValue(String),
 
-    #[error(
-        "number of function parameters not matching (expected: {expected:?}, found: {found:?})"
-    )]
-    NumberOfFunctionParamsNotMatching { expected: usize, found: usize },
-
     #[error("value not found: {0}")]
     ValueNotFound(String),
 
@@ -34,15 +31,15 @@ pub enum EvaluateError {
     #[error("unsupported compound identifier {0:#?}")]
     UnsupportedCompoundIdentifier(Expr),
 
-    #[error("unreachable wildcard expression")]
-    UnreachableWildcardExpr,
-
     #[error("unsupported stateless expression: {0:#?}")]
     UnsupportedStatelessExpr(Expr),
+
+    #[error("unreachable wildcard expression")]
+    UnreachableWildcardExpr,
 
     #[error("unreachable empty context")]
     UnreachableEmptyContext,
 
-    #[error("unreachable named function argument: {0}")]
-    UnreachableFunctionArg(String),
+    #[error("unreachable empty aggregate value: {0:?}")]
+    UnreachableEmptyAggregateValue(Aggregate),
 }

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -4,7 +4,7 @@ use {
         evaluate::evaluate,
     },
     crate::{
-        ast::{Expr, Function},
+        ast::{Aggregate, Expr},
         data::Value,
         result::Result,
         store::GStore,
@@ -17,7 +17,7 @@ pub struct Filter<'a, T: 'static + Debug> {
     storage: &'a dyn GStore<T>,
     where_clause: Option<&'a Expr>,
     context: Option<Rc<FilterContext<'a>>>,
-    aggregated: Option<Rc<HashMap<&'a Function, Value>>>,
+    aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
 }
 
 impl<'a, T: 'static + Debug> Filter<'a, T> {
@@ -25,7 +25,7 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
         storage: &'a dyn GStore<T>,
         where_clause: Option<&'a Expr>,
         context: Option<Rc<FilterContext<'a>>>,
-        aggregated: Option<Rc<HashMap<&'a Function, Value>>>,
+        aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
     ) -> Self {
         Self {
             storage,
@@ -53,7 +53,7 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
 pub async fn check_expr<'a, T: 'static + Debug>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
-    aggregated: Option<Rc<HashMap<&'a Function, Value>>>,
+    aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
     expr: &'a Expr,
 ) -> Result<bool> {
     evaluate(storage, context, aggregated, expr)

--- a/src/executor/select.rs
+++ b/src/executor/select.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        aggregate::Aggregate,
+        aggregate::Aggregator,
         blend::Blend,
         context::{BlendContext, FilterContext},
         fetch::fetch_columns,
@@ -213,7 +213,7 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
         joins,
         filter_context.as_ref().map(Rc::clone),
     ));
-    let aggregate = Aggregate::new(
+    let aggregate = Aggregator::new(
         storage,
         projection,
         group_by,

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -69,7 +69,7 @@ test_case!(aggregate, async move {
             "SELECT SUM(id.name.ok) FROM Item;",
         ),
         (
-            AggregateError::UnsupportedAggregation("AVG".to_owned()).into(),
+            TranslateError::UnsupportedFunction("AVG".to_owned()).into(),
             "SELECT AVG(*) FROM Item;",
         ),
         (

--- a/src/tests/function/left_right.rs
+++ b/src/tests/function/left_right.rs
@@ -108,26 +108,10 @@ test_case!(left_right, async move {
                 "n".to_owned()
             )),
         ),
-        // TODO: Cast cannot handle
-        /*(
-            r#"SELECT LEFT('Words', CAST(NULL AS INTEGER)) AS test FROM SingleItem"#,
-            Ok(select!(
-                "Words"
-                OptStr;
-                Some("blu".to_owned())
-            )),
-        ),
-        (
-            r#"SELECT LEFT(CAST(NULL AS TEXT), 10) AS test FROM SingleItem"#,
-            Ok(select!(
-                ""
-                OptStr;
-                Some("blu".to_owned())
-            )),
-        ),*/
         (
             r#"SELECT RIGHT(name, 10, 10) AS test FROM SingleItem"#,
-            Err(EvaluateError::NumberOfFunctionParamsNotMatching {
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "RIGHT".to_owned(),
                 expected: 2,
                 found: 3,
             }
@@ -135,7 +119,8 @@ test_case!(left_right, async move {
         ),
         (
             r#"SELECT RIGHT(name) AS test FROM SingleItem"#,
-            Err(EvaluateError::NumberOfFunctionParamsNotMatching {
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "RIGHT".to_owned(),
                 expected: 2,
                 found: 1,
             }
@@ -143,7 +128,8 @@ test_case!(left_right, async move {
         ),
         (
             r#"SELECT RIGHT() AS test FROM SingleItem"#,
-            Err(EvaluateError::NumberOfFunctionParamsNotMatching {
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "RIGHT".to_owned(),
                 expected: 2,
                 found: 0,
             }

--- a/src/tests/function/upper_lower.rs
+++ b/src/tests/function/upper_lower.rs
@@ -55,7 +55,8 @@ test_case!(upper_lower, async move {
         ),
         (
             "SELECT LOWER() FROM Item",
-            Err(EvaluateError::NumberOfFunctionParamsNotMatching {
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "LOWER".to_owned(),
                 expected: 1,
                 found: 0,
             }
@@ -67,7 +68,11 @@ test_case!(upper_lower, async move {
         ),
         (
             "SELECT WHATEVER(1) FROM Item",
-            Err(EvaluateError::FunctionNotSupported("WHATEVER".to_owned()).into()),
+            Err(TranslateError::UnsupportedFunction("WHATEVER".to_owned()).into()),
+        ),
+        (
+            "SELECT LOWER(a => 2) FROM Item",
+            Err(TranslateError::NamedFunctionArgNotSupported.into()),
         ),
     ];
 

--- a/src/translate/error.rs
+++ b/src/translate/error.rs
@@ -14,6 +14,19 @@ pub enum TranslateError {
     #[error("too many params in drop index")]
     TooManyParamsInDropIndex,
 
+    #[error("function args.length not matching: {name}, expected: {expected}, found: {found}")]
+    FunctionArgsLengthNotMatching {
+        name: String,
+        expected: usize,
+        found: usize,
+    },
+
+    #[error("named function arg is not supported")]
+    NamedFunctionArgNotSupported,
+
+    #[error("unsupported function: {0}")]
+    UnsupportedFunction(String),
+
     #[error("unsupported statement: {0}")]
     UnsupportedStatement(String),
 

--- a/src/translate/expr.rs
+++ b/src/translate/expr.rs
@@ -76,7 +76,7 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             data_type: translate_data_type(data_type)?,
             value: value.to_owned(),
         }),
-        SqlExpr::Function(function) => translate_function(function).map(Expr::Function),
+        SqlExpr::Function(function) => translate_function(function),
         SqlExpr::Exists(query) => translate_query(query).map(Box::new).map(Expr::Exists),
         SqlExpr::Subquery(query) => translate_query(query).map(Box::new).map(Expr::Subquery),
         _ => Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into()),

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -1,26 +1,90 @@
 use {
-    super::{expr::translate_expr, translate_object_name},
+    super::{expr::translate_expr, translate_object_name, TranslateError},
     crate::{
-        ast::{Function, FunctionArg},
+        ast::{Aggregate, Expr, Function, ObjectName},
         result::Result,
     },
     sqlparser::ast::{Function as SqlFunction, FunctionArg as SqlFunctionArg},
 };
 
-pub fn translate_function(sql_function: &SqlFunction) -> Result<Function> {
+pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let SqlFunction { name, args, .. } = sql_function;
+    let name = {
+        let ObjectName(names) = translate_object_name(name);
 
-    let name = translate_object_name(name);
+        names[0].to_uppercase()
+    };
     let args = args
         .iter()
         .map(|arg| match arg {
-            SqlFunctionArg::Named { name, arg } => Ok(FunctionArg::Named {
-                name: name.value.to_owned(),
-                arg: translate_expr(arg)?,
-            }),
-            SqlFunctionArg::Unnamed(expr) => translate_expr(expr).map(FunctionArg::Unnamed),
+            SqlFunctionArg::Named { .. } => {
+                Err(TranslateError::NamedFunctionArgNotSupported.into())
+            }
+            SqlFunctionArg::Unnamed(expr) => Ok(expr),
         })
-        .collect::<Result<_>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
-    Ok(Function { name, args })
+    let check_len = |name, found, expected| -> Result<_> {
+        if found == expected {
+            Ok(())
+        } else {
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name,
+                expected,
+                found,
+            }
+            .into())
+        }
+    };
+
+    macro_rules! aggr {
+        ($aggregate: expr) => {{
+            check_len(name, args.len(), 1)?;
+
+            translate_expr(args[0])
+                .map(Box::new)
+                .map($aggregate)
+                .map(Expr::Aggregate)
+        }};
+    }
+
+    match name.as_str() {
+        "LOWER" => {
+            check_len(name, args.len(), 1)?;
+
+            translate_expr(args[0])
+                .map(Box::new)
+                .map(Function::Lower)
+                .map(Expr::Function)
+        }
+        "UPPER" => {
+            check_len(name, args.len(), 1)?;
+
+            translate_expr(args[0])
+                .map(Box::new)
+                .map(Function::Upper)
+                .map(Expr::Function)
+        }
+        "LEFT" => {
+            check_len(name, args.len(), 2)?;
+
+            let expr = translate_expr(args[0]).map(Box::new)?;
+            let size = translate_expr(args[1]).map(Box::new)?;
+
+            Ok(Expr::Function(Function::Left { expr, size }))
+        }
+        "RIGHT" => {
+            check_len(name, args.len(), 2)?;
+
+            let expr = translate_expr(args[0]).map(Box::new)?;
+            let size = translate_expr(args[1]).map(Box::new)?;
+
+            Ok(Expr::Function(Function::Right { expr, size }))
+        }
+        "COUNT" => aggr!(Aggregate::Count),
+        "SUM" => aggr!(Aggregate::Sum),
+        "MIN" => aggr!(Aggregate::Min),
+        "MAX" => aggr!(Aggregate::Max),
+        _ => Err(TranslateError::UnsupportedFunction(name).into()),
+    }
 }


### PR DESCRIPTION
Now executor can handle aggregate functions & non-aggregate functions separately.
Function argument parsing is now done in translation, not in execution

Now AST explicitly provides function names & args using enum

Below enums show all functions which are currently supported.
```rust
#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
pub enum Function {
    Lower(Box<Expr>),
    Upper(Box<Expr>),
    Left { expr: Box<Expr>, size: Box<Expr> },
    Right { expr: Box<Expr>, size: Box<Expr> },
}

#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
pub enum Aggregate {
    Count(Box<Expr>),
    Sum(Box<Expr>),
    Max(Box<Expr>),
    Min(Box<Expr>),
}
```