### PR TITLE
Support `limit`, `offset` clause in `Insert into Table Select ~`

### DIFF
--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -7,7 +7,7 @@ use {
         validate::{validate_unique, ColumnValidation},
     },
     crate::{
-        ast::{Query, SetExpr, Statement, Values},
+        ast::{SetExpr, Statement, Values},
         data::{get_name, Row, Schema, Value},
         result::{MutResult, Result},
         store::{GStore, GStoreMut},
@@ -186,14 +186,8 @@ pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
                         .iter()
                         .map(|values| Row::new(&column_defs, columns, values))
                         .collect::<Result<Vec<Row>>>()?,
-                    SetExpr::Select(select_query) => {
-                        let query = || Query {
-                            body: SetExpr::Select(select_query.clone()),
-                            limit: None,
-                            offset: None,
-                        };
-
-                        select(&storage, &query(), None)
+                    SetExpr::Select(_) => {
+                        select(&storage, &source, None)
                             .await?
                             .and_then(|row| {
                                 let column_defs = Rc::clone(&column_defs);

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -187,7 +187,7 @@ pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
                         .map(|values| Row::new(&column_defs, columns, values))
                         .collect::<Result<Vec<Row>>>()?,
                     SetExpr::Select(_) => {
-                        select(&storage, &source, None)
+                        select(&storage, source, None)
                             .await?
                             .and_then(|row| {
                                 let column_defs = Rc::clone(&column_defs);

--- a/test-suite/src/limit.rs
+++ b/test-suite/src/limit.rs
@@ -52,6 +52,18 @@ test_case!(limit, async move {
                 5     1
             ),
         ),
+        (
+            "INSERT INTO Test SELECT * FROM Test OFFSET 1;",
+            Payload::Insert(7),
+        ),
+        (
+            "INSERT INTO Test SELECT * FROM Test LIMIT 1;",
+            Payload::Insert(1),
+        ),
+        (
+            "INSERT INTO Test SELECT * FROM Test ORDER BY id LIMIT 1 OFFSET 1;",
+            Payload::Insert(1),
+        ),
     ];
 
     for (sql, expected) in test_cases {


### PR DESCRIPTION
It is possible to use `limit`, `offset` clause in `Insert into Table Select ~` sentence.
So, remove redundant query closure.
```rs
let query = || Query {
                            body: SetExpr::Select(select_query.clone()),
                            limit: None,
                            offset: None,
                        };
```