### PR TITLE
Move Box from ast::Function to ast::Expr,

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -46,8 +46,8 @@ pub enum Expr {
         data_type: DataType,
         value: String,
     },
-    Function(Function),
-    Aggregate(Aggregate),
+    Function(Box<Function>),
+    Aggregate(Box<Aggregate>),
     Exists(Box<Query>),
     Subquery(Box<Query>),
 }

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -5,16 +5,16 @@ use {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Function {
-    Lower(Box<Expr>),
-    Upper(Box<Expr>),
-    Left { expr: Box<Expr>, size: Box<Expr> },
-    Right { expr: Box<Expr>, size: Box<Expr> },
+    Lower(Expr),
+    Upper(Expr),
+    Left { expr: Expr, size: Expr },
+    Right { expr: Expr, size: Expr },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Aggregate {
-    Count(Box<Expr>),
-    Sum(Box<Expr>),
-    Max(Box<Expr>),
-    Min(Box<Expr>),
+    Count(Expr),
+    Sum(Expr),
+    Max(Expr),
+    Min(Expr),
 }

--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -195,9 +195,9 @@ fn aggregate<'a>(
             .try_fold(state, |state, expr| aggr(state, expr)),
         Expr::UnaryOp { expr, .. } => aggr(state, expr),
         Expr::Nested(expr) => aggr(state, expr),
-        Expr::Aggregate(aggr) => match aggr {
+        Expr::Aggregate(aggr) => match aggr.as_ref() {
             Aggregate::Count(expr) => {
-                let value = Value::I64(match expr.as_ref() {
+                let value = Value::I64(match expr {
                     Expr::Wildcard => 1,
                     _ => {
                         if get_value(expr)?.is_null() {

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -91,11 +91,11 @@ pub async fn evaluate<'a, T: 'static + Debug>(
         }
         Expr::Aggregate(aggr) => match aggregated
             .as_ref()
-            .map(|aggregated| aggregated.get(aggr))
+            .map(|aggregated| aggregated.get(aggr.as_ref()))
             .flatten()
         {
             Some(value) => Ok(Evaluated::from(value.clone())),
-            None => Err(EvaluateError::UnreachableEmptyAggregateValue(aggr.clone()).into()),
+            None => Err(EvaluateError::UnreachableEmptyAggregateValue(*aggr.clone()).into()),
         },
         Expr::Function(func) => {
             let context = context.as_ref().map(Rc::clone);

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -42,8 +42,8 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             check_len(name, args.len(), 1)?;
 
             translate_expr(args[0])
-                .map(Box::new)
                 .map($aggregate)
+                .map(Box::new)
                 .map(Expr::Aggregate)
         }};
     }
@@ -53,33 +53,33 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             check_len(name, args.len(), 1)?;
 
             translate_expr(args[0])
-                .map(Box::new)
                 .map(Function::Lower)
+                .map(Box::new)
                 .map(Expr::Function)
         }
         "UPPER" => {
             check_len(name, args.len(), 1)?;
 
             translate_expr(args[0])
-                .map(Box::new)
                 .map(Function::Upper)
+                .map(Box::new)
                 .map(Expr::Function)
         }
         "LEFT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0]).map(Box::new)?;
-            let size = translate_expr(args[1]).map(Box::new)?;
+            let expr = translate_expr(args[0])?;
+            let size = translate_expr(args[1])?;
 
-            Ok(Expr::Function(Function::Left { expr, size }))
+            Ok(Expr::Function(Box::new(Function::Left { expr, size })))
         }
         "RIGHT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0]).map(Box::new)?;
-            let size = translate_expr(args[1]).map(Box::new)?;
+            let expr = translate_expr(args[0])?;
+            let size = translate_expr(args[1])?;
 
-            Ok(Expr::Function(Function::Right { expr, size }))
+            Ok(Expr::Function(Box::new(Function::Right { expr, size })))
         }
         "COUNT" => aggr!(Aggregate::Count),
         "SUM" => aggr!(Aggregate::Sum),


### PR DESCRIPTION
Remove Box uses in ast::Function and ast::Aggregate.
Use Box in Expr::Function and Expr::Aggregate.

Related to #240 