### PR TITLE
Remove unnecessary IntoIterator call syntax

### DIFF
--- a/src/storages/sled_storage/snapshot.rs
+++ b/src/storages/sled_storage/snapshot.rs
@@ -81,7 +81,7 @@ impl<T: Debug + Clone> Snapshot<T> {
             lock_txid
         };
 
-        for item in self.0.into_iter() {
+        for item in self.0 {
             if Some(item.created_by) == lock_txid {
                 continue;
             }

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -59,7 +59,7 @@ test_case!(aggregate, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 
@@ -82,7 +82,7 @@ test_case!(aggregate, async move {
         ),
     ];
 
-    for (error, sql) in error_cases.into_iter() {
+    for (error, sql) in error_cases {
         test!(Err(error), sql);
     }
 });
@@ -162,7 +162,7 @@ test_case!(group_by, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 
@@ -171,7 +171,7 @@ test_case!(group_by, async move {
         "SELECT * FROM Item GROUP BY ratio;",
     )];
 
-    for (error, sql) in error_cases.into_iter() {
+    for (error, sql) in error_cases {
         test!(Err(error), sql);
     }
 });

--- a/src/tests/alter/alter_table.rs
+++ b/src/tests/alter/alter_table.rs
@@ -29,7 +29,7 @@ test_case!(alter_table_rename, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });
@@ -137,7 +137,7 @@ test_case!(alter_table_add_drop, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/alter/create_table.rs
+++ b/src/tests/alter/create_table.rs
@@ -66,7 +66,7 @@ test_case!(create_table, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/alter/drop_table.rs
+++ b/src/tests/alter/drop_table.rs
@@ -58,7 +58,7 @@ CREATE TABLE DropTable (
         ),
     ];
 
-    for (sql, expected) in sqls.into_iter() {
+    for (sql, expected) in sqls {
         test!(expected, sql);
     }
 });

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -102,7 +102,7 @@ test_case!(arithmetic, async move {
         ),
     ];
 
-    for (error, sql) in test_cases.into_iter() {
+    for (error, sql) in test_cases {
         test!(Err(error), sql);
     }
 });

--- a/src/tests/basic.rs
+++ b/src/tests/basic.rs
@@ -65,7 +65,7 @@ CREATE TABLE TestA (
         ),
     ];
 
-    for (expected, sql) in test_cases.into_iter() {
+    for (expected, sql) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/blend.rs
+++ b/src/tests/blend.rs
@@ -138,7 +138,7 @@ test_case!(blend, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 
@@ -157,7 +157,7 @@ test_case!(blend, async move {
         ),
     ];
 
-    for (error, sql) in error_cases.into_iter() {
+    for (error, sql) in error_cases {
         test!(Err(error), sql);
     }
 });

--- a/src/tests/default.rs
+++ b/src/tests/default.rs
@@ -36,7 +36,7 @@ test_case!(default, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 

--- a/src/tests/error.rs
+++ b/src/tests/error.rs
@@ -102,7 +102,7 @@ test_case!(error, async move {
         ),
     ];
 
-    for (error, sql) in test_cases.into_iter() {
+    for (error, sql) in test_cases {
         test!(Err(error), sql);
     }
 });

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -130,7 +130,7 @@ test_case!(filter, async move {
         ),
     ];
 
-    for (error, sql) in error_sqls.into_iter() {
+    for (error, sql) in error_sqls {
         test!(Err(error), sql);
     }
 });

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -92,7 +92,7 @@ test_case!(cast_literal, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });
@@ -143,7 +143,7 @@ test_case!(cast_value, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/function/left_right.rs
+++ b/src/tests/function/left_right.rs
@@ -148,7 +148,7 @@ test_case!(left_right, async move {
             Err(EvaluateError::FunctionRequiresUSizeValue("RIGHT".to_string()).into()),
         ),
     ];
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/function/upper_lower.rs
+++ b/src/tests/function/upper_lower.rs
@@ -76,7 +76,7 @@ test_case!(upper_lower, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/limit.rs
+++ b/src/tests/limit.rs
@@ -55,7 +55,7 @@ test_case!(limit, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 });

--- a/src/tests/migrate.rs
+++ b/src/tests/migrate.rs
@@ -43,7 +43,7 @@ test_case!(migrate, async move {
         ),
     ];
 
-    for (error, sql) in error_cases.into_iter() {
+    for (error, sql) in error_cases {
         test!(Err(error), sql);
     }
 

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -211,7 +211,7 @@ CREATE TABLE Test (
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(Ok(expected), sql);
     }
 
@@ -235,7 +235,7 @@ CREATE TABLE Test (
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/synthesize.rs
+++ b/src/tests/synthesize.rs
@@ -82,7 +82,7 @@ test_case!(synthesize, async move {
         ),
     ];
 
-    for (expected, sql) in test_cases.into_iter() {
+    for (expected, sql) in test_cases {
         test!(Ok(expected), sql);
     }
 });

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -61,7 +61,7 @@ pub fn test(expected: Result<Payload>, found: Result<Payload>) {
 
     let rows = expected.into_iter().zip(found.into_iter()).enumerate();
 
-    for (i, (expected, found)) in rows.into_iter() {
+    for (i, (expected, found)) in rows {
         let Row(expected) = expected;
         let Row(found) = found;
 

--- a/src/tests/validate/types.rs
+++ b/src/tests/validate/types.rs
@@ -61,7 +61,7 @@ test_case!(types, async move {
         ),
     ];
 
-    for (sql, expected) in test_cases.into_iter() {
+    for (sql, expected) in test_cases {
         test!(expected, sql);
     }
 });

--- a/src/tests/validate/unique.rs
+++ b/src/tests/validate/unique.rs
@@ -79,7 +79,7 @@ CREATE TABLE TestC (
         ),
     ];
 
-    for (error, sql) in error_cases.into_iter() {
+    for (error, sql) in error_cases {
         test!(Err(error), sql);
     }
 });


### PR DESCRIPTION
- check this: [std/keyword.for](https://doc.rust-lang.org/stable/std/keyword.for.html)
```
for-in-loops, or to be more precise, iterator loops, are a simple syntactic sugar over a common practice within Rust,
which is to loop over anything that implements IntoIterator until the iterator returned by .into_iter() returns None (or the loop body uses break).
```
- Calling IntoIterator to default, so I think I can remove it.