### PR TITLE
Implement MVCC transaction,

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,10 +25,16 @@ jobs:
       run: cargo clippy --no-default-features --features index -- -D warnings
     - name: Clippy (sorter)
       run: cargo clippy --no-default-features --features sorter -- -D warnings
+    - name: Clippy (alter-table & index)
+      run: cargo clippy --no-default-features --features "alter-table index" -- -D warnings
+    - name: Clippy (alter-table & transaction)
+      run: cargo clippy --no-default-features --features "alter-table transaction" -- -D warnings
+    - name: Clippy (index & transaction)
+      run: cargo clippy --no-default-features --features "index transaction" -- -D warnings
+    - name: Clippy (alter-table & index & transaction)
+      run: cargo clippy --no-default-features --features "alter-table index transaction" -- -D warnings
     - name: Clippy (sled-storage)
       run: cargo clippy --no-default-features --features sled-storage -- -D warnings
-    - name: Clippy (sled-storage & index)
-      run: cargo clippy --no-default-features --features "sled-storage index" -- -D warnings
     - name: Clippy (sled-storage & sorter)
       run: cargo clippy --no-default-features --features "sled-storage sorter" -- -D warnings
     - name: Clippy (sled-storage & alter-table)
@@ -43,8 +49,6 @@ jobs:
       run: cargo test --no-default-features --verbose
     - name: Run tests with features (sled-storage)
       run: cargo test --no-default-features --features sled-storage --verbose
-    - name: Run tests with features (sled-storage & index)
-      run: cargo test --no-default-features --features "sled-storage index" --verbose
     - name: Run tests with features (sled-storage & sorter)
       run: cargo test --no-default-features --features "sled-storage sorter" --verbose
     - name: Run tests with all features

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # GlueSQL project files
 /data/
