### PR TITLE
Add support for like operaror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sorter = []
 sled-storage = ["sled", "bincode"]
 
 [dependencies]
+regex = "1.5"
 async-trait = "0.1"
 async-recursion = "0.3"
 boolinator = "2.4"

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -22,6 +22,8 @@ pub enum BinaryOperator {
     NotEq,
     And,
     Or,
+    Like,
+    NotLike,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -7,16 +7,13 @@ use {
     std::{borrow::Cow, cmp::Ordering, convert::TryFrom, fmt::Debug},
     thiserror::Error,
     Literal::*,
-    regex::{Regex},
+    super::StringExt,
 };
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum LiteralError {
     #[error("unsupported literal binary arithmetic between {0} and {1}")]
     UnsupportedBinaryArithmetic(String, String),
-
-    #[error("failed to parse pattern: {0}")]
-    FailedToParsePattern(String),
 
     #[error("literal unary operation on non-numeric")]
     UnaryOperationOnNonNumeric,
@@ -273,17 +270,7 @@ impl<'a> Literal<'a> {
 
     pub fn like(&self, other: &Literal<'a>) -> Result<Self> {
         match (self, other) {
-            (Text(l), Text(r)) => Ok(Boolean(Regex::new(
-                &format!(
-                    "^{}$",
-                    regex::escape(r)
-                        .replace("%", ".*")
-                        .replace("_", ".")
-                )
-            )
-            .map_err(|e| LiteralError::FailedToParsePattern(e.to_string()))?
-            .is_match(l)
-        )),
+            (Text(l), Text(r)) => Ok(Boolean(l.as_ref().like(&r)?)),
             _ => Ok(Boolean(false)),
         }
     }

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -7,12 +7,16 @@ use {
     std::{borrow::Cow, cmp::Ordering, convert::TryFrom, fmt::Debug},
     thiserror::Error,
     Literal::*,
+    regex::{Regex},
 };
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum LiteralError {
     #[error("unsupported literal binary arithmetic between {0} and {1}")]
     UnsupportedBinaryArithmetic(String, String),
+
+    #[error("failed to parse pattern: {0}")]
+    FailedToParsePattern(String),
 
     #[error("literal unary operation on non-numeric")]
     UnaryOperationOnNonNumeric,
@@ -264,6 +268,23 @@ impl<'a> Literal<'a> {
                 format!("{:?}", other),
             )
             .into()),
+        }
+    }
+
+    pub fn like(&self, other: &Literal<'a>) -> Result<Self> {
+        match (self, other) {
+            (Text(l), Text(r)) => Ok(Boolean(Regex::new(
+                &format!(
+                    "^{}$",
+                    regex::escape(r)
+                        .replace("%", ".*")
+                        .replace("_", ".")
+                )
+            )
+            .map_err(|e| LiteralError::FailedToParsePattern(e.to_string()))?
+            .is_match(l)
+        )),
+            _ => Ok(Boolean(false)),
         }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,7 @@ mod interval;
 mod literal;
 mod row;
 mod table;
+mod string_ext;
 
 pub mod schema;
 pub mod value;
@@ -13,4 +14,5 @@ pub use {
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
     table::{get_name, Table, TableError},
     value::{Value, ValueError},
+    string_ext::{StringExt, StringExtError}
 };

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,8 +1,8 @@
 mod interval;
 mod literal;
 mod row;
-mod table;
 mod string_ext;
+mod table;
 
 pub mod schema;
 pub mod value;
@@ -12,7 +12,7 @@ pub use {
     literal::{Literal, LiteralError},
     row::{Row, RowError},
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
+    string_ext::{StringExt, StringExtError},
     table::{get_name, Table, TableError},
     value::{Value, ValueError},
-    string_ext::{StringExt, StringExtError}
 };

--- a/src/data/string_ext.rs
+++ b/src/data/string_ext.rs
@@ -1,16 +1,9 @@
-use {
-    crate::result::Result,
-    regex::Regex,
-    thiserror::Error,
-    serde::Serialize,
-};
-
+use {crate::result::Result, regex::Regex, serde::Serialize, thiserror::Error};
 
 #[derive(Error, Serialize, Debug, PartialEq)]
 pub enum StringExtError {
-
     #[error("unreachable literal unary operation")]
-    UnreachablePatternParsing
+    UnreachablePatternParsing,
 }
 
 pub trait StringExt {
@@ -19,14 +12,10 @@ pub trait StringExt {
 
 impl StringExt for String {
     fn like(&self, pattern: &str) -> Result<bool> {
-        Ok(Regex::new(
-            &format!(
-                "^{}$",
-                regex::escape(pattern)
-                    .replace("%", ".*")
-                    .replace("_", ".")
-            )
-        )
+        Ok(Regex::new(&format!(
+            "^{}$",
+            regex::escape(pattern).replace("%", ".*").replace("_", ".")
+        ))
         .map_err(|_| StringExtError::UnreachablePatternParsing)?
         .is_match(self))
     }

--- a/src/data/string_ext.rs
+++ b/src/data/string_ext.rs
@@ -1,0 +1,33 @@
+use {
+    crate::result::Result,
+    regex::Regex,
+    thiserror::Error,
+    serde::Serialize,
+};
+
+
+#[derive(Error, Serialize, Debug, PartialEq)]
+pub enum StringExtError {
+
+    #[error("unreachable literal unary operation")]
+    UnreachablePatternParsing
+}
+
+pub trait StringExt {
+    fn like(&self, pattern: &str) -> Result<bool>;
+}
+
+impl StringExt for String {
+    fn like(&self, pattern: &str) -> Result<bool> {
+        Ok(Regex::new(
+            &format!(
+                "^{}$",
+                regex::escape(pattern)
+                    .replace("%", ".*")
+                    .replace("_", ".")
+            )
+        )
+        .map_err(|_| StringExtError::UnreachablePatternParsing)?
+        .is_match(self))
+    }
+}

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -31,6 +31,9 @@ pub enum ValueError {
     #[error("failed to parse time: {0}")]
     FailedToParseTime(String),
 
+    #[error("failed to parse pattern: {0}")]
+    FailedToParsePattern(String),
+
     #[error("add on non-numeric values: {0:?} + {1:?}")]
     AddOnNonNumeric(Value, Value),
 

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -86,4 +86,7 @@ pub enum ValueError {
 
     #[error("unreachable integer overflow: {0}")]
     UnreachableIntegerOverflow(String),
+
+    #[error("operator doesn't exist: {0:?} LIKE {1:?}")]
+    LikeOnNonString(Value, Value),
 }

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -31,9 +31,6 @@ pub enum ValueError {
     #[error("failed to parse time: {0}")]
     FailedToParseTime(String),
 
-    #[error("failed to parse pattern: {0}")]
-    FailedToParsePattern(String),
-
     #[error("add on non-numeric values: {0:?} + {1:?}")]
     AddOnNonNumeric(Value, Value),
 

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -5,7 +5,7 @@ use {
     core::ops::Sub,
     serde::{Deserialize, Serialize},
     std::{cmp::Ordering, convert::TryInto, fmt::Debug},
-    regex::{Regex},
+    super::StringExt,
 };
 
 mod big_edian;
@@ -289,17 +289,7 @@ impl Value {
         use Value::*;
 
         match (self, other) {
-            (Str(a), Str(b)) => Ok(Bool(Regex::new(
-                &format!(
-                    "^{}$",
-                    regex::escape(b)
-                        .replace("%", ".*")
-                        .replace("_", ".")
-                )
-            )
-            .map_err(|e| ValueError::FailedToParsePattern(e.to_string()))?
-            .is_match(a)
-        )),
+            (Str(a), Str(b)) => Ok(Bool(a.like(&b)?)),
             _ => Ok(Bool(false)),
         }
     }

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -1,11 +1,11 @@
 use {
     super::Interval,
+    super::StringExt,
     crate::{ast::DataType, result::Result},
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
     core::ops::Sub,
     serde::{Deserialize, Serialize},
     std::{cmp::Ordering, convert::TryInto, fmt::Debug},
-    super::StringExt,
 };
 
 mod big_edian;
@@ -289,8 +289,8 @@ impl Value {
         use Value::*;
 
         match (self, other) {
-            (Str(a), Str(b)) => Ok(Bool(a.like(&b)?)),
-            _ => Ok(Bool(false)),
+            (Str(a), Str(b)) => a.like(&b).map(Bool),
+            _ => Err(ValueError::LikeOnNonString(self.clone(), other.clone()).into()),
         }
     }
 }

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -154,6 +154,23 @@ impl<'a> Evaluated<'a> {
         Ok(evaluated)
     }
 
+    pub fn like(&self, other: Evaluated<'a>) -> Result<Evaluated<'a>> {
+        let evaluated = match (self, other) {
+            (Evaluated::Literal(l), Evaluated::Literal(r)) => Evaluated::Literal(l.like(&r)?),
+            (Evaluated::Literal(l), Evaluated::Value(r)) => {
+                Evaluated::from((&Value::try_from(l)?).like(r.as_ref())?)
+            }
+            (Evaluated::Value(l), Evaluated::Literal(r)) => {
+                Evaluated::from(l.as_ref().like(&Value::try_from(r)?)?)
+            }
+            (Evaluated::Value(l), Evaluated::Value(r)) => {
+                Evaluated::from(l.as_ref().like(r.as_ref())?)
+            }
+        };
+
+        Ok(evaluated)
+    }
+
     pub fn is_null(&self) -> bool {
         match self {
             Evaluated::Value(v) => v.is_null(),

--- a/src/executor/evaluate/expr.rs
+++ b/src/executor/evaluate/expr.rs
@@ -56,6 +56,8 @@ pub fn binary_op<'a>(
         BinaryOperator::GtEq => cmp!(l >= r),
         BinaryOperator::And => cond!(l && r),
         BinaryOperator::Or => cond!(l || r),
+        BinaryOperator::Like => l.like(r),
+        BinaryOperator::NotLike => cmp!(l.like(r)? == Evaluated::Literal(Literal::Boolean(false))),
     }
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        data::{IntervalError, LiteralError, RowError, TableError, ValueError, StringExtError},
+        data::{IntervalError, LiteralError, RowError, StringExtError, TableError, ValueError},
         executor::{
             AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, SelectError,
             UpdateError, ValidateError,

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        data::{IntervalError, LiteralError, RowError, TableError, ValueError},
+        data::{IntervalError, LiteralError, RowError, TableError, ValueError, StringExtError},
         executor::{
             AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, SelectError,
             UpdateError, ValidateError,
@@ -63,6 +63,8 @@ pub enum Error {
     Literal(#[from] LiteralError),
     #[error(transparent)]
     Interval(#[from] IntervalError),
+    #[error(transparent)]
+    StringExt(#[from] StringExtError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -92,6 +94,7 @@ impl PartialEq for Error {
             (Value(e), Value(e2)) => e == e2,
             (Literal(e), Literal(e2)) => e == e2,
             (Interval(e), Interval(e2)) => e == e2,
+            (StringExt(e), StringExt(e2)) => e == e2,
             _ => false,
         }
     }

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -76,6 +76,11 @@ test_case!(filter, async move {
         (3, "SELECT id FROM Hunter WHERE +2 > +1.0"),
         (2, "SELECT name FROM Boss WHERE id <= +2"),
         (2, "SELECT name FROM Boss WHERE +id <= 2"),
+        (2, "SELECT name FROM Boss WHERE name LIKE '_a%'"),
+        (2, "SELECT name FROM Boss WHERE name LIKE '%r%'"),
+        (2, "SELECT name FROM Boss WHERE name LIKE '%a'"),
+        (5, "SELECT name FROM Boss WHERE name LIKE '%%'"),
+        (1, "SELECT name FROM Boss WHERE name NOT LIKE '%a%'"),
     ];
 
     for (num, sql) in select_sqls.iter() {

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -81,6 +81,8 @@ test_case!(filter, async move {
         (2, "SELECT name FROM Boss WHERE name LIKE '%a'"),
         (5, "SELECT name FROM Boss WHERE name LIKE '%%'"),
         (1, "SELECT name FROM Boss WHERE name NOT LIKE '%a%'"),
+        (5, "SELECT name FROM Boss WHERE 'ABC' LIKE '_B_'"),
+        (0, "SELECT name FROM Boss WHERE name LIKE 10"),
     ];
 
     for (num, sql) in select_sqls.iter() {

--- a/src/translate/operator.rs
+++ b/src/translate/operator.rs
@@ -33,6 +33,8 @@ pub fn translate_binary_operator(
         SqlBinaryOperator::NotEq => Ok(BinaryOperator::NotEq),
         SqlBinaryOperator::And => Ok(BinaryOperator::And),
         SqlBinaryOperator::Or => Ok(BinaryOperator::Or),
+        SqlBinaryOperator::Like => Ok(BinaryOperator::Like),
+        SqlBinaryOperator::NotLike => Ok(BinaryOperator::NotLike),
         _ => Err(TranslateError::UnsupportedBinaryOperator(sql_binary_operator.to_string()).into()),
     }
 }


### PR DESCRIPTION
Support for like operator such in postgres :
[PostgreSQL: Documentation: 8.3: Pattern Matching](www.postgresql.org/docs/8.3/functions-matching.html)

Implemented using [regex](https://github.com/rust-lang/regex) library
Take a look on filter test for example
Should close #251
Feel free to review it :smile: 