### PR TITLE
Remove Row from Payload::Select,

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -45,8 +45,7 @@ mod hello_world {
         };
 
         let first_row = &rows[0];
-        let first_row_unwrapped = &first_row.0;
-        let first_value = &first_row_unwrapped[0];
+        let first_value = &first_row[0];
 
         /*
             Row values are wrapped into a value enum, on the basis of the result type

--- a/examples/sled_multi_threaded.rs
+++ b/examples/sled_multi_threaded.rs
@@ -52,8 +52,7 @@ mod sled_multi_threaded {
         };
 
         let first_row = &rows[0];
-        let first_row_unwrapped = &first_row.0;
-        let first_value = &first_row_unwrapped[0];
+        let first_value = &first_row[0];
         let to_greet = match first_value {
             Value::Str(to_greet) => to_greet,
             value => panic!("Unexpected type: {:?}", value),

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -52,7 +52,7 @@ impl Glue {
 #[cfg(test)]
 mod tests {
     use {
-        crate::{Glue, Payload, Row, SledStorage, Value},
+        crate::{Glue, Payload, SledStorage, Value},
         std::convert::TryFrom,
     };
 
@@ -83,16 +83,16 @@ mod tests {
             Ok(Payload::Select {
                 labels: vec![String::from("id"), String::from("name"), String::from("is")],
                 rows: vec![
-                    Row(vec![
+                    vec![
                         Value::I64(1),
                         Value::Str(String::from("test1")),
                         Value::Bool(true)
-                    ]),
-                    Row(vec![
+                    ],
+                    vec![
                         Value::I64(2),
                         Value::Str(String::from("test2")),
                         Value::Bool(false)
-                    ])
+                    ]
                 ]
             })
         );

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! row {
     ( $( $p:path )* ; $( $v:expr )* ) => (
-        Row(vec![$( $p($v) ),*])
+        vec![$( $p($v) ),*]
     )
 }
 
@@ -88,12 +88,12 @@ macro_rules! select_with_null {
     ( $( $c: tt )|* ; $( $v: expr )* ) => (
         Payload::Select {
             labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
-            rows: vec![Row(vec![$( $v ),*])],
+            rows: vec![vec![$( $v ),*]],
         }
     );
     ( $( $c: tt )|* ; $( $v: expr )* ; $( $( $v2: expr )* );*) => ({
         let mut rows = vec![
-            Row(vec![$( $v ),*])
+            vec![$( $v ),*]
         ];
 
         Payload::Select {
@@ -106,12 +106,12 @@ macro_rules! select_with_null {
 #[macro_export]
 macro_rules! concat_with_null {
     ( $rows: ident ; $( $v: expr )* ) => ({
-        $rows.push(Row(vec![$( $v ),*]));
+        $rows.push(vec![$( $v ),*]);
 
         $rows
     });
     ( $rows: ident ; $( $v: expr )* ; $( $( $v2: expr )* );* ) => ({
-        $rows.push(Row(vec![$( $v ),*]));
+        $rows.push(vec![$( $v ),*]);
 
         concat_with_null!($rows ; $( $( $v2 )* );* )
     });

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ast::{Expr, IndexItem, Query, SetExpr, Statement, TableFactor},
-        data::{Row, Value},
+        data::Value,
         executor::{execute, Payload},
         parse_sql::{parse, parse_expr},
         plan::plan,
@@ -62,9 +62,6 @@ pub fn test(expected: Result<Payload>, found: Result<Payload>) {
     let rows = expected.into_iter().zip(found.into_iter()).enumerate();
 
     for (i, (expected, found)) in rows {
-        let Row(expected) = expected;
-        let Row(found) = found;
-
         assert_eq!(
             expected.len(),
             found.len(),


### PR DESCRIPTION
`Row` is useful only in execution layer codes, not a good idea to expose `Row` to db users.
Remove `Row` from `Payload::Select`, so it now returns `Vec<Vec<Value>>` for `rows` field.