### PR TITLE
Add `Metadata` optional store trait,

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 all-features = true
 
 [features]
-default = ["sled-storage", "memory-storage", "alter-table", "sorter"]
+default = ["sled-storage", "memory-storage", "alter-table", "metadata", "sorter"]
 
 # optional: ALTER TABLE
 # you can include whether ALTER TABLE support or not for your custom database implementation.
@@ -31,6 +31,10 @@ index = []
 
 # optional: TRANSACTION
 transaction = []
+
+# optional: METADATA
+# e.g. SHOW TABLES;
+metadata = []
 
 # optional: ORDER BY for non-indexed expressions
 # disable this feature if you use GlueSQL for big data analysis.

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -93,10 +93,20 @@ pub enum Statement {
     /// ROLLBACK
     #[cfg(feature = "transaction")]
     Rollback,
+    /// SHOW VARIABLE
+    #[cfg(feature = "metadata")]
+    ShowVariable(Variable),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Assignment {
     pub id: String,
     pub value: Expr,
+}
+
+#[cfg(feature = "metadata")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Variable {
+    Tables,
+    Version,
 }

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -24,6 +24,9 @@ use super::alter::alter_table;
 #[cfg(feature = "index")]
 use super::alter::{create_index, drop_index};
 
+#[cfg(feature = "metadata")]
+use crate::{ast::Variable, result::TrySelf};
+
 #[derive(ThisError, Serialize, Debug, PartialEq)]
 pub enum ExecuteError {
     #[error("table not found: {0}")]
@@ -57,6 +60,16 @@ pub enum Payload {
     Commit,
     #[cfg(feature = "transaction")]
     Rollback,
+
+    #[cfg(feature = "metadata")]
+    ShowVariable(PayloadVariable),
+}
+
+#[cfg(feature = "metadata")]
+#[derive(Serialize, Debug, PartialEq)]
+pub enum PayloadVariable {
+    Tables(Vec<String>),
+    Version(String),
 }
 
 #[cfg(feature = "transaction")]
@@ -297,5 +310,21 @@ pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
 
             Ok((storage, Payload::Select { labels, rows }))
         }
+
+        //- Metadata
+        #[cfg(feature = "metadata")]
+        Statement::ShowVariable(variable) => match variable {
+            Variable::Tables => storage
+                .schema_names()
+                .await
+                .map(|table_names| Payload::ShowVariable(PayloadVariable::Tables(table_names)))
+                .try_self(storage),
+            Variable::Version => {
+                let version = storage.version();
+                let payload = Payload::ShowVariable(PayloadVariable::Version(version));
+
+                Ok((storage, payload))
+            }
+        },
     }
 }

