### PR TITLE
Add `MAP` data type and `UNWRAP` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ iter-enum = "1"
 itertools = "0.10"
 pin-project = "1.0"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs/", rev = "014b82f03d82d6f36b5271376e33461002709a55" }
 thiserror = "1.0"
 strum = "0.21"

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -11,4 +11,5 @@ pub enum DataType {
     Time,
     Interval,
     UUID,
+    Map,
 }

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -88,6 +88,8 @@ pub enum Function {
         start: Expr,
         count: Option<Expr>,
     },
+    #[strum(to_string = "UNWRAP")]
+    Unwrap { expr: Expr, selector: Expr },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -1,0 +1,92 @@
+use {
+    crate::{data::Value, result::Result},
+    serde::{Deserialize, Serialize},
+    serde_json::{Map as JsonMap, Value as JsonValue},
+    std::{collections::HashMap, fmt::Debug, ops::ControlFlow},
+    thiserror::Error as ThisError,
+};
+
+#[derive(Debug, PartialEq, ThisError, Serialize)]
+pub enum MapError {
+    #[error("parse failed - invalid json")]
+    InvalidJsonString,
+
+    #[error("parse failed - json object type is required")]
+    ObjectTypeJsonRequired,
+
+    #[error("Array type is not yet supported")]
+    ArrayTypeNotSupported,
+
+    #[error("unreachable - failed to parse json number value: {0}")]
+    UnreachableJsonNumberParseFailure(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Map(HashMap<String, Value>);
+
+impl Map {
+    pub fn parse_json(value: &str) -> Result<Self> {
+        let value: JsonValue =
+            serde_json::from_str(value).map_err(|_| MapError::InvalidJsonString)?;
+
+        match value {
+            JsonValue::Object(json_map) => parse_json_map(json_map),
+            _ => Err(MapError::ObjectTypeJsonRequired.into()),
+        }
+    }
+
+    pub fn get_value(&self, selector: &str) -> Value {
+        let splitted = selector.split('.').collect::<Vec<_>>();
+        let size = splitted.len();
+        let result = splitted
+            .into_iter()
+            .enumerate()
+            .map(|(i, key)| (i == size - 1, key))
+            .try_fold(&self.0, |map, (is_last, key)| {
+                let value = match map.get(key) {
+                    Some(value) => value,
+                    None => {
+                        return ControlFlow::Break(Value::Null);
+                    }
+                };
+
+                match (is_last, value) {
+                    (true, value) => ControlFlow::Break(value.clone()),
+                    (false, Value::Map(map)) => ControlFlow::Continue(&map.0),
+                    (false, _) => ControlFlow::Break(Value::Null),
+                }
+            });
+
+        match result {
+            ControlFlow::Continue(map) => Value::Map(Self(map.clone())),
+            ControlFlow::Break(value) => value,
+        }
+    }
+}
+
+fn parse_json_map(json_map: JsonMap<String, JsonValue>) -> Result<Map> {
+    json_map
+        .into_iter()
+        .map(|(key, value)| parse_json_value(value).map(|value| (key, value)))
+        .collect::<Result<HashMap<String, Value>>>()
+        .map(Map)
+}
+
+fn parse_json_value(json_value: JsonValue) -> Result<Value> {
+    match json_value {
+        JsonValue::Null => Ok(Value::Null),
+        JsonValue::Bool(v) => Ok(Value::Bool(v)),
+        JsonValue::Number(v) => {
+            if let Some(value) = v.as_i64().map(Value::I64) {
+                return Ok(value);
+            }
+
+            v.as_f64()
+                .map(Value::F64)
+                .ok_or_else(|| MapError::UnreachableJsonNumberParseFailure(v.to_string()).into())
+        }
+        JsonValue::String(v) => Ok(Value::Str(v)),
+        JsonValue::Array(_) => Err(MapError::ArrayTypeNotSupported.into()),
+        JsonValue::Object(json_map) => parse_json_map(json_map).map(Value::Map),
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,5 +1,6 @@
 mod interval;
 mod literal;
+mod map;
 mod row;
 mod string_ext;
 mod table;
@@ -10,6 +11,7 @@ pub mod value;
 pub use {
     interval::{Interval, IntervalError},
     literal::{Literal, LiteralError},
+    map::{Map, MapError},
     row::{Row, RowError},
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
     string_ext::{StringExt, StringExtError},

--- a/src/data/value/big_edian.rs
+++ b/src/data/value/big_edian.rs
@@ -1,6 +1,6 @@
 use {
-    super::Value,
-    crate::data::Interval,
+    super::{Value, ValueError},
+    crate::{data::Interval, result::Result},
     chrono::{Datelike, Timelike},
 };
 
@@ -8,8 +8,9 @@ const VALUE: u8 = 0;
 const NULL: u8 = 1;
 
 impl Value {
-    pub fn to_be_bytes(&self) -> Vec<u8> {
-        match self {
+    /// Value to Big-Edian for comparison purpose
+    pub fn to_cmp_be_bytes(&self) -> Result<Vec<u8>> {
+        let value = match self {
             Value::Bool(v) => {
                 if *v {
                     vec![VALUE, 1]
@@ -80,7 +81,12 @@ impl Value {
                 .copied()
                 .collect::<Vec<_>>(),
             Value::Null => vec![NULL],
-        }
+            Value::Map(_) => {
+                return Err(ValueError::BigEdianExportNotSupported("MAP".to_owned()).into());
+            }
+        };
+
+        Ok(value)
     }
 }
 
@@ -106,42 +112,42 @@ mod tests {
     fn cmp_big_edian() {
         use crate::{
             chrono::{NaiveDate, NaiveTime},
-            data::{Interval as I, Value::*},
+            data::{self, Interval as I, Value::*, ValueError},
         };
 
-        let null = Null.to_be_bytes();
+        let null = Null.to_cmp_be_bytes().unwrap();
 
-        let n1 = Bool(true).to_be_bytes();
-        let n2 = Bool(false).to_be_bytes();
+        let n1 = Bool(true).to_cmp_be_bytes().unwrap();
+        let n2 = Bool(false).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Greater);
         assert_eq!(cmp(&n2, &n1), Ordering::Less);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = I64(3).to_be_bytes();
-        let n2 = I64(20).to_be_bytes();
-        let n3 = I64(100).to_be_bytes();
+        let n1 = I64(3).to_cmp_be_bytes().unwrap();
+        let n2 = I64(20).to_cmp_be_bytes().unwrap();
+        let n3 = I64(100).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);
         assert_eq!(cmp(&n3, &n1), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = F64(3.0).to_be_bytes();
-        let n2 = F64(100.0).to_be_bytes();
-        let n3 = F64(1324.0).to_be_bytes();
+        let n1 = F64(3.0).to_cmp_be_bytes().unwrap();
+        let n2 = F64(100.0).to_cmp_be_bytes().unwrap();
+        let n3 = F64(1324.0).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);
         assert_eq!(cmp(&n3, &n1), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = Str("a".to_owned()).to_be_bytes();
-        let n2 = Str("ab".to_owned()).to_be_bytes();
-        let n3 = Str("aaa".to_owned()).to_be_bytes();
-        let n4 = Str("aaz".to_owned()).to_be_bytes();
-        let n5 = Str("c".to_owned()).to_be_bytes();
+        let n1 = Str("a".to_owned()).to_cmp_be_bytes().unwrap();
+        let n2 = Str("ab".to_owned()).to_cmp_be_bytes().unwrap();
+        let n3 = Str("aaa".to_owned()).to_cmp_be_bytes().unwrap();
+        let n4 = Str("aaz".to_owned()).to_cmp_be_bytes().unwrap();
+        let n5 = Str("c".to_owned()).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);
@@ -151,32 +157,43 @@ mod tests {
         assert_eq!(cmp(&n5, &n4), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = Date(NaiveDate::from_ymd(2021, 1, 1)).to_be_bytes();
-        let n2 = Date(NaiveDate::from_ymd(1989, 3, 20)).to_be_bytes();
+        let n1 = Date(NaiveDate::from_ymd(2021, 1, 1))
+            .to_cmp_be_bytes()
+            .unwrap();
+        let n2 = Date(NaiveDate::from_ymd(1989, 3, 20))
+            .to_cmp_be_bytes()
+            .unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = Time(NaiveTime::from_hms_milli(20, 1, 9, 100)).to_be_bytes();
-        let n2 = Time(NaiveTime::from_hms_milli(3, 10, 30, 0)).to_be_bytes();
+        let n1 = Time(NaiveTime::from_hms_milli(20, 1, 9, 100))
+            .to_cmp_be_bytes()
+            .unwrap();
+        let n2 = Time(NaiveTime::from_hms_milli(3, 10, 30, 0))
+            .to_cmp_be_bytes()
+            .unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = Timestamp(NaiveDate::from_ymd(2021, 1, 1).and_hms_milli(1, 2, 3, 0)).to_be_bytes();
-        let n2 =
-            Timestamp(NaiveDate::from_ymd(1989, 3, 20).and_hms_milli(10, 0, 0, 1000)).to_be_bytes();
+        let n1 = Timestamp(NaiveDate::from_ymd(2021, 1, 1).and_hms_milli(1, 2, 3, 0))
+            .to_cmp_be_bytes()
+            .unwrap();
+        let n2 = Timestamp(NaiveDate::from_ymd(1989, 3, 20).and_hms_milli(10, 0, 0, 1000))
+            .to_cmp_be_bytes()
+            .unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = Interval(I::Month(30)).to_be_bytes();
-        let n2 = Interval(I::Month(2)).to_be_bytes();
-        let n3 = Interval(I::Microsecond(1000)).to_be_bytes();
-        let n4 = Interval(I::Microsecond(30)).to_be_bytes();
+        let n1 = Interval(I::Month(30)).to_cmp_be_bytes().unwrap();
+        let n2 = Interval(I::Month(2)).to_cmp_be_bytes().unwrap();
+        let n3 = Interval(I::Microsecond(1000)).to_cmp_be_bytes().unwrap();
+        let n4 = Interval(I::Microsecond(30)).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n1, &n1), Ordering::Equal);
         assert_eq!(cmp(&n2, &n1), Ordering::Less);
@@ -184,12 +201,20 @@ mod tests {
         assert_eq!(cmp(&n3, &n4), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = UUID(100).to_be_bytes();
-        let n2 = UUID(101).to_be_bytes();
+        let n1 = UUID(100).to_cmp_be_bytes().unwrap();
+        let n2 = UUID(101).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n1, &n1), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);
         assert_eq!(cmp(&n2, &n1), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
+
+        let n1 = data::Map::parse_json(r#"{ "a": 10 }"#).unwrap();
+        let n1 = Map(n1).to_cmp_be_bytes();
+
+        assert_eq!(
+            n1,
+            Err(ValueError::BigEdianExportNotSupported("MAP".to_owned()).into())
+        );
     }
 }

--- a/src/data/value/error.rs
+++ b/src/data/value/error.rs
@@ -52,8 +52,8 @@ pub enum ValueError {
     #[error("modulo on non-numeric values: {0:?} % {1:?}")]
     ModuloOnNonNumeric(Value, Value),
 
-    #[error("floating numbers cannot be grouped by")]
-    FloatCannotBeGroupedBy,
+    #[error("{0} type cannot be grouped by")]
+    GroupByNotSupported(String),
 
     #[error("unary plus operation for non numeric value")]
     UnaryPlusOnNonNumeric,
@@ -64,8 +64,8 @@ pub enum ValueError {
     #[error("unreachable failure on parsing number")]
     UnreachableNumberParsing,
 
-    #[error("floating columns cannot be set to unique constraint")]
-    ConflictOnFloatWithUniqueConstraint,
+    #[error("conflict - unique constraint cannot be used for {0} type")]
+    ConflictDataTypeOnUniqueConstraint(String),
 
     // Cast errors from value to value
     #[error("impossible cast")]
@@ -101,4 +101,7 @@ pub enum ValueError {
 
     #[error("operator doesn't exist: {0:?} ILIKE {1:?}")]
     ILikeOnNonString(Value, Value),
+
+    #[error("big edian export not supported for {0} type")]
+    BigEdianExportNotSupported(String),
 }

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -7,27 +7,6 @@ use {
     std::convert::TryInto,
 };
 
-impl TryInto<GroupKey> for &Value {
-    type Error = Error;
-
-    fn try_into(self) -> Result<GroupKey> {
-        use Value::*;
-
-        match self {
-            Bool(v) => Ok(GroupKey::Bool(*v)),
-            I64(v) => Ok(GroupKey::I64(*v)),
-            Str(v) => Ok(GroupKey::Str(v.clone())),
-            Date(v) => Ok(GroupKey::Date(*v)),
-            Timestamp(v) => Ok(GroupKey::Timestamp(*v)),
-            Time(v) => Ok(GroupKey::Time(*v)),
-            Interval(v) => Ok(GroupKey::Interval(*v)),
-            UUID(v) => Ok(GroupKey::UUID(*v)),
-            Null => Ok(GroupKey::None),
-            F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
-        }
-    }
-}
-
 impl TryInto<GroupKey> for Value {
     type Error = Error;
 
@@ -44,7 +23,16 @@ impl TryInto<GroupKey> for Value {
             Interval(v) => Ok(GroupKey::Interval(v)),
             UUID(v) => Ok(GroupKey::UUID(v)),
             Null => Ok(GroupKey::None),
-            F64(_) => Err(ValueError::FloatCannotBeGroupedBy.into()),
+            F64(_) => Err(ValueError::GroupByNotSupported("FLOAT".to_owned()).into()),
+            Map(_) => Err(ValueError::GroupByNotSupported("MAP".to_owned()).into()),
         }
+    }
+}
+
+impl TryInto<GroupKey> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<GroupKey> {
+        self.clone().try_into()
     }
 }

--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -21,6 +21,7 @@ impl From<&Value> for String {
             Value::Time(value) => value.to_string(),
             Value::Interval(value) => String::from(value),
             Value::UUID(value) => Uuid::from_u128(*value).to_string(),
+            Value::Map(_) => "[MAP]".to_owned(),
             Value::Null => String::from("NULL"),
         }
     }
@@ -65,6 +66,7 @@ impl TryInto<bool> for &Value {
             | Value::Time(_)
             | Value::Interval(_)
             | Value::UUID(_)
+            | Value::Map(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -100,6 +102,7 @@ impl TryInto<i64> for &Value {
             | Value::Time(_)
             | Value::Interval(_)
             | Value::UUID(_)
+            | Value::Map(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -135,6 +138,7 @@ impl TryInto<f64> for &Value {
             | Value::Time(_)
             | Value::Interval(_)
             | Value::UUID(_)
+            | Value::Map(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }

--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -2,7 +2,7 @@ use {
     super::{error::ValueError, Value},
     crate::{
         ast::DataType,
-        data::{Interval, Literal},
+        data::{Interval, Literal, Map},
         result::{Error, Result},
     },
     chrono::{offset::Utc, DateTime, NaiveDate, NaiveDateTime, NaiveTime},
@@ -144,17 +144,10 @@ impl Value {
             (DataType::Time, Literal::Text(v)) => parse_time(v)
                 .map(Value::Time)
                 .map_err(|_| ValueError::FailedToParseTime(v.to_string()).into()),
-            (DataType::UUID, Literal::Text(v)) => parse_uuid(v).map(Value::UUID),
             (DataType::Interval, Literal::Interval(v)) => Ok(Value::Interval(*v)),
-            (DataType::Boolean, Literal::Null)
-            | (DataType::Int, Literal::Null)
-            | (DataType::Float, Literal::Null)
-            | (DataType::Text, Literal::Null)
-            | (DataType::Date, Literal::Null)
-            | (DataType::Timestamp, Literal::Null)
-            | (DataType::Time, Literal::Null)
-            | (DataType::Interval, Literal::Null)
-            | (DataType::UUID, Literal::Null) => Ok(Value::Null),
+            (DataType::UUID, Literal::Text(v)) => parse_uuid(v).map(Value::UUID),
+            (DataType::Map, Literal::Text(v)) => Map::parse_json(v).map(Value::Map),
+            (_, Literal::Null) => Ok(Value::Null),
             _ => Err(ValueError::IncompatibleLiteralForDataType {
                 data_type: data_type.clone(),
                 literal: format!("{:?}", literal),

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -13,6 +13,10 @@ impl TryInto<Option<UniqueKey>> for &Value {
     fn try_into(self) -> Result<Option<UniqueKey>> {
         use Value::*;
 
+        let conflict = |data_type: &str| {
+            Err(ValueError::ConflictDataTypeOnUniqueConstraint(data_type.to_owned()).into())
+        };
+
         let unique_key = match self {
             Bool(v) => Some(UniqueKey::Bool(*v)),
             I64(v) => Some(UniqueKey::I64(*v)),
@@ -23,9 +27,8 @@ impl TryInto<Option<UniqueKey>> for &Value {
             Interval(v) => Some(UniqueKey::Interval(*v)),
             UUID(v) => Some(UniqueKey::UUID(*v)),
             Null => None,
-            F64(_) => {
-                return Err(ValueError::ConflictOnFloatWithUniqueConstraint.into());
-            }
+            F64(_) => return conflict("FLOAT"),
+            Map(_) => return conflict("MAP"),
         };
 
         Ok(unique_key)

--- a/src/executor/alter/validate.rs
+++ b/src/executor/alter/validate.rs
@@ -16,7 +16,7 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
     } = column_def;
 
     // unique + data type
-    if matches!(data_type, DataType::Float)
+    if matches!(data_type, DataType::Float | DataType::Map)
         && options
             .iter()
             .any(|ColumnOptionDef { option, .. }| matches!(option, ColumnOption::Unique { .. }))

--- a/src/executor/evaluate/error.rs
+++ b/src/executor/evaluate/error.rs
@@ -28,6 +28,9 @@ pub enum EvaluateError {
     #[error("function requires float value: {0}")]
     FunctionRequiresFloatValue(String),
 
+    #[error("function requires map value: {0}")]
+    FunctionRequiresMapValue(String),
+
     #[error("value not found: {0}")]
     ValueNotFound(String),
 

--- a/src/executor/sort.rs
+++ b/src/executor/sort.rs
@@ -107,15 +107,6 @@ impl<'a, T: 'static + Debug> Sort<'a, T> {
                         Some(ord) if ord != Ordering::Equal => {
                             return apply_asc(ord);
                         }
-                        None => {
-                            let a = String::from(value_a);
-                            let b = String::from(value_b);
-                            let ord = a.cmp(&b);
-
-                            if ord != Ordering::Equal {
-                                return apply_asc(ord);
-                            }
-                        }
                         _ => {}
                     }
                 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        data::{IntervalError, LiteralError, RowError, StringExtError, TableError, ValueError},
+        data::{
+            IntervalError, LiteralError, MapError, RowError, StringExtError, TableError, ValueError,
+        },
         executor::{
             AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, SelectError,
             UpdateError, ValidateError,
@@ -69,6 +71,8 @@ pub enum Error {
     #[error(transparent)]
     Interval(#[from] IntervalError),
     #[error(transparent)]
+    Map(#[from] MapError),
+    #[error(transparent)]
     StringExt(#[from] StringExtError),
 }
 
@@ -100,6 +104,7 @@ impl PartialEq for Error {
             (Value(e), Value(e2)) => e == e2,
             (Literal(e), Literal(e2)) => e == e2,
             (Interval(e), Interval(e2)) => e == e2,
+            (Map(e), Map(e2)) => e == e2,
             (StringExt(e), StringExt(e2)) => e == e2,
             _ => false,
         }

--- a/src/storages/sled_storage/index.rs
+++ b/src/storages/sled_storage/index.rs
@@ -61,7 +61,7 @@ impl Index<IVec> for SledStorage {
                     };
                     let lower = || build_index_key_prefix(table_name, index_name);
                     let upper = || incr(build_index_key_prefix(table_name, index_name));
-                    let key = build_index_key(table_name, index_name, value);
+                    let key = build_index_key(table_name, index_name, value)?;
 
                     match op {
                         IndexOperator::Eq => match self.tree.get(&key).transpose() {

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -1,8 +1,11 @@
 use {
     super::{err_into, fetch_schema, key, Snapshot},
     crate::{
-        ast::Expr, evaluate_stateless, utils::Vector, Error, IndexError, Row, Schema, SchemaIndex,
-        Value,
+        ast::Expr,
+        evaluate_stateless,
+        result::{Error, Result},
+        utils::Vector,
+        IndexError, Row, Schema, SchemaIndex, Value,
     },
     sled::{
         transaction::{
@@ -250,16 +253,16 @@ fn evaluate_index_key(
         .try_into()
         .map_err(ConflictableTransactionError::Abort)?;
 
-    Ok(build_index_key(table_name, index_name, value))
+    build_index_key(table_name, index_name, value).map_err(ConflictableTransactionError::Abort)
 }
 
 pub fn build_index_key_prefix(table_name: &str, index_name: &str) -> Vec<u8> {
     format!("index/{}/{}/", table_name, index_name).into_bytes()
 }
 
-pub fn build_index_key(table_name: &str, index_name: &str, value: Value) -> Vec<u8> {
-    build_index_key_prefix(table_name, index_name)
+pub fn build_index_key(table_name: &str, index_name: &str, value: Value) -> Result<Vec<u8>> {
+    Ok(build_index_key_prefix(table_name, index_name)
         .into_iter()
-        .chain(value.to_be_bytes().into_iter())
-        .collect::<Vec<_>>()
+        .chain(value.to_cmp_be_bytes()?)
+        .collect::<Vec<_>>())
 }

--- a/src/tests/aggregate.rs
+++ b/src/tests/aggregate.rs
@@ -167,7 +167,7 @@ test_case!(group_by, async move {
     }
 
     let error_cases = vec![(
-        ValueError::FloatCannotBeGroupedBy.into(),
+        ValueError::GroupByNotSupported("FLOAT".to_owned()).into(),
         "SELECT * FROM Item GROUP BY ratio;",
     )];
 

--- a/src/tests/alter/create_table.rs
+++ b/src/tests/alter/create_table.rs
@@ -45,6 +45,10 @@ test_case!(create_table, async move {
             Err(TranslateError::UnsupportedDataType("SOMEWHAT".to_owned()).into()),
         ),
         (
+            "CREATE TABLE Gluery (id BYTEA);",
+            Err(TranslateError::UnsupportedDataType("BYTEA".to_owned()).into()),
+        ),
+        (
             "CREATE TABLE Gluery (id INTEGER CHECK (true));",
             Err(TranslateError::UnsupportedColumnOption("CHECK (true)".to_owned()).into()),
         ),

--- a/src/tests/data_type/map.rs
+++ b/src/tests/data_type/map.rs
@@ -1,0 +1,77 @@
+use crate::{EvaluateError, Value::*, *};
+
+test_case!(map, async move {
+    run!(
+        r#"
+CREATE TABLE MapType (
+    id INTEGER,
+    nested MAP
+)"#
+    );
+
+    run!(
+        r#"
+INSERT INTO MapType VALUES
+    (1, '{"a": true, "b": 2}'),
+    (2, '{"a": {"foo": "ok", "b": "steak"}, "b": 30}'),
+    (3, '{"a": {"b": {"c": {"d": 10}}}}');
+"#
+    );
+
+    let m = |s: &str| Map(data::Map::parse_json(s).unwrap());
+    let s = |v: &str| Str(v.to_owned());
+
+    test!(
+        Ok(select_with_null!(
+            id     | nested;
+            I64(1)   m(r#"{"a": true, "b": 2}"#)
+        )),
+        "SELECT id, nested FROM MapType LIMIT 1"
+    );
+
+    test!(
+        Ok(select_with_null!(
+            id     | foo          | good    | good2   | b;
+            I64(1)   Null           Null      Null      Null;
+            I64(2)   s("ok.yeah")   Null      Null      s("steak");
+            I64(3)   Null           I64(10)   I64(20)   m(r#"{"c": { "d": 10 } }"#)
+        )),
+        r#"SELECT
+            id,
+            UNWRAP(nested, "a.foo") || ".yeah" AS foo,
+            UNWRAP(nested, 'a.b.c.d') as good,
+            UNWRAP(nested, 'a.b.c.d') * 2 as good2,
+            UNWRAP(nested, "a.b") as b
+        FROM MapType"#
+    );
+
+    test!(
+        Ok(select_with_null!(id | foo | bar; I64(1) Null Null)),
+        r#"SELECT
+            id,
+            UNWRAP(NULL, "a.b") as foo,
+            UNWRAP(nested, NULL) as bar
+        FROM MapType LIMIT 1"#
+    );
+
+    test!(
+        Err(EvaluateError::FunctionRequiresMapValue("UNWRAP".to_owned()).into()),
+        r#"SELECT UNWRAP(id, "a.b.c") FROM MapType"#
+    );
+    test!(
+        Err(ValueError::GroupByNotSupported("MAP".to_owned()).into()),
+        r#"SELECT id FROM MapType GROUP BY nested"#
+    );
+    test!(
+        Err(MapError::ArrayTypeNotSupported.into()),
+        r#"INSERT INTO MapType VALUES (1, '{ "a": [1, 2, 3] }');"#
+    );
+    test!(
+        Err(MapError::InvalidJsonString.into()),
+        r#"INSERT INTO MapType VALUES (1, '{{ ok [1, 2, 3] }');"#
+    );
+    test!(
+        Err(MapError::ObjectTypeJsonRequired.into()),
+        r#"INSERT INTO MapType VALUES (1, '[1, 2, 3]');"#
+    );
+});

--- a/src/tests/data_type/mod.rs
+++ b/src/tests/data_type/mod.rs
@@ -1,5 +1,6 @@
 pub mod date;
 pub mod interval;
+pub mod map;
 pub mod sql_types;
 pub mod time;
 pub mod timestamp;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -100,6 +100,7 @@ macro_rules! generate_store_tests {
         glue!(timestamp, data_type::timestamp::timestamp);
         glue!(time, data_type::time::time);
         glue!(interval, data_type::interval::interval);
+        glue!(map, data_type::map::map);
         glue!(synthesize, synthesize::synthesize);
         glue!(validate_unique, validate::unique::unique);
         glue!(validate_types, validate::types::types);

--- a/src/translate/data_type.rs
+++ b/src/translate/data_type.rs
@@ -15,6 +15,14 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Time => Ok(DataType::Time),
         SqlDataType::Interval => Ok(DataType::Interval),
         SqlDataType::Uuid => Ok(DataType::UUID),
+        SqlDataType::Custom(name) => {
+            let name = name.0.get(0).map(|v| v.value.to_uppercase());
+
+            match name.as_deref() {
+                Some("MAP") => Ok(DataType::Map),
+                _ => Err(TranslateError::UnsupportedDataType(sql_data_type.to_string()).into()),
+            }
+        }
         _ => Err(TranslateError::UnsupportedDataType(sql_data_type.to_string()).into()),
     }
 }


### PR DESCRIPTION
User can access internal data by `UNWRAP` function.
e.g. `UNWRAP(column, "a.b.c")`
Currently, JSON string is the only accepted type for `INSERT`.