### PR TITLE
Remove `'static` lifetime of generic types for `GStore`

### DIFF
--- a/src/executor/aggregate/mod.rs
+++ b/src/executor/aggregate/mod.rs
@@ -21,7 +21,7 @@ use {
 
 pub use {error::AggregateError, hash::GroupKey};
 
-pub struct Aggregator<'a, T: 'static + Debug> {
+pub struct Aggregator<'a, T: Debug> {
     storage: &'a dyn GStore<T>,
     fields: &'a [SelectItem],
     group_by: &'a [Expr],
@@ -32,7 +32,7 @@ pub struct Aggregator<'a, T: 'static + Debug> {
 type Applied<'a> = dyn TryStream<Ok = AggregateContext<'a>, Error = Error, Item = Result<AggregateContext<'a>>>
     + 'a;
 
-impl<'a, T: 'static + Debug> Aggregator<'a, T> {
+impl<'a, T: Debug> Aggregator<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         fields: &'a [SelectItem],

--- a/src/executor/evaluate/mod.rs
+++ b/src/executor/evaluate/mod.rs
@@ -29,7 +29,7 @@ use {
 pub use {error::EvaluateError, evaluated::Evaluated, stateless::evaluate_stateless};
 
 #[async_recursion(?Send)]
-pub async fn evaluate<'a, T: 'static + Debug>(
+pub async fn evaluate<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
@@ -196,7 +196,7 @@ pub async fn evaluate<'a, T: 'static + Debug>(
     }
 }
 
-async fn evaluate_function<'a, T: 'static + Debug>(
+async fn evaluate_function<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,

--- a/src/executor/fetch.rs
+++ b/src/executor/fetch.rs
@@ -18,7 +18,7 @@ pub enum FetchError {
     TableNotFound(String),
 }
 
-pub async fn fetch_columns<T: 'static + Debug>(
+pub async fn fetch_columns<T: Debug>(
     storage: &dyn GStore<T>,
     table_name: &str,
 ) -> Result<Vec<String>> {
@@ -32,7 +32,7 @@ pub async fn fetch_columns<T: 'static + Debug>(
         .collect::<Vec<String>>())
 }
 
-pub async fn fetch<'a, T: 'static + Debug>(
+pub async fn fetch<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     table_name: &'a str,
     columns: Rc<[String]>,

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -13,14 +13,14 @@ use {
     std::{fmt::Debug, rc::Rc},
 };
 
-pub struct Filter<'a, T: 'static + Debug> {
+pub struct Filter<'a, T: Debug> {
     storage: &'a dyn GStore<T>,
     where_clause: Option<&'a Expr>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
 }
 
-impl<'a, T: 'static + Debug> Filter<'a, T> {
+impl<'a, T: Debug> Filter<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         where_clause: Option<&'a Expr>,
@@ -50,7 +50,7 @@ impl<'a, T: 'static + Debug> Filter<'a, T> {
     }
 }
 
-pub async fn check_expr<'a, T: 'static + Debug>(
+pub async fn check_expr<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,

--- a/src/executor/join.rs
+++ b/src/executor/join.rs
@@ -14,7 +14,7 @@ use {
     std::{fmt::Debug, pin::Pin, rc::Rc},
 };
 
-pub struct Join<'a, T: 'static + Debug> {
+pub struct Join<'a, T: Debug> {
     storage: &'a dyn GStore<T>,
     join_clauses: &'a [AstJoin],
     filter_context: Option<Rc<FilterContext<'a>>>,
@@ -24,7 +24,7 @@ type JoinItem<'a> = Rc<BlendContext<'a>>;
 type Joined<'a> =
     Pin<Box<dyn TryStream<Ok = JoinItem<'a>, Error = Error, Item = Result<JoinItem<'a>>> + 'a>>;
 
-impl<'a, T: 'static + Debug> Join<'a, T> {
+impl<'a, T: Debug> Join<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         join_clauses: &'a [AstJoin],
@@ -81,7 +81,7 @@ impl<'a, T: 'static + Debug> Join<'a, T> {
     }
 }
 
-async fn join<'a, T: 'static + Debug>(
+async fn join<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     ast_join: &'a AstJoin,
@@ -131,7 +131,7 @@ async fn join<'a, T: 'static + Debug>(
     }
 }
 
-async fn fetch_joined<'a, T: 'static + Debug>(
+async fn fetch_joined<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     table_name: &'a str,
     table_alias: &'a str,

--- a/src/executor/select/blend.rs
+++ b/src/executor/select/blend.rs
@@ -15,13 +15,13 @@ use {
     std::{fmt::Debug, rc::Rc},
 };
 
-pub struct Blend<'a, T: 'static + Debug> {
+pub struct Blend<'a, T: Debug> {
     storage: &'a dyn GStore<T>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     fields: &'a [SelectItem],
 }
 
-impl<'a, T: 'static + Debug> Blend<'a, T> {
+impl<'a, T: Debug> Blend<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         filter_context: Option<Rc<FilterContext<'a>>>,

--- a/src/executor/select/mod.rs
+++ b/src/executor/select/mod.rs
@@ -28,8 +28,8 @@ use {
 #[cfg(feature = "index")]
 use {super::evaluate::evaluate, crate::ast::IndexItem};
 
-async fn fetch_blended<'a, T: 'static + Debug>(
-    storage: &dyn GStore<T>,
+async fn fetch_blended<'a, T: Debug>(
+    storage: &'a dyn GStore<T>,
     table: Table<'a>,
     columns: Rc<[String]>,
 ) -> Result<impl Stream<Item = Result<BlendContext<'a>>> + 'a> {
@@ -145,7 +145,7 @@ fn get_labels<'a>(
         .collect::<Result<_>>()
 }
 
-pub async fn select_with_labels<'a, T: 'static + Debug>(
+pub async fn select_with_labels<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     query: &'a Query,
     filter_context: Option<Rc<FilterContext<'a>>>,
@@ -267,7 +267,7 @@ pub async fn select_with_labels<'a, T: 'static + Debug>(
     Ok((labels, rows))
 }
 
-pub async fn select<'a, T: 'static + Debug>(
+pub async fn select<'a, T: Debug>(
     storage: &'a dyn GStore<T>,
     query: &'a Query,
     filter_context: Option<Rc<FilterContext<'a>>>,

--- a/src/executor/sort.rs
+++ b/src/executor/sort.rs
@@ -15,7 +15,7 @@ use {
     std::{cmp::Ordering, fmt::Debug, pin::Pin, rc::Rc},
 };
 
-pub struct Sort<'a, T: 'static + Debug> {
+pub struct Sort<'a, T: Debug> {
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     order_by: &'a [OrderByExpr],
@@ -26,7 +26,7 @@ type Item<'a> = Result<(
     Rc<BlendContext<'a>>,
 )>;
 
-impl<'a, T: 'static + Debug> Sort<'a, T> {
+impl<'a, T: Debug> Sort<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         context: Option<Rc<FilterContext<'a>>>,


### PR DESCRIPTION
### How does `'static` lifetime work?

Ref: <https://www.reddit.com/r/rust/comments/8rhmj8/comment/e0rr3y1/?utm_source=share&utm_medium=web2x&context=3>

---

### We were using it like this:

- in related `Store` generic type
- generic type means: Indicates the type of Row in `RowIter`


### So do we need a `'static` lifetime?

Well... I don't think it's necessary.
If there is another reason for using it, please let me know in the comments.