### PR TITLE
Implement substr function

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -82,6 +82,12 @@ pub enum Function {
     Rtrim { expr: Expr, chars: Option<Expr> },
     #[strum(to_string = "REVERSE")]
     Reverse(Expr),
+    #[strum(to_string = "SUBSTR")]
+    Substr {
+        expr: Expr,
+        start: Expr,
+        count: Option<Expr>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -51,4 +51,7 @@ pub enum EvaluateError {
 
     #[error("the divisor should not be zero")]
     DivisorShouldNotBeZero,
+
+    #[error("negative substring length not allowed")]
+    NegativeSubstrLenNotAllowed,
 }

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -611,7 +611,7 @@ async fn evaluate_function<'a, T: 'static + Debug>(
             };
             let start = match eval_to_integer(start).await? {
                 Nullable::Value(v) => v,
-                Nullable::Null => return Ok(Evaluated::from(Value::Null))
+                Nullable::Null => return Ok(Evaluated::from(Value::Null)),
             };
 
             let count = match count {
@@ -628,7 +628,11 @@ async fn evaluate_function<'a, T: 'static + Debug>(
             let s: i64 = if start <= 0 { 0 } else { start - 1 };
             let e: i64 = start + count - 1;
             let s = s as usize;
-            let e = if count == -1 || e > string.len() as i64 { string.len() } else { e as usize };
+            let e = if count == -1 || e > string.len() as i64 {
+                string.len()
+            } else {
+                e as usize
+            };
 
             let result = if count == 0 || s >= string.len() {
                 String::from("")

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -618,26 +618,28 @@ async fn evaluate_function<'a, T: 'static + Debug>(
                 Some(expr) => match eval_to_integer(expr).await? {
                     Nullable::Value(v) => match v {
                         x if x < 0 => return Err(EvaluateError::NegativeSubstrLenNotAllowed.into()),
-                        _ => v,
+                        _ => Some(v),
                     },
-                    Nullable::Null => -1,
+                    Nullable::Null => None,
                 },
-                None => -1,
+                None => None,
             };
 
-            let s: i64 = if start <= 0 { 0 } else { start - 1 };
-            let e: i64 = start + count - 1;
-            let s = s as usize;
-            let e = if count == -1 || e > string.len() as i64 {
-                string.len()
-            } else {
-                e as usize
+
+            let s :usize = if start <= 0 { 0 } else { (start - 1) as usize} ;
+            let e = match count {
+                Some(v) => if (start - 1 + v) < 0  {
+                    0
+                }  else if (start - 1 + v) <= string.len() as i64 {
+                    (start - 1 + v) as usize
+                } else {
+                    string.len()
+                },
+                None => string.len()
             };
 
-            let result = if count == 0 || s >= string.len() {
+            let result = if s >= string.len() {
                 String::from("")
-            } else if count == -1 {
-                String::from(&string[s..])
             } else {
                 String::from(&string[s..e])
             };

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -625,17 +625,18 @@ async fn evaluate_function<'a, T: 'static + Debug>(
                 None => None,
             };
 
-
-            let s :usize = if start <= 0 { 0 } else { (start - 1) as usize} ;
+            let s: usize = if start <= 0 { 0 } else { (start - 1) as usize };
             let e = match count {
-                Some(v) => if (start - 1 + v) < 0  {
-                    0
-                }  else if (start - 1 + v) <= string.len() as i64 {
-                    (start - 1 + v) as usize
-                } else {
-                    string.len()
-                },
-                None => string.len()
+                Some(v) => {
+                    if (start - 1 + v) < 0 {
+                        0
+                    } else if (start - 1 + v) <= string.len() as i64 {
+                        (start - 1 + v) as usize
+                    } else {
+                        string.len()
+                    }
+                }
+                None => string.len(),
             };
 
             let result = if s >= string.len() {

--- a/src/tests/function/mod.rs
+++ b/src/tests/function/mod.rs
@@ -16,3 +16,4 @@ pub mod round;
 pub mod sqrt_power;
 pub mod trim;
 pub mod upper_lower;
+pub mod substr;

--- a/src/tests/function/mod.rs
+++ b/src/tests/function/mod.rs
@@ -14,6 +14,6 @@ pub mod radians;
 pub mod reverse;
 pub mod round;
 pub mod sqrt_power;
+pub mod substr;
 pub mod trim;
 pub mod upper_lower;
-pub mod substr;

--- a/src/tests/function/substr.rs
+++ b/src/tests/function/substr.rs
@@ -1,0 +1,143 @@
+use crate::*;
+
+test_case!(substr, async move {
+    use Value::{Null, Str};
+
+    let test_cases = vec![
+        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"INSERT INTO Item VALUES ("Blop mc blee"), ("B"), ("Steven the &long named$ folken!")"#,
+            Ok(Payload::Insert(3)),
+        ),
+        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            r#"INSERT INTO SingleItem VALUES (0)"#,
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            "CREATE TABLE NullName (name TEXT NULL)",
+            Ok(Payload::Create),
+        ),
+        (
+            r#"INSERT INTO NullName VALUES (NULL)"#,
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            "CREATE TABLE NullNumber (number INTEGER NULL)",
+            Ok(Payload::Create),
+        ),
+        (
+            r#"INSERT INTO NullNumber VALUES (NULL)"#,
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            r#"SELECT SUBSTR(name, 1) AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                "Blop mc blee".to_owned();
+                "B".to_owned();
+                "Steven the &long named$ folken!".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR(name, 2) AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                "lop mc blee".to_owned();
+                "".to_owned();
+                "teven the &long named$ folken!".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR(name, 999) AS test FROM Item"#,
+            Ok(select!(
+                "test"
+                Str;
+                "".to_owned();
+                "".to_owned();
+                "".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR('ABC', -3, 0) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", 0, 3) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "AB".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", 1, 3) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "ABC".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", 1, 999) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "ABC".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", -1000, 1003) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "AB".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", -1, 3) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "A".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR("ABC", -1, 4) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "AB".to_owned()
+            )),
+        ),
+        (
+            r#"SELECT SUBSTR(name, 3) AS test FROM NullName"#,
+            Ok(select_with_null!(test; Null)),
+        ),
+        (
+            r#"SELECT SUBSTR('Words', number) AS test FROM NullNumber"#,
+            Ok(select_with_null!(test; Null)),
+        ),
+        (
+            r#"SELECT SUBSTR(1, 1) AS test FROM SingleItem"#,
+            Err(EvaluateError::FunctionRequiresStringValue("SUBSTR".to_string()).into()),
+        ),
+        (
+            r#"SELECT SUBSTR('Words', 1.1) AS test FROM SingleItem"#,
+            Err(EvaluateError::FunctionRequiresIntegerValue("SUBSTR".to_string()).into()),
+        ),
+        (
+            r#"SELECT SUBSTR('Words', 1, -4) AS test FROM SingleItem"#,
+            Err(EvaluateError::NegativeSubstrLenNotAllowed.into()),
+        ),
+    ];
+    for (sql, expected) in test_cases {
+        test!(expected, sql);
+    }
+});

--- a/src/tests/function/substr.rs
+++ b/src/tests/function/substr.rs
@@ -118,11 +118,7 @@ test_case!(substr, async move {
         ),
         (
             r#"SELECT SUBSTR("ABC", -1, NULL) AS test FROM SingleItem"#,
-            Ok(select!(
-                "test"
-                Str;
-                "ABC".to_owned()
-            )),
+            Ok(select_with_null!(test; Null)),
         ),
         (
             r#"SELECT SUBSTR(name, 3) AS test FROM NullName"#,

--- a/src/tests/function/substr.rs
+++ b/src/tests/function/substr.rs
@@ -116,7 +116,7 @@ test_case!(substr, async move {
                 "AB".to_owned()
             )),
         ),
-       (
+        (
             r#"SELECT SUBSTR("ABC", -1, NULL) AS test FROM SingleItem"#,
             Ok(select!(
                 "test"

--- a/src/tests/function/substr.rs
+++ b/src/tests/function/substr.rs
@@ -116,6 +116,14 @@ test_case!(substr, async move {
                 "AB".to_owned()
             )),
         ),
+       (
+            r#"SELECT SUBSTR("ABC", -1, NULL) AS test FROM SingleItem"#,
+            Ok(select!(
+                "test"
+                Str;
+                "ABC".to_owned()
+            )),
+        ),
         (
             r#"SELECT SUBSTR(name, 3) AS test FROM NullName"#,
             Ok(select_with_null!(test; Null)),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -99,6 +99,7 @@ macro_rules! generate_tests {
         glue!(function_degrees, function::degrees::degrees);
         glue!(function_pi, function::pi::pi);
         glue!(function_reverse, function::reverse::reverse);
+        glue!(function_substr, function::substr::substr);
 
         #[cfg(feature = "index")]
         macro_rules! glue_index {

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -259,11 +259,9 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
             let expr = translate_expr(args[0])?;
             let start = translate_expr(args[1])?;
-            let count = if args.len() == 2 {
-                None
-            } else {
-                Some(translate_expr(args[2])?)
-            };
+            let count = (args.len() > 2)
+                .then(|| translate_expr(args[2]))
+                .transpose()?;
 
             Ok(Expr::Function(Box::new(Function::Substr {
                 expr,

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -254,6 +254,23 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             })))
         }
         "REVERSE" => func_with_one_arg!(Function::Reverse),
+        "SUBSTR" => {
+            check_len_range(name, args.len(), 2, 3)?;
+
+            let expr = translate_expr(args[0])?;
+            let start = translate_expr(args[1])?;
+            let count = if args.len() == 2 {
+                None
+            } else {
+                Some(translate_expr(args[2])?)
+            };
+
+            Ok(Expr::Function(Box::new(Function::Substr {
+                expr,
+                start,
+                count,
+            })))
+        }
         _ => Err(TranslateError::UnsupportedFunction(name).into()),
     }
 }


### PR DESCRIPTION
## Resolve https://github.com/gluesql/gluesql/issues/293

substr ( string text, start integer [, count integer ] ) → text

Extracts the substring of string starting at the start'th character, and extending for count characters if that is specified. (Same as substring(string from start for count).