### PR TITLE
Support function `LOG`

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -48,6 +48,8 @@ pub enum Function {
     Exp(Expr),
     #[strum(to_string = "LN")]
     Ln(Expr),
+    #[strum(to_string = "LOG")]
+    Log { antilog: Expr, base: Expr },
     #[strum(to_string = "LOG2")]
     Log2(Expr),
     #[strum(to_string = "LOG10")]

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -435,6 +435,22 @@ async fn evaluate_function<'a, T: 'static + Debug>(
             Nullable::Null => Ok(Value::Null),
         }
         .map(Evaluated::from),
+        Function::Log { antilog, base } => {
+            let antilog = match eval_to_float(antilog).await? {
+                Nullable::Value(v) => v,
+                Nullable::Null => {
+                    return Ok(Evaluated::from(Value::Null));
+                }
+            };
+            let base = match eval_to_float(base).await? {
+                Nullable::Value(v) => v,
+                Nullable::Null => {
+                    return Ok(Evaluated::from(Value::Null));
+                }
+            };
+
+            Ok(Evaluated::from(Value::F64(antilog.log(base))))
+        }
         Function::Log2(expr) => match eval_to_float(expr).await? {
             Nullable::Value(v) => Ok(Value::F64(v.log2())),
             Nullable::Null => Ok(Value::Null),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -83,6 +83,7 @@ macro_rules! generate_store_tests {
         glue!(function_round, function::round::round);
         glue!(function_floor, function::floor::floor);
         glue!(function_ln, function::exp_log::ln);
+        glue!(function_log, function::exp_log::log);
         glue!(function_log2, function::exp_log::log2);
         glue!(function_log10, function::exp_log::log10);
         glue!(function_exp, function::exp_log::exp);

--- a/src/translate/function.rs
+++ b/src/translate/function.rs
@@ -215,6 +215,14 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "FLOOR" => translate_function_one_arg(Function::Floor, args, name),
         "EXP" => translate_function_one_arg(Function::Exp, args, name),
         "LN" => translate_function_one_arg(Function::Ln, args, name),
+        "LOG" => {
+            check_len(name, args.len(), 2)?;
+
+            let antilog = translate_expr(args[0])?;
+            let base = translate_expr(args[1])?;
+
+            Ok(Expr::Function(Box::new(Function::Log { antilog, base })))
+        }
         "LOG2" => translate_function_one_arg(Function::Log2, args, name),
         "LOG10" => translate_function_one_arg(Function::Log10, args, name),
         "SIN" => translate_function_one_arg(Function::Sin, args, name),


### PR DESCRIPTION
# CHANGE Explain

## Implementation
### src/ast/function.rs
Add a enum type `Log`, it requires two args (`antilog` & `base`).
So the function represents fromula like: log<sub>base</sub>antilog.
### src/translate/function.rs
Args count check & `Expr::Function` return. (Actually I copied similiar codes from other two args translation 😳)
### src/executor/evaluate/mod.rs
The realization of `Log` referenced the usage of [f64::log](https://doc.rust-lang.org/std/primitive.f64.html#method.log).

## Tests
Refered tests from other `expr_log`.
‘Type error’ or ‘Null value‘ of either args will cause corresponding error.