### PR TITLE
Implement ORDER BY {expr} index support

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -75,7 +75,7 @@ pub enum Statement {
     CreateIndex {
         name: ObjectName,
         table_name: ObjectName,
-        column: Expr,
+        column: OrderByExpr,
     },
     /// DROP INDEX
     #[cfg(feature = "index")]

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -46,8 +46,8 @@ pub struct TableWithJoins {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IndexItem {
     pub name: String,
-    pub op: IndexOperator,
-    pub value_expr: Expr,
+    pub asc: Option<bool>,
+    pub cmp_expr: Option<(IndexOperator, Expr)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -87,7 +87,7 @@ pub enum JoinConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OrderByExpr {
     pub expr: Expr,
-    pub asc: bool,
+    pub asc: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,7 +10,7 @@ pub use {
     interval::{Interval, IntervalError},
     literal::{Literal, LiteralError},
     row::{Row, RowError},
-    schema::Schema,
+    schema::{Schema, SchemaIndex, SchemaIndexOrd},
     table::{get_name, Table, TableError},
     value::{Value, ValueError},
 };

--- a/src/data/schema.rs
+++ b/src/data/schema.rs
@@ -3,11 +3,25 @@ use {
     serde::{Deserialize, Serialize},
 };
 
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum SchemaIndexOrd {
+    Asc,
+    Desc,
+    Both,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SchemaIndex {
+    pub name: String,
+    pub expr: Expr,
+    pub order: SchemaIndexOrd,
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Schema {
     pub table_name: String,
     pub column_defs: Vec<ColumnDef>,
-    pub indexes: Vec<(String, Expr)>,
+    pub indexes: Vec<SchemaIndex>,
 }
 
 pub trait ColumnDefExt {

--- a/src/executor/alter/index.rs
+++ b/src/executor/alter/index.rs
@@ -3,7 +3,7 @@
 use {
     super::AlterError,
     crate::{
-        ast::{ColumnDef, Expr, ObjectName},
+        ast::{ColumnDef, Expr, ObjectName, OrderByExpr},
         data::{get_name, Schema},
         result::MutResult,
         store::{GStore, GStoreMut},
@@ -15,11 +15,12 @@ pub async fn create_index<T: 'static + Debug, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     table_name: &ObjectName,
     index_name: &ObjectName,
-    expr: &Expr,
+    column: &OrderByExpr,
 ) -> MutResult<U, ()> {
     let names = (|| async {
         let table_name = get_name(table_name)?;
         let index_name = get_name(index_name)?;
+        let expr = &column.expr;
         let Schema { column_defs, .. } = storage
             .fetch_schema(table_name)
             .await?
@@ -47,7 +48,7 @@ pub async fn create_index<T: 'static + Debug, U: GStore<T> + GStoreMut<T>>(
         }
     };
 
-    storage.create_index(table_name, index_name, expr).await
+    storage.create_index(table_name, index_name, column).await
 }
 
 fn validate_index_expr(columns: &[String], expr: &Expr) -> (bool, bool) {

--- a/src/executor/sort.rs
+++ b/src/executor/sort.rs
@@ -87,10 +87,10 @@ impl<'a, T: 'static + Debug> Sort<'a, T> {
                     .iter()
                     .map(|(a, _)| a)
                     .zip(values_b.iter())
-                    .map(|(a, (b, asc))| (a, b, asc));
+                    .map(|(a, (b, asc))| (a, b, asc.unwrap_or(true)));
 
                 for (value_a, value_b, asc) in pairs {
-                    let apply_asc = |ord: Ordering| if *asc { ord } else { ord.reverse() };
+                    let apply_asc = |ord: Ordering| if asc { ord } else { ord.reverse() };
 
                     match (value_a, value_b) {
                         (Value::Null, Value::Null) => {}

--- a/src/storages/sled_storage/index.rs
+++ b/src/storages/sled_storage/index.rs
@@ -14,7 +14,7 @@ use {
         IndexError, Value,
     },
     async_trait::async_trait,
-    iter_enum::Iterator,
+    iter_enum::{DoubleEndedIterator, Iterator},
     sled::IVec,
     std::iter::{empty, once},
 };
@@ -25,90 +25,110 @@ impl Index<IVec> for SledStorage {
         &self,
         table_name: &str,
         index_name: &str,
-        op: &IndexOperator,
-        value: Value,
+        asc: Option<bool>,
+        cmp_value: Option<(&IndexOperator, Value)>,
     ) -> Result<RowIter<IVec>> {
         let index_data_ids = {
-            #[derive(Iterator)]
-            enum DataIds<I1, I2, I3> {
+            #[derive(Iterator, DoubleEndedIterator)]
+            enum DataIds<I1, I2, I3, I4> {
                 Empty(I1),
                 Once(I2),
                 Range(I3),
+                Full(I4),
             }
 
             let map = |item: std::result::Result<_, _>| item.map(|(_, v)| v);
-            let incr = |key: Vec<u8>| {
-                key.into_iter()
-                    .rev()
-                    .fold((false, Vector::new()), |(added, upper), v| {
-                        match (added, v) {
-                            (true, _) => (added, upper.push(v)),
-                            (false, u8::MAX) => (added, upper.push(v)),
-                            (false, _) => (true, upper.push(v + 1)),
-                        }
-                    })
-                    .1
-                    .reverse()
-                    .into()
-            };
-            let lower = || build_index_key_prefix(table_name, index_name);
-            let upper = || incr(build_index_key_prefix(table_name, index_name));
-            let key = build_index_key(table_name, index_name, value);
 
-            match op {
-                IndexOperator::Eq => match self.tree.get(&key).transpose() {
-                    Some(v) => DataIds::Once(once(v)),
-                    None => DataIds::Empty(empty()),
-                },
-                IndexOperator::Gt => DataIds::Range(self.tree.range(incr(key)..upper()).map(map)),
-                IndexOperator::GtEq => DataIds::Range(self.tree.range(key..upper()).map(map)),
-                IndexOperator::Lt => DataIds::Range(self.tree.range(lower()..key).map(map)),
-                IndexOperator::LtEq => DataIds::Range(self.tree.range(lower()..=key).map(map)),
+            match cmp_value {
+                None => {
+                    let prefix = build_index_key_prefix(table_name, index_name);
+
+                    DataIds::Full(self.tree.scan_prefix(prefix).map(map))
+                }
+                Some((op, value)) => {
+                    let incr = |key: Vec<u8>| {
+                        key.into_iter()
+                            .rev()
+                            .fold((false, Vector::new()), |(added, upper), v| {
+                                match (added, v) {
+                                    (true, _) => (added, upper.push(v)),
+                                    (false, u8::MAX) => (added, upper.push(v)),
+                                    (false, _) => (true, upper.push(v + 1)),
+                                }
+                            })
+                            .1
+                            .reverse()
+                            .into()
+                    };
+                    let lower = || build_index_key_prefix(table_name, index_name);
+                    let upper = || incr(build_index_key_prefix(table_name, index_name));
+                    let key = build_index_key(table_name, index_name, value);
+
+                    match op {
+                        IndexOperator::Eq => match self.tree.get(&key).transpose() {
+                            Some(v) => DataIds::Once(once(v)),
+                            None => DataIds::Empty(empty()),
+                        },
+                        IndexOperator::Gt => {
+                            DataIds::Range(self.tree.range(incr(key)..upper()).map(map))
+                        }
+                        IndexOperator::GtEq => {
+                            DataIds::Range(self.tree.range(key..upper()).map(map))
+                        }
+                        IndexOperator::Lt => DataIds::Range(self.tree.range(lower()..key).map(map)),
+                        IndexOperator::LtEq => {
+                            DataIds::Range(self.tree.range(lower()..=key).map(map))
+                        }
+                    }
+                }
             }
         };
 
         let tree = self.tree.clone();
-        let rows = index_data_ids.map(|v| v.map_err(err_into)).flat_map(
-            move |index_data_id: Result<IVec>| {
-                #[derive(Iterator)]
-                enum Rows<I1, I2> {
-                    Ok(I1),
-                    Err(I2),
+        let flat_map = move |index_data_id: Result<IVec>| {
+            #[derive(Iterator)]
+            enum Rows<I1, I2> {
+                Ok(I1),
+                Err(I2),
+            }
+
+            let index_data_id: IVec = match index_data_id {
+                Ok(id) => id,
+                Err(e) => {
+                    return Rows::Err(once(Err(e)));
                 }
+            };
 
-                let index_data_id: IVec = match index_data_id {
-                    Ok(id) => id,
-                    Err(e) => {
-                        return Rows::Err(once(Err(e)));
-                    }
-                };
+            let bytes = "indexdata/"
+                .to_owned()
+                .into_bytes()
+                .into_iter()
+                .chain(index_data_id.iter().copied())
+                .collect::<Vec<_>>();
+            let index_data_prefix = IVec::from(bytes);
 
-                let bytes = "indexdata/"
-                    .to_owned()
-                    .into_bytes()
-                    .into_iter()
-                    .chain(index_data_id.iter().copied())
-                    .collect::<Vec<_>>();
-                let index_data_prefix = IVec::from(bytes);
+            let tree2 = tree.clone();
+            let rows = tree
+                .scan_prefix(&index_data_prefix)
+                .map(move |item| -> Result<_> {
+                    let (_, data_key) = item.map_err(err_into)?;
+                    let value = tree2
+                        .get(&data_key)
+                        .map_err(err_into)?
+                        .ok_or(IndexError::ConflictOnEmptyIndexValueScan)?;
+                    let value = bincode::deserialize(&value).map_err(err_into)?;
 
-                let tree2 = tree.clone();
-                let rows = tree
-                    .scan_prefix(&index_data_prefix)
-                    .map(move |item| -> Result<_> {
-                        let (_, data_key) = item.map_err(err_into)?;
-                        let value = tree2
-                            .get(&data_key)
-                            .map_err(err_into)?
-                            .ok_or(IndexError::ConflictOnEmptyIndexValueScan)?;
-                        let value = bincode::deserialize(&value).map_err(err_into)?;
+                    Ok((data_key, value))
+                });
 
-                        Ok((data_key, value))
-                    });
+            Rows::Ok(rows)
+        };
 
-                Rows::Ok(rows)
-            },
-        );
+        let index_data_ids = index_data_ids.map(|v| v.map_err(err_into));
 
-        Ok(Box::new(rows))
+        Ok(match asc {
+            Some(true) | None => Box::new(index_data_ids.flat_map(flat_map)),
+            Some(false) => Box::new(index_data_ids.rev().flat_map(flat_map)),
+        })
     }
 }

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -2,7 +2,9 @@
 
 use {
     super::fetch_schema,
-    crate::{ast::Expr, evaluate_stateless, Error, IndexError, Result, Row, Schema, Value},
+    crate::{
+        ast::Expr, evaluate_stateless, Error, IndexError, Result, Row, Schema, SchemaIndex, Value,
+    },
     sled::{
         transaction::{
             ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
@@ -15,7 +17,7 @@ use {
 pub struct IndexSync<'a> {
     table_name: &'a str,
     columns: Vec<String>,
-    indexes: Cow<'a, Vec<(String, Expr)>>,
+    indexes: Cow<'a, Vec<SchemaIndex>>,
 }
 
 impl<'a> From<&'a Schema> for IndexSync<'a> {
@@ -69,7 +71,13 @@ impl<'a> IndexSync<'a> {
         data_key: &IVec,
         row: &Row,
     ) -> ConflictableTransactionResult<(), Error> {
-        for (index_name, index_expr) in self.indexes.iter() {
+        for index in self.indexes.iter() {
+            let SchemaIndex {
+                name: index_name,
+                expr: index_expr,
+                ..
+            } = index;
+
             let index_key =
                 &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 
@@ -86,7 +94,13 @@ impl<'a> IndexSync<'a> {
         old_row: &Row,
         new_row: &Row,
     ) -> ConflictableTransactionResult<(), Error> {
-        for (index_name, index_expr) in self.indexes.iter() {
+        for index in self.indexes.iter() {
+            let SchemaIndex {
+                name: index_name,
+                expr: index_expr,
+                ..
+            } = index;
+
             let old_index_key = &evaluate_index_key(
                 self.table_name,
                 index_name,
@@ -116,7 +130,13 @@ impl<'a> IndexSync<'a> {
         data_key: &IVec,
         row: &Row,
     ) -> ConflictableTransactionResult<(), Error> {
-        for (index_name, index_expr) in self.indexes.iter() {
+        for index in self.indexes.iter() {
+            let SchemaIndex {
+                name: index_name,
+                expr: index_expr,
+                ..
+            } = index;
+
             let index_key =
                 &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 

--- a/src/store/index.rs
+++ b/src/store/index.rs
@@ -1,7 +1,7 @@
 use {
     super::RowIter,
     crate::{
-        ast::{Expr, IndexOperator},
+        ast::{IndexOperator, OrderByExpr},
         data::Value,
         result::{MutResult, Result},
     },
@@ -44,8 +44,8 @@ pub trait Index<T: Debug> {
         &self,
         table_name: &str,
         index_name: &str,
-        op: &IndexOperator,
-        value: Value,
+        asc: Option<bool>,
+        cmp_value: Option<(&IndexOperator, Value)>,
     ) -> Result<RowIter<T>>;
 }
 
@@ -58,7 +58,7 @@ where
         self,
         table_name: &str,
         index_name: &str,
-        column: &Expr,
+        column: &OrderByExpr,
     ) -> MutResult<Self, ()>;
 
     async fn drop_index(self, table_name: &str, index_name: &str) -> MutResult<Self, ()>;

--- a/src/tests/index/mod.rs
+++ b/src/tests/index/mod.rs
@@ -4,10 +4,12 @@ mod and;
 mod basic;
 mod expr;
 mod null;
+mod order_by;
 mod value;
 
 pub use and::and;
 pub use basic::basic;
 pub use expr::expr;
 pub use null::null;
+pub use order_by::order_by;
 pub use value::value;

--- a/src/tests/index/order_by.rs
+++ b/src/tests/index/order_by.rs
@@ -1,0 +1,90 @@
+use crate::*;
+
+test_case!(order_by, async move {
+    run!(
+        r#"
+CREATE TABLE Test (
+    id INTEGER,
+    num INTEGER NULL,
+    name TEXT,
+)"#
+    );
+    run!(
+        r#"
+        INSERT INTO Test (id, num, name)
+        VALUES
+            (1, 2,    "Hello"),
+            (1, 9,    "Wild"),
+            (3, NULL, "World"),
+            (4, 7,    "Monday");
+    "#
+    );
+
+    test!(
+        Ok(Payload::CreateIndex),
+        "CREATE INDEX idx_name ON Test (name)"
+    );
+    test!(
+        Ok(Payload::CreateIndex),
+        "CREATE INDEX idx_id_num_asc ON Test (id + num ASC)"
+    );
+    test!(
+        Ok(Payload::CreateIndex),
+        "CREATE INDEX idx_num_desc ON Test (num DESC)"
+    );
+
+    use Value::*;
+
+    macro_rules! s {
+        ($v: literal) => {
+            Str($v.to_owned())
+        };
+    }
+
+    test_idx!(
+        Ok(select_with_null!(
+            id     | num    | name;
+            I64(1)   I64(2)   s!("Hello");
+            I64(4)   I64(7)   s!("Monday");
+            I64(1)   I64(9)   s!("Wild");
+            I64(3)   Null     s!("World")
+        )),
+        idx!(idx_name),
+        "SELECT * FROM Test ORDER BY name"
+    );
+
+    test_idx!(
+        Ok(select_with_null!(
+            id     | num    | name;
+            I64(1)   I64(2)   s!("Hello");
+            I64(1)   I64(9)   s!("Wild");
+            I64(4)   I64(7)   s!("Monday");
+            I64(3)   Null     s!("World")
+        )),
+        idx!(idx_id_num_asc),
+        "SELECT * FROM Test ORDER BY id + num"
+    );
+
+    test_idx!(
+        Ok(select_with_null!(
+            id     | num    | name;
+            I64(1)   I64(2)   s!("Hello");
+            I64(1)   I64(9)   s!("Wild");
+            I64(4)   I64(7)   s!("Monday");
+            I64(3)   Null     s!("World")
+        )),
+        idx!(idx_id_num_asc, ASC),
+        "SELECT * FROM Test ORDER BY id + num ASC"
+    );
+
+    test_idx!(
+        Ok(select_with_null!(
+            id     | num    | name;
+            I64(3)   Null     s!("World");
+            I64(1)   I64(9)   s!("Wild");
+            I64(1)   I64(2)   s!("Hello")
+        )),
+        idx!(idx_num_desc, DESC),
+        "SELECT * FROM Test where id < 4 ORDER BY num DESC"
+    );
+});

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -13,8 +13,32 @@ macro_rules! idx {
     ($name: path, $op: path, $sql_expr: literal) => {
         vec![ast::IndexItem {
             name: stringify!($name).to_owned(),
-            op: $op,
-            value_expr: translate_expr(&parse_expr($sql_expr).unwrap()).unwrap(),
+            asc: None,
+            cmp_expr: Some((
+                $op,
+                translate_expr(&parse_expr($sql_expr).unwrap()).unwrap(),
+            )),
+        }]
+    };
+    ($name: path) => {
+        vec![ast::IndexItem {
+            name: stringify!($name).to_owned(),
+            asc: None,
+            cmp_expr: None,
+        }]
+    };
+    ($name: path, ASC) => {
+        vec![ast::IndexItem {
+            name: stringify!($name).to_owned(),
+            asc: Some(true),
+            cmp_expr: None,
+        }]
+    };
+    ($name: path, DESC) => {
+        vec![ast::IndexItem {
+            name: stringify!($name).to_owned(),
+            asc: Some(false),
+            cmp_expr: None,
         }]
     };
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -83,6 +83,7 @@ macro_rules! generate_tests {
                 glue!(index_null, index::null);
                 glue!(index_expr, index::expr);
                 glue!(index_value, index::value);
+                glue!(index_order_by, index::order_by);
             };
         }
 

--- a/src/tests/order_by.rs
+++ b/src/tests/order_by.rs
@@ -162,7 +162,7 @@ test_case!(order_by, async move {
         Err(
             SelectError::OrderByOnNonIndexedExprNotSupported(vec![OrderByExpr {
                 expr: Expr::Identifier("id".to_owned()),
-                asc: false,
+                asc: Some(false),
             }])
             .into()
         ),

--- a/src/translate/mod.rs
+++ b/src/translate/mod.rs
@@ -7,7 +7,10 @@ mod function;
 mod operator;
 mod query;
 
-pub use self::{error::TranslateError, expr::translate_expr};
+pub use self::{
+    error::TranslateError,
+    expr::{translate_expr, translate_order_by_expr},
+};
 
 #[cfg(feature = "alter-table")]
 use ddl::translate_alter_table_operation;
@@ -100,7 +103,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             Ok(Statement::CreateIndex {
                 name: translate_object_name(name),
                 table_name: translate_object_name(table_name),
-                column: translate_expr(&columns[0].expr)?,
+                column: translate_order_by_expr(&columns[0])?,
             })
         }
         #[cfg(feature = "index")]


### PR DESCRIPTION
Now, Index can be applied to `ORDER BY` clause.
Query planner can catch index in `ORDER BY`.

e.g.
```sql
SELECT * FROM Test ORDER BY id DESC;

SELECT * FROM Test ORDER BY name || id ASC:
SELECT * FROM Test ORDER BY name || id;
```
