### PR TITLE
CAST from string to INTERVAL

### DIFF
--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -1,8 +1,11 @@
 use {
     super::{Value, ValueError},
-    crate::result::{Error, Result},
+    crate::{
+        data::Interval,
+        result::{Error, Result},
+    },
     chrono::{NaiveDate, NaiveDateTime},
-    std::convert::TryInto,
+    std::convert::{TryFrom, TryInto},
 };
 
 impl From<&Value> for String {
@@ -153,5 +156,16 @@ impl TryInto<NaiveDateTime> for &Value {
             Value::Timestamp(value) => *value,
             _ => return Err(ValueError::ImpossibleCast.into()),
         })
+    }
+}
+
+impl TryInto<Interval> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Interval> {
+        match self {
+            Value::Str(value) => Interval::try_from(value.as_str()),
+            _ => Err(ValueError::ImpossibleCast.into()),
+        }
     }
 }

--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -2,7 +2,7 @@ use {
     super::{error::ValueError, Value},
     crate::{
         ast::DataType,
-        data::Literal,
+        data::{Interval, Literal},
         result::{Error, Result},
     },
     chrono::{offset::Utc, DateTime, NaiveDate, NaiveDateTime, NaiveTime},
@@ -197,6 +197,9 @@ impl Value {
                 let v = if *v { "TRUE" } else { "FALSE" };
 
                 Ok(Value::Str(v.to_owned()))
+            }
+            (DataType::Interval, Literal::Text(v)) => {
+                Interval::try_from(v.as_str()).map(Value::Interval)
             }
             (DataType::Boolean, Literal::Null)
             | (DataType::Int, Literal::Null)

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -129,6 +129,7 @@ impl Value {
             (DataType::Text, value) => Ok(Value::Str(value.into())),
             (DataType::Date, value) => value.try_into().map(Value::Date),
             (DataType::Timestamp, value) => value.try_into().map(Value::Timestamp),
+            (DataType::Interval, value) => value.try_into().map(Value::Interval),
 
             _ => Err(ValueError::UnimplementedCast.into()),
         }

--- a/src/tests/function/cast.rs
+++ b/src/tests/function/cast.rs
@@ -1,8 +1,8 @@
 use crate::*;
+use data::Interval as I;
+use Value::*;
 
 test_case!(cast_literal, async move {
-    use Value::*;
-
     let test_cases = vec![
         ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
         (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),
@@ -90,6 +90,42 @@ test_case!(cast_literal, async move {
             }
             .into()),
         ),
+        (
+            r#"SELECT
+            CAST("'1-2' YEAR TO MONTH" as INTERVAL) as stoi_1,
+            CAST("'12' DAY" as INTERVAL) as stoi_2,
+            CAST("'12' MINUTE" as INTERVAL) as stoi_3,
+            CAST("'-3 14' DAY TO HOUR" as INTERVAL) as stoi_4,
+            CAST("'3 14:00:00' DAY TO SECOND" as INTERVAL) as stoi_5,
+            CAST("'12:00' HOUR TO MINUTE" as INTERVAL) as stoi_6,
+            CAST("'-1000-11' YEAR TO MONTH" as INTERVAL) as stoi_7,
+            CAST("'30' MONTH" as INTERVAL) as stoi_8,
+            CAST("'35' HOUR" as INTERVAL) as stoi_9,
+            CAST("'300' SECOND" as INTERVAL) as stoi_10,
+            CAST("'3 12:30' DAY TO MINUTE" as INTERVAL) as stoi_11,
+            CAST("'3 12:30:12.1324' DAY TO SECOND" as INTERVAL) as stoi_12,
+            CAST("'-12:30:12' HOUR TO SECOND" as INTERVAL) as stoi_13,
+            CAST("'-30:11' MINUTE TO SECOND" as INTERVAL) as stoi_14
+            FROM Item"#,
+            Ok(select!(
+            stoi_1|stoi_2|stoi_3|stoi_4|stoi_5|stoi_6|stoi_7|stoi_8|stoi_9|stoi_10|stoi_11|stoi_12|stoi_13|stoi_14
+            Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval;
+            I::months(14)
+            I::days(12)
+            I::minutes(12)
+            I::hours(-86)
+            I::minutes(86 * 60)
+            I::hours(12)
+            I::months(-12_011)
+            I::months(30)
+            I::hours(35)
+            I::minutes(5)
+            I::minutes(84 * 60 + 30)
+            I::microseconds((((84 * 60) + 30) * 60 + 12) * 1_000_000 + 132_400)
+            I::seconds(-(12 * 3600 + 30 * 60 + 12))
+            I::seconds(-(30 * 60 + 11))
+            )),
+        ),
     ];
 
     for (sql, expected) in test_cases {
@@ -99,8 +135,6 @@ test_case!(cast_literal, async move {
 
 test_case!(cast_value, async move {
     // More test cases are in `gluesql::Value` unit tests.
-
-    use Value::*;
 
     let test_cases = vec![
         (
@@ -138,8 +172,40 @@ test_case!(cast_value, async move {
             Err(ValueError::ImpossibleCast.into()),
         ),
         (
-            r#"SELECT CAST(number AS INTERVAL) FROM Item"#,
-            Err(ValueError::UnimplementedCast.into()),
+            r#"
+    CREATE TABLE IntervalLog (
+        id INTEGER,
+        interval_str_1 TEXT,
+        interval_str_2 TEXT,
+    )"#,
+            Ok(Payload::Create),
+        ),
+        (
+            r#"
+    INSERT INTO IntervalLog VALUES
+        (1, '"1-2" YEAR TO MONTH',         '"30" MONTH'),
+        (2, '"12" DAY',                    '"35" HOUR'),
+        (3, '"12" MINUTE',                 '"300" SECOND'),
+        (4, '"-3 14" DAY TO HOUR',         '"3 12:30" DAY TO MINUTE'),
+        (5, '"3 14:00:00" DAY TO SECOND',  '"3 12:30:12.1324" DAY TO SECOND'),
+        (6, '"12:00" HOUR TO MINUTE',      '"-12:30:12" HOUR TO SECOND'),
+        (7, '"-1000-11" YEAR TO MONTH',    '"-30:11" MINUTE TO SECOND');
+    "#,
+            Ok(Payload::Insert(7)),
+        ),
+        (
+            r#"SELECT id, CAST(interval_str_1 as INTERVAL) as stoi_1, CAST(interval_str_2 as INTERVAL) as stoi_2 FROM IntervalLog;"#,
+            Ok(select!(
+            id  | stoi_1          | stoi_2
+            I64 | Interval            | Interval;
+            1     I::months(14)         I::months(30);
+            2     I::days(12)           I::hours(35);
+            3     I::minutes(12)        I::minutes(5);
+            4     I::hours(-86)         I::minutes(84 * 60 + 30);
+            5     I::minutes(86 * 60)   I::microseconds((((84 * 60) + 30) * 60 + 12) * 1_000_000 + 132_400);
+            6     I::hours(12)          I::seconds(-(12 * 3600 + 30 * 60 + 12));
+            7     I::months(-12_011)    I::seconds(-(30 * 60 + 11))
+            )),
         ),
     ];
 


### PR DESCRIPTION
## To solve the Issue: `CAST from string to INTERVAL` #324, implemented cases for both `interval literal` and `interval value`.

### Case1. Interval literal
```rs
// src/data/value/literal.rs
(DataType::Interval, Literal::Text(v)) => {
    Ok(Value::Interval(Interval::try_from(v.as_str())?))
}
```

### Case2. Interval value
```rs
// src/data/value/mod.rs
(DataType::Interval, value) => value.try_into().map(Value::Interval),
```
```rs
// src/data/value/into.rs
impl TryInto<Interval> for &Value {
    type Error = Error;

    fn try_into(self) -> Result<Interval> {
        Ok(match self {
            Value::Str(value) => Interval::try_from(value.as_str())?,
            _ => return Err(ValueError::ImpossibleCast.into()),
        })
    }
}
```
