### PR TITLE
Update evaluate_stateless to support all existing SQL functions,

### DIFF
--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -1,0 +1,376 @@
+use {
+    super::{EvaluateError, Evaluated},
+    crate::{ast::TrimWhereField, data::Value, result::Result},
+    std::cmp::{max, min},
+    uuid::Uuid,
+};
+
+macro_rules! eval_to_str {
+    ($name: expr, $evaluated: expr) => {
+        match $evaluated.try_into()? {
+            Value::Str(value) => value,
+            Value::Null => {
+                return Ok(Value::Null);
+            }
+            _ => {
+                return Err(EvaluateError::FunctionRequiresStringValue($name).into());
+            }
+        }
+    };
+}
+
+macro_rules! eval_to_int {
+    ($name: expr, $evaluated: expr) => {
+        match $evaluated.try_into()? {
+            Value::I64(num) => num,
+            Value::Null => {
+                return Ok(Value::Null);
+            }
+            _ => {
+                return Err(EvaluateError::FunctionRequiresIntegerValue($name).into());
+            }
+        }
+    };
+}
+
+macro_rules! eval_to_float {
+    ($name: expr, $evaluated: expr) => {
+        match $evaluated.try_into()? {
+            Value::I64(v) => v as f64,
+            Value::F64(v) => v,
+            Value::Null => {
+                return Ok(Value::Null);
+            }
+            _ => {
+                return Err(EvaluateError::FunctionRequiresFloatValue($name).into());
+            }
+        }
+    };
+}
+
+// --- text ---
+
+pub fn lower(name: String, expr: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::Str(eval_to_str!(name, expr).to_lowercase()))
+}
+
+pub fn upper(name: String, expr: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::Str(eval_to_str!(name, expr).to_uppercase()))
+}
+
+pub fn left_or_right(name: String, expr: Evaluated<'_>, size: Evaluated<'_>) -> Result<Value> {
+    let string = eval_to_str!(name, expr);
+    let size = match size.try_into()? {
+        Value::I64(number) => usize::try_from(number)
+            .map_err(|_| EvaluateError::FunctionRequiresUSizeValue(name.clone()))?,
+        Value::Null => {
+            return Ok(Value::Null);
+        }
+        _ => {
+            return Err(EvaluateError::FunctionRequiresIntegerValue(name).into());
+        }
+    };
+
+    let converted = if name == "LEFT" {
+        string.get(..size).map(|v| v.to_string()).unwrap_or(string)
+    } else {
+        let start_pos = if size > string.len() {
+            0
+        } else {
+            string.len() - size
+        };
+
+        string
+            .get(start_pos..)
+            .map(|value| value.to_string())
+            .unwrap_or(string)
+    };
+
+    Ok(Value::Str(converted))
+}
+
+pub fn lpad_or_rpad(
+    name: String,
+    expr: Evaluated<'_>,
+    size: Evaluated<'_>,
+    fill: Option<Evaluated<'_>>,
+) -> Result<Value> {
+    let string = eval_to_str!(name, expr);
+    let size = match size.try_into()? {
+        Value::I64(number) => usize::try_from(number)
+            .map_err(|_| EvaluateError::FunctionRequiresUSizeValue(name.clone()))?,
+        Value::Null => {
+            return Ok(Value::Null);
+        }
+        _ => {
+            return Err(EvaluateError::FunctionRequiresIntegerValue(name).into());
+        }
+    };
+
+    let fill = match fill {
+        Some(expr) => eval_to_str!(name, expr),
+        None => " ".to_owned(),
+    };
+
+    let result = if size > string.len() {
+        let padding_size = size - string.len();
+        let repeat_count = padding_size / fill.len();
+        let plus_count = padding_size % fill.len();
+        let fill = fill.repeat(repeat_count) + &fill[0..plus_count];
+
+        if name == "LPAD" {
+            fill + &string
+        } else {
+            string + &fill
+        }
+    } else {
+        string[0..size].to_string()
+    };
+
+    Ok(Value::Str(result))
+}
+
+pub fn trim(
+    name: String,
+    expr: Evaluated<'_>,
+    filter_chars: Option<Evaluated<'_>>,
+    trim_where_field: &Option<TrimWhereField>,
+) -> Result<Value> {
+    let expr_str = eval_to_str!(name, expr);
+    let expr_str = expr_str.as_str();
+    let filter_chars = match filter_chars {
+        Some(expr) => eval_to_str!(name, expr).chars().collect::<Vec<_>>(),
+        None => vec![' '],
+    };
+
+    let value = match trim_where_field {
+        Some(TrimWhereField::Both) => expr_str.trim_matches(&filter_chars[..]),
+        Some(TrimWhereField::Leading) => expr_str.trim_start_matches(&filter_chars[..]),
+        Some(TrimWhereField::Trailing) => expr_str.trim_end_matches(&filter_chars[..]),
+        None => expr_str.trim(),
+    };
+
+    Ok(Value::Str(value.to_owned()))
+}
+
+pub fn ltrim(name: String, expr: Evaluated<'_>, chars: Option<Evaluated<'_>>) -> Result<Value> {
+    let expr = eval_to_str!(name, expr);
+    let chars = match chars {
+        Some(chars) => eval_to_str!(name, chars).chars().collect::<Vec<char>>(),
+        None => vec![' '],
+    };
+
+    let value = expr.trim_start_matches(chars.as_slice()).to_string();
+    Ok(Value::Str(value))
+}
+
+pub fn rtrim(name: String, expr: Evaluated<'_>, chars: Option<Evaluated<'_>>) -> Result<Value> {
+    let expr = eval_to_str!(name, expr);
+    let chars = match chars {
+        Some(chars) => eval_to_str!(name, chars).chars().collect::<Vec<char>>(),
+        None => vec![' '],
+    };
+
+    let value = expr.trim_end_matches(chars.as_slice()).to_string();
+    Ok(Value::Str(value))
+}
+
+pub fn reverse(name: String, expr: Evaluated<'_>) -> Result<Value> {
+    let value = eval_to_str!(name, expr).chars().rev().collect::<String>();
+
+    Ok(Value::Str(value))
+}
+
+pub fn repeat(name: String, expr: Evaluated<'_>, num: Evaluated<'_>) -> Result<Value> {
+    let expr = eval_to_str!(name, expr);
+    let num = eval_to_int!(name, num) as usize;
+    let value = expr.repeat(num);
+
+    Ok(Value::Str(value))
+}
+
+pub fn substr(
+    name: String,
+    expr: Evaluated<'_>,
+    start: Evaluated<'_>,
+    count: Option<Evaluated<'_>>,
+) -> Result<Value> {
+    let string = eval_to_str!(name, expr);
+    let start = eval_to_int!(name, start) - 1;
+    let count = match count {
+        Some(v) => eval_to_int!(name, v),
+        None => string.len() as i64,
+    };
+
+    let end = if count < 0 {
+        return Err(EvaluateError::NegativeSubstrLenNotAllowed.into());
+    } else {
+        min(max(start + count, 0) as usize, string.len())
+    };
+
+    let start = min(max(start, 0) as usize, string.len());
+    let string = String::from(&string[start..end]);
+    Ok(Value::Str(string))
+}
+
+// --- float ---
+
+pub fn sqrt(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).sqrt()))
+}
+
+pub fn power(name: String, expr: Evaluated<'_>, power: Evaluated<'_>) -> Result<Value> {
+    let expr = eval_to_float!(name, expr);
+    let power = eval_to_float!(name, power);
+
+    Ok(Value::F64(expr.powf(power)))
+}
+
+pub fn ceil(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).ceil()))
+}
+
+pub fn round(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).round()))
+}
+
+pub fn floor(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).floor()))
+}
+
+pub fn radians(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).to_radians()))
+}
+
+pub fn degrees(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).to_degrees()))
+}
+
+pub fn exp(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).exp()))
+}
+
+pub fn log(name: String, antilog: Evaluated<'_>, base: Evaluated<'_>) -> Result<Value> {
+    let antilog = eval_to_float!(name, antilog);
+    let base = eval_to_float!(name, base);
+
+    Ok(Value::F64(antilog.log(base)))
+}
+
+pub fn ln(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).ln()))
+}
+
+pub fn log2(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).log2()))
+}
+
+pub fn log10(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).log10()))
+}
+
+pub fn sin(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).sin()))
+}
+
+pub fn cos(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).cos()))
+}
+
+pub fn tan(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).tan()))
+}
+
+pub fn asin(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).asin()))
+}
+
+pub fn acos(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).acos()))
+}
+
+pub fn atan(name: String, n: Evaluated<'_>) -> Result<Value> {
+    Ok(Value::F64(eval_to_float!(name, n).atan()))
+}
+
+// --- integer ---
+
+pub fn div(name: String, dividend: Evaluated<'_>, divisor: Evaluated<'_>) -> Result<Value> {
+    let dividend = match dividend.try_into()? {
+        Value::F64(number) => number,
+        Value::I64(number) => number as f64,
+        Value::Null => {
+            return Ok(Value::Null);
+        }
+        _ => {
+            return Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(name).into());
+        }
+    };
+
+    let divisor = match divisor.try_into()? {
+        Value::F64(number) => match number {
+            x if x == 0.0 => return Err(EvaluateError::DivisorShouldNotBeZero.into()),
+            _ => number,
+        },
+        Value::I64(number) => match number {
+            0 => return Err(EvaluateError::DivisorShouldNotBeZero.into()),
+            _ => number as f64,
+        },
+        Value::Null => {
+            return Ok(Value::Null);
+        }
+        _ => {
+            return Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(name).into());
+        }
+    };
+
+    Ok(Value::I64((dividend / divisor) as i64))
+}
+
+pub fn gcd(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Result<Value> {
+    let left = eval_to_int!(name, left);
+    let right = eval_to_int!(name, right);
+
+    Ok(Value::I64(gcd_i64(left, right)))
+}
+
+pub fn lcm(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Result<Value> {
+    let left = eval_to_int!(name, left);
+    let right = eval_to_int!(name, right);
+
+    fn lcm(a: i64, b: i64) -> i64 {
+        a * b / gcd_i64(a, b)
+    }
+
+    Ok(Value::I64(lcm(left, right)))
+}
+
+fn gcd_i64(a: i64, b: i64) -> i64 {
+    if b == 0 {
+        a
+    } else {
+        gcd_i64(b, a % b)
+    }
+}
+
+// --- etc ---
+
+pub fn unwrap(name: String, expr: Evaluated<'_>, selector: Evaluated<'_>) -> Result<Value> {
+    if expr.is_null() {
+        return Ok(Value::Null);
+    }
+
+    let value = match expr {
+        Evaluated::Value(value) => value,
+        _ => {
+            return Err(EvaluateError::FunctionRequiresMapValue(name).into());
+        }
+    };
+
+    let selector = eval_to_str!(name, selector);
+    value.selector(&selector)
+}
+
+pub fn generate_uuid() -> Value {
+    Value::Uuid(Uuid::new_v4().as_u128())
+}

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -1,12 +1,12 @@
 use {
-    super::{expr, EvaluateError, Evaluated},
+    super::{expr, function, EvaluateError, Evaluated},
     crate::{
         ast::{Expr, Function},
         data::{Row, Value},
         result::Result,
     },
+    chrono::prelude::Utc,
     std::borrow::Cow,
-    uuid::Uuid,
 };
 
 type Columns<'a> = &'a [String];
@@ -105,10 +105,150 @@ pub fn evaluate_stateless<'a>(
         Expr::Wildcard | Expr::QualifiedWildcard(_) => {
             Err(EvaluateError::UnreachableWildcardExpr.into())
         }
-        Expr::Function(func) => match func.as_ref() {
-            Function::GenerateUuid() => Ok(Evaluated::from(Value::Uuid(Uuid::new_v4().as_u128()))),
-            _ => Err(EvaluateError::UnsupportedStatelessExpr(expr.clone()).into()),
-        },
+        Expr::Function(func) => evaluate_function(context, func),
         _ => Err(EvaluateError::UnsupportedStatelessExpr(expr.clone()).into()),
     }
+}
+
+fn evaluate_function<'a>(
+    context: Option<(Columns, &'a Row)>,
+    func: &'a Function,
+) -> Result<Evaluated<'a>> {
+    use function as f;
+
+    let name = || func.to_string();
+    let eval = |expr| evaluate_stateless(context, expr);
+    let eval_opt = |expr| -> Result<Option<_>> {
+        match expr {
+            Some(v) => Ok(Some(eval(v)?)),
+            None => Ok(None),
+        }
+    };
+
+    match func {
+        // --- text ---
+        Function::Lower(expr) => f::lower(name(), eval(expr)?),
+        Function::Upper(expr) => f::upper(name(), eval(expr)?),
+        Function::Left { expr, size } | Function::Right { expr, size } => {
+            let expr = eval(expr)?;
+            let size = eval(size)?;
+
+            f::left_or_right(name(), expr, size)
+        }
+        Function::Lpad { expr, size, fill } | Function::Rpad { expr, size, fill } => {
+            let expr = eval(expr)?;
+            let size = eval(size)?;
+            let fill = eval_opt(fill.as_ref())?;
+
+            f::lpad_or_rpad(name(), expr, size, fill)
+        }
+        Function::Trim {
+            expr,
+            filter_chars,
+            trim_where_field,
+        } => {
+            let expr = eval(expr)?;
+            let filter_chars = eval_opt(filter_chars.as_ref())?;
+
+            f::trim(name(), expr, filter_chars, trim_where_field)
+        }
+        Function::Ltrim { expr, chars } => {
+            let expr = eval(expr)?;
+            let chars = eval_opt(chars.as_ref())?;
+
+            f::ltrim(name(), expr, chars)
+        }
+        Function::Rtrim { expr, chars } => {
+            let expr = eval(expr)?;
+            let chars = eval_opt(chars.as_ref())?;
+
+            f::rtrim(name(), expr, chars)
+        }
+        Function::Reverse(expr) => {
+            let expr = eval(expr)?;
+
+            f::reverse(name(), expr)
+        }
+        Function::Repeat { expr, num } => {
+            let expr = eval(expr)?;
+            let num = eval(num)?;
+
+            f::repeat(name(), expr, num)
+        }
+        Function::Substr { expr, start, count } => {
+            let expr = eval(expr)?;
+            let start = eval(start)?;
+            let count = eval_opt(count.as_ref())?;
+
+            f::substr(name(), expr, start, count)
+        }
+
+        // --- float ---
+        Function::Sqrt(expr) => f::sqrt(name(), eval(expr)?),
+        Function::Power { expr, power } => {
+            let expr = eval(expr)?;
+            let power = eval(power)?;
+
+            f::power(name(), expr, power)
+        }
+        Function::Ceil(expr) => f::ceil(name(), eval(expr)?),
+        Function::Round(expr) => f::round(name(), eval(expr)?),
+        Function::Floor(expr) => f::floor(name(), eval(expr)?),
+        Function::Radians(expr) => f::radians(name(), eval(expr)?),
+        Function::Degrees(expr) => f::degrees(name(), eval(expr)?),
+        Function::Pi() => Ok(Value::F64(std::f64::consts::PI)),
+        Function::Exp(expr) => f::exp(name(), eval(expr)?),
+        Function::Log { antilog, base } => {
+            let antilog = eval(antilog)?;
+            let base = eval(base)?;
+
+            f::log(name(), antilog, base)
+        }
+        Function::Ln(expr) => f::ln(name(), eval(expr)?),
+        Function::Log2(expr) => f::log2(name(), eval(expr)?),
+        Function::Log10(expr) => f::log10(name(), eval(expr)?),
+        Function::Sin(expr) => f::sin(name(), eval(expr)?),
+        Function::Cos(expr) => f::cos(name(), eval(expr)?),
+        Function::Tan(expr) => f::tan(name(), eval(expr)?),
+        Function::ASin(expr) => f::asin(name(), eval(expr)?),
+        Function::ACos(expr) => f::acos(name(), eval(expr)?),
+        Function::ATan(expr) => f::atan(name(), eval(expr)?),
+
+        // --- integer ---
+        Function::Div { dividend, divisor } => {
+            let dividend = eval(dividend)?;
+            let divisor = eval(divisor)?;
+
+            f::div(name(), dividend, divisor)
+        }
+        Function::Mod { dividend, divisor } => {
+            let dividend = eval(dividend)?;
+            let divisor = eval(divisor)?;
+
+            return dividend.modulo(&divisor);
+        }
+        Function::Gcd { left, right } => {
+            let left = eval(left)?;
+            let right = eval(right)?;
+
+            f::gcd(name(), left, right)
+        }
+        Function::Lcm { left, right } => {
+            let left = eval(left)?;
+            let right = eval(right)?;
+
+            f::lcm(name(), left, right)
+        }
+
+        // --- etc ---
+        Function::Unwrap { expr, selector } => {
+            let expr = eval(expr)?;
+            let selector = eval(selector)?;
+
+            f::unwrap(name(), expr, selector)
+        }
+        Function::GenerateUuid() => Ok(f::generate_uuid()),
+        Function::Now() => Ok(Value::Timestamp(Utc::now().naive_utc())),
+    }
+    .map(Evaluated::from)
 }

