### PR TITLE
Support `DivisorShouldNotBeZero` error and Remove `{number} / {interval}` implementations

### DIFF
--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -233,6 +233,7 @@ impl<'a> Literal<'a> {
     }
 
     pub fn divide<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+        use super::Interval as I;
         match (self, other) {
             (Number(l), Number(r)) => {
                 if let (Ok(l), Ok(r)) = (l.parse::<i64>(), r.parse::<i64>()) {
@@ -252,6 +253,9 @@ impl<'a> Literal<'a> {
                 }
             }
             (Number(l), Interval(r)) => {
+                if (r == &I::Microsecond(0)) | (r == &I::Month(0)) {
+                    return Err(LiteralError::DivisorShouldNotBeZero.into());
+                }
                 if let Ok(l) = l.parse::<i64>() {
                     Ok(Interval(l / *r))
                 } else if let Ok(l) = l.parse::<f64>() {

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -343,4 +343,38 @@ mod tests {
         matches!(Null.concat(Boolean(true)), Null);
         matches!(Null.concat(Null), Null);
     }
+
+    #[test]
+    fn divide() {
+        use crate::data::interval::Interval as I;
+
+        macro_rules! num {
+            ($num: expr) => {
+                Number(Cow::Owned($num.to_owned()))
+            };
+        }
+
+        macro_rules! itv {
+            ($itv: expr) => {
+                Interval(I::Microsecond($itv))
+            };
+        }
+
+        let num_divisor = |x: &str| Number(Cow::Owned(x.to_owned()));
+        let itv_divisor = |x: i64| Interval(I::Microsecond(x));
+
+        assert_eq!(num!("12").divide(&num_divisor("2")).unwrap(), num!("6"));
+        assert_eq!(num!("12").divide(&num_divisor("2.0")).unwrap(), num!("6"));
+        assert_eq!(num!("12").divide(&itv_divisor(2)).unwrap(), itv!(6));
+        assert_eq!(num!("12.0").divide(&num_divisor("2")).unwrap(), num!("6"));
+        assert_eq!(num!("12.0").divide(&num_divisor("2.0")).unwrap(), num!("6"));
+        assert_eq!(num!("12.0").divide(&itv_divisor(2)).unwrap(), itv!(6));
+        assert_eq!(itv!(12).divide(&num_divisor("2")).unwrap(), itv!(6));
+        assert_eq!(itv!(12).divide(&num_divisor("2.0")).unwrap(), itv!(6));
+        matches!(num!("12").divide(&Null).unwrap(), Null);
+        matches!(itv!(12).divide(&Null).unwrap(), Null);
+        matches!(Null.divide(&itv_divisor(2)).unwrap(), Null);
+        matches!(Null.divide(&num_divisor("2")).unwrap(), Null);
+        matches!(Null.divide(&Null).unwrap(), Null);
+    }
 }

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -305,8 +305,6 @@ mod tests {
         assert_eq!(mon(3).subtract(&mon(1)), Ok(mon(2)));
         assert_eq!(mon(3).multiply(&num(-4)), Ok(mon(-12)));
         assert_eq!(num(9).multiply(&mon(2)), Ok(mon(18)));
-        assert_eq!(mon(14).divide(&num(3)), Ok(mon(4)));
-        assert_eq!(num(27).divide(&mon(9)), Ok(mon(3)));
     }
 
     #[test]

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -267,13 +267,13 @@ impl<'a> Literal<'a> {
             (Interval(l), Number(r)) => {
                 if let Ok(r) = r.parse::<i64>() {
                     if r == 0 {
-                        return Err(LiteralError::DivisorShouldNotBeZero.into());
+                        Err(LiteralError::DivisorShouldNotBeZero.into())
                     } else {
                         Ok(Interval(*l / r))
                     }
                 } else if let Ok(r) = r.parse::<f64>() {
                     if r == 0.0 {
-                        return Err(LiteralError::DivisorShouldNotBeZero.into());
+                        Err(LiteralError::DivisorShouldNotBeZero.into())
                     } else {
                         Ok(Interval(*l / r))
                     }

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -266,9 +266,17 @@ impl<'a> Literal<'a> {
             }
             (Interval(l), Number(r)) => {
                 if let Ok(r) = r.parse::<i64>() {
-                    Ok(Interval(*l / r))
+                    if r == 0 {
+                        return Err(LiteralError::DivisorShouldNotBeZero.into());
+                    } else {
+                        Ok(Interval(*l / r))
+                    }
                 } else if let Ok(r) = r.parse::<f64>() {
-                    Ok(Interval(*l / r))
+                    if r == 0.0 {
+                        return Err(LiteralError::DivisorShouldNotBeZero.into());
+                    } else {
+                        Ok(Interval(*l / r))
+                    }
                 } else {
                     Err(LiteralError::UnreachableBinaryArithmetic.into())
                 }

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -15,6 +15,9 @@ pub enum LiteralError {
     #[error("unsupported literal binary arithmetic between {0} and {1}")]
     UnsupportedBinaryArithmetic(String, String),
 
+    #[error("the divisor should not be zero")]
+    DivisorShouldNotBeZero,
+
     #[error("literal unary operation on non-numeric")]
     UnaryOperationOnNonNumeric,
 
@@ -233,9 +236,17 @@ impl<'a> Literal<'a> {
         match (self, other) {
             (Number(l), Number(r)) => {
                 if let (Ok(l), Ok(r)) = (l.parse::<i64>(), r.parse::<i64>()) {
-                    Ok(Number(Cow::Owned((l / r).to_string())))
+                    if r == 0 {
+                        Err(LiteralError::DivisorShouldNotBeZero.into())
+                    } else {
+                        Ok(Number(Cow::Owned((l / r).to_string())))
+                    }
                 } else if let (Ok(l), Ok(r)) = (l.parse::<f64>(), r.parse::<f64>()) {
-                    Ok(Number(Cow::Owned((l / r).to_string())))
+                    if r == 0.0 {
+                        Err(LiteralError::DivisorShouldNotBeZero.into())
+                    } else {
+                        Ok(Number(Cow::Owned((l / r).to_string())))
+                    }
                 } else {
                     Err(LiteralError::UnreachableBinaryArithmetic.into())
                 }

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -43,6 +43,9 @@ pub enum ValueError {
     #[error("divide on non-numeric values: {0:?} / {1:?}")]
     DivideOnNonNumeric(Value, Value),
 
+    #[error("the divisor should not be zero")]
+    DivisorShouldNotBeZero,
+
     #[error("floating numbers cannot be grouped by")]
     FloatCannotBeGroupedBy,
 

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -237,29 +237,21 @@ impl Value {
     }
 
     pub fn divide(&self, other: &Value) -> Result<Value> {
-        use super::Interval as I;
         use Value::*;
 
-        if (other == &I64(0))
-            | (other == &F64(0.0))
-            | (other == &Interval(I::Microsecond(0)))
-            | (other == &Interval(I::Month(0)))
-        {
+        if (other == &I64(0)) | (other == &F64(0.0)) {
             return Err(ValueError::DivisorShouldNotBeZero.into());
         }
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a / b)),
             (I64(a), F64(b)) => Ok(F64(*a as f64 / b)),
-            (I64(a), Interval(b)) => Ok(Interval(*a / *b)),
             (F64(a), I64(b)) => Ok(F64(a / *b as f64)),
-            (F64(a), Interval(b)) => Ok(Interval(*a / *b)),
             (F64(a), F64(b)) => Ok(F64(a / b)),
             (Interval(a), I64(b)) => Ok(Interval(*a / *b)),
             (Interval(a), F64(b)) => Ok(Interval(*a / *b)),
             (Null, I64(_))
             | (Null, F64(_))
-            | (Null, Interval(_))
             | (I64(_), Null)
             | (F64(_), Null)
             | (Interval(_), Null)
@@ -467,10 +459,8 @@ mod tests {
 
         test!(divide I64(6),   I64(2)   => I64(3));
         test!(divide I64(6),   F64(2.0) => F64(3.0));
-        test!(divide I64(6),   mon!(2)  => mon!(3));
         test!(divide F64(6.0), I64(2)   => F64(3.0));
         test!(divide F64(6.0), F64(2.0) => F64(3.0));
-        test!(divide F64(6.0), mon!(2)  => mon!(3));
         test!(divide mon!(6),  I64(2)   => mon!(3));
         test!(divide mon!(6),  F64(2.0) => mon!(3));
 
@@ -516,10 +506,8 @@ mod tests {
         null_test!(subtract Null, mon!(1));
         null_test!(multiply Null, I64(1));
         null_test!(multiply Null, F64(1.0));
-        null_test!(multiply Null, mon!(1));
         null_test!(divide   Null, I64(1));
         null_test!(divide   Null, F64(1.0));
-        null_test!(divide   Null, mon!(1));
 
         null_test!(add      Null, Null);
         null_test!(subtract Null, Null);

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -237,7 +237,16 @@ impl Value {
     }
 
     pub fn divide(&self, other: &Value) -> Result<Value> {
+        use super::Interval as I;
         use Value::*;
+
+        if (other == &I64(0))
+            | (other == &F64(0.0))
+            | (other == &Interval(I::Microsecond(0)))
+            | (other == &Interval(I::Month(0)))
+        {
+            return Err(ValueError::DivisorShouldNotBeZero.into());
+        }
 
         match (self, other) {
             (I64(a), I64(b)) => Ok(I64(a / b)),

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -83,34 +83,46 @@ impl<'a> PartialOrd for Evaluated<'a> {
     }
 }
 
-macro_rules! binary_op {
-    ($name:ident, $op:tt) => {
-        pub fn $name<'b>(&self, other: &Evaluated<'a>) -> Result<Evaluated<'b>> {
-            let value_binary_op = |l: &Value, r: &Value| l.$name(r).map(Evaluated::from);
-
-            match (self, other) {
-                (Evaluated::Literal(l), Evaluated::Literal(r)) => {
-                    l.$name(r).map(Evaluated::Literal)
-                }
-                (Evaluated::Literal(l), Evaluated::Value(r)) => {
-                    value_binary_op(&Value::try_from(l)?, r.as_ref())
-                }
-                (Evaluated::Value(l), Evaluated::Literal(r)) => {
-                    value_binary_op(l.as_ref(), &Value::try_from(r)?)
-                }
-                (Evaluated::Value(l), Evaluated::Value(r)) => {
-                    value_binary_op(l.as_ref(), r.as_ref())
-                }
-            }
+fn binary_op<'a, 'b, T, U>(
+    l: &Evaluated<'a>,
+    r: &Evaluated<'b>,
+    value_op: T,
+    literal_op: U,
+) -> Result<Evaluated<'b>>
+where
+    T: FnOnce(&Value, &Value) -> Result<Value>,
+    U: FnOnce(&Literal<'a>, &Literal<'b>) -> Result<Literal<'b>>,
+{
+    match (l, r) {
+        (Evaluated::Literal(l), Evaluated::Literal(r)) => literal_op(l, r).map(Evaluated::Literal),
+        (Evaluated::Literal(l), Evaluated::Value(r)) => {
+            value_op(&Value::try_from(l)?, r.as_ref()).map(Evaluated::from)
         }
-    };
+        (Evaluated::Value(l), Evaluated::Literal(r)) => {
+            value_op(l.as_ref(), &Value::try_from(r)?).map(Evaluated::from)
+        }
+        (Evaluated::Value(l), Evaluated::Value(r)) => {
+            value_op(l.as_ref(), r.as_ref()).map(Evaluated::from)
+        }
+    }
 }
 
 impl<'a> Evaluated<'a> {
-    binary_op!(add, +);
-    binary_op!(subtract, -);
-    binary_op!(multiply, *);
-    binary_op!(divide, /);
+    pub fn add<'b>(&'a self, other: &Evaluated<'b>) -> Result<Evaluated<'b>> {
+        binary_op(self, other, |l, r| l.add(r), |l, r| l.add(r))
+    }
+
+    pub fn subtract<'b>(&'a self, other: &Evaluated<'b>) -> Result<Evaluated<'b>> {
+        binary_op(self, other, |l, r| l.subtract(r), |l, r| l.subtract(r))
+    }
+
+    pub fn multiply<'b>(&'a self, other: &Evaluated<'b>) -> Result<Evaluated<'b>> {
+        binary_op(self, other, |l, r| l.multiply(r), |l, r| l.multiply(r))
+    }
+
+    pub fn divide<'b>(&'a self, other: &Evaluated<'b>) -> Result<Evaluated<'b>> {
+        binary_op(self, other, |l, r| l.divide(r), |l, r| l.divide(r))
+    }
 
     pub fn unary_plus(&self) -> Result<Evaluated<'a>> {
         match self {

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -105,6 +105,14 @@ test_case!(arithmetic, async move {
             "SELECT * FROM Arith WHERE id = 2 / 0.0",
         ),
         (
+            LiteralError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE id = INTERVAL '2' HOUR / 0",
+        ),
+        (
+            LiteralError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE id = INTERVAL '2' HOUR / 0.0",
+        ),
+        (
             EvaluateError::BooleanTypeRequired(format!(
                 "{:?}",
                 Literal::Text(Cow::Owned("hello".to_owned()))

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -85,10 +85,6 @@ test_case!(arithmetic, async move {
             "SELECT * FROM Arith WHERE name / 0.0 < 1",
         ),
         (
-            ValueError::DivisorShouldNotBeZero.into(),
-            "SELECT * FROM Arith WHERE name / (INTERVAL '0' MONTH) < 1",
-        ),
-        (
             UpdateError::ColumnNotFound("aaa".to_owned()).into(),
             "UPDATE Arith SET aaa = 1",
         ),
@@ -107,10 +103,6 @@ test_case!(arithmetic, async move {
         (
             LiteralError::DivisorShouldNotBeZero.into(),
             "SELECT * FROM Arith WHERE id = 2 / 0.0",
-        ),
-        (
-            LiteralError::DivisorShouldNotBeZero.into(),
-            "SELECT * FROM Arith WHERE id = 2 / (INTERVAL '0' HOUR)",
         ),
         (
             EvaluateError::BooleanTypeRequired(format!(

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -77,6 +77,10 @@ test_case!(arithmetic, async move {
             "SELECT * FROM Arith WHERE name / id < 1",
         ),
         (
+            ValueError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE name / 0 < 1",
+        ),
+        (
             UpdateError::ColumnNotFound("aaa".to_owned()).into(),
             "UPDATE Arith SET aaa = 1",
         ),
@@ -87,6 +91,10 @@ test_case!(arithmetic, async move {
             )
             .into(),
             "SELECT * FROM Arith WHERE TRUE + 1 = 1",
+        ),
+        (
+            LiteralError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE id = 2 / 0",
         ),
         (
             EvaluateError::BooleanTypeRequired(format!(

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -81,6 +81,14 @@ test_case!(arithmetic, async move {
             "SELECT * FROM Arith WHERE name / 0 < 1",
         ),
         (
+            ValueError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE name / 0.0 < 1",
+        ),
+        (
+            ValueError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE name / (INTERVAL '0' MONTH) < 1",
+        ),
+        (
             UpdateError::ColumnNotFound("aaa".to_owned()).into(),
             "UPDATE Arith SET aaa = 1",
         ),
@@ -95,6 +103,14 @@ test_case!(arithmetic, async move {
         (
             LiteralError::DivisorShouldNotBeZero.into(),
             "SELECT * FROM Arith WHERE id = 2 / 0",
+        ),
+        (
+            LiteralError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE id = 2 / 0.0",
+        ),
+        (
+            LiteralError::DivisorShouldNotBeZero.into(),
+            "SELECT * FROM Arith WHERE id = 2 / (INTERVAL '0' HOUR)",
         ),
         (
             EvaluateError::BooleanTypeRequired(format!(


### PR DESCRIPTION
As mentioned on issue #306 , current `/` operator doesn't handle divisor zero error, but panic out.

So I added two new errors: `ValueError::DivisorShouldNotBeZero` and `LiteralError::DivisorShouldNotBeZero`,
and also changed some code to handle error.