### PR TITLE
Fix sled-storage to read & write less on index sync,

### DIFF
--- a/src/tests/index/basic.rs
+++ b/src/tests/index/basic.rs
@@ -267,6 +267,19 @@ CREATE TABLE Test (
         "SELECT id FROM Test WHERE id + num = id"
     );
 
+    test_idx!(
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            2     2     "Hello".to_owned();
+            2     17    "World".to_owned();
+            2     30    "New one".to_owned();
+            4     7     "Job".to_owned()
+        )),
+        idx!(idx_id, Lt, "20"),
+        "SELECT id, num, name FROM Test WHERE id < 20"
+    );
+
     test!(
         Err(TranslateError::CompositeIndexNotSupported.into()),
         "CREATE INDEX idx_com ON Test (id, num)"

--- a/src/utils/vector.rs
+++ b/src/utils/vector.rs
@@ -22,6 +22,13 @@ impl<T> Vector<T> {
     }
 
     #[cfg(all(feature = "index", feature = "sled-storage"))]
+    pub fn remove(mut self, i: usize) -> Self {
+        self.0.remove(i);
+
+        self
+    }
+
+    #[cfg(all(feature = "index", feature = "sled-storage"))]
     pub fn reverse(mut self) -> Self {
         self.0.reverse();
 


### PR DESCRIPTION
Make index_key to contains serialized Vec<key> info rather than having the pointer to access keys

There is a but fix, too.
Prev `index_sync` was updating all indexes when a specific index is created or dropped, now fixed.