### PR TITLE
Update query planner to find index in multi-expr-based ORDER BY,

### DIFF
--- a/src/executor/sort.rs
+++ b/src/executor/sort.rs
@@ -82,7 +82,7 @@ impl<'a, T: 'static + Debug> Sort<'a, T> {
             .try_collect::<Vec<_>>()
             .await
             .map(Vector::from)?
-            .sort_unstable_by(|(values_a, _, _), (values_b, _, _)| {
+            .sort_by(|(values_a, _, _), (values_b, _, _)| {
                 let pairs = values_a
                     .iter()
                     .map(|(a, _)| a)

--- a/src/tests/index/mod.rs
+++ b/src/tests/index/mod.rs
@@ -11,5 +11,5 @@ pub use and::and;
 pub use basic::basic;
 pub use expr::expr;
 pub use null::null;
-pub use order_by::order_by;
+pub use order_by::{order_by, order_by_multi};
 pub use value::value;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -84,6 +84,7 @@ macro_rules! generate_tests {
                 glue!(index_expr, index::expr);
                 glue!(index_value, index::value);
                 glue!(index_order_by, index::order_by);
+                glue!(index_order_by_multi, index::order_by_multi);
             };
         }
 

--- a/src/utils/vector.rs
+++ b/src/utils/vector.rs
@@ -28,13 +28,19 @@ impl<T> Vector<T> {
         self
     }
 
-    pub fn sort_unstable_by<F>(mut self, compare: F) -> Self
+    pub fn sort_by<F>(mut self, compare: F) -> Self
     where
         F: FnMut(&T, &T) -> std::cmp::Ordering,
     {
         self.0.sort_by(compare);
 
         self
+    }
+
+    pub fn pop(mut self) -> (Self, Option<T>) {
+        let v = self.0.pop();
+
+        (self, v)
     }
 
     pub fn get(&self, i: usize) -> Option<&T> {


### PR DESCRIPTION
If ORDER BY clauses have multiple exprs and the last expr is indexed, new query planner can catch it.
e.g.
```sql
CREATE INDEX idx_id ON Sample (id ASC);
SELECT * FROM Sample ORDER BY num DESC, id ASC;
- Then, query planner finds the last expr (id ASC) as indexed one.
```