+/tmp/
+/reports/
 
 # Vim
 *.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["sql-database", "sql", "functional", "no-mut-in-the-middle", "webass
 all-features = true
 
 [features]
-default = ["sled-storage", "alter-table", "index", "sorter"]
+default = ["sled-storage", "alter-table", "index", "transaction", "sorter"]
 
 # optional: ALTER TABLE
 # you can include whether ALTER TABLE support or not for your custom database implementation.
@@ -23,13 +23,16 @@ alter-table = []
 # optional: INDEX
 index = []
 
+# optional: TRANSACTION
+transaction = []
+
 # optional: ORDER BY for non-indexed expressions
 # disable this feature if you use GlueSQL for big data analysis.
 sorter = []
 
 # for someone who wants to make a custom storage engine,
 # default storage engine sled-storage is not required.
-sled-storage = ["sled", "bincode"]
+sled-storage = ["transaction", "index", "sled", "bincode"]
 
 [dependencies]
 regex = "1.5"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -83,6 +83,15 @@ pub enum Statement {
         name: ObjectName,
         table_name: ObjectName,
     },
+    /// START TRANSACTION, BEGIN
+    #[cfg(feature = "transaction")]
+    StartTransaction,
+    /// COMMIT
+    #[cfg(feature = "transaction")]
+    Commit,
+    /// ROLLBACK
+    #[cfg(feature = "transaction")]
+    Rollback,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/data/schema.rs
+++ b/src/data/schema.rs
@@ -1,23 +1,24 @@
 use {
     crate::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Expr},
     serde::{Deserialize, Serialize},
+    std::fmt::Debug,
 };
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SchemaIndexOrd {
     Asc,
     Desc,
     Both,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SchemaIndex {
     pub name: String,
     pub expr: Expr,
     pub order: SchemaIndexOrd,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Schema {
     pub table_name: String,
     pub column_defs: Vec<ColumnDef>,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -15,8 +15,13 @@ mod validate;
 pub use aggregate::{AggregateError, GroupKey};
 pub use alter::AlterError;
 pub use evaluate::{evaluate_stateless, EvaluateError};
-pub use execute::{execute, ExecuteError, Payload};
+pub use execute::{ExecuteError, Payload};
 pub use fetch::FetchError;
 pub use select::SelectError;
 pub use update::UpdateError;
 pub use validate::{UniqueKey, ValidateError};
+
+#[cfg(not(feature = "transaction"))]
+pub use execute::execute;
+#[cfg(feature = "transaction")]
+pub use execute::execute_atomic as execute;

--- a/src/result.rs
+++ b/src/result.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[serde(with = "stringify")]
     Storage(#[from] Box<dyn std::error::Error>),
 
+    #[error("storage error: {0}")]
+    StorageMsg(String),
+
     #[error("parsing failed: {0}")]
     Parser(String),
 
@@ -76,6 +79,7 @@ impl PartialEq for Error {
 
         match (self, other) {
             (Parser(e), Parser(e2)) => e == e2,
+            (StorageMsg(e), StorageMsg(e2)) => e == e2,
             (Translate(e), Translate(e2)) => e == e2,
             #[cfg(feature = "alter-table")]
             (AlterTable(e), AlterTable(e2)) => e == e2,

--- a/src/storages/mod.rs
+++ b/src/storages/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "sled-storage")]
-mod sled_storage;
+pub mod sled_storage;
 
 #[cfg(feature = "sled-storage")]
 pub use sled_storage::SledStorage;

--- a/src/storages/sled_storage/alter_table.rs
+++ b/src/storages/sled_storage/alter_table.rs
@@ -248,7 +248,7 @@ impl AlterTable for SledStorage {
                         .map_err(ConflictableTransactionError::Abort)?;
 
                     evaluated
-                        .try_into_value(&data_type, nullable)
+                        .try_into_value(data_type, nullable)
                         .map_err(ConflictableTransactionError::Abort)?
                 }
                 (None, true) => Value::Null,
@@ -364,7 +364,7 @@ impl AlterTable for SledStorage {
 
             // migrate data
             for (key, snapshot) in items.iter() {
-                let snapshot: Snapshot<Row> = bincode::deserialize(&snapshot)
+                let snapshot: Snapshot<Row> = bincode::deserialize(snapshot)
                     .map_err(err_into)
                     .map_err(ConflictableTransactionError::Abort)?;
                 let row = match snapshot.clone().extract(txid, None) {

--- a/src/storages/sled_storage/gc.rs
+++ b/src/storages/sled_storage/gc.rs
@@ -1,0 +1,140 @@
+use {
+    super::{
+        err_into, key,
+        lock::{get_txdata_key, Lock, TxData},
+        SledStorage, Snapshot,
+    },
+    crate::{
+        data::{Row, Schema},
+        result::Result,
+    },
+};
+
+impl SledStorage {
+    pub fn gc(&self) -> Result<()> {
+        let txids = self
+            .tree
+            .scan_prefix("tx_data/")
+            .map(|item| -> Result<TxData> {
+                item.map(|(_, v)| bincode::deserialize(&v))
+                    .map_err(err_into)?
+                    .map_err(err_into)
+            })
+            .take_while(|tx_data| match tx_data {
+                Ok(TxData { alive, .. }) => !alive,
+                Err(_) => false,
+            })
+            .map(|tx_data| tx_data.map(|TxData { txid, .. }| txid))
+            .collect::<Result<Vec<u64>>>()?;
+
+        let max_txid = match txids.iter().last() {
+            Some(txid) => txid,
+            None => {
+                return Ok(());
+            }
+        };
+
+        let Lock { lock_txid, .. } = self
+            .tree
+            .get("lock/")
+            .map_err(err_into)?
+            .map(|l| bincode::deserialize(&l))
+            .transpose()
+            .map_err(err_into)?
+            .unwrap_or_default();
+
+        let lock = Lock {
+            lock_txid,
+            gc_txid: Some(*max_txid),
+        };
+
+        bincode::serialize(&lock)
+            .map(|lock| self.tree.insert("lock/", lock))
+            .map_err(err_into)?
+            .map_err(err_into)?;
+
+        let fetch_keys = |prefix| {
+            self.tree
+                .scan_prefix(prefix)
+                .map(|item| item.map_err(err_into))
+                .collect::<Result<Vec<_>>>()
+        };
+
+        macro_rules! gc_txid {
+            ($txid: expr, $prefix: expr, $T: ty) => {
+                for (temp_key, data_key) in fetch_keys($prefix)? {
+                    let snapshot: Option<Snapshot<$T>> = self
+                        .tree
+                        .get(&data_key)
+                        .map_err(err_into)?
+                        .map(|v| bincode::deserialize(&v))
+                        .transpose()
+                        .map_err(err_into)?;
+
+                    let snapshot = match snapshot {
+                        None => {
+                            continue;
+                        }
+                        Some(snapshot) => snapshot.gc($txid),
+                    };
+
+                    match snapshot {
+                        Some(snapshot) => {
+                            bincode::serialize(&snapshot)
+                                .map_err(err_into)
+                                .map(|v| self.tree.insert(data_key, v))?
+                                .map_err(err_into)?;
+                        }
+                        None => {
+                            self.tree.remove(data_key).map_err(err_into)?;
+                        }
+                    }
+
+                    self.tree.remove(temp_key).map_err(err_into)?;
+                }
+            };
+        }
+
+        for txid in txids {
+            gc_txid!(txid, key::temp_data_prefix(txid), Row);
+            gc_txid!(txid, key::temp_schema_prefix(txid), Schema);
+
+            for (temp_key, data_key) in fetch_keys(key::temp_index_prefix(txid))? {
+                let snapshots: Option<Vec<Snapshot<Vec<u8>>>> = self
+                    .tree
+                    .get(&data_key)
+                    .map_err(err_into)?
+                    .map(|v| bincode::deserialize(&v))
+                    .transpose()
+                    .map_err(err_into)?;
+
+                let snapshots = match snapshots {
+                    Some(snapshots) => snapshots,
+                    None => {
+                        continue;
+                    }
+                };
+
+                let snapshots = snapshots
+                    .into_iter()
+                    .filter_map(|snapshot| snapshot.gc(txid))
+                    .collect::<Vec<_>>();
+
+                if snapshots.is_empty() {
+                    self.tree.remove(data_key).map_err(err_into)?;
+                } else {
+                    bincode::serialize(&snapshots)
+                        .map_err(err_into)
+                        .map(|v| self.tree.insert(data_key, v))?
+                        .map_err(err_into)?;
+                }
+
+                self.tree.remove(temp_key).map_err(err_into)?;
+            }
+
+            self.tree.remove(&get_txdata_key(txid)).map_err(err_into)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/storages/sled_storage/index_mut.rs
+++ b/src/storages/sled_storage/index_mut.rs
@@ -1,5 +1,7 @@
 use {
-    super::{err_into, error::StorageError, index_sync::IndexSync, lock, SledStorage, Snapshot},
+    super::{
+        err_into, error::StorageError, index_sync::IndexSync, key, lock, SledStorage, Snapshot,
+    },
     crate::{
         ast::OrderByExpr,
         data::{Schema, SchemaIndex, SchemaIndexOrd},
@@ -125,8 +127,8 @@ impl IndexMut<IVec> for SledStorage {
 
             tree.insert(schema_key.as_bytes(), schema_snapshot)?;
 
-            let temp_key = format!("temp_schema/{}", table_name);
-            tree.insert(temp_key.as_bytes(), schema_key.as_bytes())?;
+            let temp_key = key::temp_schema(txid, table_name);
+            tree.insert(temp_key, schema_key.as_bytes())?;
 
             Ok(())
         })
@@ -186,8 +188,8 @@ impl IndexMut<IVec> for SledStorage {
 
             tree.insert(schema_key.as_bytes(), schema_snapshot)?;
 
-            let temp_key = format!("temp_schema/{}", table_name);
-            tree.insert(temp_key.as_bytes(), schema_key.as_bytes())?;
+            let temp_key = key::temp_schema(txid, table_name);
+            tree.insert(temp_key, schema_key.as_bytes())?;
 
             Ok(())
         })

--- a/src/storages/sled_storage/index_mut.rs
+++ b/src/storages/sled_storage/index_mut.rs
@@ -1,19 +1,18 @@
-#![cfg(feature = "index")]
-
 use {
-    super::{
-        err_into, error::StorageError, fetch_schema, index_sync::IndexSync, scan_data, SledStorage,
-    },
+    super::{err_into, error::StorageError, index_sync::IndexSync, lock, SledStorage, Snapshot},
     crate::{
         ast::OrderByExpr,
         data::{Schema, SchemaIndex, SchemaIndexOrd},
-        result::{MutResult, Result},
-        store::IndexMut,
+        result::{Error, MutResult, Result},
+        store::{IndexMut, Store},
         IndexError,
     },
     async_trait::async_trait,
     sled::{
-        transaction::{ConflictableTransactionError, TransactionError},
+        transaction::{
+            ConflictableTransactionError, ConflictableTransactionResult, TransactionError,
+            TransactionalTree,
+        },
         IVec,
     },
     std::iter::once,
@@ -24,17 +23,6 @@ macro_rules! try_self {
         match $expr {
             Err(e) => {
                 return Err(($self, e.into()));
-            }
-            Ok(v) => v,
-        }
-    };
-}
-
-macro_rules! try_into {
-    ($self: expr, $expr: expr) => {
-        match $expr.map_err(err_into) {
-            Err(e) => {
-                return Err(($self, e));
             }
             Ok(v) => v,
         }
@@ -55,6 +43,21 @@ macro_rules! transaction {
     }};
 }
 
+fn fetch_schema(
+    tree: &TransactionalTree,
+    table_name: &str,
+) -> ConflictableTransactionResult<(String, Option<Snapshot<Schema>>), Error> {
+    let key = format!("schema/{}", table_name);
+    let value = tree.get(&key.as_bytes())?;
+    let schema_snapshot = value
+        .map(|v| bincode::deserialize(&v))
+        .transpose()
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)?;
+
+    Ok((key, schema_snapshot))
+}
+
 #[async_trait(?Send)]
 impl IndexMut<IVec> for SledStorage {
     async fn create_index(
@@ -63,109 +66,128 @@ impl IndexMut<IVec> for SledStorage {
         index_name: &str,
         column: &OrderByExpr,
     ) -> MutResult<Self, ()> {
-        let index_expr = &column.expr;
-        let (schema_key, schema) = try_self!(self, fetch_schema(&self.tree, table_name));
-        let Schema {
-            column_defs,
-            indexes,
-            ..
-        } = try_into!(
-            self,
-            schema.ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()))
-        );
+        let rows = try_self!(self, self.scan_data(table_name).await);
+        let rows = try_self!(self, rows.collect::<Result<Vec<_>>>());
 
-        if indexes.iter().any(|index| index.name == index_name) {
-            return Err((
-                self,
-                IndexError::IndexNameAlreadyExists(index_name.to_owned()).into(),
-            ));
-        }
-
-        let index = SchemaIndex {
-            name: index_name.to_owned(),
-            expr: index_expr.clone(),
-            order: SchemaIndexOrd::Both,
-        };
-
-        let indexes = indexes
-            .into_iter()
-            .chain(once(index.clone()))
-            .collect::<Vec<_>>();
-
-        let schema = Schema {
-            table_name: table_name.to_owned(),
-            column_defs,
-            indexes,
-        };
-
-        let rows = try_self!(
-            self,
-            scan_data(&self.tree, table_name).collect::<Result<Vec<_>>>()
-        );
-        let index_sync = IndexSync::from(&schema);
+        let state = &self.state;
 
         transaction!(self, |tree| {
-            let schema_value = bincode::serialize(&schema)
+            let (txid, _) = lock::acquire(tree, state)?;
+
+            let index_expr = &column.expr;
+
+            let (schema_key, schema_snapshot) = fetch_schema(tree, table_name)?;
+            let schema_snapshot = schema_snapshot
+                .ok_or_else(|| IndexError::TableNotFound(table_name.to_string()).into())
+                .map_err(ConflictableTransactionError::Abort)?;
+
+            let (schema_snapshot, schema) = schema_snapshot.delete(txid);
+            let Schema {
+                column_defs,
+                indexes,
+                ..
+            } = schema
+                .ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()).into())
+                .map_err(ConflictableTransactionError::Abort)?;
+
+            if indexes.iter().any(|index| index.name == index_name) {
+                return Err(IndexError::IndexNameAlreadyExists(index_name.to_owned()).into())
+                    .map_err(ConflictableTransactionError::Abort);
+            }
+
+            let index = SchemaIndex {
+                name: index_name.to_owned(),
+                expr: index_expr.clone(),
+                order: SchemaIndexOrd::Both,
+            };
+
+            let indexes = indexes
+                .into_iter()
+                .chain(once(index.clone()))
+                .collect::<Vec<_>>();
+
+            let schema = Schema {
+                table_name: table_name.to_owned(),
+                column_defs,
+                indexes,
+            };
+
+            let index_sync = IndexSync::from_schema(tree, txid, &schema);
+
+            let schema_snapshot = schema_snapshot.update(txid, schema.clone());
+            let schema_snapshot = bincode::serialize(&schema_snapshot)
                 .map_err(err_into)
                 .map_err(ConflictableTransactionError::Abort)?;
 
-            tree.insert(schema_key.as_bytes(), schema_value)?;
-
             for (data_key, row) in rows.iter() {
-                index_sync.insert_index(&tree, &index, data_key, row)?;
+                index_sync.insert_index(&index, data_key, row)?;
             }
+
+            tree.insert(schema_key.as_bytes(), schema_snapshot)?;
+
+            let temp_key = format!("temp_schema/{}", table_name);
+            tree.insert(temp_key.as_bytes(), schema_key.as_bytes())?;
 
             Ok(())
         })
     }
 
     async fn drop_index(self, table_name: &str, index_name: &str) -> MutResult<Self, ()> {
-        let (schema_key, schema) = try_self!(self, fetch_schema(&self.tree, table_name));
-        let Schema {
-            column_defs,
-            indexes,
-            ..
-        } = try_into!(
-            self,
-            schema.ok_or_else(|| IndexError::TableNotFound(table_name.to_owned()))
-        );
+        let rows = try_self!(self, self.scan_data(table_name).await);
+        let rows = try_self!(self, rows.collect::<Result<Vec<_>>>());
 
-        let (index, indexes): (Vec<_>, _) = indexes
-            .into_iter()
-            .partition(|index| index.name == index_name);
-
-        let index = match index.into_iter().next() {
-            Some(index) => index,
-            None => {
-                return Err((
-                    self,
-                    IndexError::IndexNameDoesNotExist(index_name.to_owned()).into(),
-                ));
-            }
-        };
-
-        let schema = Schema {
-            table_name: table_name.to_owned(),
-            column_defs,
-            indexes,
-        };
-
-        let rows = try_self!(
-            self,
-            scan_data(&self.tree, table_name).collect::<Result<Vec<_>>>()
-        );
-        let index_sync = IndexSync::from(&schema);
+        let state = &self.state;
 
         transaction!(self, |tree| {
-            let schema_value = bincode::serialize(&schema)
+            let (txid, _) = lock::acquire(tree, state)?;
+
+            let (schema_key, schema_snapshot) = fetch_schema(tree, table_name)?;
+            let schema_snapshot = schema_snapshot
+                .ok_or_else(|| IndexError::TableNotFound(table_name.to_string()).into())
+                .map_err(ConflictableTransactionError::Abort)?;
+
+            let (schema_snapshot, schema) = schema_snapshot.delete(txid);
+            let Schema {
+                column_defs,
+                indexes,
+                ..
+            } = schema
+                .ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()).into())
+                .map_err(ConflictableTransactionError::Abort)?;
+
+            let (index, indexes): (Vec<_>, _) = indexes
+                .into_iter()
+                .partition(|index| index.name == index_name);
+
+            let index = match index.into_iter().next() {
+                Some(index) => index,
+                None => {
+                    return Err(IndexError::IndexNameDoesNotExist(index_name.to_owned()).into())
+                        .map_err(ConflictableTransactionError::Abort);
+                }
+            };
+
+            let schema = Schema {
+                table_name: table_name.to_owned(),
+                column_defs,
+                indexes,
+            };
+
+            let index_sync = IndexSync::from_schema(tree, txid, &schema);
+
+            let schema_snapshot = schema_snapshot.update(txid, schema.clone());
+            let schema_snapshot = bincode::serialize(&schema_snapshot)
                 .map_err(err_into)
                 .map_err(ConflictableTransactionError::Abort)?;
 
-            tree.insert(schema_key.as_bytes(), schema_value)?;
-
             for (data_key, row) in rows.iter() {
-                index_sync.delete_index(&tree, &index, data_key, row)?;
+                index_sync.delete_index(&index, data_key, row)?;
             }
+
+            tree.insert(schema_key.as_bytes(), schema_snapshot)?;
+
+            let temp_key = format!("temp_schema/{}", table_name);
+            tree.insert(temp_key.as_bytes(), schema_key.as_bytes())?;
 
             Ok(())
         })

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -79,7 +79,7 @@ impl<'a> IndexSync<'a> {
 
     pub fn insert(&self, data_key: &IVec, row: &Row) -> ConflictableTransactionResult<(), Error> {
         for index in self.indexes.iter() {
-            self.insert_index(&index, data_key, row)?;
+            self.insert_index(index, data_key, row)?;
         }
 
         Ok(())
@@ -100,7 +100,7 @@ impl<'a> IndexSync<'a> {
         let index_key =
             &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 
-        self.insert_index_data(&index_key, &data_key)?;
+        self.insert_index_data(index_key, data_key)?;
 
         Ok(())
     }
@@ -134,8 +134,8 @@ impl<'a> IndexSync<'a> {
                 new_row,
             )?;
 
-            self.delete_index_data(&old_index_key, &data_key)?;
-            self.insert_index_data(&new_index_key, &data_key)?;
+            self.delete_index_data(old_index_key, data_key)?;
+            self.insert_index_data(new_index_key, data_key)?;
         }
 
         Ok(())
@@ -164,7 +164,7 @@ impl<'a> IndexSync<'a> {
         let index_key =
             &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 
-        self.delete_index_data(&index_key, &data_key)?;
+        self.delete_index_data(index_key, data_key)?;
 
         Ok(())
     }

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -189,7 +189,7 @@ impl<'a> IndexSync<'a> {
             .map_err(err_into)
             .map_err(ConflictableTransactionError::Abort)?;
 
-        let temp_key = key::temp_index(index_key);
+        let temp_key = key::temp_index(self.txid, index_key);
 
         self.tree.insert(index_key, data_keys)?;
         self.tree.insert(temp_key, index_key)?;
@@ -228,7 +228,7 @@ impl<'a> IndexSync<'a> {
             .map_err(err_into)
             .map_err(ConflictableTransactionError::Abort)?;
 
-        let temp_key = key::temp_index(index_key);
+        let temp_key = key::temp_index(self.txid, index_key);
 
         self.tree.insert(index_key, data_keys)?;
         self.tree.insert(temp_key, index_key)?;

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -1,28 +1,28 @@
-#![cfg(feature = "index")]
-
 use {
-    super::{err_into, fetch_schema},
+    super::{err_into, fetch_schema, key, Snapshot},
     crate::{
-        ast::Expr, evaluate_stateless, utils::Vector, Error, IndexError, Result, Row, Schema,
-        SchemaIndex, Value,
+        ast::Expr, evaluate_stateless, utils::Vector, Error, IndexError, Row, Schema, SchemaIndex,
+        Value,
     },
     sled::{
         transaction::{
             ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
         },
-        Db, IVec,
+        IVec,
     },
     std::{borrow::Cow, convert::TryInto},
 };
 
 pub struct IndexSync<'a> {
+    tree: &'a TransactionalTree,
+    txid: u64,
     table_name: &'a str,
     columns: Vec<String>,
     indexes: Cow<'a, Vec<SchemaIndex>>,
 }
 
-impl<'a> From<&'a Schema> for IndexSync<'a> {
-    fn from(schema: &'a Schema) -> Self {
+impl<'a> IndexSync<'a> {
+    pub fn from_schema(tree: &'a TransactionalTree, txid: u64, schema: &'a Schema) -> Self {
         let Schema {
             table_name,
             column_defs,
@@ -38,21 +38,30 @@ impl<'a> From<&'a Schema> for IndexSync<'a> {
         let indexes = Cow::Borrowed(indexes);
 
         Self {
+            tree,
+            txid,
             table_name,
             columns,
             indexes,
         }
     }
-}
 
-impl<'a> IndexSync<'a> {
-    pub fn new(tree: &Db, table_name: &'a str) -> Result<Self> {
-        let (_, schema) = fetch_schema(tree, table_name)?;
+    pub fn new(
+        tree: &'a TransactionalTree,
+        txid: u64,
+        table_name: &'a str,
+    ) -> sled::transaction::ConflictableTransactionResult<Self, Error> {
         let Schema {
             column_defs,
             indexes,
             ..
-        } = schema.ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()))?;
+        } = fetch_schema(tree, table_name)
+            .map(|(_, snapshot)| snapshot)?
+            .map(|snapshot| snapshot.extract(txid, None))
+            .flatten()
+            .ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()))
+            .map_err(err_into)
+            .map_err(ConflictableTransactionError::Abort)?;
 
         let columns = column_defs
             .into_iter()
@@ -60,20 +69,17 @@ impl<'a> IndexSync<'a> {
             .collect::<Vec<_>>();
 
         Ok(Self {
+            tree,
+            txid,
             table_name,
             columns,
             indexes: Cow::Owned(indexes),
         })
     }
 
-    pub fn insert(
-        &self,
-        tree: &TransactionalTree,
-        data_key: &IVec,
-        row: &Row,
-    ) -> ConflictableTransactionResult<(), Error> {
+    pub fn insert(&self, data_key: &IVec, row: &Row) -> ConflictableTransactionResult<(), Error> {
         for index in self.indexes.iter() {
-            self.insert_index(tree, &index, data_key, row)?;
+            self.insert_index(&index, data_key, row)?;
         }
 
         Ok(())
@@ -81,7 +87,6 @@ impl<'a> IndexSync<'a> {
 
     pub fn insert_index(
         &self,
-        tree: &TransactionalTree,
         index: &SchemaIndex,
         data_key: &IVec,
         row: &Row,
@@ -95,14 +100,13 @@ impl<'a> IndexSync<'a> {
         let index_key =
             &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 
-        insert_index_data(tree, &index_key, &data_key)?;
+        self.insert_index_data(&index_key, &data_key)?;
 
         Ok(())
     }
 
     pub fn update(
         &self,
-        tree: &TransactionalTree,
         data_key: &IVec,
         old_row: &Row,
         new_row: &Row,
@@ -130,21 +134,16 @@ impl<'a> IndexSync<'a> {
                 &new_row,
             )?;
 
-            delete_index_data(tree, &old_index_key, &data_key)?;
-            insert_index_data(tree, &new_index_key, &data_key)?;
+            self.delete_index_data(&old_index_key, &data_key)?;
+            self.insert_index_data(&new_index_key, &data_key)?;
         }
 
         Ok(())
     }
 
-    pub fn delete(
-        &self,
-        tree: &TransactionalTree,
-        data_key: &IVec,
-        row: &Row,
-    ) -> ConflictableTransactionResult<(), Error> {
+    pub fn delete(&self, data_key: &IVec, row: &Row) -> ConflictableTransactionResult<(), Error> {
         for index in self.indexes.iter() {
-            self.delete_index(tree, index, data_key, row)?;
+            self.delete_index(index, data_key, row)?;
         }
 
         Ok(())
@@ -152,7 +151,6 @@ impl<'a> IndexSync<'a> {
 
     pub fn delete_index(
         &self,
-        tree: &TransactionalTree,
         index: &SchemaIndex,
         data_key: &IVec,
         row: &Row,
@@ -166,64 +164,77 @@ impl<'a> IndexSync<'a> {
         let index_key =
             &evaluate_index_key(self.table_name, index_name, index_expr, &self.columns, row)?;
 
-        delete_index_data(tree, &index_key, &data_key)?;
+        self.delete_index_data(&index_key, &data_key)?;
 
         Ok(())
     }
-}
 
-fn insert_index_data(
-    tree: &TransactionalTree,
-    index_key: &[u8],
-    data_key: &IVec,
-) -> ConflictableTransactionResult<(), Error> {
-    let data_keys: Vec<Vec<u8>> = tree
-        .get(index_key)?
-        .map(|v| bincode::deserialize(&v))
-        .transpose()
-        .map_err(err_into)
-        .map_err(ConflictableTransactionError::Abort)?
-        .unwrap_or_default();
+    fn insert_index_data(
+        &self,
+        index_key: &[u8],
+        data_key: &IVec,
+    ) -> ConflictableTransactionResult<(), Error> {
+        let data_keys: Vec<Snapshot<Vec<u8>>> = self
+            .tree
+            .get(index_key)?
+            .map(|v| bincode::deserialize(&v))
+            .transpose()
+            .map_err(err_into)
+            .map_err(ConflictableTransactionError::Abort)?
+            .unwrap_or_default();
 
-    let data_keys = Vector::from(data_keys).push(data_key.to_vec());
-    let data_keys = bincode::serialize(&Vec::from(data_keys))
-        .map_err(err_into)
-        .map_err(ConflictableTransactionError::Abort)?;
+        let key_snapshot = Snapshot::<Vec<u8>>::new(self.txid, data_key.to_vec());
+        let data_keys = Vector::from(data_keys).push(key_snapshot);
+        let data_keys = bincode::serialize(&Vec::from(data_keys))
+            .map_err(err_into)
+            .map_err(ConflictableTransactionError::Abort)?;
 
-    tree.insert(index_key, data_keys)?;
+        let temp_key = key::temp_index(index_key);
 
-    Ok(())
-}
+        self.tree.insert(index_key, data_keys)?;
+        self.tree.insert(temp_key, index_key)?;
 
-fn delete_index_data(
-    tree: &TransactionalTree,
-    index_key: &[u8],
-    data_key: &IVec,
-) -> ConflictableTransactionResult<(), Error> {
-    let data_keys: Vec<Vec<u8>> = tree
-        .get(index_key)?
-        .map(|v| bincode::deserialize(&v))
-        .ok_or_else(|| IndexError::ConflictOnIndexDataDeleteSync.into())
-        .map_err(ConflictableTransactionError::Abort)?
-        .map_err(err_into)
-        .map_err(ConflictableTransactionError::Abort)?;
+        Ok(())
+    }
 
-    let data_keys = data_keys
-        .into_iter()
-        .filter(|k| k != data_key.as_ref())
-        .collect::<Vec<_>>();
+    fn delete_index_data(
+        &self,
+        index_key: &[u8],
+        data_key: &IVec,
+    ) -> ConflictableTransactionResult<(), Error> {
+        let data_keys: Vec<Snapshot<Vec<u8>>> = self
+            .tree
+            .get(index_key)?
+            .map(|v| bincode::deserialize(&v))
+            .ok_or_else(|| IndexError::ConflictOnIndexDataDeleteSync.into())
+            .map_err(ConflictableTransactionError::Abort)?
+            .map_err(err_into)
+            .map_err(ConflictableTransactionError::Abort)?;
 
-    if data_keys.is_empty() {
-        tree.remove(index_key)?;
-    } else {
+        let data_keys = data_keys
+            .into_iter()
+            .map(|snapshot| {
+                let key = snapshot.get(self.txid, None);
+
+                if Some(data_key) == key.map(IVec::from).as_ref() {
+                    snapshot.delete(self.txid).0
+                } else {
+                    snapshot
+                }
+            })
+            .collect::<Vec<_>>();
+
         let data_keys = bincode::serialize(&data_keys)
             .map_err(err_into)
             .map_err(ConflictableTransactionError::Abort)?;
 
-        tree.insert(index_key, data_keys)?;
-    }
+        let temp_key = key::temp_index(index_key);
 
-    Ok(())
+        self.tree.insert(index_key, data_keys)?;
+        self.tree.insert(temp_key, index_key)?;
+
+        Ok(())
+    }
 }
 
 fn evaluate_index_key(

--- a/src/storages/sled_storage/key.rs
+++ b/src/storages/sled_storage/key.rs
@@ -1,0 +1,40 @@
+use sled::IVec;
+
+pub const TEMP_DATA: &str = "temp_data/";
+pub const TEMP_SCHEMA: &str = "temp_schema/";
+pub const TEMP_INDEX: &str = "temp_index/";
+
+pub fn temp_data(data_key: &IVec) -> IVec {
+    let key = TEMP_DATA
+        .to_owned()
+        .into_bytes()
+        .into_iter()
+        .chain(data_key.iter().copied())
+        .collect::<Vec<_>>();
+
+    IVec::from(key)
+}
+
+#[cfg(feature = "alter-table")]
+pub fn temp_data_str(data_key: &str) -> IVec {
+    let key = format!("{}{}", TEMP_DATA, data_key);
+
+    IVec::from(key.into_bytes())
+}
+
+pub fn temp_schema(table_name: &str) -> IVec {
+    let key = format!("{}{}", TEMP_SCHEMA, table_name);
+
+    IVec::from(key.into_bytes())
+}
+
+pub fn temp_index(index_key: &[u8]) -> IVec {
+    let key = TEMP_INDEX
+        .to_owned()
+        .into_bytes()
+        .into_iter()
+        .chain(index_key.iter().copied())
+        .collect::<Vec<_>>();
+
+    IVec::from(key)
+}

--- a/src/storages/sled_storage/key.rs
+++ b/src/storages/sled_storage/key.rs
@@ -1,14 +1,33 @@
 use sled::IVec;
 
-pub const TEMP_DATA: &str = "temp_data/";
-pub const TEMP_SCHEMA: &str = "temp_schema/";
-pub const TEMP_INDEX: &str = "temp_index/";
+const TEMP_DATA: &str = "temp_data/";
+const TEMP_SCHEMA: &str = "temp_schema/";
+const TEMP_INDEX: &str = "temp_index/";
 
-pub fn temp_data(data_key: &IVec) -> IVec {
-    let key = TEMP_DATA
-        .to_owned()
-        .into_bytes()
-        .into_iter()
+macro_rules! prefix {
+    ($txid: ident, $prefix: ident) => {
+        $prefix
+            .to_owned()
+            .into_bytes()
+            .into_iter()
+            .chain($txid.to_be_bytes().iter().copied())
+    };
+}
+
+pub fn temp_data_prefix(txid: u64) -> IVec {
+    IVec::from(prefix!(txid, TEMP_DATA).collect::<Vec<_>>())
+}
+
+pub fn temp_schema_prefix(txid: u64) -> IVec {
+    IVec::from(prefix!(txid, TEMP_SCHEMA).collect::<Vec<_>>())
+}
+
+pub fn temp_index_prefix(txid: u64) -> IVec {
+    IVec::from(prefix!(txid, TEMP_INDEX).collect::<Vec<_>>())
+}
+
+pub fn temp_data(txid: u64, data_key: &IVec) -> IVec {
+    let key = prefix!(txid, TEMP_DATA)
         .chain(data_key.iter().copied())
         .collect::<Vec<_>>();
 
@@ -16,23 +35,24 @@ pub fn temp_data(data_key: &IVec) -> IVec {
 }
 
 #[cfg(feature = "alter-table")]
-pub fn temp_data_str(data_key: &str) -> IVec {
-    let key = format!("{}{}", TEMP_DATA, data_key);
+pub fn temp_data_str(txid: u64, data_key: &str) -> IVec {
+    let key = prefix!(txid, TEMP_DATA)
+        .chain(data_key.as_bytes().iter().copied())
+        .collect::<Vec<_>>();
 
-    IVec::from(key.into_bytes())
+    IVec::from(key)
 }
 
-pub fn temp_schema(table_name: &str) -> IVec {
-    let key = format!("{}{}", TEMP_SCHEMA, table_name);
+pub fn temp_schema(txid: u64, table_name: &str) -> IVec {
+    let key = prefix!(txid, TEMP_SCHEMA)
+        .chain(table_name.as_bytes().iter().copied())
+        .collect::<Vec<_>>();
 
-    IVec::from(key.into_bytes())
+    IVec::from(key)
 }
 
-pub fn temp_index(index_key: &[u8]) -> IVec {
-    let key = TEMP_INDEX
-        .to_owned()
-        .into_bytes()
-        .into_iter()
+pub fn temp_index(txid: u64, index_key: &[u8]) -> IVec {
+    let key = prefix!(txid, TEMP_INDEX)
         .chain(index_key.iter().copied())
         .collect::<Vec<_>>();
 

--- a/src/storages/sled_storage/lock.rs
+++ b/src/storages/sled_storage/lock.rs
@@ -1,0 +1,65 @@
+use {
+    super::{err_into, State},
+    crate::{Error, Result},
+    sled::{
+        transaction::{
+            ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
+        },
+        Db,
+    },
+};
+
+pub fn fetch(tree: &Db) -> Result<Option<u64>> {
+    tree.get("lock/")
+        .map_err(err_into)?
+        .map(|l| bincode::deserialize(&l))
+        .transpose()
+        .map_err(err_into)
+}
+
+pub fn acquire(
+    tree: &TransactionalTree,
+    state: &State,
+) -> ConflictableTransactionResult<(u64, bool), Error> {
+    let lock_txid: Option<u64> = tree
+        .get("lock/")?
+        .map(|l| bincode::deserialize(&l))
+        .transpose()
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)?;
+
+    let (txid, autocommit) = match state {
+        State::Transaction { txid, autocommit } => (txid, autocommit),
+        State::Idle => {
+            return Err(Error::StorageMsg(
+                "conflict - cannot acquire lock from idle state".to_owned(),
+            ))
+            .map_err(ConflictableTransactionError::Abort);
+        }
+    };
+
+    let txid = match lock_txid {
+        Some(lock_txid) if txid == &lock_txid => txid,
+        Some(_) => {
+            return Err(Error::StorageMsg("database is locked".to_owned()))
+                .map_err(ConflictableTransactionError::Abort);
+        }
+        None => {
+            let lock = bincode::serialize(txid)
+                .map_err(err_into)
+                .map_err(ConflictableTransactionError::Abort)?;
+
+            tree.insert("lock/", lock)?;
+
+            txid
+        }
+    };
+
+    Ok((*txid, *autocommit))
+}
+
+pub fn release(tree: &TransactionalTree) -> ConflictableTransactionResult<(), Error> {
+    tree.remove("lock/")?;
+
+    Ok(())
+}

--- a/src/storages/sled_storage/lock.rs
+++ b/src/storages/sled_storage/lock.rs
@@ -1,6 +1,7 @@
 use {
     super::{err_into, State},
     crate::{Error, Result},
+    serde::{Deserialize, Serialize},
     sled::{
         transaction::{
             ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
@@ -9,24 +10,73 @@ use {
     },
 };
 
-pub fn fetch(tree: &Db) -> Result<Option<u64>> {
-    tree.get("lock/")
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TxData {
+    pub txid: u64,
+    pub alive: bool,
+    // TODO: support timeout based garbage collection
+    // - created_at: u128,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Lock {
+    pub lock_txid: Option<u64>,
+    pub gc_txid: Option<u64>,
+    // TODO: support serializable transaction isolation level
+    // - prev_done_at: u128,
+}
+
+pub fn get_txdata_key(txid: u64) -> Vec<u8> {
+    "tx_data/"
+        .to_owned()
+        .into_bytes()
+        .into_iter()
+        .chain(txid.to_be_bytes().iter().copied())
+        .collect::<Vec<_>>()
+}
+
+pub fn register(tree: &Db) -> Result<u64> {
+    let txid = tree.generate_id().map_err(err_into)?;
+    let key = get_txdata_key(txid);
+    let tx_data = TxData { txid, alive: true };
+
+    bincode::serialize(&tx_data)
+        .map_err(err_into)
+        .map(|tx_data| tree.insert(key, tx_data))?
+        .map_err(err_into)?;
+
+    Ok(txid)
+}
+
+pub fn fetch(tree: &Db, txid: u64) -> Result<Option<u64>> {
+    let Lock { lock_txid, gc_txid } = tree
+        .get("lock/")
         .map_err(err_into)?
         .map(|l| bincode::deserialize(&l))
         .transpose()
-        .map_err(err_into)
+        .map_err(err_into)?
+        .unwrap_or_default();
+
+    if gc_txid.is_some() && Some(txid) <= gc_txid {
+        return Err(Error::StorageMsg(
+            "fetch failed - expired transaction is used".to_owned(),
+        ));
+    }
+
+    Ok(lock_txid)
 }
 
 pub fn acquire(
     tree: &TransactionalTree,
     state: &State,
 ) -> ConflictableTransactionResult<(u64, bool), Error> {
-    let lock_txid: Option<u64> = tree
+    let Lock { lock_txid, gc_txid } = tree
         .get("lock/")?
         .map(|l| bincode::deserialize(&l))
         .transpose()
         .map_err(err_into)
-        .map_err(ConflictableTransactionError::Abort)?;
+        .map_err(ConflictableTransactionError::Abort)?
+        .unwrap_or_default();
 
     let (txid, autocommit) = match state {
         State::Transaction { txid, autocommit } => (txid, autocommit),
@@ -38,6 +88,13 @@ pub fn acquire(
         }
     };
 
+    if gc_txid.is_some() && Some(txid) <= gc_txid.as_ref() {
+        return Err(Error::StorageMsg(
+            "acquire failed - expired transaction is used".to_owned(),
+        ))
+        .map_err(ConflictableTransactionError::Abort);
+    }
+
     let txid = match lock_txid {
         Some(lock_txid) if txid == &lock_txid => txid,
         Some(_) => {
@@ -45,11 +102,15 @@ pub fn acquire(
                 .map_err(ConflictableTransactionError::Abort);
         }
         None => {
-            let lock = bincode::serialize(txid)
-                .map_err(err_into)
-                .map_err(ConflictableTransactionError::Abort)?;
+            let lock = Lock {
+                lock_txid: Some(*txid),
+                gc_txid,
+            };
 
-            tree.insert("lock/", lock)?;
+            bincode::serialize(&lock)
+                .map_err(err_into)
+                .map_err(ConflictableTransactionError::Abort)
+                .map(|lock| tree.insert("lock/", lock))??;
 
             txid
         }
@@ -58,8 +119,59 @@ pub fn acquire(
     Ok((*txid, *autocommit))
 }
 
-pub fn release(tree: &TransactionalTree) -> ConflictableTransactionResult<(), Error> {
-    tree.remove("lock/")?;
+pub fn unregister(tree: &Db, txid: u64) -> Result<()> {
+    let key = get_txdata_key(txid);
+    let mut tx_data: TxData = tree
+        .get(&key)
+        .map_err(err_into)?
+        .ok_or_else(|| Error::StorageMsg("conflict - lock does not exist".to_owned()))
+        .map(|tx_data| bincode::deserialize(&tx_data))?
+        .map_err(err_into)?;
+
+    tx_data.alive = false;
+
+    bincode::serialize(&tx_data)
+        .map(|tx_data| tree.insert(key, tx_data))
+        .map_err(err_into)?
+        .map_err(err_into)?;
+
+    Ok(())
+}
+
+pub fn release(tree: &TransactionalTree, txid: u64) -> ConflictableTransactionResult<(), Error> {
+    let Lock { gc_txid, .. } = tree
+        .get("lock/")?
+        .map(|l| bincode::deserialize(&l))
+        .transpose()
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)?
+        .unwrap_or_default();
+
+    let lock = Lock {
+        lock_txid: None,
+        gc_txid,
+    };
+
+    bincode::serialize(&lock)
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)
+        .map(|lock| tree.insert("lock/", lock))??;
+
+    let key = get_txdata_key(txid);
+    let mut tx_data: TxData = tree
+        .get(&key)?
+        .ok_or_else(|| Error::StorageMsg("conflict - lock does not exist".to_owned()))
+        .map(|tx_data| bincode::deserialize(&tx_data))
+        .map_err(ConflictableTransactionError::Abort)?
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)?;
+
+    tx_data.alive = false;
+
+    bincode::serialize(&tx_data)
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)
+        .map(|tx_data| tree.insert(key, tx_data))??;
 
     Ok(())
 }

--- a/src/storages/sled_storage/mod.rs
+++ b/src/storages/sled_storage/mod.rs
@@ -3,29 +3,48 @@ mod error;
 mod index;
 mod index_mut;
 mod index_sync;
+mod key;
+mod lock;
+mod snapshot;
 mod store;
 mod store_mut;
+mod transaction;
 
 use {
+    self::snapshot::Snapshot,
     crate::{
         store::{GStore, GStoreMut},
-        Error, Result, RowIter, Schema,
+        Error, Result,
     },
     error::err_into,
-    sled::{self, Config, Db, IVec},
+    sled::{
+        self,
+        transaction::{
+            ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
+        },
+        Config, Db, IVec,
+    },
     std::convert::TryFrom,
 };
 
 #[derive(Debug, Clone)]
+pub enum State {
+    Idle,
+    Transaction { txid: u64, autocommit: bool },
+}
+
+#[derive(Debug, Clone)]
 pub struct SledStorage {
     tree: Db,
+    state: State,
 }
 
 impl SledStorage {
     pub fn new(filename: &str) -> Result<Self> {
         let tree = sled::open(filename).map_err(err_into)?;
+        let state = State::Idle;
 
-        Ok(Self { tree })
+        Ok(Self { tree, state })
     }
 }
 
@@ -34,33 +53,25 @@ impl TryFrom<Config> for SledStorage {
 
     fn try_from(config: Config) -> Result<Self> {
         let tree = config.open().map_err(err_into)?;
+        let state = State::Idle;
 
-        Ok(Self { tree })
+        Ok(Self { tree, state })
     }
 }
 
-fn fetch_schema(tree: &Db, table_name: &str) -> Result<(String, Option<Schema>)> {
+fn fetch_schema(
+    tree: &TransactionalTree,
+    table_name: &str,
+) -> ConflictableTransactionResult<(String, Option<Snapshot<crate::data::Schema>>), Error> {
     let key = format!("schema/{}", table_name);
-    let value = tree.get(&key.as_bytes()).map_err(err_into)?;
-    let schema = value
+    let value = tree.get(&key.as_bytes())?;
+    let schema_snapshot = value
         .map(|v| bincode::deserialize(&v))
         .transpose()
-        .map_err(err_into)?;
+        .map_err(err_into)
+        .map_err(ConflictableTransactionError::Abort)?;
 
-    Ok((key, schema))
-}
-
-fn scan_data(tree: &Db, table_name: &str) -> RowIter<IVec> {
-    let prefix = format!("data/{}/", table_name);
-
-    let result_set = tree.scan_prefix(prefix.as_bytes()).map(move |item| {
-        let (key, value) = item.map_err(err_into)?;
-        let value = bincode::deserialize(&value).map_err(err_into)?;
-
-        Ok((key, value))
-    });
-
-    Box::new(result_set)
+    Ok((key, schema_snapshot))
 }
 
 impl GStore<IVec> for SledStorage {}

--- a/src/storages/sled_storage/mod.rs
+++ b/src/storages/sled_storage/mod.rs
@@ -1,5 +1,6 @@
 mod alter_table;
 mod error;
+mod gc;
 mod index;
 mod index_mut;
 mod index_sync;
@@ -35,8 +36,8 @@ pub enum State {
 
 #[derive(Debug, Clone)]
 pub struct SledStorage {
-    tree: Db,
-    state: State,
+    pub tree: Db,
+    pub state: State,
 }
 
 impl SledStorage {

--- a/src/storages/sled_storage/snapshot.rs
+++ b/src/storages/sled_storage/snapshot.rs
@@ -121,4 +121,17 @@ impl<T: Debug + Clone> Snapshot<T> {
 
         None
     }
+
+    pub fn gc(self, txid: u64) -> Option<Self> {
+        let items = self
+            .0
+            .into_iter()
+            .skip_while(|SnapshotItem { deleted_by, .. }| match deleted_by {
+                Some(d_txid) => d_txid <= &txid,
+                None => false,
+            })
+            .collect::<Vec<_>>();
+
+        (!items.is_empty()).then(|| Self(items))
+    }
 }

--- a/src/storages/sled_storage/snapshot.rs
+++ b/src/storages/sled_storage/snapshot.rs
@@ -1,0 +1,124 @@
+use {
+    serde::{Deserialize, Serialize},
+    std::fmt::Debug,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SnapshotItem<T> {
+    data: T,
+    created_by: u64,
+    deleted_by: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot<T>(Vec<SnapshotItem<T>>);
+
+impl<T: Debug + Clone> Snapshot<T> {
+    pub fn new(txid: u64, data: T) -> Self {
+        Self(vec![SnapshotItem {
+            data,
+            created_by: txid,
+            deleted_by: None,
+        }])
+    }
+
+    pub fn update(mut self, txid: u64, data: T) -> (Self, Option<T>) {
+        let old_data = if !self.0.is_empty() && self.0[0].deleted_by.is_none() {
+            self.0[0].deleted_by = Some(txid);
+
+            Some(self.0[0].data.clone())
+        } else {
+            None
+        };
+
+        let new_item = SnapshotItem {
+            data,
+            created_by: txid,
+            deleted_by: None,
+        };
+
+        self.0.insert(0, new_item);
+
+        (self, old_data)
+    }
+
+    pub fn delete(mut self, txid: u64) -> (Self, Option<T>) {
+        if !self.0.is_empty() {
+            self.0[0].deleted_by = Some(txid);
+
+            let data = self.0[0].data.clone();
+
+            (self, Some(data))
+        } else {
+            (self, None)
+        }
+    }
+
+    pub fn rollback(self, txid: u64) -> Option<Self> {
+        let items = self
+            .0
+            .into_iter()
+            .filter_map(|mut item| {
+                if item.created_by == txid {
+                    None
+                } else if item.deleted_by == Some(txid) {
+                    item.deleted_by = None;
+
+                    Some(item)
+                } else {
+                    Some(item)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        (!items.is_empty()).then(|| Snapshot(items))
+    }
+
+    pub fn extract(self, txid: u64, lock_txid: Option<u64>) -> Option<T> {
+        let lock_txid = if Some(txid) == lock_txid {
+            None
+        } else {
+            lock_txid
+        };
+
+        for item in self.0.into_iter() {
+            if Some(item.created_by) == lock_txid {
+                continue;
+            }
+
+            let deleted = item.deleted_by.is_some()
+                && item.deleted_by != lock_txid
+                && Some(txid) >= item.deleted_by;
+
+            if txid >= item.created_by && !deleted {
+                return Some(item.data);
+            }
+        }
+
+        None
+    }
+
+    pub fn get(&self, txid: u64, lock_txid: Option<u64>) -> Option<T> {
+        let lock_txid = if Some(txid) == lock_txid {
+            None
+        } else {
+            lock_txid
+        };
+
+        for item in self.0.iter() {
+            if Some(item.created_by) == lock_txid {
+                continue;
+            }
+
+            let deleted = item.deleted_by.is_some()
+                && item.deleted_by != lock_txid
+                && Some(txid) >= item.deleted_by;
+
+            if txid >= item.created_by && !deleted {
+                return Some(item.data.clone());
+            }
+        }
+
+        None
+    }
+}

--- a/src/storages/sled_storage/store.rs
+++ b/src/storages/sled_storage/store.rs
@@ -1,6 +1,9 @@
 use {
-    super::{fetch_schema, scan_data, SledStorage},
-    crate::{Result, RowIter, Schema, Store},
+    super::{err_into, lock, SledStorage, Snapshot, State},
+    crate::{
+        data::{Row, Schema},
+        Result, RowIter, Store,
+    },
     async_trait::async_trait,
     sled::IVec,
 };
@@ -8,10 +11,47 @@ use {
 #[async_trait(?Send)]
 impl Store<IVec> for SledStorage {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
-        fetch_schema(&self.tree, table_name).map(|(_, schema)| schema)
+        let lock_txid = lock::fetch(&self.tree)?;
+        let txid = match self.state {
+            State::Transaction { txid, .. } => txid,
+            State::Idle => self.tree.generate_id().map_err(err_into)?,
+        };
+
+        let key = format!("schema/{}", table_name);
+        let schema = self
+            .tree
+            .get(key.as_bytes())
+            .map_err(err_into)?
+            .map(|v| bincode::deserialize(&v))
+            .transpose()
+            .map_err(err_into)?
+            .map(|snapshot: Snapshot<Schema>| snapshot.extract(txid, lock_txid))
+            .flatten();
+
+        Ok(schema)
     }
 
     async fn scan_data(&self, table_name: &str) -> Result<RowIter<IVec>> {
-        Ok(scan_data(&self.tree, table_name))
+        let lock_txid = lock::fetch(&self.tree)?;
+        let txid = match self.state {
+            State::Transaction { txid, .. } => txid,
+            State::Idle => self.tree.generate_id().map_err(err_into)?,
+        };
+
+        let prefix = format!("data/{}/", table_name);
+        let result_set = self
+            .tree
+            .scan_prefix(prefix.as_bytes())
+            .map(move |item| {
+                let (key, value) = item.map_err(err_into)?;
+                let snapshot: Snapshot<Row> = bincode::deserialize(&value).map_err(err_into)?;
+                let row = snapshot.extract(txid, lock_txid);
+                let item = row.map(|row| (key, row));
+
+                Ok(item)
+            })
+            .filter_map(|item| item.transpose());
+
+        Ok(Box::new(result_set))
     }
 }

--- a/src/storages/sled_storage/store_mut.rs
+++ b/src/storages/sled_storage/store_mut.rs
@@ -205,7 +205,7 @@ impl StoreMut<IVec> for SledStorage {
                     .map_err(ConflictableTransactionError::Abort)
                     .map(|snapshot| tree.insert(key, snapshot))??;
 
-                index_sync.update(&key, &old_row, new_row)?;
+                index_sync.update(key, &old_row, new_row)?;
 
                 if !autocommit {
                     let temp_key = key::temp_data(txid, key);
@@ -247,7 +247,7 @@ impl StoreMut<IVec> for SledStorage {
                     .map_err(ConflictableTransactionError::Abort)
                     .map(|snapshot| tree.insert(key, snapshot))??;
 
-                index_sync.delete(&key, &row)?;
+                index_sync.delete(key, &row)?;
 
                 if !autocommit {
                     let temp_key = key::temp_data(txid, key);

--- a/src/storages/sled_storage/transaction.rs
+++ b/src/storages/sled_storage/transaction.rs
@@ -1,0 +1,287 @@
+#![cfg(feature = "transaction")]
+
+use {
+    super::{
+        err_into,
+        error::StorageError,
+        key::{TEMP_DATA, TEMP_INDEX, TEMP_SCHEMA},
+        lock, SledStorage, Snapshot, State,
+    },
+    crate::{
+        data::{Row, Schema},
+        Error, MutResult, Result, Transaction,
+    },
+    async_trait::async_trait,
+    sled::transaction::{ConflictableTransactionError, TransactionError},
+};
+
+macro_rules! try_block {
+    ($self: expr, $block: block) => {{
+        let block = || $block;
+
+        match block() {
+            Err(e) => {
+                return Err(($self, e));
+            }
+            Ok(v) => v,
+        }
+    }};
+}
+
+macro_rules! transaction {
+    ($self: expr, $expr: expr) => {{
+        let result = $self.tree.transaction($expr).map_err(|e| match e {
+            TransactionError::Abort(e) => e,
+            TransactionError::Storage(e) => StorageError::Sled(e).into(),
+        });
+
+        match result {
+            Ok(_) => {
+                let storage = Self {
+                    tree: $self.tree,
+                    state: State::Idle,
+                };
+
+                Ok((storage, ()))
+            }
+            Err(e) => Err(($self, e)),
+        }
+    }};
+}
+
+#[async_trait(?Send)]
+impl Transaction for SledStorage {
+    async fn begin(self, autocommit: bool) -> MutResult<Self, bool> {
+        let (txid, autocommit) = try_block!(self, {
+            match (&self.state, autocommit) {
+                (State::Transaction { .. }, false) => Err(Error::StorageMsg(
+                    "nested transaction is not supported".to_owned(),
+                )),
+                (State::Transaction { txid, autocommit }, true) => Ok((*txid, *autocommit)),
+                (State::Idle, _) => self
+                    .tree
+                    .generate_id()
+                    .map_err(err_into)
+                    .map(|txid| (txid, autocommit)),
+            }
+        });
+
+        let storage = Self {
+            tree: self.tree,
+            state: State::Transaction { txid, autocommit },
+        };
+
+        Ok((storage, autocommit))
+    }
+
+    async fn rollback(self) -> MutResult<Self, ()> {
+        let txid = match self.state {
+            State::Transaction { txid, .. } => txid,
+            State::Idle => {
+                return Err((
+                    self,
+                    Error::StorageMsg("no transaction to rollback".to_owned()),
+                ));
+            }
+        };
+
+        let fetch_items = |prefix| {
+            self.tree
+                .scan_prefix(prefix)
+                .map(|item| item.map_err(err_into))
+                .collect::<Result<Vec<_>>>()
+        };
+
+        let temp_items = try_block!(self, {
+            let lock_txid = lock::fetch(&self.tree)?;
+
+            if Some(txid) != lock_txid {
+                return Ok(None);
+            }
+
+            let data_items = fetch_items(TEMP_DATA)?;
+            let schema_items = fetch_items(TEMP_SCHEMA)?;
+            let index_items = fetch_items(TEMP_INDEX)?;
+
+            Ok(Some((data_items, schema_items, index_items)))
+        });
+
+        let (data_items, schema_items, index_items) = match temp_items {
+            Some(items) => items,
+            None => {
+                return Ok((
+                    Self {
+                        tree: self.tree,
+                        state: State::Idle,
+                    },
+                    (),
+                ));
+            }
+        };
+
+        transaction!(self, move |tree| {
+            for (temp_key, value_key) in data_items.iter() {
+                tree.remove(temp_key)?;
+
+                let snapshot = tree
+                    .get(value_key)?
+                    .map(|l| bincode::deserialize(&l))
+                    .transpose()
+                    .map_err(err_into)
+                    .map_err(ConflictableTransactionError::Abort)?;
+
+                let snapshot: Snapshot<Row> = match snapshot {
+                    Some(snapshot) => snapshot,
+                    None => {
+                        continue;
+                    }
+                };
+
+                match snapshot.rollback(txid) {
+                    Some(snapshot) => {
+                        let snapshot = bincode::serialize(&snapshot)
+                            .map_err(err_into)
+                            .map_err(ConflictableTransactionError::Abort)?;
+
+                        tree.insert(value_key, snapshot)?;
+                    }
+                    None => {
+                        tree.remove(value_key)?;
+                    }
+                };
+            }
+
+            for (temp_key, value_key) in schema_items.iter() {
+                tree.remove(temp_key)?;
+
+                let snapshot = tree
+                    .get(value_key)?
+                    .map(|l| bincode::deserialize(&l))
+                    .transpose()
+                    .map_err(err_into)
+                    .map_err(ConflictableTransactionError::Abort)?;
+
+                let snapshot: Snapshot<Schema> = match snapshot {
+                    Some(snapshot) => snapshot,
+                    None => {
+                        continue;
+                    }
+                };
+
+                match snapshot.rollback(txid) {
+                    Some(snapshot) => {
+                        let snapshot = bincode::serialize(&snapshot)
+                            .map_err(err_into)
+                            .map_err(ConflictableTransactionError::Abort)?;
+
+                        tree.insert(value_key, snapshot)?;
+                    }
+                    None => {
+                        tree.remove(value_key)?;
+                    }
+                };
+            }
+
+            for (temp_key, value_key) in index_items.iter() {
+                tree.remove(temp_key)?;
+
+                let snapshots = tree
+                    .get(value_key)?
+                    .map(|l| bincode::deserialize(&l))
+                    .transpose()
+                    .map_err(err_into)
+                    .map_err(ConflictableTransactionError::Abort)?;
+
+                let snapshots: Vec<Snapshot<Vec<u8>>> = match snapshots {
+                    Some(snapshots) => snapshots,
+                    None => {
+                        continue;
+                    }
+                };
+
+                let snapshots = snapshots
+                    .into_iter()
+                    .filter_map(|snapshot| snapshot.rollback(txid))
+                    .collect::<Vec<_>>();
+
+                if snapshots.is_empty() {
+                    tree.remove(value_key)?;
+                } else {
+                    let snapshots = bincode::serialize(&snapshots)
+                        .map_err(err_into)
+                        .map_err(ConflictableTransactionError::Abort)?;
+
+                    tree.insert(value_key, snapshots)?;
+                }
+            }
+
+            lock::release(tree)?;
+
+            Ok(())
+        })
+    }
+
+    async fn commit(self) -> MutResult<Self, ()> {
+        let txid = match self.state {
+            State::Transaction { txid, .. } => txid,
+            State::Idle => {
+                return Err((
+                    self,
+                    Error::StorageMsg("no transaction to commit".to_owned()),
+                ));
+            }
+        };
+
+        let fetch_keys = |prefix| {
+            self.tree
+                .scan_prefix(prefix)
+                .map(|item| item.map(|(key, _)| key).map_err(err_into))
+                .collect::<Result<Vec<_>>>()
+        };
+
+        let temp_keys = try_block!(self, {
+            let lock_txid = lock::fetch(&self.tree)?;
+
+            if Some(txid) != lock_txid {
+                return Ok(None);
+            }
+
+            let data_keys = fetch_keys(TEMP_DATA)?;
+            let schema_keys = fetch_keys(TEMP_SCHEMA)?;
+            let index_keys = fetch_keys(TEMP_INDEX)?;
+
+            Ok(Some((data_keys, schema_keys, index_keys)))
+        });
+
+        let (data_keys, schema_keys, index_keys) = match temp_keys {
+            Some(keys) => keys,
+            None => {
+                return Ok((
+                    Self {
+                        tree: self.tree,
+                        state: State::Idle,
+                    },
+                    (),
+                ));
+            }
+        };
+
+        transaction!(self, move |tree| {
+            for key in data_keys.iter() {
+                tree.remove(key)?;
+            }
+
+            for key in schema_keys.iter() {
+                tree.remove(key)?;
+            }
+
+            for key in index_keys.iter() {
+                tree.remove(key)?;
+            }
+
+            lock::release(tree)?;
+
+            Ok(())
+        })
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,6 +15,13 @@ cfg_if! {
 }
 
 cfg_if! {
+    if #[cfg(feature = "transaction")] {
+        mod transaction;
+        pub use transaction::Transaction;
+    }
+}
+
+cfg_if! {
     if #[cfg(feature = "index")] {
         pub trait GStore<T: Debug>: Store<T> + Index<T> {}
     } else {
@@ -23,12 +30,20 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(all(feature = "alter-table", feature = "index"))] {
+    if #[cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))] {
+        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + AlterTable + Transaction {}
+    } else if #[cfg(all(feature = "alter-table", feature = "index"))] {
         pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + AlterTable {}
+    } else if #[cfg(all(feature = "alter-table", feature = "transaction"))] {
+        pub trait GStoreMut<T: Debug>: StoreMut<T> + Transaction + AlterTable {}
+    } else if #[cfg(all(feature = "index", feature = "transaction"))] {
+        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + Transaction {}
     } else if #[cfg(feature = "alter-table")] {
         pub trait GStoreMut<T: Debug>: StoreMut<T> + AlterTable {}
     } else if #[cfg(feature = "index")] {
         pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> {}
+    } else if #[cfg(feature = "transaction")] {
+        pub trait GStoreMut<T: Debug>: StoreMut<T> + Transaction {}
     } else {
         pub trait GStoreMut<T: Debug>: Store<T> + StoreMut<T> {}
     }

--- a/src/store/transaction.rs
+++ b/src/store/transaction.rs
@@ -1,0 +1,13 @@
+use {crate::MutResult, async_trait::async_trait};
+
+#[async_trait(?Send)]
+pub trait Transaction
+where
+    Self: Sized,
+{
+    async fn begin(self, autocommit: bool) -> MutResult<Self, bool>;
+
+    async fn rollback(self) -> MutResult<Self, ()>;
+
+    async fn commit(self) -> MutResult<Self, ()>;
+}

--- a/src/tests/alter/mod.rs
+++ b/src/tests/alter/mod.rs
@@ -1,11 +1,11 @@
 mod alter_table;
 mod create_table;
-mod drop_indexed_column;
+mod drop_indexed;
 mod drop_table;
 
 #[cfg(feature = "alter-table")]
 pub use alter_table::{alter_table_add_drop, alter_table_rename};
 pub use create_table::create_table;
 #[cfg(all(feature = "alter-table", feature = "index"))]
-pub use drop_indexed_column::drop_indexed_column;
+pub use drop_indexed::{drop_indexed_column, drop_indexed_table};
 pub use drop_table::drop_table;

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -6,8 +6,8 @@ test_case!(error, async move {
 
     let test_cases = vec![
         (
-            TranslateError::UnsupportedStatement("COMMIT".to_owned()).into(),
-            "COMMIT;",
+            TranslateError::UnsupportedStatement("TRUNCATE TABLE TableA".to_owned()).into(),
+            "TRUNCATE TABLE TableA;",
         ),
         (
             TranslateError::UnsupportedUnaryOperator("!".to_owned()).into(),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -18,6 +18,7 @@ pub mod nullable;
 pub mod order_by;
 pub mod ordering;
 pub mod synthesize;
+pub mod transaction;
 pub mod validate;
 
 mod tester;
@@ -89,6 +90,8 @@ macro_rules! generate_tests {
                 glue!(index_order_by_multi, index::order_by_multi);
             };
         }
+        #[cfg(feature = "index")]
+        glue_index!();
 
         #[cfg(feature = "alter-table")]
         macro_rules! glue_alter_table {
@@ -97,13 +100,60 @@ macro_rules! generate_tests {
                 glue!(alter_table_add_drop, alter::alter_table_add_drop);
             };
         }
-
-        #[cfg(all(feature = "alter-table", feature = "index"))]
-        glue!(alter_table_drop_indexed_column, alter::drop_indexed_column);
-
-        #[cfg(feature = "index")]
-        glue_index!();
         #[cfg(feature = "alter-table")]
         glue_alter_table!();
+
+        #[cfg(all(feature = "alter-table", feature = "index"))]
+        macro_rules! glue_alter_table_index {
+            () => {
+                glue!(alter_table_drop_indexed_table, alter::drop_indexed_table);
+                glue!(alter_table_drop_indexed_column, alter::drop_indexed_column);
+            };
+        }
+        #[cfg(all(feature = "alter-table", feature = "index"))]
+        glue_alter_table_index!();
+
+        #[cfg(feature = "transaction")]
+        macro_rules! glue_transaction {
+            () => {
+                glue!(transaction_basic, transaction::basic);
+                glue!(
+                    transaction_create_drop_table,
+                    transaction::create_drop_table
+                );
+            };
+        }
+        #[cfg(feature = "transaction")]
+        glue_transaction!();
+
+        #[cfg(all(feature = "transaction", feature = "alter-table"))]
+        macro_rules! glue_transaction_alter_table {
+            () => {
+                glue!(
+                    transaction_alter_table_rename_column,
+                    transaction::alter_table_rename_column
+                );
+                glue!(
+                    transaction_alter_table_add_column,
+                    transaction::alter_table_add_column
+                );
+                glue!(
+                    transaction_alter_table_drop_column,
+                    transaction::alter_table_drop_column
+                );
+            };
+        }
+        #[cfg(all(feature = "transaction", feature = "alter-table"))]
+        glue_transaction_alter_table!();
+
+        #[cfg(all(feature = "transaction", feature = "index"))]
+        macro_rules! glue_transaction_index {
+            () => {
+                glue!(transaction_index_create, transaction::index_create);
+                glue!(transaction_index_drop, transaction::index_drop);
+            };
+        }
+        #[cfg(all(feature = "transaction", feature = "index"))]
+        glue_transaction_index!();
     };
 }

--- a/src/tests/transaction/alter_table.rs
+++ b/src/tests/transaction/alter_table.rs
@@ -1,0 +1,96 @@
+#![cfg(all(feature = "transaction", feature = "alter-table"))]
+
+use crate::{Value::I64, *};
+
+test_case!(alter_table_rename_table, async move {
+    run!("CREATE TABLE RenameTable (id INTEGER);");
+    run!("INSERT INTO RenameTable VALUES (1);");
+    run!("BEGIN;");
+    run!("ALTER TABLE RenameTable RENAME TO NewName;");
+    test!(
+        Err(AlterTableError::TableNotFound("RenameTable".to_owned()).into()),
+        "SELECT * FROM RenameTable"
+    );
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM NewName");
+    run!("ROLLBACK;");
+    test!(
+        Err(AlterTableError::TableNotFound("NewName".to_owned()).into()),
+        "SELECT * FROM NewName"
+    );
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM RenameTable");
+});
+
+test_case!(alter_table_rename_column, async move {
+    run!("CREATE TABLE RenameCol (id INTEGER);");
+    run!("INSERT INTO RenameCol VALUES (1);");
+
+    // ROLLBACK
+    run!("BEGIN;");
+    run!("ALTER TABLE RenameCol RENAME COLUMN id TO new_id;");
+    test!(Ok(select!(new_id I64; 1)), "SELECT * FROM RenameCol");
+    run!("ROLLBACK;");
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM RenameCol");
+
+    // COMMIT
+    run!("BEGIN;");
+    run!("ALTER TABLE RenameCol RENAME COLUMN id TO new_id;");
+    run!("COMMIT;");
+    test!(Ok(select!(new_id I64; 1)), "SELECT * FROM RenameCol");
+});
+
+test_case!(alter_table_add_column, async move {
+    run!("CREATE TABLE AddCol (id INTEGER);");
+    run!("INSERT INTO AddCol VALUES (1);");
+
+    // ROLLBACK
+    run!("BEGIN;");
+    run!("ALTER TABLE AddCol ADD COLUMN new_col INTEGER DEFAULT 3;");
+    test!(
+        Ok(select!(
+            id  | new_col
+            I64 | I64;
+            1     3
+        )),
+        "SELECT * FROM AddCol"
+    );
+    run!("ROLLBACK;");
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM AddCol");
+
+    // COMMIT
+    run!("BEGIN;");
+    run!("ALTER TABLE AddCol ADD COLUMN new_col INTEGER DEFAULT 3;");
+    run!("COMMIT;");
+    test!(
+        Ok(select!(
+            id  | new_col
+            I64 | I64;
+            1     3
+        )),
+        "SELECT * FROM AddCol"
+    );
+});
+
+test_case!(alter_table_drop_column, async move {
+    run!("CREATE TABLE DropCol (id INTEGER, num INTEGER);");
+    run!("INSERT INTO DropCol VALUES (1, 2);");
+
+    // ROLLBACK
+    run!("BEGIN;");
+    run!("ALTER TABLE DropCol DROP COLUMN num;");
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM DropCol");
+    run!("ROLLBACK;");
+    test!(
+        Ok(select!(
+            id  | num
+            I64 | I64;
+            1     2
+        )),
+        "SELECT * FROM DropCol"
+    );
+
+    // COMMIT
+    run!("BEGIN;");
+    run!("ALTER TABLE DropCol DROP COLUMN num;");
+    run!("COMMIT;");
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM DropCol");
+});

--- a/src/tests/transaction/basic.rs
+++ b/src/tests/transaction/basic.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "transaction")]
+
+use crate::*;
+
+test_case!(basic, async move {
+    use Value::*;
+
+    run!(
+        "
+        CREATE TABLE TxTest (
+            id INTEGER,
+            name TEXT
+        );
+    "
+    );
+    run!(
+        r#"
+        INSERT INTO TxTest VALUES
+            (1, "Friday"),
+            (2, "Phone");
+    "#
+    );
+
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(
+        Ok(Payload::Insert(1)),
+        r#"INSERT INTO TxTest VALUES (3, "New one");"#
+    );
+    test!(Ok(Payload::Rollback), "ROLLBACK;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(
+        Ok(Payload::Insert(1)),
+        r#"INSERT INTO TxTest VALUES (3, "Vienna");"#
+    );
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned();
+            3     "Vienna".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+
+    test!(Ok(Payload::Commit), "COMMIT;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned();
+            3     "Vienna".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+
+    // DELETE
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(Ok(Payload::Delete(1)), "DELETE FROM TxTest WHERE id = 3;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::Rollback), "ROLLBACK;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned();
+            3     "Vienna".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(Ok(Payload::Delete(1)), "DELETE FROM TxTest WHERE id = 3;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::Commit), "COMMIT;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+
+    // UPDATE
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(
+        Ok(Payload::Update(1)),
+        r#"UPDATE TxTest SET name = "Sunday" WHERE id = 1;"#
+    );
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Sunday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::Rollback), "ROLLBACK;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Friday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::StartTransaction), "BEGIN;");
+    test!(
+        Ok(Payload::Update(1)),
+        r#"UPDATE TxTest SET name = "Sunday" WHERE id = 1;"#
+    );
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Sunday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+    test!(Ok(Payload::Commit), "COMMIT;");
+    test!(
+        Ok(select!(
+            id  | name
+            I64 | Str;
+            1     "Sunday".to_owned();
+            2     "Phone".to_owned()
+        )),
+        "SELECT id, name FROM TxTest"
+    );
+
+    run!("BEGIN;");
+    run!("SELECT * FROM TxTest;");
+    run!("ROLLBACK;");
+
+    run!("BEGIN;");
+    run!("SELECT * FROM TxTest;");
+    run!("COMMIT;");
+
+    run!("BEGIN;");
+    run!("COMMIT;");
+});

--- a/src/tests/transaction/index.rs
+++ b/src/tests/transaction/index.rs
@@ -1,0 +1,103 @@
+#![cfg(all(feature = "transaction", feature = "index"))]
+
+use crate::{ast::IndexOperator::Eq, Value::I64, *};
+
+test_case!(index_create, async move {
+    run!("CREATE TABLE IdxCreate (id INTEGER);");
+    run!("INSERT INTO IdxCreate VALUES (1);");
+
+    // ROLLBACK
+    run!("BEGIN;");
+    run!("CREATE INDEX idx_id ON IdxCreate (id);");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(idx_id, Eq, "1"),
+        "SELECT id FROM IdxCreate WHERE id = 1"
+    );
+    run!("ROLLBACK;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(),
+        "SELECT id FROM IdxCreate WHERE id = 1"
+    );
+
+    // COMMIT;
+    run!("BEGIN;");
+    run!("CREATE INDEX idx_id ON IdxCreate (id);");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(idx_id, Eq, "1"),
+        "SELECT id FROM IdxCreate WHERE id = 1"
+    );
+    run!("COMMIT;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(idx_id, Eq, "1"),
+        "SELECT id FROM IdxCreate WHERE id = 1"
+    );
+
+    run!("DELETE FROM IdxCreate;");
+    run!("INSERT INTO IdxCreate VALUES (3);");
+
+    // CREATE MORE
+    run!("BEGIN;");
+    run!("CREATE INDEX idx_id2 ON IdxCreate (id * 2);");
+    test_idx!(
+        Ok(select!(id I64; 3)),
+        idx!(idx_id, Eq, "3"),
+        "SELECT id FROM IdxCreate WHERE id = 3"
+    );
+    test_idx!(
+        Ok(select!(id I64; 3)),
+        idx!(idx_id2, Eq, "6"),
+        "SELECT id FROM IdxCreate WHERE id * 2 = 6"
+    );
+    run!("ROLLBACK;");
+
+    test_idx!(
+        Ok(select!(id I64; 3)),
+        idx!(idx_id, Eq, "3"),
+        "SELECT id FROM IdxCreate WHERE id = 3"
+    );
+    test_idx!(
+        Ok(select!(id I64; 3)),
+        idx!(),
+        "SELECT id FROM IdxCreate WHERE id * 2 = 6"
+    );
+});
+
+test_case!(index_drop, async move {
+    run!("CREATE TABLE IdxDrop (id INTEGER);");
+    run!("INSERT INTO IdxDrop VALUES (1);");
+    run!("CREATE INDEX idx_id ON IdxDrop (id);");
+
+    // ROLLBACK
+    run!("BEGIN;");
+    run!("DROP INDEX IdxDrop.idx_id;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(),
+        "SELECT id FROM IdxDrop WHERE id = 1"
+    );
+    run!("ROLLBACK;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(idx_id, Eq, "1"),
+        "SELECT id FROM IdxDrop WHERE id = 1"
+    );
+
+    // COMMIT;
+    run!("BEGIN;");
+    run!("DROP INDEX IdxDrop.idx_id;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(),
+        "SELECT id FROM IdxDrop WHERE id = 1"
+    );
+    run!("COMMIT;");
+    test_idx!(
+        Ok(select!(id I64; 1)),
+        idx!(),
+        "SELECT id FROM IdxDrop WHERE id = 1"
+    );
+});

--- a/src/tests/transaction/mod.rs
+++ b/src/tests/transaction/mod.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "transaction")]
+
+mod alter_table;
+mod basic;
+mod index;
+mod table;
+
+#[cfg(feature = "alter-table")]
+pub use alter_table::*;
+pub use basic::basic;
+#[cfg(feature = "index")]
+pub use index::*;
+pub use table::*;

--- a/src/tests/transaction/table.rs
+++ b/src/tests/transaction/table.rs
@@ -1,0 +1,40 @@
+use crate::{Value::I64, *};
+
+test_case!(create_drop_table, async move {
+    // CREATE && ROLLBACK
+    run!("BEGIN;");
+    run!("CREATE TABLE Test (id INTEGER);");
+    run!("INSERT INTO Test VALUES (1);");
+    test!(Ok(select!(id I64; 1)), "SELECT * FROM Test;");
+    run!("ROLLBACK;");
+    test!(
+        Err(FetchError::TableNotFound("Test".to_owned()).into()),
+        "SELECT * FROM Test;"
+    );
+
+    // CREATE && COMMIT
+    run!("BEGIN;");
+    run!("CREATE TABLE Test (id INTEGER);");
+    run!("INSERT INTO Test VALUES (3);");
+    run!("COMMIT;");
+    test!(Ok(select!(id I64; 3)), "SELECT * FROM Test;");
+
+    // DROP && ROLLBACK
+    run!("BEGIN;");
+    run!("DROP TABLE Test;");
+    test!(
+        Err(FetchError::TableNotFound("Test".to_owned()).into()),
+        "SELECT * FROM Test;"
+    );
+    run!("ROLLBACK;");
+    test!(Ok(select!(id I64; 3)), "SELECT * FROM Test;");
+
+    // DROP && COMMIT
+    run!("BEGIN;");
+    run!("DROP TABLE Test;");
+    run!("COMMIT;");
+    test!(
+        Err(FetchError::TableNotFound("Test".to_owned()).into()),
+        "SELECT * FROM Test;"
+    );
+});

--- a/src/translate/mod.rs
+++ b/src/translate/mod.rs
@@ -123,6 +123,12 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
 
             Ok(Statement::DropIndex { name, table_name })
         }
+        #[cfg(feature = "transaction")]
+        SqlStatement::StartTransaction { .. } => Ok(Statement::StartTransaction),
+        #[cfg(feature = "transaction")]
+        SqlStatement::Commit { .. } => Ok(Statement::Commit),
+        #[cfg(feature = "transaction")]
+        SqlStatement::Rollback { .. } => Ok(Statement::Rollback),
         _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
     }
 }

--- a/tests/sled_transaction.rs
+++ b/tests/sled_transaction.rs
@@ -1,0 +1,315 @@
+#![cfg(feature = "sled-storage")]
+
+//! # SledStorage transaction tests
+//!
+//! REPEATABLE READ or SNAPSHOT ISOLATION is a transaction level which SledStorage provides.
+//! Therefore, SledStorage is safe from READ UNCOMMITTED or READ COMMITTED concurrency conflict
+//! scenarios, but not PHANTOM READ safe.
+
+use {
+    gluesql::{tests::test_indexes, Value::I64, *},
+    std::fs,
+};
+
+const PATH_PREFIX: &'static str = "tmp/gluesql";
+
+macro_rules! exec {
+    ($glue: ident $sql: literal) => {
+        $glue.execute($sql).unwrap();
+    };
+}
+
+macro_rules! test {
+    ($glue: ident $sql: literal, $result: expr) => {
+        assert_eq!($glue.execute($sql), $result);
+    };
+}
+
+macro_rules! test_idx {
+    ($glue: ident $sql: literal, $idx: expr, $result: expr) => {
+        let statement = $glue.plan($sql).unwrap();
+
+        test_indexes(&statement, Some($idx));
+        assert_eq!($glue.execute_stmt(statement), $result);
+    };
+}
+
+#[test]
+fn sled_transaction_basic() {
+    let path = &format!("{}/basic", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage = SledStorage::new(path).unwrap();
+    let storage2 = storage.clone();
+    let mut glue = Glue::new(storage);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue "BEGIN");
+    test!(glue "BEGIN", Err(Error::StorageMsg("nested transaction is not supported".to_owned())));
+    exec!(glue "COMMIT;");
+
+    test!(glue "ROLLBACK", Err(Error::StorageMsg("no transaction to rollback".to_owned())));
+    test!(glue "COMMIT", Err(Error::StorageMsg("no transaction to commit".to_owned())));
+
+    exec!(glue "BEGIN;");
+    exec!(glue "CREATE TABLE AcquireLock (id INTEGER);");
+    test!(
+        glue2 "CREATE TABLE MeTooTheLock (id INTEGER);",
+        Err(Error::StorageMsg("database is locked".to_owned()))
+    );
+}
+
+#[test]
+fn sled_transaction_read_uncommitted() {
+    let path = &format!("{}/read_uncommitted", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage1 = SledStorage::new(path).unwrap();
+    let storage2 = storage1.clone();
+    let mut glue1 = Glue::new(storage1);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue1 "BEGIN;");
+    exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (30);");
+
+    test!(
+        glue2 "SELECT * FROM Sample",
+        Err(FetchError::TableNotFound("Sample".to_owned()).into())
+    );
+    exec!(glue2 "BEGIN;");
+    test!(
+        glue2 "SELECT * FROM Sample",
+        Err(FetchError::TableNotFound("Sample".to_owned()).into())
+    );
+    exec!(glue2 "COMMIT;");
+    exec!(glue1 "COMMIT;");
+}
+
+#[test]
+fn sled_transaction_read_committed() {
+    let path = &format!("{}/read_committed", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage1 = SledStorage::new(path).unwrap();
+    let storage2 = storage1.clone();
+    let mut glue1 = Glue::new(storage1);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue2 "BEGIN;");
+
+    exec!(glue1 "BEGIN;");
+    exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (30);");
+    exec!(glue1 "COMMIT;");
+
+    test!(
+        glue2 "SELECT * FROM Sample",
+        Err(FetchError::TableNotFound("Sample".to_owned()).into())
+    );
+    exec!(glue2 "COMMIT;");
+
+    test!(
+        glue2 "SELECT * FROM Sample",
+        Ok(select!(id I64; 30))
+    );
+}
+
+#[test]
+fn sled_transaction_schema_mut() {
+    let path = &format!("{}/transaction_schema_mut", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage1 = SledStorage::new(path).unwrap();
+    let storage2 = storage1.clone();
+    let mut glue1 = Glue::new(storage1);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (1);");
+
+    exec!(glue2 "BEGIN;");
+    exec!(glue1 "BEGIN;");
+    exec!(glue1 "DROP TABLE Sample;");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Err(FetchError::TableNotFound("Sample".to_owned()).into())
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "COMMIT;");
+    exec!(glue1 "CREATE TABLE Sample (new_id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (5);");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(select!(new_id I64; 5))
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+    exec!(glue2 "COMMIT;");
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(new_id I64; 5))
+    );
+}
+
+#[test]
+fn sled_transaction_data_mut() {
+    let path = &format!("{}/transaction_data_mut", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage1 = SledStorage::new(path).unwrap();
+    let storage2 = storage1.clone();
+    let mut glue1 = Glue::new(storage1);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (1);");
+
+    exec!(glue2 "BEGIN;");
+    exec!(glue1 "BEGIN;");
+
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "DELETE FROM Sample;");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(Payload::Select {
+            labels: vec!["id".to_owned()],
+            rows: vec![],
+        })
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "INSERT INTO Sample VALUES (3), (5);");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 3; 5))
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "UPDATE Sample SET id = id + 1;");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 4; 6))
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "COMMIT;");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 4; 6))
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue2 "COMMIT;");
+    test!(
+        glue1 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 4; 6))
+    );
+    test!(
+        glue2 "SELECT * FROM Sample;",
+        Ok(select!(id I64; 4; 6))
+    );
+}
+
+#[tokio::test]
+async fn sled_transaction_index_mut() {
+    use ast::IndexOperator::Eq;
+
+    let path = &format!("{}/transaction_index_mut", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage1 = SledStorage::new(path).unwrap();
+    let storage2 = storage1.clone();
+    let mut glue1 = Glue::new(storage1);
+    let mut glue2 = Glue::new(storage2);
+
+    exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
+    exec!(glue1 "INSERT INTO Sample VALUES (1);");
+
+    exec!(glue2 "BEGIN;");
+    exec!(glue1 "BEGIN;");
+
+    exec!(glue1 "CREATE INDEX idx_id ON Sample (id);");
+
+    test_idx!(
+        glue1 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(idx_id, Eq, "1"),
+        Ok(select!(id I64; 1))
+    );
+    test_idx!(
+        glue2 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(),
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "COMMIT;");
+    test_idx!(
+        glue2 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(),
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue2 "COMMIT;");
+    test_idx!(
+        glue1 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(idx_id, Eq, "1"),
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue2 "BEGIN;");
+    exec!(glue1 "BEGIN;");
+
+    exec!(glue1 "DROP INDEX Sample.idx_id;");
+
+    test_idx!(
+        glue2 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(idx_id, Eq, "1"),
+        Ok(select!(id I64; 1))
+    );
+    test_idx!(
+        glue1 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(),
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue1 "COMMIT;");
+    test_idx!(
+        glue2 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(idx_id, Eq, "1"),
+        Ok(select!(id I64; 1))
+    );
+
+    exec!(glue2 "COMMIT;");
+    test_idx!(
+        glue1 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(),
+        Ok(select!(id I64; 1))
+    );
+    test_idx!(
+        glue2 "SELECT * FROM Sample WHERE id = 1;",
+        idx!(),
+        Ok(select!(id I64; 1))
+    );
+}

--- a/tests/sled_transaction.rs
+++ b/tests/sled_transaction.rs
@@ -344,6 +344,7 @@ async fn sled_transaction_gc() {
     exec!(glue1 "CREATE INDEX idx_id ON Garlic (id);");
     exec!(glue1 "INSERT INTO Garlic VALUES (1), (2);");
     exec!(glue1 "CREATE INDEX idx_gc ON Garlic (id + 2);");
+    #[cfg(feature = "alter-table")]
     exec!(glue1 "ALTER TABLE Garlic ADD COLUMN num INTEGER NULL;");
     assert_some!();
     exec!(glue1 "COMMIT;");

--- a/tests/sled_transaction.rs
+++ b/tests/sled_transaction.rs
@@ -11,7 +11,7 @@ use {
     std::fs,
 };
 
-const PATH_PREFIX: &'static str = "tmp/gluesql";
+const PATH_PREFIX: &str = "tmp/gluesql";
 
 macro_rules! exec {
     ($glue: ident $sql: literal) => {


### PR DESCRIPTION
* Implement snapshot based MVCC transaction.
* Add Transaction store trait which has three methods; begin, rollback and commit.
* Current transaction isolation level is REPEATABLE READ or SNAPSHOT ISOLATION.
* Only a single global write lock can exists at the same time.
* Write lock does not affect read operations at all.
Read can be done at any time no matter the write lock is acquired or not.
* Not only for rows, but also schema and index data also use snapshot.
Snapshot stores all changes from rows, schema and index:
  INSERT, DELETE, UPDATE, ALTER TABLE .., CREATE INDEX, DROP INDEX ...

resolve #44 

Remaining task
- [x] Garbage Collector for removing temp data of expired transaction