### PR TITLE
328 replace macros to functions

### DIFF
--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -44,8 +44,7 @@ pub fn translate_trim(
 fn check_len(name: String, found: usize, expected: usize) -> Result<()> {
     if found == expected {
         Ok(())
-    }
-    else {
+    } else {
         Err(TranslateError::FunctionArgsLengthNotMatching {
             name,
             found,
@@ -55,11 +54,15 @@ fn check_len(name: String, found: usize, expected: usize) -> Result<()> {
     }
 }
 
-fn check_len_range(name: String, found:usize, expected_minimum: usize, expected_maximum:usize) -> Result<()> {
+fn check_len_range(
+    name: String,
+    found: usize,
+    expected_minimum: usize,
+    expected_maximum: usize,
+) -> Result<()> {
     if found >= expected_minimum && found <= expected_maximum {
         Ok(())
-    }
-    else {
+    } else {
         Err(TranslateError::FunctionArgsLengthNotWithinRange {
             name,
             expected_minimum,
@@ -76,7 +79,11 @@ fn translate_function_zero_arg(func: Function, args: Vec<&SqlExpr>, name: String
     Ok(Expr::Function(Box::new(func)))
 }
 
-fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(
+    func: T,
+    args: Vec<&SqlExpr>,
+    name: String,
+) -> Result<Expr> {
     check_len(name, args.len(), 1)?;
 
     translate_expr(args[0])
@@ -85,7 +92,11 @@ fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(func: T, args: Vec<&S
         .map(Expr::Function)
 }
 
-fn translate_aggrecate_one_arg<T: FnOnce(Expr) -> Aggregate>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+fn translate_aggrecate_one_arg<T: FnOnce(Expr) -> Aggregate>(
+    func: T,
+    args: Vec<&SqlExpr>,
+    name: String,
+) -> Result<Expr> {
     check_len(name, args.len(), 1)?;
 
     translate_expr(args[0])
@@ -94,7 +105,11 @@ fn translate_aggrecate_one_arg<T: FnOnce(Expr) -> Aggregate>(func: T, args: Vec<
         .map(Expr::Aggregate)
 }
 
-fn translate_function_range<T: FnOnce(Expr, Option<Expr>) -> Function>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+fn translate_function_range<T: FnOnce(Expr, Option<Expr>) -> Function>(
+    func: T,
+    args: Vec<&SqlExpr>,
+    name: String,
+) -> Result<Expr> {
     check_len_range(name, args.len(), 1, 2)?;
 
     let expr = translate_expr(args[0])?;
@@ -227,8 +242,12 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
             Ok(Expr::Function(Box::new(Function::Lcm { left, right })))
         }
-        "LTRIM" => translate_function_range(|expr, chars| Function::Ltrim{expr, chars}, args, name),
-        "RTRIM" => translate_function_range(|expr, chars| Function::Rtrim{expr, chars}, args, name),
+        "LTRIM" => {
+            translate_function_range(|expr, chars| Function::Ltrim { expr, chars }, args, name)
+        }
+        "RTRIM" => {
+            translate_function_range(|expr, chars| Function::Rtrim { expr, chars }, args, name)
+        }
         "COUNT" => translate_aggrecate_one_arg(Aggregate::Count, args, name),
         "SUM" => translate_aggrecate_one_arg(Aggregate::Sum, args, name),
         "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -41,6 +41,74 @@ pub fn translate_trim(
     })))
 }
 
+fn check_len(name: String, found: usize, expected: usize) -> Result<()> {
+    if found == expected {
+        Ok(())
+    }
+    else {
+        Err(TranslateError::FunctionArgsLengthNotMatching {
+            name,
+            found,
+            expected,
+        }
+        .into())
+    }
+}
+
+fn check_len_range(name: String, found:usize, expected_minimum: usize, expected_maximum:usize) -> Result<()> {
+    if found >= expected_minimum && found <= expected_maximum {
+        Ok(())
+    }
+    else {
+        Err(TranslateError::FunctionArgsLengthNotWithinRange {
+            name,
+            expected_minimum,
+            expected_maximum,
+            found,
+        }
+        .into())
+    }
+}
+
+fn translate_function_zero_arg(func: Function, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+    check_len(name, args.len(), 0)?;
+
+    Ok(Expr::Function(Box::new(func)))
+}
+
+fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+    check_len(name, args.len(), 1)?;
+
+    translate_expr(args[0])
+        .map(func)
+        .map(Box::new)
+        .map(Expr::Function)
+}
+
+fn translate_aggrecate_one_arg<T: FnOnce(Expr) -> Aggregate>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+    check_len(name, args.len(), 1)?;
+
+    translate_expr(args[0])
+        .map(func)
+        .map(Box::new)
+        .map(Expr::Aggregate)
+}
+
+fn translate_function_range<T: FnOnce(Expr, Option<Expr>) -> Function>(func: T, args: Vec<&SqlExpr>, name: String) -> Result<Expr> {
+    check_len_range(name, args.len(), 1, 2)?;
+
+    let expr = translate_expr(args[0])?;
+    let chars = if args.len() == 1 {
+        None
+    } else {
+        Some(translate_expr(args[1])?)
+    };
+
+    let result = func(expr, chars);
+
+    Ok(Expr::Function(Box::new(result)))
+}
+
 pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let SqlFunction { name, args, .. } = sql_function;
     let name = {
@@ -58,71 +126,9 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let check_len = |name, found, expected| -> Result<_> {
-        if found == expected {
-            Ok(())
-        } else {
-            Err(TranslateError::FunctionArgsLengthNotMatching {
-                name,
-                expected,
-                found,
-            }
-            .into())
-        }
-    };
-
-    let check_len_range = |name, found, expected_minimum, expected_maximum| -> Result<_> {
-        if found >= expected_minimum && found <= expected_maximum {
-            Ok(())
-        } else {
-            Err(TranslateError::FunctionArgsLengthNotWithinRange {
-                name,
-                expected_minimum,
-                expected_maximum,
-                found,
-            }
-            .into())
-        }
-    };
-
-    macro_rules! aggr {
-        ($aggregate: expr) => {{
-            check_len(name, args.len(), 1)?;
-
-            translate_expr(args[0])
-                .map($aggregate)
-                .map(Box::new)
-                .map(Expr::Aggregate)
-        }};
-    }
-
-    macro_rules! func_with_one_arg {
-        ($func: expr) => {{
-            check_len(name, args.len(), 1)?;
-
-            translate_expr(args[0])
-                .map($func)
-                .map(Box::new)
-                .map(Expr::Function)
-        }};
-    }
-
-    macro_rules! func_with_two_arg {
-        ($func: ident) => {{
-            check_len_range(stringify!($func).to_owned(), args.len(), 1, 2)?;
-            let expr = translate_expr(args[0])?;
-            let chars = if args.len() == 1 {
-                None
-            } else {
-                Some(translate_expr(args[1])?)
-            };
-            Ok(Expr::Function(Box::new(Function::$func { expr, chars })))
-        }};
-    }
-
     match name.as_str() {
-        "LOWER" => func_with_one_arg!(Function::Lower),
-        "UPPER" => func_with_one_arg!(Function::Upper),
+        "LOWER" => translate_function_one_arg(Function::Lower, args, name),
+        "UPPER" => translate_function_one_arg(Function::Upper, args, name),
         "LEFT" => {
             check_len(name, args.len(), 2)?;
 
@@ -189,26 +195,22 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
                 fill,
             })))
         }
-        "CEIL" => func_with_one_arg!(Function::Ceil),
-        "ROUND" => func_with_one_arg!(Function::Round),
-        "FLOOR" => func_with_one_arg!(Function::Floor),
-        "EXP" => func_with_one_arg!(Function::Exp),
-        "LN" => func_with_one_arg!(Function::Ln),
-        "LOG2" => func_with_one_arg!(Function::Log2),
-        "LOG10" => func_with_one_arg!(Function::Log10),
-        "SIN" => func_with_one_arg!(Function::Sin),
-        "COS" => func_with_one_arg!(Function::Cos),
-        "TAN" => func_with_one_arg!(Function::Tan),
-        "ASIN" => func_with_one_arg!(Function::ASin),
-        "ACOS" => func_with_one_arg!(Function::ACos),
-        "ATAN" => func_with_one_arg!(Function::ATan),
-        "RADIANS" => func_with_one_arg!(Function::Radians),
-        "DEGREES" => func_with_one_arg!(Function::Degrees),
-        "PI" => {
-            check_len(name, args.len(), 0)?;
-
-            Ok(Expr::Function(Box::new(Function::Pi())))
-        }
+        "CEIL" => translate_function_one_arg(Function::Ceil, args, name),
+        "ROUND" => translate_function_one_arg(Function::Round, args, name),
+        "FLOOR" => translate_function_one_arg(Function::Floor, args, name),
+        "EXP" => translate_function_one_arg(Function::Exp, args, name),
+        "LN" => translate_function_one_arg(Function::Ln, args, name),
+        "LOG2" => translate_function_one_arg(Function::Log2, args, name),
+        "LOG10" => translate_function_one_arg(Function::Log10, args, name),
+        "SIN" => translate_function_one_arg(Function::Sin, args, name),
+        "COS" => translate_function_one_arg(Function::Cos, args, name),
+        "TAN" => translate_function_one_arg(Function::Tan, args, name),
+        "ASIN" => translate_function_one_arg(Function::ASin, args, name),
+        "ACOS" => translate_function_one_arg(Function::ACos, args, name),
+        "ATAN" => translate_function_one_arg(Function::ATan, args, name),
+        "RADIANS" => translate_function_one_arg(Function::Radians, args, name),
+        "DEGREES" => translate_function_one_arg(Function::Degrees, args, name),
+        "PI" => translate_function_zero_arg(Function::Pi(), args, name),
         "GCD" => {
             check_len(name, args.len(), 2)?;
 
@@ -225,12 +227,12 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
             Ok(Expr::Function(Box::new(Function::Lcm { left, right })))
         }
-        "LTRIM" => func_with_two_arg!(Ltrim),
-        "RTRIM" => func_with_two_arg!(Rtrim),
-        "COUNT" => aggr!(Aggregate::Count),
-        "SUM" => aggr!(Aggregate::Sum),
-        "MIN" => aggr!(Aggregate::Min),
-        "MAX" => aggr!(Aggregate::Max),
+        "LTRIM" => translate_function_range(|expr, chars| Function::Ltrim{expr, chars}, args, name),
+        "RTRIM" => translate_function_range(|expr, chars| Function::Rtrim{expr, chars}, args, name),
+        "COUNT" => translate_aggrecate_one_arg(Aggregate::Count, args, name),
+        "SUM" => translate_aggrecate_one_arg(Aggregate::Sum, args, name),
+        "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),
+        "MAX" => translate_aggrecate_one_arg(Aggregate::Max, args, name),
         "DIV" => {
             check_len(name, args.len(), 2)?;
 
@@ -253,7 +255,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
                 divisor,
             })))
         }
-        "REVERSE" => func_with_one_arg!(Function::Reverse),
+        "REVERSE" => translate_function_one_arg(Function::Reverse, args, name),
         "SUBSTR" => {
             check_len_range(name, args.len(), 2, 3)?;
 


### PR DESCRIPTION
#328 

change macros to functions

- change, aggr to translate_aggregate_one_arg
- change, func_with_one_arg to translate_functioin_one_arg
- change, func_with_two_arg to translate_function_range

- new translate_function_zero_arg (use pi function)