### PR TITLE
Remove explicit uses of TryFrom & TryInto,

### DIFF
--- a/src/data/interval/string.rs
+++ b/src/data/interval/string.rs
@@ -6,7 +6,6 @@ use {
         result::{Error, Result},
         translate::translate_expr,
     },
-    std::convert::TryFrom,
 };
 
 impl TryFrom<&str> for Interval {
@@ -148,7 +147,7 @@ impl From<Interval> for String {
 
 #[cfg(test)]
 mod tests {
-    use {super::Interval, std::convert::TryFrom};
+    use super::Interval;
 
     #[test]
     fn into_string() {

--- a/src/data/literal.rs
+++ b/src/data/literal.rs
@@ -5,7 +5,7 @@ use {
         result::{Error, Result},
     },
     serde::Serialize,
-    std::{borrow::Cow, cmp::Ordering, convert::TryFrom, fmt::Debug},
+    std::{borrow::Cow, cmp::Ordering, fmt::Debug},
     thiserror::Error,
     Literal::*,
 };

--- a/src/data/value/group_key.rs
+++ b/src/data/value/group_key.rs
@@ -4,7 +4,6 @@ use {
         executor::GroupKey,
         result::{Error, Result},
     },
-    std::convert::TryInto,
 };
 
 impl TryInto<GroupKey> for Value {

--- a/src/data/value/into.rs
+++ b/src/data/value/into.rs
@@ -8,7 +8,6 @@ use {
         result::{Error, Result},
     },
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
-    std::convert::{TryFrom, TryInto},
     uuid::Uuid,
 };
 

--- a/src/data/value/literal.rs
+++ b/src/data/value/literal.rs
@@ -10,7 +10,7 @@ use {
         result::{Error, Result},
     },
     chrono::NaiveDate,
-    std::{cmp::Ordering, convert::TryFrom},
+    std::cmp::Ordering,
 };
 
 impl PartialEq<Literal<'_>> for Value {

--- a/src/data/value/mod.rs
+++ b/src/data/value/mod.rs
@@ -4,7 +4,7 @@ use {
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
     core::ops::Sub,
     serde::{Deserialize, Serialize},
-    std::{cmp::Ordering, collections::HashMap, convert::TryInto, fmt::Debug},
+    std::{cmp::Ordering, collections::HashMap, fmt::Debug},
 };
 
 mod big_edian;

--- a/src/data/value/unique_key.rs
+++ b/src/data/value/unique_key.rs
@@ -4,7 +4,6 @@ use {
         executor::UniqueKey,
         result::{Error, Result},
     },
-    std::convert::TryInto,
 };
 
 impl TryInto<Option<UniqueKey>> for &Value {

--- a/src/executor/aggregate/hash.rs
+++ b/src/executor/aggregate/hash.rs
@@ -5,10 +5,7 @@ use {
         result::{Error, Result},
     },
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
-    std::{
-        convert::{TryFrom, TryInto},
-        fmt::Debug,
-    },
+    std::fmt::Debug,
 };
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]

--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -16,7 +16,7 @@ use {
         store::GStore,
     },
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
-    std::{convert::TryFrom, fmt::Debug, pin::Pin, rc::Rc},
+    std::{fmt::Debug, pin::Pin, rc::Rc},
 };
 
 pub use {error::AggregateError, hash::GroupKey};

--- a/src/executor/evaluate/evaluated.rs
+++ b/src/executor/evaluate/evaluated.rs
@@ -5,11 +5,7 @@ use {
         data::{Literal, Value},
         result::{Error, Result},
     },
-    std::{
-        borrow::Cow,
-        cmp::Ordering,
-        convert::{TryFrom, TryInto},
-    },
+    std::{borrow::Cow, cmp::Ordering},
 };
 
 #[derive(Clone)]

--- a/src/executor/evaluate/expr.rs
+++ b/src/executor/evaluate/expr.rs
@@ -5,10 +5,7 @@ use {
         data::{Literal, Value},
         result::Result,
     },
