### PR TITLE
Implement Function: LTRIM, RTRIM

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -66,6 +66,10 @@ pub enum Function {
     Degrees(Expr),
     #[strum(to_string = "PI")]
     Pi(),
+    #[strum(to_string = "LTRIM")]
+    Ltrim { expr: Expr, chars: Option<Expr> },
+    #[strum(to_string = "RTRIM")]
+    Rtrim { expr: Expr, chars: Option<Expr> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/tests/function/ltrim_rtrim.rs
+++ b/src/tests/function/ltrim_rtrim.rs
@@ -1,0 +1,99 @@
+use crate::*;
+
+test_case!(ltrim_rtrim, async move {
+    use Value::Str;
+    let test_cases = vec![
+        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"INSERT INTO Item VALUES (" zzzytest"), ("testxxzx ")"#,
+            Ok(Payload::Insert(2)),
+        ),
+        (
+            r#"SELECT LTRIM(name) AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                "zzzytest".to_owned();
+                "testxxzx ".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT LTRIM(name, ' xyz') AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                "test".to_owned();
+                "testxxzx ".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT RTRIM(name) AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                " zzzytest".to_owned();
+                "testxxzx".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT RTRIM(name, 'xyz ') AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                " zzzytest".to_owned();
+                "test".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT LTRIM(1) AS test FROM Item"#,
+            Err(EvaluateError::FunctionRequiresStringValue("LTRIM".to_owned()).into()),
+        ),
+        (
+            r#"SELECT LTRIM(name, 1) AS test FROM Item"#,
+            Err(EvaluateError::FunctionRequiresStringValue("LTRIM".to_owned()).into()),
+        ),
+        (
+            r#"SELECT RTRIM(1) AS test FROM Item"#,
+            Err(EvaluateError::FunctionRequiresStringValue("RTRIM".to_owned()).into()),
+        ),
+        (
+            r#"SELECT RTRIM(name, 1) AS test FROM Item"#,
+            Err(EvaluateError::FunctionRequiresStringValue("RTRIM".to_owned()).into()),
+        ),
+        (
+            "CREATE TABLE NullTest (name TEXT null)",
+            Ok(Payload::Create),
+        ),
+        (
+            r#"INSERT INTO NullTest VALUES (null)"#,
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            r#"SELECT LTRIM(name) AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+        (
+            r#"SELECT RTRIM(name) AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+        (
+            r#"SELECT LTRIM(NULL, '123') AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+        (
+            r#"SELECT LTRIM(name, NULL) AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+        (
+            r#"SELECT RTRIM(NULL, '123') AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+        (
+            r#"SELECT RTRIM(name, NULL) AS test FROM NullTest"#,
+            Ok(select_with_null!(test; Value::Null)),
+        ),
+    ];
+    for (sql, expected) in test_cases {
+        test!(expected, sql);
+    }
+});

--- a/src/tests/function/mod.rs
+++ b/src/tests/function/mod.rs
@@ -7,6 +7,7 @@ pub mod floor;
 pub mod gcd_lcm;
 pub mod left_right;
 pub mod lpad_rpad;
+pub mod ltrim_rtrim;
 pub mod math_function;
 pub mod pi;
 pub mod radians;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -63,6 +63,7 @@ macro_rules! generate_tests {
         glue!(function_lpad_rpad, function::lpad_rpad::lpad_rpad);
         glue!(function_trim, function::trim::trim);
         glue!(function_div_mod, function::div_mod::div_mod);
+        glue!(function_ltrim_rtrim, function::ltrim_rtrim::ltrim_rtrim);
         glue!(function_cast_literal, function::cast::cast_literal);
         glue!(function_cast_value, function::cast::cast_value);
         glue!(function_math_function_sin, function::math_function::sin);

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -73,6 +73,19 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         }};
     }
 
+    macro_rules! func_with_two_arg {
+        ($func: ident) => {{
+            check_len_range(stringify!($func).to_owned(), args.len(), 1, 2)?;
+            let expr = translate_expr(args[0])?;
+            let chars = if args.len() == 1 {
+                None
+            } else {
+                Some(translate_expr(args[1])?)
+            };
+            Ok(Expr::Function(Box::new(Function::$func { expr, chars })))
+        }};
+    }
+
     match name.as_str() {
         "LOWER" => func_with_one_arg!(Function::Lower),
         "UPPER" => func_with_one_arg!(Function::Upper),
@@ -175,6 +188,8 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
             Ok(Expr::Function(Box::new(Function::Lcm { left, right })))
         }
+        "LTRIM" => func_with_two_arg!(Ltrim),
+        "RTRIM" => func_with_two_arg!(Rtrim),
         "COUNT" => aggr!(Aggregate::Count),
         "SUM" => aggr!(Aggregate::Sum),
         "MIN" => aggr!(Aggregate::Min),


### PR DESCRIPTION
## These functions will remove the longest string containing only characters in characters (a space by default) from the start(LTRIM) or end(RTRIM) of string. #282 

```rs
// src/executor/evaluate/mod.rs
Function::Ltrim { expr, chars } | Function::Rtrim { expr, chars } => {
            let name = if matches!(func, Function::Ltrim { .. }) {
                "LTRIM"
            } else {
                "RTRIM"
            };
            let pattern: Result<Vec<char>> = match chars {
                Some(chars) => match eval_to_str(chars).await? {
                    Nullable::Value(v) => Ok(v.chars().collect::<Vec<char>>()),
                    Nullable::Null => {
                        return Ok(Evaluated::from(Value::Null));
                    }
                },
                None => Ok(" ".chars().collect::<Vec<char>>()),
            };
            match eval_to_str(expr).await? {
                Nullable::Value(v) => {
                    if name == "LTRIM" {
                        Ok(Value::Str(v.trim_start_matches(&pattern?[..]).to_string()))
                    } else {
                        Ok(Value::Str(v.trim_end_matches(&pattern?[..]).to_string()))
                    }
                }
                Nullable::Null => Ok(Value::Null),
            }
            .map(Evaluated::from)
        }
```

## Create `func_with_two_arg` macro to handle optional second argument.
```rs
// src/translate/function.rs
    macro_rules! func_with_two_arg {
        ($func: ident) => {{
            check_len_range(stringify!($func).to_owned(), args.len(), 1, 2)?;
            let expr = translate_expr(args[0])?;
            let chars = if args.len() == 1 {
                None
            } else {
                Some(translate_expr(args[1])?)
            };
            Ok(Expr::Function(Box::new(Function::$func { expr, chars })))
        }};
    }
```