--- a/src/executor/execute.rs
+++ b/src/executor/execute.rs
@@ -50,7 +50,6 @@ pub enum Payload {
 
     #[cfg(feature = "index")]
     CreateIndex,
-
     #[cfg(feature = "index")]
     DropIndex,
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -25,3 +25,6 @@ pub use validate::{UniqueKey, ValidateError};
 pub use execute::execute;
 #[cfg(feature = "transaction")]
 pub use execute::execute_atomic as execute;
+
+#[cfg(feature = "metadata")]
+pub use execute::PayloadVariable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@
 //!
 //! ## Custom Storage
 //! To get started, all you need to implement for `gluesql` is implementing three traits
-//! (two for functions, one running tests).  
-//! There are also three optional traits (`AlterTable`, `Index`, `IndexMut`, and `Transaction`),
-//! whether implementing it or not is all up to you.
+//! (two for functions, one for running tests).  
+//! There are also optional traits.
+//! Whether to implement it or not is all up to you.
 //!
 //! ### Store traits
 //! * [Store](store/trait.Store.html)
@@ -49,6 +49,7 @@
 //! * [Index](store/trait.Index.html)
 //! * [IndexMut](store/trait.IndexMut.html)
 //! * [Transaction](store/trait.Transaction.html)
+//! * [Metadata](store/trait.Metadata.html)
 //!
 //! ### Trait to run integration tests
 //! * [Tester](tests/trait.Tester.html)
@@ -90,6 +91,9 @@ pub mod prelude {
 
     #[cfg(feature = "memory-storage")]
     pub use crate::storages::MemoryStorage;
+
+    #[cfg(feature = "metadata")]
+    pub use crate::executor::PayloadVariable;
 
     pub use crate::{
         data::value::Value,

--- a/src/storages/memory_storage/metadata.rs
+++ b/src/storages/memory_storage/metadata.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "metadata")]
+
+use {
+    super::MemoryStorage,
+    crate::{result::Result, store::Metadata},
+    async_trait::async_trait,
+};
+
+#[async_trait(?Send)]
+impl Metadata for MemoryStorage {
+    async fn schema_names(&self) -> Result<Vec<String>> {
+        let mut names: Vec<_> = self.items.keys().map(Clone::clone).collect();
+        names.sort();
+
+        Ok(names)
+    }
+}

--- a/src/storages/memory_storage/mod.rs
+++ b/src/storages/memory_storage/mod.rs
@@ -1,5 +1,6 @@
 mod alter_table;
 mod index;
+mod metadata;
 mod transaction;
 
 use {

--- a/src/storages/sled_storage/metadata.rs
+++ b/src/storages/sled_storage/metadata.rs
@@ -11,6 +11,8 @@ use {
     std::str,
 };
 
+const SCHEMA_PREFIX: &str = "schema/";
+
 #[async_trait(?Send)]
 impl Metadata for SledStorage {
     async fn schema_names(&self) -> Result<Vec<String>> {
@@ -25,22 +27,26 @@ impl Metadata for SledStorage {
             }
         };
         let lock_txid = lock::fetch(&self.tree, txid, created_at, self.tx_timeout)?;
-        let prefix = "schema/";
 
         self.tree
-            .scan_prefix(prefix)
+            .scan_prefix(SCHEMA_PREFIX)
             .map(move |item| {
                 let (key, value) = item.map_err(err_into)?;
                 let snapshot: Snapshot<Schema> = bincode::deserialize(&value).map_err(err_into)?;
                 let schema = snapshot.extract(txid, lock_txid);
+                if schema.is_none() {
+                    return Ok(None);
+                }
 
-                schema
-                    .map(|_| {
-                        str::from_utf8(key.as_ref())
-                            .map(|s| s.replacen(prefix, "", 1))
-                            .map_err(err_into)
+                str::from_utf8(key.as_ref())
+                    .map_err(err_into)?
+                    .strip_prefix(SCHEMA_PREFIX)
+                    .map(|prefix| Some(prefix.to_owned()))
+                    .ok_or_else(|| {
+                        Error::StorageMsg(
+                            "conflict - schema_names failed, strip_prefix not matched".to_owned(),
+                        )
                     })
-                    .transpose()
             })
             .filter_map(|item| item.transpose())
             .collect::<Result<Vec<_>>>()

--- a/src/storages/sled_storage/metadata.rs
+++ b/src/storages/sled_storage/metadata.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "metadata")]
+
+use {
+    super::{err_into, lock, SledStorage, Snapshot, State},
+    crate::{
+        data::Schema,
+        result::{Error, Result},
+        store::Metadata,
+    },
+    async_trait::async_trait,
+    std::str,
+};
+
+#[async_trait(?Send)]
+impl Metadata for SledStorage {
+    async fn schema_names(&self) -> Result<Vec<String>> {
+        let (txid, created_at) = match self.state {
+            State::Transaction {
+                txid, created_at, ..
+            } => (txid, created_at),
+            State::Idle => {
+                return Err(Error::StorageMsg(
+                    "conflict - schema_names failed, lock does not exist".to_owned(),
+                ));
+            }
+        };
+        let lock_txid = lock::fetch(&self.tree, txid, created_at, self.tx_timeout)?;
+        let prefix = "schema/";
+
+        self.tree
+            .scan_prefix(prefix)
+            .map(move |item| {
+                let (key, value) = item.map_err(err_into)?;
+                let snapshot: Snapshot<Schema> = bincode::deserialize(&value).map_err(err_into)?;
+                let schema = snapshot.extract(txid, lock_txid);
+
+                schema
+                    .map(|_| {
+                        str::from_utf8(key.as_ref())
+                            .map(|s| s.replacen(prefix, "", 1))
+                            .map_err(err_into)
+                    })
+                    .transpose()
+            })
+            .filter_map(|item| item.transpose())
+            .collect::<Result<Vec<_>>>()
+    }
+}

--- a/src/storages/sled_storage/mod.rs
+++ b/src/storages/sled_storage/mod.rs
@@ -6,6 +6,7 @@ mod index_mut;
 mod index_sync;
 mod key;
 mod lock;
+mod metadata;
 mod snapshot;
 mod store;
 mod store_mut;

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -1,0 +1,10 @@
+use {crate::result::Result, async_trait::async_trait};
+
+#[async_trait(?Send)]
+pub trait Metadata {
+    fn version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_owned()
+    }
+
+    async fn schema_names(&self) -> Result<Vec<String>>;
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -22,7 +22,19 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(feature = "index")] {
+    if #[cfg(feature = "metadata")] {
+        mod metadata;
+        pub use metadata::Metadata;
+    }
+
+}
+
+cfg_if! {
+    if #[cfg(all(feature = "metadata", feature = "index"))] {
+        pub trait GStore<T: Debug>: Store<T> + Metadata + Index<T> {}
+    } else if #[cfg(feature = "metadata")] {
+        pub trait GStore<T: Debug>: Store<T> + Metadata {}
+    } else if #[cfg(feature = "index")] {
         pub trait GStore<T: Debug>: Store<T> + Index<T> {}
     } else {
         pub trait GStore<T: Debug>: Store<T> {}

--- a/src/tests/metadata.rs
+++ b/src/tests/metadata.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "metadata")]
+
+use crate::{
+    prelude::{Payload::ShowVariable, PayloadVariable},
+    translate::TranslateError,
+    *,
+};
+
+test_case!(metadata, async move {
+    let tables = |v: Vec<&str>| {
+        Ok(ShowVariable(PayloadVariable::Tables(
+            v.into_iter().map(ToOwned::to_owned).collect(),
+        )))
+    };
+
+    let found = run!("SHOW VERSION;");
+    let expected = ShowVariable(PayloadVariable::Version(
+        env!("CARGO_PKG_VERSION").to_owned(),
+    ));
+    assert_eq!(expected, found);
+
+    test!(tables(Vec::new()), "SHOW TABLES");
+
+    run!("CREATE TABLE Foo (id INTEGER);");
+    test!(tables(vec!["Foo"]), "SHOW TABLES");
+
+    run!("CREATE TABLE Zoo (id INTEGER);");
+    run!("CREATE TABLE Bar (id INTEGER);");
+    test!(tables(vec!["Bar", "Foo", "Zoo"]), "SHOW TABLES");
+
+    test!(
+        Err(TranslateError::UnsupportedShowVariableKeyword("WHATEVER".to_owned()).into()),
+        "SHOW WHATEVER"
+    );
+
+    test!(
+        Err(
+            TranslateError::UnsupportedShowVariableStatement("SHOW ME THE CHICKEN".to_owned())
+                .into()
+        ),
+        "SHOW ME THE CHICKEN"
+    );
+});

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,7 @@ pub mod function;
 pub mod index;
 pub mod join;
 pub mod limit;
