### PR TITLE
Fix `UUID` to `Uuid` to follow the naming convention of Enums

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -10,7 +10,7 @@ pub enum DataType {
     Timestamp,
     Time,
     Interval,
-    UUID,
+    Uuid,
     Map,
     List,
 }

--- a/src/data/value/big_edian.rs
+++ b/src/data/value/big_edian.rs
@@ -75,7 +75,7 @@ impl Value {
                     .copied()
                     .collect::<Vec<_>>()
             }
-            Value::UUID(v) => [VALUE]
+            Value::Uuid(v) => [VALUE]
                 .iter()
                 .chain(v.to_be_bytes().iter())
                 .copied()
@@ -208,8 +208,8 @@ mod tests {
         assert_eq!(cmp(&n3, &n4), Ordering::Greater);
         assert_eq!(cmp(&n1, &null), Ordering::Less);
 
-        let n1 = UUID(100).to_cmp_be_bytes().unwrap();
-        let n2 = UUID(101).to_cmp_be_bytes().unwrap();
+        let n1 = Uuid(100).to_cmp_be_bytes().unwrap();
+        let n2 = Uuid(101).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n1, &n1), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -21,7 +21,7 @@ impl TryInto<GroupKey> for Value {
             Timestamp(v) => Ok(GroupKey::Timestamp(v)),
             Time(v) => Ok(GroupKey::Time(v)),
             Interval(v) => Ok(GroupKey::Interval(v)),
-            UUID(v) => Ok(GroupKey::UUID(v)),
+            Uuid(v) => Ok(GroupKey::Uuid(v)),
             Null => Ok(GroupKey::None),
             F64(_) => Err(ValueError::GroupByNotSupported("FLOAT".to_owned()).into()),
             Map(_) => Err(ValueError::GroupByNotSupported("MAP".to_owned()).into()),

--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -20,7 +20,7 @@ impl From<&Value> for String {
             Value::Timestamp(value) => value.to_string(),
             Value::Time(value) => value.to_string(),
             Value::Interval(value) => String::from(value),
-            Value::UUID(value) => Uuid::from_u128(*value).to_string(),
+            Value::Uuid(value) => Uuid::from_u128(*value).to_string(),
             Value::Map(_) => "[MAP]".to_owned(),
             Value::List(_) => "[LIST]".to_owned(),
             Value::Null => String::from("NULL"),
@@ -66,7 +66,7 @@ impl TryInto<bool> for &Value {
             | Value::Timestamp(_)
             | Value::Time(_)
             | Value::Interval(_)
-            | Value::UUID(_)
+            | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
@@ -103,7 +103,7 @@ impl TryInto<i64> for &Value {
             | Value::Timestamp(_)
             | Value::Time(_)
             | Value::Interval(_)
-            | Value::UUID(_)
+            | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
@@ -140,7 +140,7 @@ impl TryInto<f64> for &Value {
             | Value::Timestamp(_)
             | Value::Time(_)
             | Value::Interval(_)
-            | Value::UUID(_)
+            | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
@@ -188,7 +188,7 @@ impl TryInto<u128> for &Value {
 
     fn try_into(self) -> Result<u128> {
         match self {
-            Value::UUID(value) => Ok(*value),
+            Value::Uuid(value) => Ok(*value),
             _ => Err(ValueError::ImpossibleCast.into()),
         }
     }

--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -42,7 +42,7 @@ impl PartialEq<Literal<'_>> for Value {
                 Err(_) => false,
             },
             (Value::Interval(l), Literal::Interval(r)) => l == r,
-            (Value::UUID(l), Literal::Text(r)) => parse_uuid(r).map(|r| l == &r).unwrap_or(false),
+            (Value::Uuid(l), Literal::Text(r)) => parse_uuid(r).map(|r| l == &r).unwrap_or(false),
             _ => false,
         }
     }
@@ -79,7 +79,7 @@ impl PartialOrd<Literal<'_>> for Value {
                 Err(_) => None,
             },
             (Value::Interval(l), Literal::Interval(r)) => l.partial_cmp(r),
-            (Value::UUID(l), Literal::Text(r)) => {
+            (Value::Uuid(l), Literal::Text(r)) => {
                 parse_uuid(r).map(|r| l.partial_cmp(&r)).unwrap_or(None)
             }
             _ => None,
@@ -145,7 +145,7 @@ impl Value {
                 .map(Value::Time)
                 .map_err(|_| ValueError::FailedToParseTime(v.to_string()).into()),
             (DataType::Interval, Literal::Interval(v)) => Ok(Value::Interval(*v)),
-            (DataType::UUID, Literal::Text(v)) => parse_uuid(v).map(Value::UUID),
+            (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Map, Literal::Text(v)) => Value::parse_json_map(v),
             (DataType::List, Literal::Text(v)) => Value::parse_json_list(v),
             (_, Literal::Null) => Ok(Value::Null),
@@ -202,7 +202,7 @@ impl Value {
             (DataType::Interval, Literal::Text(v)) => {
                 Interval::try_from(v.as_str()).map(Value::Interval)
             }
-            (DataType::UUID, Literal::Text(v)) => parse_uuid(v).map(Value::UUID),
+            (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Boolean, Literal::Null)
             | (DataType::Int, Literal::Null)
             | (DataType::Float, Literal::Null)

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -28,7 +28,7 @@ pub enum Value {
     Timestamp(NaiveDateTime),
     Time(NaiveTime),
     Interval(Interval),
-    UUID(u128),
+    Uuid(u128),
     Map(HashMap<String, Value>),
     List(Vec<Value>),
     Null,
@@ -49,7 +49,7 @@ impl PartialEq<Value> for Value {
             (Value::Timestamp(l), Value::Timestamp(r)) => l == r,
             (Value::Time(l), Value::Time(r)) => l == r,
             (Value::Interval(l), Value::Interval(r)) => l == r,
-            (Value::UUID(l), Value::UUID(r)) => l == r,
+            (Value::Uuid(l), Value::Uuid(r)) => l == r,
             (Value::Map(l), Value::Map(r)) => l == r,
             (Value::List(l), Value::List(r)) => l == r,
             _ => false,
@@ -72,7 +72,7 @@ impl PartialOrd<Value> for Value {
             (Value::Timestamp(l), Value::Timestamp(r)) => Some(l.cmp(r)),
             (Value::Time(l), Value::Time(r)) => Some(l.cmp(r)),
             (Value::Interval(l), Value::Interval(r)) => l.partial_cmp(r),
-            (Value::UUID(l), Value::UUID(r)) => Some(l.cmp(r)),
+            (Value::Uuid(l), Value::Uuid(r)) => Some(l.cmp(r)),
             _ => None,
         }
     }
@@ -89,7 +89,7 @@ impl Value {
             Value::Timestamp(_) => matches!(data_type, DataType::Timestamp),
             Value::Time(_) => matches!(data_type, DataType::Time),
             Value::Interval(_) => matches!(data_type, DataType::Interval),
-            Value::UUID(_) => matches!(data_type, DataType::UUID),
+            Value::Uuid(_) => matches!(data_type, DataType::Uuid),
             Value::Map(_) => matches!(data_type, DataType::Map),
             Value::List(_) => matches!(data_type, DataType::List),
             Value::Null => true,
@@ -124,7 +124,7 @@ impl Value {
             | (DataType::Timestamp, Value::Timestamp(_))
             | (DataType::Time, Value::Time(_))
             | (DataType::Interval, Value::Interval(_))
-            | (DataType::UUID, Value::UUID(_)) => Ok(self.clone()),
+            | (DataType::Uuid, Value::Uuid(_)) => Ok(self.clone()),
 
             (_, Value::Null) => Ok(Value::Null),
 
@@ -135,7 +135,7 @@ impl Value {
             (DataType::Date, value) => value.try_into().map(Value::Date),
             (DataType::Timestamp, value) => value.try_into().map(Value::Timestamp),
             (DataType::Interval, value) => value.try_into().map(Value::Interval),
-            (DataType::UUID, value) => value.try_into().map(Value::UUID),
+            (DataType::Uuid, value) => value.try_into().map(Value::Uuid),
 
             _ => Err(ValueError::UnimplementedCast.into()),
         }
@@ -356,12 +356,12 @@ mod tests {
         assert_eq!(timestamp, date);
 
         assert_eq!(
-            UUID(
+            Uuid(
                 Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8")
                     .unwrap()
                     .as_u128()
             ),
-            UUID(
+            Uuid(
                 Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8")
                     .unwrap()
                     .as_u128()
@@ -593,7 +593,7 @@ mod tests {
         cast!(Str("a".to_owned())   => Text         , Str("a".to_owned()));
         cast!(I64(1)                => Int          , I64(1));
         cast!(F64(1.0)              => Float        , F64(1.0));
-        cast!(Value::UUID(123)      => UUID         , Value::UUID(123));
+        cast!(Value::Uuid(123)      => Uuid         , Value::Uuid(123));
 
         // Boolean
         cast!(Str("TRUE".to_owned())    => Boolean, Bool(true));
@@ -670,7 +670,7 @@ mod tests {
         let timestamp = Timestamp(NaiveDate::from_ymd(2021, 5, 1).and_hms(12, 34, 50));
         let time = Time(NaiveTime::from_hms(12, 30, 11));
         let interval = Interval(I::hours(5));
-        let uuid = UUID(
+        let uuid = Uuid(
             Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8")
                 .unwrap()
                 .as_u128(),
@@ -694,7 +694,7 @@ mod tests {
         assert!(time.validate_type(&D::Date).is_err());
         assert!(interval.validate_type(&D::Interval).is_ok());
         assert!(interval.validate_type(&D::Date).is_err());
-        assert!(uuid.validate_type(&D::UUID).is_ok());
+        assert!(uuid.validate_type(&D::Uuid).is_ok());
         assert!(uuid.validate_type(&D::Boolean).is_err());
         assert!(map.validate_type(&D::Map).is_ok());
         assert!(map.validate_type(&D::Int).is_err());

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -25,7 +25,7 @@ impl TryInto<Option<UniqueKey>> for &Value {
             Timestamp(v) => Some(UniqueKey::Timestamp(*v)),
             Time(v) => Some(UniqueKey::Time(*v)),
             Interval(v) => Some(UniqueKey::Interval(*v)),
-            UUID(v) => Some(UniqueKey::UUID(*v)),
+            Uuid(v) => Some(UniqueKey::Uuid(*v)),
             Null => None,
             F64(_) => return conflict("FLOAT"),
             Map(_) => return conflict("MAP"),

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -20,7 +20,7 @@ pub enum GroupKey {
     Timestamp(NaiveDateTime),
     Time(NaiveTime),
     Interval(Interval),
-    UUID(u128),
+    Uuid(u128),
     None,
 }
 

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -36,7 +36,7 @@ pub enum UniqueKey {
     Timestamp(NaiveDateTime),
     Time(NaiveTime),
     Interval(Interval),
-    UUID(u128),
+    Uuid(u128),
 }
 
 #[derive(Debug)]

--- a/src/tests/data_type/uuid.rs
+++ b/src/tests/data_type/uuid.rs
@@ -1,4 +1,4 @@
-use {crate::*, ast::DataType, std::borrow::Cow, uuid::Uuid};
+use {crate::*, ast::DataType, std::borrow::Cow, uuid::Uuid as UUID};
 
 test_case!(uuid, async move {
     use Value::*;
@@ -8,7 +8,7 @@ test_case!(uuid, async move {
         (
             r#"INSERT INTO UUID VALUES (0)"#,
             Err(ValueError::IncompatibleLiteralForDataType {
-                data_type: DataType::UUID,
+                data_type: DataType::Uuid,
                 literal: format!("{:?}", Literal::Number(Cow::Owned("0".to_owned()))),
             }
             .into()),
@@ -32,10 +32,10 @@ test_case!(uuid, async move {
             r#"SELECT uuid_field AS uuid_field FROM UUID;"#,
             Ok(select!(
                 uuid_field
-                UUID;
-                Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap().as_u128();
-                Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap().as_u128();
-                Uuid::parse_str("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap().as_u128()
+                Uuid;
+                UUID::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap().as_u128();
+                UUID::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap().as_u128();
+                UUID::parse_str("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap().as_u128()
             )),
         ),
         (
@@ -46,9 +46,9 @@ test_case!(uuid, async move {
             r#"SELECT uuid_field AS uuid_field, COUNT(*) FROM UUID GROUP BY uuid_field"#,
             Ok(select!(
                 uuid_field | "COUNT(*)"
-                UUID | I64;
-                Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap().as_u128()  1;
-                Uuid::parse_str("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap().as_u128()  2
+                Uuid | I64;
+                UUID::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap().as_u128()  1;
+                UUID::parse_str("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap().as_u128()  2
             )),
         ),
         (

--- a/src/translate/data_type.rs
+++ b/src/translate/data_type.rs
@@ -14,7 +14,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Timestamp => Ok(DataType::Timestamp),
         SqlDataType::Time => Ok(DataType::Time),
         SqlDataType::Interval => Ok(DataType::Interval),
-        SqlDataType::Uuid => Ok(DataType::UUID),
+        SqlDataType::Uuid => Ok(DataType::Uuid),
         SqlDataType::Custom(name) => {
             let name = name.0.get(0).map(|v| v.value.to_uppercase());
 


### PR DESCRIPTION
Current version of clippy will catch the name `UUID`, which should be corrected as `Uuid` by naming conventions of `Enum`s. 
So I fixed it.
