### PR TITLE
Remove Boolinator crate dependency,

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ sled-storage = ["sled", "bincode"]
 [dependencies]
 async-trait = "0.1"
 async-recursion = "0.3"
-boolinator = "2.4"
 cfg-if = "1"
 chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 rust_decimal = "1.14"

--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -15,7 +15,6 @@ use {
         result::{Error, Result},
         store::GStore,
     },
-    boolinator::Boolinator,
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
     std::{convert::TryFrom, fmt::Debug, pin::Pin, rc::Rc},
 };
@@ -127,7 +126,7 @@ impl<'a, T: 'static + Debug> Aggregator<'a, T> {
                                 having,
                             )
                             .await
-                            .map(|pass| pass.as_some((aggregated, next)))
+                            .map(|pass| pass.then(|| (aggregated, next)))
                             .transpose()
                         }
                     }

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -12,7 +12,6 @@ use {
         store::GStore,
     },
     async_recursion::async_recursion,
-    boolinator::Boolinator,
     futures::stream::{self, StreamExt, TryStreamExt},
     im_rc::HashMap,
     std::{
@@ -119,7 +118,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
                     async move {
                         eval(expr).await.map_or_else(
                             |error| Some(Err(error)),
-                            |evaluated| (target == &evaluated).as_some(Ok(!negated)),
+                            |evaluated| (target == &evaluated).then(|| Ok(!negated)),
                         )
                     }
                 })
@@ -148,7 +147,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
                         let value = row.take_first_value()?;
 
                         (target == &Evaluated::from(&value))
-                            .as_some(Ok(!negated))
+                            .then(|| Ok(!negated))
                             .transpose()
                     }
                 })

--- a/src/executor/evaluate/stateless.rs
+++ b/src/executor/evaluate/stateless.rs
@@ -5,7 +5,6 @@ use {
         data::{Row, Value},
         result::Result,
     },
-    boolinator::Boolinator,
     std::borrow::Cow,
 };
 
@@ -69,7 +68,7 @@ pub fn evaluate_stateless<'a>(
 
                     eval(expr).map_or_else(
                         |error| Some(Err(error)),
-                        |evaluated| (target == &evaluated).as_some(Ok(!negated)),
+                        |evaluated| (target == &evaluated).then(|| Ok(!negated)),
                     )
                 })
                 .take(1)

--- a/src/executor/fetch.rs
+++ b/src/executor/fetch.rs
@@ -6,7 +6,6 @@ use {
         result::{Error, Result},
         store::GStore,
     },
-    boolinator::Boolinator,
     futures::stream::{self, TryStream, TryStreamExt},
     serde::Serialize,
     std::{fmt::Debug, rc::Rc},
@@ -58,7 +57,7 @@ pub async fn fetch<'a, T: 'static + Debug>(
 
                 check_expr(storage, Some(Rc::new(context)), None, expr)
                     .await
-                    .map(|pass| pass.as_some((columns, key, row)))
+                    .map(|pass| pass.then(|| (columns, key, row)))
             }
         });
 

--- a/src/executor/join.rs
+++ b/src/executor/join.rs
@@ -10,7 +10,6 @@ use {
         store::GStore,
         utils::OrStream,
     },
-    boolinator::Boolinator,
     futures::stream::{self, once, StreamExt, TryStream, TryStreamExt},
     std::{fmt::Debug, pin::Pin, rc::Rc},
 };
@@ -171,7 +170,7 @@ async fn fetch_joined<'a, T: 'static + Debug>(
                 filter
                     .check(Rc::clone(&context))
                     .await
-                    .map(|pass| pass.as_some(context))
+                    .map(|pass| pass.then(|| context))
             }
         });
 

--- a/src/executor/select/mod.rs
+++ b/src/executor/select/mod.rs
@@ -20,7 +20,6 @@ use {
         result::{Error, Result},
         store::GStore,
     },
-    boolinator::Boolinator,
     futures::stream::{self, Stream, StreamExt, TryStream, TryStreamExt},
     iter_enum::Iterator,
     std::{fmt::Debug, iter::once, rc::Rc},
@@ -250,7 +249,7 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
                 filter
                     .check(Rc::clone(&blend_context))
                     .await
-                    .map(|pass| pass.as_some(blend_context))
+                    .map(|pass| pass.then(|| blend_context))
             }
         });
 

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -6,7 +6,6 @@ use {
         store::Store,
         utils::Vector,
     },
-    boolinator::Boolinator,
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
     im_rc::HashSet,
     serde::Serialize,
@@ -74,17 +73,14 @@ impl UniqueConstraint {
 
     fn check(&self, value: &Value) -> Result<Option<UniqueKey>> {
         match value.try_into()? {
-            Some(new_key) => (!self.keys.contains(&new_key)).as_result_from(
-                || Some(new_key),
-                || {
-                    ValidateError::DuplicateEntryOnUniqueField(
-                        value.clone(),
-                        self.column_name.to_owned(),
-                    )
-                    .into()
-                },
-            ),
-            None => Ok(None),
+            Some(new_key) if self.keys.contains(&new_key) => {
+                Err(ValidateError::DuplicateEntryOnUniqueField(
+                    value.clone(),
+                    self.column_name.to_owned(),
+                )
+                .into())
+            }
+            new_key => Ok(new_key),
         }
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -10,7 +10,6 @@ use {
         utils::Vector,
     },
     async_recursion::async_recursion,
-    boolinator::Boolinator,
     std::fmt::Debug,
 };
 
@@ -387,7 +386,7 @@ fn search_index_op(
 ) -> Planned {
     if let Some(index_name) = indexes
         .find(left.as_ref())
-        .and_then(|index_name| is_stateless(right.as_ref()).as_some(index_name))
+        .and_then(|index_name| is_stateless(right.as_ref()).then(|| index_name))
     {
         Planned::IndexedExpr {
             index_name,
@@ -397,7 +396,7 @@ fn search_index_op(
         }
     } else if let Some(index_name) = indexes
         .find(right.as_ref())
-        .and_then(|index_name| is_stateless(left.as_ref()).as_some(index_name))
+        .and_then(|index_name| is_stateless(left.as_ref()).then(|| index_name))
     {
         Planned::IndexedExpr {
             index_name,

--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -7,7 +7,6 @@ use {
         AlterTable, AlterTableError, MutResult, Row, Schema, Value,
     },
     async_trait::async_trait,
-    boolinator::Boolinator,
     std::{iter::once, str},
 };
 
@@ -239,7 +238,7 @@ impl AlterTable for SledStorage {
                 .0
                 .into_iter()
                 .enumerate()
-                .filter_map(|(i, v)| (i != index).as_some(v))
+                .filter_map(|(i, v)| (i != index).then(|| v))
                 .collect());
             let row = try_into!(self, bincode::serialize(&row));
 
@@ -250,7 +249,7 @@ impl AlterTable for SledStorage {
         let column_defs = column_defs
             .into_iter()
             .enumerate()
-            .filter_map(|(i, v)| (i != index).as_some(v))
+            .filter_map(|(i, v)| (i != index).then(|| v))
             .collect::<Vec<ColumnDef>>();
 
         let schema = Schema {


### PR DESCRIPTION
Since Rust 1.50.0, Boolinator become no longer needed due to `bool::then` support.
Replace Boolinator as_some to `bool::then`

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11