### PR TITLE
Refactor `Values` clause from `execute` to `select`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -8,6 +8,7 @@ pub struct Query {
     pub body: SetExpr,
     pub limit: Option<Expr>,
     pub offset: Option<Expr>,
+    // pub order_by: Vec<OrderByExpr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -35,7 +35,7 @@ pub enum Payload {
     Create,
     Insert(usize),
     Select {
-        labels: Vec<String>,
+        labels: Option<Vec<String>>,
         rows: Vec<Vec<Value>>,
     },
     Delete(usize),

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -108,7 +108,11 @@ mod tests {
         assert_eq!(
             glue.execute("SELECT id, name, is FROM api_test"),
             Ok(Payload::Select {
-                labels: vec![String::from("id"), String::from("name"), String::from("is")],
+                labels: Some(vec![
+                    String::from("id"),
+                    String::from("name"),
+                    String::from("is")
+                ]),
                 rows: vec![
                     vec![
                         Value::I64(1),

--- a/src/tests/index/basic.rs
+++ b/src/tests/index/basic.rs
@@ -188,7 +188,7 @@ CREATE TABLE Test (
 
     test_idx!(
         Ok(Payload::Select {
-            labels: vec!["id".to_owned(), "num".to_owned(), "name".to_owned()],
+            labels: Some(vec!["id".to_owned(), "num".to_owned(), "name".to_owned()]),
             rows: vec![]
         }),
         idx!(idx_id2, Eq, "10"),
@@ -265,7 +265,7 @@ CREATE TABLE Test (
 
     test_idx!(
         Ok(Payload::Select {
-            labels: vec!["id".to_owned()],
+            labels: Some(vec!["id".to_owned()]),
             rows: vec![],
         }),
         idx!(),

--- a/src/tests/index/null.rs
+++ b/src/tests/index/null.rs
@@ -112,7 +112,7 @@ CREATE TABLE NullIdx (
 
     test_idx!(
         Ok(Payload::Select {
-            labels: vec!["id".to_owned(), "date".to_owned(), "flag".to_owned()],
+            labels: Some(vec!["id".to_owned(), "date".to_owned(), "flag".to_owned()]),
             rows: vec![],
         }),
         idx!(),

--- a/src/tests/limit.rs
+++ b/src/tests/limit.rs
@@ -29,7 +29,7 @@ test_case!(limit, async move {
         (
             "SELECT * FROM Test OFFSET 10;",
             Payload::Select {
-                labels: vec!["id".to_owned()],
+                labels: Some(vec!["id".to_owned()]),
                 rows: vec![],
             },
         ),

--- a/src/tests/macros.rs
+++ b/src/tests/macros.rs
@@ -51,19 +51,19 @@ macro_rules! select {
         ];
 
         executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: Some(vec![$( stringify!($c).to_owned().replace("\"", "")),+]),
             rows: concat_with!(rows ; $( $t )+ ; $( $( $v2 )+ );+)
         }
     });
     ( $( $c: tt )|+ $( ; )? $( $t: path )|+ ; $( $v: expr )+ ) => (
         executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: Some(vec![$( stringify!($c).to_owned().replace("\"", "")),+]),
             rows: vec![row!($( $t )+ ; $( $v )+ )],
         }
     );
     ( $( $c: tt )|+ $( ; )?) => (
         executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: Some(vec![$( stringify!($c).to_owned().replace("\"", "")),+]),
             rows: vec![],
         }
     );
@@ -87,7 +87,7 @@ macro_rules! concat_with {
 macro_rules! select_with_null {
     ( $( $c: tt )|* ; $( $v: expr )* ) => (
         executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: Some(vec![$( stringify!($c).to_owned().replace("\"", "")),+]),
             rows: vec![vec![$( $v ),*]],
         }
     );
@@ -97,7 +97,7 @@ macro_rules! select_with_null {
         ];
 
         executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: Some(vec![$( stringify!($c).to_owned().replace("\"", "")),+]),
             rows: concat_with_null!(rows ; $( $( $v2 )* );*),
         }
     });

--- a/tests/sled_transaction.rs
+++ b/tests/sled_transaction.rs
@@ -201,7 +201,7 @@ fn sled_transaction_data_mut() {
     test!(
         glue1 "SELECT * FROM Sample;",
         Ok(Payload::Select {
-            labels: vec!["id".to_owned()],
+            labels: Some(vec!["id".to_owned()]),
             rows: vec![],
         })
     );


### PR DESCRIPTION
~~# 🚧 Draft PR yet~~
~~## To implement #417,  move `Values` clause from executor/execute.rs to select/mod.rs~~
~~- [ ] diverge select_with_labels~~
~~- [x] select_inner (temporary name)~~
~~- [ ] select_values (temporary name)~~
~~- ⏳ return type has error~~
~~- [ ] rename each functions~~
## #454 will cover this PR