### PR TITLE
Implement TRIM function

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -9,6 +9,7 @@ pub enum Function {
     Upper(Expr),
     Left { expr: Expr, size: Expr },
     Right { expr: Expr, size: Expr },
+    Trim(Expr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -281,5 +281,10 @@ async fn evaluate_function<'a, T: 'static + Debug>(
 
             Ok(Evaluated::from(Value::Str(converted)))
         }
+        Function::Trim(expr) => match eval_to_str("TRIM", expr).await? {
+            Nullable::Value(string) => Ok(Value::Str(string.trim().to_owned())),
+            Nullable::Null => Ok(Value::Null),
+        }
+        .map(Evaluated::from),
     }
 }

--- a/src/tests/function/mod.rs
+++ b/src/tests/function/mod.rs
@@ -1,3 +1,4 @@
 pub mod cast;
 pub mod left_right;
+pub mod trim;
 pub mod upper_lower;

--- a/src/tests/function/trim.rs
+++ b/src/tests/function/trim.rs
@@ -39,6 +39,15 @@ test_case!(trim, async move {
             "SELECT TRIM(a => 2) FROM Item;",
             Err(TranslateError::NamedFunctionArgNotSupported.into()),
         ),
+        (
+            "CREATE TABLE NullName (name TEXT NULL)",
+            Ok(Payload::Create),
+        ),
+        ("INSERT INTO NullName VALUES (NULL)", Ok(Payload::Insert(1))),
+        (
+            "SELECT TRIM(name) AS test FROM NullName;",
+            Ok(select_with_null!(test; Value::Null)),
+        ),
     ];
 
     for (sql, expected) in test_cases {

--- a/src/tests/function/trim.rs
+++ b/src/tests/function/trim.rs
@@ -1,0 +1,47 @@
+use crate::*;
+
+test_case!(trim, async move {
+    let test_cases = vec![
+        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"INSERT INTO Item VALUES
+                ("      Left blank"), 
+                ("Right blank     "), 
+                ("     Blank!     "), 
+                ("Not Blank");"#,
+            Ok(Payload::Insert(4)),
+        ),
+        (
+            "SELECT TRIM(name) FROM Item;",
+            Ok(select!(
+                "TRIM(name)"
+                Value::Str;
+                "Left blank".to_owned();
+                "Right blank".to_owned();
+                "Blank!".to_owned();
+                "Not Blank".to_owned()
+            )),
+        ),
+        (
+            "SELECT TRIM() FROM Item;",
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "TRIM".to_owned(),
+                expected: 1,
+                found: 0,
+            }
+            .into()),
+        ),
+        (
+            "SELECT TRIM(1) FROM Item;",
+            Err(EvaluateError::FunctionRequiresStringValue("TRIM".to_owned()).into()),
+        ),
+        (
+            "SELECT TRIM(a => 2) FROM Item;",
+            Err(TranslateError::NamedFunctionArgNotSupported.into()),
+        ),
+    ];
+
+    for (sql, expected) in test_cases {
+        test!(expected, sql);
+    }
+});

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -57,6 +57,7 @@ macro_rules! generate_tests {
         glue!(filter, filter::filter);
         glue!(function_upper_lower, function::upper_lower::upper_lower);
         glue!(function_left_right, function::left_right::left_right);
+        glue!(function_trim, function::trim::trim);
         glue!(function_cast_literal, function::cast::cast_literal);
         glue!(function_cast_value, function::cast::cast_value);
         glue!(join, join::join);

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -48,23 +48,20 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         }};
     }
 
+    macro_rules! func_with_one_arg {
+        ($func: expr) => {{
+            check_len(name, args.len(), 1)?;
+
+            translate_expr(args[0])
+                .map($func)
+                .map(Box::new)
+                .map(Expr::Function)
+        }};
+    }
+
     match name.as_str() {
-        "LOWER" => {
-            check_len(name, args.len(), 1)?;
-
-            translate_expr(args[0])
-                .map(Function::Lower)
-                .map(Box::new)
-                .map(Expr::Function)
-        }
-        "UPPER" => {
-            check_len(name, args.len(), 1)?;
-
-            translate_expr(args[0])
-                .map(Function::Upper)
-                .map(Box::new)
-                .map(Expr::Function)
-        }
+        "LOWER" => func_with_one_arg!(Function::Lower),
+        "UPPER" => func_with_one_arg!(Function::Upper),
         "LEFT" => {
             check_len(name, args.len(), 2)?;
 

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -82,6 +82,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "SUM" => aggr!(Aggregate::Sum),
         "MIN" => aggr!(Aggregate::Min),
         "MAX" => aggr!(Aggregate::Max),
+        "TRIM" => func_with_one_arg!(Function::Trim),
         _ => Err(TranslateError::UnsupportedFunction(name).into()),
     }
 }


### PR DESCRIPTION
resolved #267 

### ISSUE Reopen
- Other features are not implemented, so the issue must be reopened in the near future.

### Implemented
- TRIM function
- macro that can be used when function has one argument

### Check List
- [x] `cargo check --all`
- [x] `cargo fmt`
- [x] `cargo clippy --release --all --all-targets` 