+pub mod metadata;
 pub mod migrate;
 pub mod nested_select;
 pub mod nullable;
@@ -183,6 +184,20 @@ macro_rules! generate_transaction_tests {
     };
 }
 
+#[cfg(feature = "metadata")]
+#[macro_export]
+macro_rules! generate_metadata_tests {
+    ($test: meta, $storage: ident) => {
+        macro_rules! glue {
+            ($title: ident, $func: path) => {
+                declare_test_fn!($test, $storage, $title, $func);
+            };
+        }
+
+        glue!(metadata, metadata::metadata);
+    };
+}
+
 #[cfg(all(feature = "alter-table", feature = "index"))]
 #[macro_export]
 macro_rules! generate_alter_table_index_tests {
@@ -235,5 +250,19 @@ macro_rules! generate_transaction_index_tests {
 
         glue!(transaction_index_create, transaction::index_create);
         glue!(transaction_index_drop, transaction::index_drop);
+    };
+}
+
+#[cfg(all(feature = "transaction", feature = "metadata"))]
+#[macro_export]
+macro_rules! generate_transaction_metadata_tests {
+    ($test: meta, $storage: ident) => {
+        macro_rules! glue {
+            ($title: ident, $func: path) => {
+                declare_test_fn!($test, $storage, $title, $func);
+            };
+        }
+
+        glue!(transaction_metadata, transaction::metadata);
     };
 }

