### PR TITLE
Implement implicit null insert.

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -92,6 +92,7 @@ macro_rules! generate_store_tests {
         glue!(nested_select, nested_select::nested_select);
         glue!(nullable, nullable::nullable);
         glue!(nullable_text, nullable::nullable_text);
+        glue!(nullable_implicit_insert, nullable::nullable_implicit_insert);
         glue!(ordering, ordering::ordering);
         glue!(order_by, order_by::order_by);
         glue!(sql_types, data_type::sql_types::sql_types);

--- a/src/tests/nullable.rs
+++ b/src/tests/nullable.rs
@@ -252,3 +252,24 @@ test_case!(nullable_text, async move {
 
     run!("INSERT INTO Foo (id, name) VALUES (1, \"Hello\"), (2, Null);");
 });
+
+test_case!(nullable_implicit_insert, async move {
+    use Value::*;
+    run!(
+        "
+        CREATE TABLE Foo (
+            id INTEGER,
+            name TEXT NULL
+        );
+    "
+    );
+
+    run!("INSERT INTO Foo (id) VALUES (1)");
+    test!(
+        Ok(select_with_null!(
+            id   | name;
+            I64(1)  Null
+        )),
+        "SELECT id, name FROM Foo"
+    );
+});


### PR DESCRIPTION
Regarding issue #197 . 

Now it checks `column_def` is nullable and then if it's nullable and have no value(`None`), it returns `Expr::Literal(Null)` 