--- a/test-suite/src/data_type/map.rs
+++ b/test-suite/src/data_type/map.rs
@@ -11,7 +11,7 @@ test_case!(map, async move {
     run!(
         r#"
 CREATE TABLE MapType (
-    id INTEGER,
+    id INTEGER NULL DEFAULT UNWRAP(NULL, "a"),
     nested MAP
 )"#
     );

--- a/test-suite/src/default.rs
+++ b/test-suite/src/default.rs
@@ -58,8 +58,8 @@ test_case!(default, async move {
             Ok(Payload::Insert(1)),
         ),
         (
-            "INSERT INTO FunctionTest VALUES (GENERATE_UUID(), SIN(1))",
-            Err(EvaluateError::UnsupportedStatelessExpr(expr!("SIN(1)")).into()),
+            "INSERT INTO FunctionTest VALUES (GENERATE_UUID(), (SELECT id FROM Foo))",
+            Err(EvaluateError::UnsupportedStatelessExpr(expr!("(SELECT id FROM Foo)")).into()),
         ),
     ];
 

--- a/test-suite/src/function/ceil.rs
+++ b/test-suite/src/function/ceil.rs
@@ -5,7 +5,10 @@ test_case!(ceil, async move {
         executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
     };
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT CEIL(0.5))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/degrees.rs
+++ b/test-suite/src/function/degrees.rs
@@ -8,7 +8,10 @@ test_case!(degrees, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id FLOAT)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id FLOAT DEFAULT DEGREES(90))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/div_mod.rs
+++ b/test-suite/src/function/div_mod.rs
@@ -11,7 +11,10 @@ test_case!(div_mod, async move {
     let eval_mod = |dividend, divisor| dividend % divisor;
     let test_cases = vec![
         (
-            "CREATE TABLE FloatDiv (dividend FLOAT, divisor FLOAT)",
+            "CREATE TABLE FloatDiv (
+                dividend FLOAT DEFAULT MOD(30, 11),
+                divisor FLOAT DEFAULT DIV(3, 2)
+            )",
             Ok(Payload::Create),
         ),
         (

--- a/test-suite/src/function/exp_log.rs
+++ b/test-suite/src/function/exp_log.rs
@@ -8,7 +8,10 @@ use {
 
 test_case!(log2, async move {
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT LOG2(1024))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -51,7 +54,10 @@ test_case!(log10, async move {
     use gluesql_core::prelude::Value::{Null, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT LOG10(100))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -94,7 +100,10 @@ test_case!(ln, async move {
     use gluesql_core::prelude::Value::{Null, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT LN(10))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -137,7 +146,10 @@ test_case!(log, async move {
     use gluesql_core::prelude::Value::{Null, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT LOG(2, 64))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -188,7 +200,10 @@ test_case!(exp, async move {
     use gluesql_core::prelude::Value::{Null, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT EXP(3.3))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/floor.rs
+++ b/test-suite/src/function/floor.rs
@@ -8,7 +8,10 @@ test_case!(floor, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT FLOOR(3.3))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -10,8 +10,8 @@ test_case!(gcd_lcm, async move {
         (
             r#"
         CREATE TABLE GcdI64 (
-            left INTEGER NULL DEFAULT true,
-            right INTEGER NULL DEFAULT true
+            left INTEGER NULL DEFAULT GCD(3, 4),
+            right INTEGER NULL DEFAULT LCM(10, 2)
          )"#,
             Ok(Payload::Create),
         ),

--- a/test-suite/src/function/generate_uuid.rs
+++ b/test-suite/src/function/generate_uuid.rs
@@ -4,7 +4,10 @@ test_case!(generate_uuid, async move {
     use gluesql_core::{ast::DataType, prelude::Payload, translate::TranslateError};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id UUID)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id UUID DEFAULT GENERATE_UUID())",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (GENERATE_UUID())"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/left_right.rs
+++ b/test-suite/src/function/left_right.rs
@@ -8,7 +8,10 @@ test_case!(left_right, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT LEFT("abc", 1))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES ("Blop mc blee"), ("B"), ("Steven the &long named$ folken!")"#,
             Ok(Payload::Insert(3)),

--- a/test-suite/src/function/lpad_rpad.rs
+++ b/test-suite/src/function/lpad_rpad.rs
@@ -8,7 +8,10 @@ test_case!(lpad_rpad, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT LPAD("a", 5) || LPAD("b", 3))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES ("hello")"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/ltrim_rtrim.rs
+++ b/test-suite/src/function/ltrim_rtrim.rs
@@ -10,7 +10,10 @@ test_case!(ltrim_rtrim, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT RTRIM(LTRIM("   abc   ")))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES (" zzzytest"), ("testxxzx ")"#,
             Ok(Payload::Insert(2)),

--- a/test-suite/src/function/math_function.rs
+++ b/test-suite/src/function/math_function.rs
@@ -12,7 +12,10 @@ use {
 
 test_case!(sin, async move {
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT SIN(3.141592))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -70,7 +73,10 @@ test_case!(cos, async move {
     use gluesql_core::prelude::Value::{self, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT COS(3.141592))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -128,7 +134,10 @@ test_case!(tan, async move {
     use gluesql_core::prelude::Value::{self, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT TAN(3.141592))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -187,7 +196,10 @@ test_case!(asin, async move {
     use gluesql_core::prelude::Value::F64;
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT ASIN(3.1415926))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -235,7 +247,10 @@ test_case!(asin, async move {
 
 test_case!(acos, async move {
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT ACOS(3.1415926))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -290,7 +305,10 @@ test_case!(atan, async move {
     use gluesql_core::prelude::Value::F64;
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT ATAN(3.14))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/now.rs
+++ b/test-suite/src/function/now.rs
@@ -11,7 +11,10 @@ test_case!(now, async move {
     }
 
     let test_cases = vec![
-        ("CREATE TABLE Item (time TIMESTAMP)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE Item (time TIMESTAMP DEFAULT NOW())",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES
                 ("2021-10-13T06:42:40.364832862"),

--- a/test-suite/src/function/pi.rs
+++ b/test-suite/src/function/pi.rs
@@ -7,7 +7,10 @@ test_case!(pi, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id FLOAT)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id FLOAT DEFAULT PI())",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/radians.rs
+++ b/test-suite/src/function/radians.rs
@@ -8,7 +8,10 @@ test_case!(radians, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id FLOAT)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id FLOAT DEFAULT RADIANS(180))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/repeat.rs
+++ b/test-suite/src/function/repeat.rs
@@ -8,7 +8,10 @@ test_case!(repeat, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT REPEAT("hello", 2))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES ("hello")"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/reverse.rs
+++ b/test-suite/src/function/reverse.rs
@@ -7,7 +7,10 @@ test_case!(reverse, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT REVERSE("world"))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES ("Let's meet")"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/round.rs
+++ b/test-suite/src/function/round.rs
@@ -9,7 +9,7 @@ test_case!(round, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE SingleItem (id INTEGER)",
+            "CREATE TABLE SingleItem (id INTEGER DEFAULT ROUND(3.5))",
             Ok(Payload::Create),
         ),
         (

--- a/test-suite/src/function/sqrt_power.rs
+++ b/test-suite/src/function/sqrt_power.rs
@@ -8,7 +8,10 @@ use {
 
 test_case!(sqrt, async move {
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id FLOAT)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id FLOAT DEFAULT SQRT(4))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),
@@ -59,7 +62,10 @@ test_case!(power, async move {
     use gluesql_core::prelude::Value::{Null, F64};
 
     let test_cases = vec![
-        ("CREATE TABLE SingleItem (id FLOAT)", Ok(Payload::Create)),
+        (
+            "CREATE TABLE SingleItem (id FLOAT DEFAULT POWER(3, 4))",
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO SingleItem VALUES (0)"#,
             Ok(Payload::Insert(1)),

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -10,7 +10,10 @@ test_case!(substr, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (name TEXT DEFAULT SUBSTR("abc", 0, 2))"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES ("Blop mc blee"), ("B"), ("Steven the &long named$ folken!")"#,
             Ok(Payload::Insert(3)),

--- a/test-suite/src/function/trim.rs
+++ b/test-suite/src/function/trim.rs
@@ -10,7 +10,12 @@ test_case!(trim, async move {
     };
 
     let test_cases = vec![
-        ("CREATE TABLE Item (name TEXT)", Ok(Payload::Create)),
+        (
+            r#"CREATE TABLE Item (
+                name TEXT DEFAULT TRIM(LEADING "a" FROM "aabc") || TRIM("   good  ")
+            )"#,
+            Ok(Payload::Create),
+        ),
         (
             r#"INSERT INTO Item VALUES
                 ("      Left blank"),

--- a/test-suite/src/function/upper_lower.rs
+++ b/test-suite/src/function/upper_lower.rs
@@ -12,7 +12,10 @@ test_case!(upper_lower, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE Item (name TEXT, opt_name TEXT NULL)",
+            r#"CREATE TABLE Item (
+                name TEXT DEFAULT UPPER("abc"),
+                opt_name TEXT NULL DEFAULT LOWER("ABC")
+            )"#,
             Ok(Payload::Create),
         ),
         (


### PR DESCRIPTION
Like `evaluate`, now `evaluate_stateless` also provides all SQL functions supported by GlueSQL

- [x] Update `evaluate_stateless` to support all GlueSQL SQL functions
- [x] Add tests