--- a/src/tests/transaction/metadata.rs
+++ b/src/tests/transaction/metadata.rs
@@ -1,0 +1,32 @@
+#![cfg(all(feature = "transaction", feature = "metadata"))]
+
+use crate::*;
+use prelude::*;
+
+test_case!(metadata, async move {
+    let tables = |v: Vec<&str>| {
+        Ok(Payload::ShowVariable(PayloadVariable::Tables(
+            v.into_iter().map(ToOwned::to_owned).collect(),
+        )))
+    };
+
+    run!("CREATE TABLE Garlic (id INTEGER);");
+    test!(tables(vec!["Garlic"]), "SHOW TABLES;");
+
+    run!("BEGIN;");
+    test!(tables(vec!["Garlic"]), "SHOW TABLES;");
+
+    run!("CREATE TABLE Noodle (id INTEGER);");
+    test!(tables(vec!["Garlic", "Noodle"]), "SHOW TABLES;");
+
+    run!("ROLLBACK;");
+    test!(tables(vec!["Garlic"]), "SHOW TABLES;");
+
+    run!("BEGIN;");
+    run!("CREATE TABLE Apple (id INTEGER);");
+    run!("CREATE TABLE Rice (id INTEGER);");
+    test!(tables(vec!["Apple", "Garlic", "Rice"]), "SHOW TABLES;");
+
+    run!("COMMIT;");
+    test!(tables(vec!["Apple", "Garlic", "Rice"]), "SHOW TABLES;");
+});

--- a/src/tests/transaction/mod.rs
+++ b/src/tests/transaction/mod.rs
@@ -3,6 +3,7 @@
 mod alter_table;
 mod basic;
 mod index;
+mod metadata;
 mod table;
 
 #[cfg(feature = "alter-table")]
@@ -10,4 +11,6 @@ pub use alter_table::*;
 pub use basic::basic;
 #[cfg(feature = "index")]
 pub use index::*;
+#[cfg(feature = "metadata")]
+pub use metadata::metadata;
 pub use table::*;

