### PR TITLE
Raise error when column option `PRIMARY KEY` is used.

### DIFF
--- a/src/tests/alter/create_table.rs
+++ b/src/tests/alter/create_table.rs
@@ -49,6 +49,10 @@ test_case!(create_table, async move {
             Err(TranslateError::UnsupportedColumnOption("CHECK (true)".to_owned()).into()),
         ),
         (
+            "CREATE TABLE Glue (id INTEGER PRIMARY KEY)",
+            Err(TranslateError::UnsupportedColumnOption(("PRIMARY KEY").to_owned()).into()),
+        ),
+        (
             r#"
         CREATE TABLE CreateTable3 (
             id INTEGER,

--- a/src/tests/function/math_function.rs
+++ b/src/tests/function/math_function.rs
@@ -180,7 +180,7 @@ test_case!(asin, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE SingleItem (id INTEGER PRIMARY KEY)",
+            "CREATE TABLE SingleItem (id INTEGER)",
             Ok(Payload::Create),
         ),
         (
@@ -234,7 +234,7 @@ test_case!(acos, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE SingleItem (id INTEGER PRIMARY KEY)",
+            "CREATE TABLE SingleItem (id INTEGER)",
             Ok(Payload::Create),
         ),
         (
@@ -292,7 +292,7 @@ test_case!(atan, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE SingleItem (id INTEGER PRIMARY KEY)",
+            "CREATE TABLE SingleItem (id INTEGER)",
             Ok(Payload::Create),
         ),
         (

--- a/src/tests/function/math_function.rs
+++ b/src/tests/function/math_function.rs
@@ -179,10 +179,7 @@ test_case!(asin, async move {
     use Value::F64;
 
     let test_cases = vec![
-        (
-            "CREATE TABLE SingleItem (id INTEGER)",
-            Ok(Payload::Create),
-        ),
+        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -233,10 +230,7 @@ test_case!(acos, async move {
     use Value::F64;
 
     let test_cases = vec![
-        (
-            "CREATE TABLE SingleItem (id INTEGER)",
-            Ok(Payload::Create),
-        ),
+        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -291,10 +285,7 @@ test_case!(atan, async move {
     use Value::F64;
 
     let test_cases = vec![
-        (
-            "CREATE TABLE SingleItem (id INTEGER)",
-            Ok(Payload::Create),
-        ),
+        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/src/translate/ddl.rs
+++ b/src/translate/ddl.rs
@@ -79,7 +79,9 @@ fn translate_column_option_def(
         SqlColumnOption::Null => Ok(ColumnOption::Null),
         SqlColumnOption::NotNull => Ok(ColumnOption::NotNull),
         SqlColumnOption::Default(expr) => translate_expr(expr).map(ColumnOption::Default),
-        SqlColumnOption::Unique { is_primary: false } => Ok(ColumnOption::Unique { is_primary: false }),
+        SqlColumnOption::Unique { is_primary: false } => {
+            Ok(ColumnOption::Unique { is_primary: false })
+        }
         _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
     }?;
 

--- a/src/translate/ddl.rs
+++ b/src/translate/ddl.rs
@@ -79,9 +79,7 @@ fn translate_column_option_def(
         SqlColumnOption::Null => Ok(ColumnOption::Null),
         SqlColumnOption::NotNull => Ok(ColumnOption::NotNull),
         SqlColumnOption::Default(expr) => translate_expr(expr).map(ColumnOption::Default),
-        SqlColumnOption::Unique { is_primary } => Ok(ColumnOption::Unique {
-            is_primary: *is_primary,
-        }),
+        SqlColumnOption::Unique { is_primary: false } => Ok(ColumnOption::Unique { is_primary: false }),
         _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
     }?;
 


### PR DESCRIPTION
Motivation:
- `PRIMARY KEY` is not supported in `GlueSQL`. However `GlueSQL` allows `PRIMARY KEY` attr. Until the feature is implemented, it should be an error.

Modification:
- Modify pattern matching of `translate_column_option_def`
- Add TC about primary key

Result:
- Raise error when user try to make column with `PRIMARY KEY`
- Closes #308