-    std::{
-        borrow::Cow,
-        convert::{TryFrom, TryInto},
-    },
+    std::borrow::Cow,
 };
 
 pub fn literal(ast_literal: &AstLiteral) -> Result<Evaluated<'_>> {

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -20,7 +20,6 @@ use {
     std::{
         borrow::Cow,
         cmp::{max, min},
-        convert::{TryFrom, TryInto},
         fmt::Debug,
         rc::Rc,
     },

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -10,7 +10,7 @@ use {
         store::GStore,
     },
     im_rc::HashMap,
-    std::{convert::TryInto, fmt::Debug, rc::Rc},
+    std::{fmt::Debug, rc::Rc},
 };
 
 pub struct Filter<'a, T: 'static + Debug> {

--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -6,7 +6,7 @@ use {
         result::Result,
     },
     futures::stream::{Stream, StreamExt},
-    std::{convert::TryInto, pin::Pin},
+    std::pin::Pin,
 };
 
 pub struct Limit {

--- a/src/executor/select/blend.rs
+++ b/src/executor/select/blend.rs
@@ -12,7 +12,6 @@ use {
     },
     futures::stream::{self, StreamExt, TryStreamExt},
     im_rc::HashMap,
-    std::convert::TryInto,
     std::{fmt::Debug, rc::Rc},
 };
 

--- a/src/executor/select/mod.rs
+++ b/src/executor/select/mod.rs
@@ -26,7 +26,7 @@ use {
 };
 
 #[cfg(feature = "index")]
-use {super::evaluate::evaluate, crate::ast::IndexItem, std::convert::TryInto};
+use {super::evaluate::evaluate, crate::ast::IndexItem};
 
 async fn fetch_blended<'a, T: 'static + Debug>(
     storage: &dyn GStore<T>,

--- a/src/executor/sort.rs
+++ b/src/executor/sort.rs
@@ -12,7 +12,7 @@ use {
     },
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
     im_rc::HashMap,
-    std::{cmp::Ordering, convert::TryInto, fmt::Debug, pin::Pin, rc::Rc},
+    std::{cmp::Ordering, fmt::Debug, pin::Pin, rc::Rc},
 };
 
 pub struct Sort<'a, T: 'static + Debug> {

--- a/src/executor/validate.rs
+++ b/src/executor/validate.rs
@@ -9,7 +9,7 @@ use {
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
     im_rc::HashSet,
     serde::Serialize,
-    std::{convert::TryInto, fmt::Debug, rc::Rc},
+    std::{fmt::Debug, rc::Rc},
     thiserror::Error as ThisError,
 };
 

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -140,7 +140,6 @@ mod tests {
     #[test]
     fn sled_basic() {
         use crate::sled_storage::SledStorage;
-        use std::convert::TryFrom;
 
         let config = sled::Config::default()
             .path("data/using_config")

--- a/src/storages/sled_storage/index_sync.rs
+++ b/src/storages/sled_storage/index_sync.rs
@@ -13,7 +13,7 @@ use {
         },
         IVec,
     },
-    std::{borrow::Cow, convert::TryInto},
+    std::borrow::Cow,
 };
 
 pub struct IndexSync<'a> {

--- a/src/storages/sled_storage/mod.rs
+++ b/src/storages/sled_storage/mod.rs
@@ -26,7 +26,6 @@ use {
         },
         Config, Db, IVec,
     },
-    std::convert::TryFrom,
 };
 
 /// default transaction timeout : 1 hour

--- a/tests/sled_storage.rs
+++ b/tests/sled_storage.rs
@@ -2,7 +2,7 @@
 
 use {
     cfg_if::cfg_if,
-    std::{cell::RefCell, convert::TryFrom, rc::Rc},
+    std::{cell::RefCell, rc::Rc},
 };
 
 use gluesql::{sled::IVec, sled_storage::SledStorage, tests::*, *};


### PR DESCRIPTION
From v1.56, TryFrom & TryInto are provided by prelude so it is not required to import explicitly.