--- a/src/translate/error.rs
+++ b/src/translate/error.rs
@@ -38,6 +38,12 @@ pub enum TranslateError {
     #[error("unsupported function: {0}")]
     UnsupportedFunction(String),
 
+    #[error("unsupported SHOW VARIABLE keyword: {0}")]
+    UnsupportedShowVariableKeyword(String),
+
+    #[error("unsupported SHOW VARIABLE statement: {0}")]
+    UnsupportedShowVariableStatement(String),
+
     #[error("unsupported statement: {0}")]
     UnsupportedStatement(String),
 

--- a/src/translate/mod.rs
+++ b/src/translate/mod.rs
@@ -15,6 +15,9 @@ pub use self::{
 #[cfg(feature = "alter-table")]
 use ddl::translate_alter_table_operation;
 
+#[cfg(feature = "metadata")]
+use crate::ast::Variable;
+
 use {
     self::{ddl::translate_column_def, query::translate_query},
     crate::{
@@ -134,6 +137,17 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
         SqlStatement::Commit { .. } => Ok(Statement::Commit),
         #[cfg(feature = "transaction")]
         SqlStatement::Rollback { .. } => Ok(Statement::Rollback),
+        #[cfg(feature = "metadata")]
+        SqlStatement::ShowVariable { variable } => match (variable.len(), variable.get(0)) {
+            (1, Some(keyword)) => match keyword.value.to_uppercase().as_str() {
+                "TABLES" => Ok(Statement::ShowVariable(Variable::Tables)),
+                "VERSION" => Ok(Statement::ShowVariable(Variable::Version)),
+                v => Err(TranslateError::UnsupportedShowVariableKeyword(v.to_string()).into()),
+            },
+            _ => Err(
+                TranslateError::UnsupportedShowVariableStatement(sql_statement.to_string()).into(),
+            ),
+        },
         _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
     }
 }

--- a/tests/memory_storage.rs
+++ b/tests/memory_storage.rs
@@ -24,6 +24,12 @@ impl Tester<Key, MemoryStorage> for MemoryTester {
 
 generate_store_tests!(tokio::test, MemoryTester);
 
+#[cfg(feature = "metadata")]
+generate_metadata_tests!(tokio::test, MemoryTester);
+
+#[cfg(feature = "alter-table")]
+generate_alter_table_tests!(tokio::test, MemoryTester);
+
 #[cfg(any(feature = "alter-table", feature = "index", feature = "transaction"))]
 macro_rules! exec {
     ($glue: ident $sql: literal) => {
@@ -36,13 +42,6 @@ macro_rules! test {
     ($glue: ident $sql: literal, $result: expr) => {
         assert_eq!($glue.execute($sql), $result);
     };
-}
-
-#[cfg(feature = "alter-table")]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "alter-table")] {
-        generate_alter_table_tests!(tokio::test, MemoryTester);
-    }
 }
 
 #[cfg(feature = "index")]

--- a/tests/sled_storage.rs
+++ b/tests/sled_storage.rs
@@ -52,3 +52,9 @@ cfg_if! {
         generate_transaction_index_tests!(tokio::test, SledTester);
     }
 }
+
+#[cfg(feature = "metadata")]
+generate_metadata_tests!(tokio::test, SledTester);
+
+#[cfg(all(feature = "transaction", feature = "metadata"))]
+generate_transaction_metadata_tests!(tokio::test, SledTester);

--- a/tests/sled_transaction.rs
+++ b/tests/sled_transaction.rs
@@ -146,6 +146,9 @@ fn sled_transaction_schema_mut() {
     exec!(glue1 "CREATE TABLE Sample (id INTEGER);");
     exec!(glue1 "INSERT INTO Sample VALUES (1);");
 
+    #[cfg(feature = "metadata")]
+    test!(glue1 "SHOW TABLES;", Ok(Payload::ShowVariable(PayloadVariable::Tables(vec!["Sample".to_owned()]))));
+
     exec!(glue2 "BEGIN;");
     exec!(glue1 "BEGIN;");
     exec!(glue1 "DROP TABLE Sample;");
@@ -728,4 +731,55 @@ async fn sled_transaction_timeout_index() {
         idx!(idx_id, Eq, "1"),
         Ok(select!(id I64; 1))
     );
+}
+
+#[cfg(feature = "metadata")]
+#[test]
+fn sled_transaction_metadata() {
+    macro_rules! test_tables {
+        ($glue: ident []) => {
+            assert_eq!(
+                $glue.execute("SHOW TABLES"),
+                Ok(Payload::ShowVariable(PayloadVariable::Tables(Vec::new()))),
+            );
+        };
+        ($glue: ident $tables: expr) => {
+            let expected = Ok(Payload::ShowVariable(PayloadVariable::Tables(
+                $tables.into_iter().map(ToOwned::to_owned).collect(),
+            )));
+
+            assert_eq!($glue.execute("SHOW TABLES"), expected);
+        };
+    }
+
+    let path = &format!("{}/metadata", PATH_PREFIX);
+    fs::remove_dir_all(path).unwrap_or(());
+
+    let storage = SledStorage::new(path).unwrap();
+    let mut glue1 = Glue::new(storage.clone());
+    let mut glue2 = Glue::new(storage.clone());
+    let mut glue3 = Glue::new(storage);
+
+    exec!(glue2 "BEGIN");
+    exec!(glue1 "BEGIN");
+
+    exec!(glue1 "CREATE TABLE Foo (id INTEGER);");
+    test_tables!(glue1["Foo"]);
+    test_tables!(glue2 []);
+    test_tables!(glue3 []);
+
+    exec!(glue1 "COMMIT");
+    test_tables!(glue1["Foo"]);
+    test_tables!(glue2 []);
+    test_tables!(glue3["Foo"]);
+
+    exec!(glue2 "CREATE TABLE Bar (id INTEGER);");
+    test_tables!(glue1["Foo"]);
+    test_tables!(glue2["Bar"]);
+    test_tables!(glue3["Foo"]);
+
+    exec!(glue2 "ROLLBACK");
+    test_tables!(glue1["Foo"]);
+    test_tables!(glue2["Foo"]);
+    test_tables!(glue3["Foo"]);
 }


### PR DESCRIPTION
`Metadata` provides two methods which are currently matching `SHOW {VARIABLE};` queries.
- `schema_names`: `SHOW TABLES;`
- `version`: `SHOW VERSION;`

Add `Metadata` store traits and implement it for both `MemoryStorage` and `SledStorage`.