### PR TITLE
Apply limit after aggregate & sort finished,

### DIFF
--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -1,8 +1,12 @@
 use {
-    super::{context::BlendContext, evaluate::evaluate_stateless},
-    crate::{ast::Expr, data::Value, result::Result},
+    super::evaluate::evaluate_stateless,
+    crate::{
+        ast::Expr,
+        data::{Row, Value},
+        result::Result,
+    },
     futures::stream::{Stream, StreamExt},
-    std::{convert::TryInto, pin::Pin, rc::Rc},
+    std::{convert::TryInto, pin::Pin},
 };
 
 pub struct Limit {
@@ -27,8 +31,8 @@ impl Limit {
 
     pub fn apply<'a>(
         &self,
-        rows: impl Stream<Item = Result<Rc<BlendContext<'a>>>> + 'a,
-    ) -> Pin<Box<dyn Stream<Item = Result<Rc<BlendContext<'a>>>> + 'a>> {
+        rows: impl Stream<Item = Result<Row>> + 'a,
+    ) -> Pin<Box<dyn Stream<Item = Result<Row>> + 'a>> {
         match (self.offset, self.limit) {
             (Some(offset), Some(limit)) => Box::pin(rows.skip(offset).take(limit)),
             (Some(offset), None) => Box::pin(rows.skip(offset)),

--- a/src/executor/select/mod.rs
+++ b/src/executor/select/mod.rs
@@ -250,7 +250,6 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
             }
         });
 
-    let rows = limit.apply(rows);
     let rows = aggregate.apply(rows).await?;
     let rows = sort
         .apply(rows)
@@ -260,6 +259,7 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
 
             async move { blend.apply(aggregated, context).await }
         });
+    let rows = limit.apply(rows);
 
     Ok((labels, rows))
 }

--- a/src/tests/limit.rs
+++ b/src/tests/limit.rs
@@ -38,6 +38,20 @@ test_case!(limit, async move {
             r#"SELECT * FROM Test LIMIT 4 OFFSET 3;"#,
             select!(id; I64; 4; 5; 6; 7),
         ),
+        (
+            "SELECT * FROM Test ORDER BY id DESC LIMIT 3",
+            select!(id; I64; 8; 7; 6),
+        ),
+        (
+            "SELECT id, COUNT(*) as c FROM Test GROUP BY id LIMIT 3 OFFSET 2",
+            select!(
+                id  | c;
+                I64 | I64;
+                3     1;
+                4     1;
+                5     1
+            ),
+        ),
     ];
 
     for (sql, expected) in test_cases.into_iter() {


### PR DESCRIPTION
LIMIT must be evaluated after aggregate (SUM, COUNT...) and sort (ORDER BY), but it was not.