### PR TITLE
renew Usage at README.md and Doc: executing multiple queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GlueSQL
+
 [![crates.io](https://img.shields.io/crates/v/gluesql.svg)](https://crates.io/crates/gluesql)
 [![docs.rs](https://docs.rs/gluesql/badge.svg)](https://docs.rs/gluesql)
 [![LICENSE](https://img.shields.io/crates/l/gluesql.svg)](https://github.com/gluesql/gluesql/blob/main/LICENSE)
@@ -6,20 +7,25 @@
 [![Chat](https://img.shields.io/discord/780298017940176946)](https://discord.gg/C6TDEgzDzY)
 
 ## SQL Database Engine as a Library
+
 GlueSQL is a SQL database library written in Rust. It provides a parser ([sqlparser-rs](https://github.com/ballista-compute/sqlparser-rs)), execution layer, and optional storage ([sled](https://github.com/spacejam/sled)) packaged into a single library.
-Developers can choose to use GlueSQL to build their own SQL database, or as an embedded SQL database using the default storage engine.  
+Developers can choose to use GlueSQL to build their own SQL database, or as an embedded SQL database using the default storage engine.
 
 ## Standalone Mode
+
 You can use GlueSQL as an embedded SQL database. GlueSQL provides [sled](https://github.com/spacejam/sled "sled") as a default storage engine.
 
 ### Installation
+
 In your `Cargo.toml`:
+
 ```toml
 [dependencies]
 gluesql = "0.7"
 ```
 
 ### Usage
+
 ```rust
 use gluesql::{parse, Glue, SledStorage};
 
@@ -34,7 +40,7 @@ fn main() {
         SELECT * FROM Glue WHERE id > 100;
         DROP TABLE Glue;
     ";
-    
+
     for query in parse(sqls).unwrap() {
         glue.execute(&query).unwrap();
     }
@@ -42,22 +48,29 @@ fn main() {
 ```
 
 ## SQL Library Mode (For Custom Storage)
+
 ### Installation
+
 `sled-storage` is optional. So in `Cargo.toml`:
+
 ```toml
 [dependencies.gluesql]
 version = "0.7"
 default-features = false
 features = ["sorter", "alter-table", "index"]
 ```
+
 #### Three features above are optional, too.
-* `sorter` - ORDER BY support for non-indexed expressions.
-* `alter-table` - ALTER TABLE query support
-* `index` - CREATE INDEX & DROP INDEX, index support
+
+- `sorter` - ORDER BY support for non-indexed expressions.
+- `alter-table` - ALTER TABLE query support
+- `index` - CREATE INDEX & DROP INDEX, index support
 
 ### Usage
+
 There are two required 2 traits for using GlueSQL: `Store` and `StoreMut`.
 In `src/store/mod.rs`,
+
 ```rust
 pub trait Store<T: Debug> {
     async fn fetch_schema(..) -> ..;
@@ -75,6 +88,7 @@ pub trait StoreMut<T: Debug> where Self: Sized {
 
 There is also optional store traits
 In `src/store/alter_table.rs` & `src/store/index.rs`
+
 ```rust
 pub trait AlterTable where Self: Sized {
     async fn rename_schema(..) -> ..;
@@ -94,40 +108,48 @@ pub trait IndexMut<T: Debug> where Self: Sized {
 ```
 
 ## Use Cases
+
 ### [GlueSQL-js](https://github.com/gluesql/gluesql-js)
+
 https://github.com/gluesql/gluesql-js  
 Use SQL in web browsers!
 GlueSQL-js provides 3 storage options,
-* in-memory
-* localStorage
-* sessionStorage
+
+- in-memory
+- localStorage
+- sessionStorage
 
 ### [GlueSQL Sheets](https://sheets.gluesql.com)
+
 https://sheets.gluesql.com  
 Turn **Google Sheets** into a SQL database!  
 It uses Google Sheets as a storage.  
 Data is stored and updated from Google Sheets.
 
 ### Other expected use cases
-* Add SQL layer to NoSQL databases: Redis, CouchDB...
-* Build new SQL database management system
+
+- Add SQL layer to NoSQL databases: Redis, CouchDB...
+- Build new SQL database management system
 
 ## SQL Features
+
 GlueSQL currently supports a limited subset of queries. It's being actively developed.
 
-* `CREATE TABLE` with 8 types: `INTEGER`, `FLOAT`, `BOOLEAN`, `TEXT`, `DATE`, `TIMESTAMP`, `TIME` and `INTERVAL`.
-* `ALTER TABLE` with 4 operations: `ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN` and `RENAME TO`.
-* `CREATE INDEX`, `DROP INDEX`
-* `INSERT`, `UPDATE`, `DELETE`, `SELECT`, `DROP TABLE`
-* `GROUP BY`, `HAVING`
-* `ORDER BY`
-* Nested select, join, aggregations ...
+- `CREATE TABLE` with 8 types: `INTEGER`, `FLOAT`, `BOOLEAN`, `TEXT`, `DATE`, `TIMESTAMP`, `TIME` and `INTERVAL`.
+- `ALTER TABLE` with 4 operations: `ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN` and `RENAME TO`.
+- `CREATE INDEX`, `DROP INDEX`
+- `INSERT`, `UPDATE`, `DELETE`, `SELECT`, `DROP TABLE`
+- `GROUP BY`, `HAVING`
+- `ORDER BY`
+- Nested select, join, aggregations ...
 
-You can see tests for the currently supported queries in [src/tests/*](https://github.com/gluesql/gluesql/tree/main/src/tests).
+You can see tests for the currently supported queries in [src/tests/\*](https://github.com/gluesql/gluesql/tree/main/src/tests).
 
 ## Contribution
+
 There are a few simple rules to follow.
+
 - No `mut` keywords in `src/executor` and `src/data`.
 - Iterator should not be evaluated in the middle of execution layer.
 - Every error must have corresponding integration test cases to generate.  
-(except for `Unreachable-` and `Conflict-` error types)
+  (except for `Unreachable-` and `Conflict-` error types)

--- a/README.md
+++ b/README.md
@@ -27,22 +27,20 @@ gluesql = "0.7"
 ### Usage
 
 ```rust
-use gluesql::{parse, Glue, SledStorage};
-
+use gluesql::*;
 fn main() {
-    let storage = SledStorage::new("data.db").unwrap();
+    let storage = SledStorage::new("data/doc-db").unwrap();
     let mut glue = Glue::new(storage);
-
-    let sqls = "
-        CREATE TABLE Glue (id INTEGER);
-        INSERT INTO Glue VALUES (100);
-        INSERT INTO Glue VALUES (200);
-        SELECT * FROM Glue WHERE id > 100;
-        DROP TABLE Glue;
-    ";
-
-    for query in parse(sqls).unwrap() {
-        glue.execute(&query).unwrap();
+    let sqls = vec![
+        "DROP TABLE IF EXISTS Glue;",
+        "CREATE TABLE Glue (id INTEGER);",
+        "INSERT INTO Glue VALUES (100);",
+        "INSERT INTO Glue VALUES (200);",
+        "SELECT * FROM Glue WHERE id > 100;",
+    ];
+    for sql in sqls {
+        let output = glue.execute(sql).unwrap();
+        println!("{:?}", output)
     }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,18 @@
 //! fn main() {
 //!     let storage = SledStorage::new("data/doc-db").unwrap();
 //!     let mut glue = Glue::new(storage);
-//!
-//!     let sqls = "
-//!         DROP TABLE IF EXISTS Glue;
-//!         CREATE TABLE Glue (id INTEGER);
-//!         INSERT INTO Glue VALUES (100);
-//!         INSERT INTO Glue VALUES (200);
-//!         SELECT * FROM Glue WHERE id > 100;
-//!         DROP TABLE Glue;
-//!     ";
-//!
-//!     glue.execute(&sqls).unwrap();
+//!     
+//!     let sqls = vec![
+//!         "DROP TABLE IF EXISTS Glue;",
+//!         "CREATE TABLE Glue (id INTEGER);",
+//!         "INSERT INTO Glue VALUES (100);",
+//!         "INSERT INTO Glue VALUES (200);",
+//!         "SELECT * FROM Glue WHERE id > 100;",
+//!     ];
+//!     for sql in sqls {
+//!         let output = glue.execute(sql).unwrap();
+//!         println!("{:?}", output)
+//!     }
 //! }
 //!
 //! #[cfg(not(feature = "sled-storage"))]


### PR DESCRIPTION
## 1. Renew Usage to run multiple queries

Current `execute()` method can execute the first parsed query only.  
I changed both src/lib.rs and README.md with for loop like below.

```rs
use gluesql::*;
fn main() {
    let storage = SledStorage::new("data/doc-db").unwrap();
    let mut glue = Glue::new(storage);
    let sqls = vec![
        "DROP TABLE IF EXISTS Glue;",
        "CREATE TABLE Glue (id INTEGER);",
        "INSERT INTO Glue VALUES (100);",
        "INSERT INTO Glue VALUES (200);",
        "SELECT * FROM Glue WHERE id > 100;",
    ];
    for sql in sqls {
        let output = glue.execute(sql).unwrap();
        println!("{:?}", output)
    }
}
``` 

## 2. Prettify README.md with prettier of VSC

## What to do next?

Improve `execute` to be compatible with mutiple queries.

## Outdated PR

~~## Tried to fix issue #258 to execute multiple queries at glue.rs: Glue.execute~~

~~A return type is changed from `Result<Payload>` to `(Vec<Result<Payload>>, Option<Result<Payload>>)` which means we can store executed results and return the results and error(or None).~~

```rs
// src/glue.rs
pub fn execute(&mut self, sql: &str) -> (Vec<Result<Payload>>, Option<Result<Payload>>) {
        let mut results: Vec<Result<Payload>> = Vec::new();
        let parsed = parse(sql);
        for a_sql in parsed.unwrap().iter() {
            let statement = translate(a_sql).unwrap();
            let storage = self.storage.take().unwrap();
            match block_on(execute(storage, &statement)) {
                Ok((storage, payload)) => {
                    self.storage = Some(storage);
                    results.push(Ok(payload));
                }
                Err((storage, error)) => {
                    self.storage = Some(storage);
                    return (results, Some(Err(error)));
                }
            }
        }
        (results, None)
    }
```

~~## According to above fixed Glue.execute method, I renewed README.md to fix issue #259~~

```rs
// README.md
use gluesql::{Glue, SledStorage};

fn main() {
    let storage = SledStorage::new("data/doc-db").unwrap();
    let mut glue = Glue::new(storage);
    let sqls = "
        DROP TABLE IF EXISTS Glue;
        CREATE TABLE Glue (id INTEGER);
        INSERT INTO Glue VALUES (100);
        INSERT INTO Glue VALUES (200);
        SELECT * FROM Glue WHERE id > 100;
    ";
    let (results, error) = glue.execute(&sqls);
    println!("Results: {:?}\nError: {:?}", results, error);
    // Results: [Ok(DropTable), Ok(Create), Ok(Insert(1)), Ok(Insert(1)), Ok(Select { labels: ["id"], rows: [Row([I64(200)])] })]
    // Error: None
}
```