### PR TITLE
Support binary operator `XOR`, update data-type `Int`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ iter-enum = "1"
 itertools = "0.10"
 pin-project = "1.0"
 serde = { version = "1", features = ["derive"] }
-sqlparser = { version = "0.10", features = ["serde"] }
+sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs/", rev = "014b82f03d82d6f36b5271376e33461002709a55" }
 thiserror = "1.0"
 strum = "0.21"
 strum_macros = "0.21"

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -23,6 +23,7 @@ pub enum BinaryOperator {
     NotEq,
     And,
     Or,
+    Xor,
     Like,
     ILike,
     NotLike,

--- a/src/executor/evaluate/expr.rs
+++ b/src/executor/evaluate/expr.rs
@@ -57,6 +57,7 @@ pub fn binary_op<'a>(
         BinaryOperator::GtEq => cmp!(l >= r),
         BinaryOperator::And => cond!(l && r),
         BinaryOperator::Or => cond!(l || r),
+        BinaryOperator::Xor => cond!(l ^ r),
         BinaryOperator::Like => l.like(r, true),
         BinaryOperator::ILike => l.like(r, false),
         BinaryOperator::NotLike => {

--- a/src/tests/arithmetic.rs
+++ b/src/tests/arithmetic.rs
@@ -188,4 +188,14 @@ test_case!(blend, async move {
     let found = run!(sql);
     let expected = select!("a.id + b.id"; I64; 3; 5; 7; 9);
     assert_eq!(expected, found);
+
+    let sql =
+        "SELECT TRUE XOR TRUE, FALSE XOR FALSE, TRUE XOR FALSE, FALSE XOR TRUE FROM Arith LIMIT 1";
+    let found = run!(sql);
+    let expected = select!(
+        "true XOR true" | "false XOR false" | "true XOR false" | "false XOR true"
+        Value::Bool     | Value::Bool       | Value::Bool      | Value::Bool;
+        false             false               true               true
+    );
+    assert_eq!(expected, found);
 });

--- a/src/translate/data_type.rs
+++ b/src/translate/data_type.rs
@@ -7,7 +7,7 @@ use {
 pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
     match sql_data_type {
         SqlDataType::Boolean => Ok(DataType::Boolean),
-        SqlDataType::Int => Ok(DataType::Int),
+        SqlDataType::Int(_) => Ok(DataType::Int),
         SqlDataType::Float(_) => Ok(DataType::Float),
         SqlDataType::Text => Ok(DataType::Text),
         SqlDataType::Date => Ok(DataType::Date),

--- a/src/translate/operator.rs
+++ b/src/translate/operator.rs
@@ -34,6 +34,7 @@ pub fn translate_binary_operator(
         SqlBinaryOperator::NotEq => Ok(BinaryOperator::NotEq),
         SqlBinaryOperator::And => Ok(BinaryOperator::And),
         SqlBinaryOperator::Or => Ok(BinaryOperator::Or),
+        SqlBinaryOperator::Xor => Ok(BinaryOperator::Xor),
         SqlBinaryOperator::Like => Ok(BinaryOperator::Like),
         SqlBinaryOperator::ILike => Ok(BinaryOperator::ILike),
         SqlBinaryOperator::NotLike => Ok(BinaryOperator::NotLike),


### PR DESCRIPTION
1. Adding a `XOR` operator to the `Sqlparser` and then adding a function to the current project. Add unit test code to determine `XOR` of two Boolean values.
2. Modify data-type `Int` factors according to the updated data-type from `Sqlparser`