### PR TITLE
Move `order_by` from query to select

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -6,7 +6,6 @@ use {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Query {
     pub body: SetExpr,
-    pub order_by: Vec<OrderByExpr>,
     pub limit: Option<Expr>,
     pub offset: Option<Expr>,
 }
@@ -25,6 +24,7 @@ pub struct Select {
     pub selection: Option<Expr>,
     pub group_by: Vec<Expr>,
     pub having: Option<Expr>,
+    pub order_by: Vec<OrderByExpr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -177,7 +177,6 @@ pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
                     SetExpr::Select(select_query) => {
                         let query = || Query {
                             body: SetExpr::Select(select_query.clone()),
-                            order_by: vec![],
                             limit: None,
                             offset: None,
                         };

--- a/src/executor/select/mod.rs
+++ b/src/executor/select/mod.rs
@@ -164,6 +164,7 @@ pub async fn select_with_labels<'a, T: Debug>(
         projection,
         group_by,
         having,
+        order_by,
     } = match &query.body {
         SetExpr::Select(statement) => statement.as_ref(),
         _ => {
@@ -231,7 +232,7 @@ pub async fn select_with_labels<'a, T: Debug>(
         None,
     ));
     let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-    let sort = Sort::new(storage, filter_context, &query.order_by);
+    let sort = Sort::new(storage, filter_context, order_by);
 
     let rows = fetch_blended(storage, table, columns)
         .await?

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -7,6 +7,7 @@ use {
         data::{get_name, Schema, SchemaIndex, SchemaIndexOrd},
         result::Result,
         store::Store,
+        utils::Vector,
     },
     async_recursion::async_recursion,
     std::fmt::Debug,
@@ -121,7 +122,7 @@ async fn plan_query<T: Debug>(storage: &dyn Store<T>, query: Query) -> Result<Qu
                 selection,
                 group_by,
                 having,
-                order_by,
+                order_by: Vector::from(order_by).pop().0.into(),
             };
 
             Ok(Query {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -86,8 +86,7 @@ async fn plan_query<T: Debug>(storage: &dyn Store<T>, query: Query) -> Result<Qu
         }
     };
 
-    let Select { order_by, .. } = select.as_ref();
-    let index = order_by.last().and_then(|value_expr| {
+    let index = select.order_by.last().and_then(|value_expr| {
         indexes.find_ordered(value_expr).map(|name| IndexItem {
             name,
             asc: value_expr.asc,

--- a/src/translate/query.rs
+++ b/src/translate/query.rs
@@ -42,7 +42,7 @@ pub fn translate_query(sql_query: &SqlQuery) -> Result<Query> {
     })
 }
 
-fn translate_set_expr(sql_set_expr: &SqlSetExpr, order_by: &Vec<OrderByExpr>) -> Result<SetExpr> {
+fn translate_set_expr(sql_set_expr: &SqlSetExpr, order_by: &[OrderByExpr]) -> Result<SetExpr> {
     match sql_set_expr {
         SqlSetExpr::Select(select) => translate_select(select, order_by)
             .map(Box::new)
@@ -58,7 +58,7 @@ fn translate_set_expr(sql_set_expr: &SqlSetExpr, order_by: &Vec<OrderByExpr>) ->
     }
 }
 
-fn translate_select(sql_select: &SqlSelect, order_by: &Vec<OrderByExpr>) -> Result<Select> {
+fn translate_select(sql_select: &SqlSelect, order_by: &[OrderByExpr]) -> Result<Select> {
     let order_by = order_by
         .iter()
         .map(translate_order_by_expr)
@@ -89,7 +89,7 @@ fn translate_select(sql_select: &SqlSelect, order_by: &Vec<OrderByExpr>) -> Resu
         selection: selection.as_ref().map(translate_expr).transpose()?,
         group_by: group_by.iter().map(translate_expr).collect::<Result<_>>()?,
         having: having.as_ref().map(translate_expr).transpose()?,
-        order_by: order_by,
+        order_by,
     })
 }
 


### PR DESCRIPTION
To implement #417 , #418 
We decided to move `order_by` from `Query` to `Select` first. 

At sqlparser::ast::query, `order_by` is on `Query`,
but from now, our translated gluesql::ast::query will consider `order_by` as on `Select`.