### PR TITLE
Decimal precision and scale

### DIFF
--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -14,5 +14,5 @@ pub enum DataType {
     Uuid,
     Map,
     List,
-    Decimal,
+    Decimal(Option<u64>, Option<u64>),
 }

--- a/core/src/data/value/decimal.rs
+++ b/core/src/data/value/decimal.rs
@@ -2,50 +2,40 @@ use {
     super::{Value, ValueError},
     crate::result::Result,
     bigdecimal::BigDecimal,
-    bigdecimal::FromPrimitive,
     bigdecimal::ToPrimitive,
     rust_decimal::Decimal,
-    std::borrow::Cow,
 };
 
-
-impl Value {
-    pub fn parse_decimal(precision: &Option<u64>, scale: &Option<u64>, value: &Cow<'_, BigDecimal>) -> Result<Value> {
-        
-        println!("precision: {:?}, scale: {:?}, value: {:?}", precision, scale, value);
-
-        match (precision, scale) {
-            (None, None) => return value
-                .to_string()
-                .parse::<Decimal>()
-                .map(Value::Decimal)
-                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into()),
-            (Some(p), None) => {
-                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p).try_into().unwrap()) {
-                    println!("left: {}, right: {}",value.with_scale(0).to_u64().unwrap(), 10^*p);
-                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
-                }
-                return value.with_prec(*p).with_scale(0)
-                    .to_string()
-                    .parse::<Decimal>()
-                    .map(Value::Decimal)
-                    .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
-            (Some(p), Some(s)) => {
-                // println!("value prec,scaled: {:?}", value.with_prec(*p).with_scale(*s as i64));
-                // println!("p: {}, *p, {:?}",p,*p);
-                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p - *s).try_into().unwrap()) {
-                    println!("digits: {}, p - s: {}", value.digits(), (*p - *s));
-                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
-                }
-                return value.with_prec(*p).with_scale(*s as i64)
-                    .to_string()
-                    .parse::<Decimal>()
-                    .map(Value::Decimal)
-                    .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
-            (None, Some(_)) => return Err(ValueError::NoPrecisionDecimalNotSupported.into())
-        }
-    }
-
+fn bigdecimal_literal_to_decimal_value(value: &BigDecimal) -> Result<Value> {
+    value
+        .to_string()
+        .parse::<Decimal>()
+        .map(Value::Decimal)
+        .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())
 }
 
-
+impl Value {
+    pub fn parse_decimal(
+        precision: &Option<u64>,
+        scale: &Option<u64>,
+        value: &BigDecimal,
+    ) -> Result<Value> {
+        match (precision, scale) {
+            (None, None) => bigdecimal_literal_to_decimal_value(value),
+            (Some(p), None) => {
+                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p).try_into().unwrap()) {
+                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
+                }
+                bigdecimal_literal_to_decimal_value(&value.with_prec(*p).with_scale(0))
+            }
+            (Some(p), Some(s)) => {
+                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p - *s).try_into().unwrap())
+                {
+                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
+                }
+                bigdecimal_literal_to_decimal_value(&value.with_prec(*p).with_scale(*s as i64))
+            }
+            (None, Some(_)) => Err(ValueError::NoPrecisionDecimalNotSupported.into()),
+        }
+    }
+}

--- a/core/src/data/value/decimal.rs
+++ b/core/src/data/value/decimal.rs
@@ -3,6 +3,7 @@ use {
     crate::result::Result,
     bigdecimal::BigDecimal,
     bigdecimal::FromPrimitive,
+    bigdecimal::ToPrimitive,
     rust_decimal::Decimal,
     std::borrow::Cow,
 };
@@ -10,12 +11,8 @@ use {
 
 impl Value {
     pub fn parse_decimal(precision: &Option<u64>, scale: &Option<u64>, value: &Cow<'_, BigDecimal>) -> Result<Value> {
-        // let value = value.to_string()
-        //     .parse::<Decimal>()
-        //     .map(Value::Decimal)
-        //     .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())?;
+        
         println!("precision: {:?}, scale: {:?}, value: {:?}", precision, scale, value);
-        // let t = value;
 
         match (precision, scale) {
             (None, None) => return value
@@ -24,27 +21,27 @@ impl Value {
                 .map(Value::Decimal)
                 .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into()),
             (Some(p), None) => {
-                // if value.is_integer() {
-
-                // }
-                // if t > BigDecimal::from_u64(10^(*p)).unwrap() {
-                //     return Err(ValueError::FailedToParseDecimal(value.to_string()).into())
-                // }
-                // println!("cut! : {:?}", value.with_scale(0));
-                // println!("cut! : {:?}", value.with_prec(*p));
-                if value.digits() > *p {
+                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p).try_into().unwrap()) {
+                    println!("left: {}, right: {}",value.with_scale(0).to_u64().unwrap(), 10^*p);
                     return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
                 }
                 return value.with_prec(*p).with_scale(0)
-                .to_string()
-                .parse::<Decimal>()
-                .map(Value::Decimal)
-                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
-            (Some(p), Some(s)) => return value.with_prec(*p).with_scale(*s as i64)
-                .to_string()
-                .parse::<Decimal>()
-                .map(Value::Decimal)
-                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into()),
+                    .to_string()
+                    .parse::<Decimal>()
+                    .map(Value::Decimal)
+                    .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
+            (Some(p), Some(s)) => {
+                // println!("value prec,scaled: {:?}", value.with_prec(*p).with_scale(*s as i64));
+                // println!("p: {}, *p, {:?}",p,*p);
+                if value.with_scale(0).to_u64().unwrap() > 10_u64.pow((*p - *s).try_into().unwrap()) {
+                    println!("digits: {}, p - s: {}", value.digits(), (*p - *s));
+                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
+                }
+                return value.with_prec(*p).with_scale(*s as i64)
+                    .to_string()
+                    .parse::<Decimal>()
+                    .map(Value::Decimal)
+                    .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
             (None, Some(_)) => return Err(ValueError::NoPrecisionDecimalNotSupported.into())
         }
     }

--- a/core/src/data/value/decimal.rs
+++ b/core/src/data/value/decimal.rs
@@ -1,0 +1,54 @@
+use {
+    super::{Value, ValueError},
+    crate::result::Result,
+    bigdecimal::BigDecimal,
+    bigdecimal::FromPrimitive,
+    rust_decimal::Decimal,
+    std::borrow::Cow,
+};
+
+
+impl Value {
+    pub fn parse_decimal(precision: &Option<u64>, scale: &Option<u64>, value: &Cow<'_, BigDecimal>) -> Result<Value> {
+        // let value = value.to_string()
+        //     .parse::<Decimal>()
+        //     .map(Value::Decimal)
+        //     .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())?;
+        println!("precision: {:?}, scale: {:?}, value: {:?}", precision, scale, value);
+        // let t = value;
+
+        match (precision, scale) {
+            (None, None) => return value
+                .to_string()
+                .parse::<Decimal>()
+                .map(Value::Decimal)
+                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into()),
+            (Some(p), None) => {
+                // if value.is_integer() {
+
+                // }
+                // if t > BigDecimal::from_u64(10^(*p)).unwrap() {
+                //     return Err(ValueError::FailedToParseDecimal(value.to_string()).into())
+                // }
+                // println!("cut! : {:?}", value.with_scale(0));
+                // println!("cut! : {:?}", value.with_prec(*p));
+                if value.digits() > *p {
+                    return Err(ValueError::FailedToParseDecimal(value.to_string()).into());
+                }
+                return value.with_prec(*p).with_scale(0)
+                .to_string()
+                .parse::<Decimal>()
+                .map(Value::Decimal)
+                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into())},
+            (Some(p), Some(s)) => return value.with_prec(*p).with_scale(*s as i64)
+                .to_string()
+                .parse::<Decimal>()
+                .map(Value::Decimal)
+                .map_err(|_| ValueError::FailedToParseDecimal(value.to_string()).into()),
+            (None, Some(_)) => return Err(ValueError::NoPrecisionDecimalNotSupported.into())
+        }
+    }
+
+}
+
+

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -37,6 +37,9 @@ pub enum ValueError {
     #[error("failed to parse Decimal: {0}")]
     FailedToParseDecimal(String),
 
+    #[error("decimal with no precision not supported")]
+    NoPrecisionDecimalNotSupported,
+
     #[error("add on non-numeric values: {0:?} + {1:?}")]
     AddOnNonNumeric(Value, Value),
 

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -135,7 +135,7 @@ impl Value {
             (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Map, Literal::Text(v)) => Value::parse_json_map(v),
             (DataType::List, Literal::Text(v)) => Value::parse_json_list(v),
-            (DataType::Decimal(_,_), Literal::Number(v)) => v
+            (DataType::Decimal(_, _), Literal::Number(v)) => v
                 .to_string()
                 .parse::<Decimal>()
                 .map(Value::Decimal)

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -135,11 +135,11 @@ impl Value {
             (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Map, Literal::Text(v)) => Value::parse_json_map(v),
             (DataType::List, Literal::Text(v)) => Value::parse_json_list(v),
-            (DataType::Decimal(_, _), Literal::Number(v)) => v
-                .to_string()
-                .parse::<Decimal>()
-                .map(Value::Decimal)
-                .map_err(|_| ValueError::FailedToParseDecimal(v.to_string()).into()),
+            (DataType::Decimal(p, s), Literal::Number(v)) => Value::parse_decimal(p,s,v),
+            // v.to_string()
+            //     .parse::<Decimal>()
+            //     .map(Value::Decimal)
+            //     .map_err(|_| ValueError::FailedToParseDecimal(v.to_string()).into()),
             (_, Literal::Null) => Ok(Value::Null),
             _ => Err(ValueError::IncompatibleLiteralForDataType {
                 data_type: data_type.clone(),

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -135,7 +135,7 @@ impl Value {
             (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Map, Literal::Text(v)) => Value::parse_json_map(v),
             (DataType::List, Literal::Text(v)) => Value::parse_json_list(v),
-            (DataType::Decimal, Literal::Number(v)) => v
+            (DataType::Decimal(_,_), Literal::Number(v)) => v
                 .to_string()
                 .parse::<Decimal>()
                 .map(Value::Decimal)

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -10,7 +10,6 @@ use {
         result::{Error, Result},
     },
     chrono::NaiveDate,
-    rust_decimal::Decimal,
     std::cmp::Ordering,
 };
 
@@ -135,11 +134,7 @@ impl Value {
             (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Map, Literal::Text(v)) => Value::parse_json_map(v),
             (DataType::List, Literal::Text(v)) => Value::parse_json_list(v),
-            (DataType::Decimal(p, s), Literal::Number(v)) => Value::parse_decimal(p,s,v),
-            // v.to_string()
-            //     .parse::<Decimal>()
-            //     .map(Value::Decimal)
-            //     .map_err(|_| ValueError::FailedToParseDecimal(v.to_string()).into()),
+            (DataType::Decimal(p, s), Literal::Number(v)) => Value::parse_decimal(p, s, v),
             (_, Literal::Null) => Ok(Value::Null),
             _ => Err(ValueError::IncompatibleLiteralForDataType {
                 data_type: data_type.clone(),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -100,7 +100,7 @@ impl Value {
             Value::I8(_) => matches!(data_type, DataType::Int8),
             Value::I64(_) => matches!(data_type, DataType::Int),
             Value::F64(_) => matches!(data_type, DataType::Float),
-            Value::Decimal(_) => matches!(data_type, DataType::Decimal),
+            Value::Decimal(_) => matches!(data_type, DataType::Decimal(_,_)),
             Value::Bool(_) => matches!(data_type, DataType::Boolean),
             Value::Str(_) => matches!(data_type, DataType::Text),
             Value::Date(_) => matches!(data_type, DataType::Date),
@@ -137,7 +137,7 @@ impl Value {
             (DataType::Int8, Value::I8(_))
             | (DataType::Int, Value::I64(_))
             | (DataType::Float, Value::F64(_))
-            | (DataType::Decimal, Value::Decimal(_))
+            | (DataType::Decimal(_,_), Value::Decimal(_))
             | (DataType::Boolean, Value::Bool(_))
             | (DataType::Text, Value::Str(_))
             | (DataType::Date, Value::Date(_))

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -12,6 +12,7 @@ use {
 mod big_endian;
 mod binary_op;
 mod date;
+mod decimal;
 mod error;
 mod group_key;
 mod into;
@@ -20,7 +21,6 @@ mod literal;
 mod selector;
 mod unique_key;
 mod uuid;
-mod decimal;
 
 pub use error::ValueError;
 
@@ -101,14 +101,11 @@ impl Value {
             Value::I8(_) => matches!(data_type, DataType::Int8),
             Value::I64(_) => matches!(data_type, DataType::Int),
             Value::F64(_) => matches!(data_type, DataType::Float),
-            Value::Decimal(_) => {
-                // matches!(data_type, DataType::Decimal(_,_))
-                match data_type {
-                    DataType::Decimal(None, None) => true,
-                    DataType::Decimal(p, s) => p.unwrap() >= s.unwrap(), //(*v).to_u64() < (10^(p.unwrap()-s.unwrap())),
-                    _ => false,
-                }
-            }
+            Value::Decimal(_) => match data_type {
+                DataType::Decimal(None, None) => true,
+                DataType::Decimal(p, s) => p.unwrap() >= s.unwrap(),
+                _ => false,
+            },
             Value::Bool(_) => matches!(data_type, DataType::Boolean),
             Value::Str(_) => matches!(data_type, DataType::Text),
             Value::Date(_) => matches!(data_type, DataType::Date),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -100,7 +100,14 @@ impl Value {
             Value::I8(_) => matches!(data_type, DataType::Int8),
             Value::I64(_) => matches!(data_type, DataType::Int),
             Value::F64(_) => matches!(data_type, DataType::Float),
-            Value::Decimal(_) => matches!(data_type, DataType::Decimal(_,_)),
+            Value::Decimal(_) => {
+                // matches!(data_type, DataType::Decimal(_,_))
+                match data_type {
+                    DataType::Decimal(None, None) => true,
+                    DataType::Decimal(p, s) => p.unwrap() >= s.unwrap(), //(*v).to_u64() < (10^(p.unwrap()-s.unwrap())),
+                    _ => false,
+                }
+            }
             Value::Bool(_) => matches!(data_type, DataType::Boolean),
             Value::Str(_) => matches!(data_type, DataType::Text),
             Value::Date(_) => matches!(data_type, DataType::Date),
@@ -137,7 +144,7 @@ impl Value {
             (DataType::Int8, Value::I8(_))
             | (DataType::Int, Value::I64(_))
             | (DataType::Float, Value::F64(_))
-            | (DataType::Decimal(_,_), Value::Decimal(_))
+            | (DataType::Decimal(_, _), Value::Decimal(_))
             | (DataType::Boolean, Value::Bool(_))
             | (DataType::Text, Value::Str(_))
             | (DataType::Date, Value::Date(_))

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -20,6 +20,7 @@ mod literal;
 mod selector;
 mod unique_key;
 mod uuid;
+mod decimal;
 
 pub use error::ValueError;
 

--- a/core/src/executor/alter/error.rs
+++ b/core/src/executor/alter/error.rs
@@ -28,4 +28,7 @@ pub enum AlterError {
 
     #[error("identifier not found: {0:#?}")]
     IdentifierNotFound(Expr),
+
+    #[error("NUMERIC scale '{0}' must be between 0 and between precision {1}")]
+    UnsupportedDecimalScale(String, String),
 }

--- a/core/src/executor/alter/mod.rs
+++ b/core/src/executor/alter/mod.rs
@@ -9,6 +9,7 @@ use validate::validate;
 #[cfg(feature = "alter-table")]
 pub use alter_table::alter_table;
 pub use error::AlterError;
+pub use error::CreateError;
 #[cfg(feature = "index")]
 pub use index::{create_index, drop_index};
 pub use table::{create_table, drop_table};

--- a/core/src/executor/alter/mod.rs
+++ b/core/src/executor/alter/mod.rs
@@ -9,7 +9,6 @@ use validate::validate;
 #[cfg(feature = "alter-table")]
 pub use alter_table::alter_table;
 pub use error::AlterError;
-pub use error::CreateError;
 #[cfg(feature = "index")]
 pub use index::{create_index, drop_index};
 pub use table::{create_table, drop_table};

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -28,6 +28,21 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
         .into());
     }
 
+    match data_type {
+        DataType::Decimal(None, None) => (),
+        DataType::Decimal(_p, None) => (),
+        DataType::Decimal(p, s) => {
+            if *p < *s {
+                return Err(AlterError::UnsupportedDecimalScale(
+                    (*s).unwrap().to_string(),
+                    (*p).unwrap().to_string(),
+                )
+                .into());
+            }
+        }
+        _ => (),
+    }
+
     let default = options
         .iter()
         .find_map(|ColumnOptionDef { option, .. }| match option {

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -17,8 +17,8 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Interval => Ok(DataType::Interval),
         SqlDataType::Uuid => Ok(DataType::Uuid),
         // SqlDataType::Decimal(None, None) => Ok(DataType::Decimal),
-        // SqlDataType::Decimal(_, None) => Ok(DataType::Decimal),
-        SqlDataType::Decimal(_, _) => Ok(DataType::Decimal),
+        // SqlDataType::Decimal(p, None) => Ok(DataType::DecimalPrecision(p.unwrap())),
+        SqlDataType::Decimal(p, s) => Ok(DataType::Decimal(*p,*s)),
         SqlDataType::Custom(name) => {
             let name = name.0.get(0).map(|v| v.value.to_uppercase());
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -18,7 +18,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Uuid => Ok(DataType::Uuid),
         // SqlDataType::Decimal(None, None) => Ok(DataType::Decimal),
         // SqlDataType::Decimal(p, None) => Ok(DataType::DecimalPrecision(p.unwrap())),
-        SqlDataType::Decimal(p, s) => Ok(DataType::Decimal(*p,*s)),
+        SqlDataType::Decimal(p, s) => Ok(DataType::Decimal(*p, *s)),
         SqlDataType::Custom(name) => {
             let name = name.0.get(0).map(|v| v.value.to_uppercase());
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -16,7 +16,9 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Time => Ok(DataType::Time),
         SqlDataType::Interval => Ok(DataType::Interval),
         SqlDataType::Uuid => Ok(DataType::Uuid),
-        SqlDataType::Decimal(None, None) => Ok(DataType::Decimal),
+        // SqlDataType::Decimal(None, None) => Ok(DataType::Decimal),
+        // SqlDataType::Decimal(_, None) => Ok(DataType::Decimal),
+        SqlDataType::Decimal(_, _) => Ok(DataType::Decimal),
         SqlDataType::Custom(name) => {
             let name = name.0.get(0).map(|v| v.value.to_uppercase());
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -16,8 +16,6 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Time => Ok(DataType::Time),
         SqlDataType::Interval => Ok(DataType::Interval),
         SqlDataType::Uuid => Ok(DataType::Uuid),
-        // SqlDataType::Decimal(None, None) => Ok(DataType::Decimal),
-        // SqlDataType::Decimal(p, None) => Ok(DataType::DecimalPrecision(p.unwrap())),
         SqlDataType::Decimal(p, s) => Ok(DataType::Decimal(*p, *s)),
         SqlDataType::Custom(name) => {
             let name = name.0.get(0).map(|v| v.value.to_uppercase());

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1"
 bigdecimal = "0.3"
 uuid = "0.8"
 chrono = "0.4"
+rust_decimal = "1"
 
 [features]
 alter-table = ["gluesql-core/alter-table"]

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::Payload, prelude::Value::*},
+    gluesql_core::{executor::AlterError, executor::Payload, prelude::Value::*},
 };
 
 test_case!(decimal, async move {
@@ -22,9 +22,17 @@ test_case!(decimal, async move {
             )),
         ),
         (
+            "CREATE TABLE ILLEGAL_DECIMAL (d1 DECIMAL(1,4))",
+            Err(AlterError::UnsupportedDecimalScale("4".to_owned(), "1".to_owned()).into()),
+            // Err(ValueError::IncompatibleDataType {
+            //     data_type: DataType::Decimal(Some(1),Some(4)).clone(),
+            //     value: Value::Decimal(0.into()).clone(),
+            // }).into(),
+        ),
+        (
             "CREATE TABLE DECIMAL_EXTENDED (d1 DECIMAL(5), d2 DECIMAL(5,2))",
             Ok(Payload::Create),
-        )
+        ),
     ];
 
     for (sql, expected) in test_cases.into_iter() {

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,8 +1,7 @@
 use {
     crate::*,
-    gluesql_core::{executor::AlterError, executor::Payload, prelude::Value::*, data::ValueError},
-    rust_decimal::prelude::*,  
-    rust_decimal::Decimal,
+    gluesql_core::{data::ValueError, executor::AlterError, executor::Payload, prelude::Value::*},
+    rust_decimal::prelude::*,
 };
 
 test_case!(decimal, async move {
@@ -57,7 +56,7 @@ test_case!(decimal, async move {
                 d1
                 Decimal;
                 rust_decimal::Decimal::from_str("123.46").unwrap()
-            ))
+            )),
         ),
     ];
 

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::AlterError, executor::Payload, prelude::Value::*},
+    gluesql_core::{executor::AlterError, executor::Payload, prelude::Value::*, data::ValueError},
 };
 
 test_case!(decimal, async move {
@@ -26,8 +26,16 @@ test_case!(decimal, async move {
             Err(AlterError::UnsupportedDecimalScale("4".to_owned(), "1".to_owned()).into()),
         ),
         (
-            "CREATE TABLE DECIMAL_EXTENDED (d1 DECIMAL(5), d2 DECIMAL(5,2))",
+            "CREATE TABLE DECIMAL_PRECISION (d1 DECIMAL(5))",
             Ok(Payload::Create),
+        ),
+        (
+            "INSERT INTO DECIMAL_PRECISION (d1) VALUES (12345)",
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            "INSERT INTO DECIMAL_PRECISION (d1) VALUES (123456)",
+            Err(ValueError::FailedToParseDecimal("123456".to_owned()).into()),
         ),
     ];
 

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,6 +1,8 @@
 use {
     crate::*,
     gluesql_core::{executor::AlterError, executor::Payload, prelude::Value::*, data::ValueError},
+    rust_decimal::prelude::*,  
+    rust_decimal::Decimal,
 };
 
 test_case!(decimal, async move {
@@ -36,6 +38,26 @@ test_case!(decimal, async move {
         (
             "INSERT INTO DECIMAL_PRECISION (d1) VALUES (123456)",
             Err(ValueError::FailedToParseDecimal("123456".to_owned()).into()),
+        ),
+        (
+            "CREATE TABLE DECIMAL_PRECISION_SCALE (d1 DECIMAL(5,2))",
+            Ok(Payload::Create),
+        ),
+        (
+            "INSERT INTO DECIMAL_PRECISION_SCALE (d1) VALUES (1234.56)",
+            Err(ValueError::FailedToParseDecimal("1234.56".to_owned()).into()),
+        ),
+        (
+            "INSERT INTO DECIMAL_PRECISION_SCALE (d1) VALUES (123.456)",
+            Ok(Payload::Insert(1)),
+        ),
+        (
+            "SELECT d1 AS d1 FROM DECIMAL_PRECISION_SCALE",
+            Ok(select!(
+                d1
+                Decimal;
+                rust_decimal::Decimal::from_str("123.46").unwrap()
+            ))
         ),
     ];
 

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -21,6 +21,10 @@ test_case!(decimal, async move {
                 1.into()
             )),
         ),
+        (
+            "CREATE TABLE DECIMAL_EXTENDED (d1 DECIMAL(5), d2 DECIMAL(5,2))",
+            Ok(Payload::Create),
+        )
     ];
 
     for (sql, expected) in test_cases.into_iter() {

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -24,10 +24,6 @@ test_case!(decimal, async move {
         (
             "CREATE TABLE ILLEGAL_DECIMAL (d1 DECIMAL(1,4))",
             Err(AlterError::UnsupportedDecimalScale("4".to_owned(), "1".to_owned()).into()),
-            // Err(ValueError::IncompatibleDataType {
-            //     data_type: DataType::Decimal(Some(1),Some(4)).clone(),
-            //     value: Value::Decimal(0.into()).clone(),
-            // }).into(),
         ),
         (
             "CREATE TABLE DECIMAL_EXTENDED (d1 DECIMAL(5), d2 DECIMAL(5,2))",


### PR DESCRIPTION
Implementing Decimal precision and scale. 
I have implemented create, and insert logic with deciaml precision and scale. 
However, while I was trying to implement `insert into t1 select ~~~` I thought we should discuss it before I go any further. 

below is what I implemented in this draft. 

###  We can create table with `decimal(precision,scale)` type.
```sql
CREATE TABLE DECIMAL_PRECISION_SCALE (d1 DECIMAL(5,2))
```

### Also we can insert value into Decimal type. It validates the precision, and rounds conform to declared scale. 
```sql 
INSERT INTO DECIMAL_PRECISION_SCALE (d1) VALUES (123456); -- fail, exceeds precision. 
INSERT INTO DECIMAL_PRECISION_SCALE (d1) VALUES (123.456); -- success with rounded value: 123.46
```

### Since `eq` for Decimal type is not implemented, for now, it only supports create, insert, and select. 
```sql
UPDATE DECIMAL_PRECISION_SCALE SET d1=234.567 WHERE d1=123.46 -- fail, we cannot compare decimal values and literal (eq is not implemented) 
```

---

And below is what I have in concerned to go further. 

### We need to implement validate and round decimal value to conform to the declared schema. 

For example, `insert into t1 select decimal_value from t2` is available but validation and round is not implemented yet.(which means not perfect decimal type). For now, it only validate and round for literals. 

In this situation, I thought about how to work only when inserting and updating values from literal without precision verification and scale of decimal.

One way to think of it is to add precision validation to the row validation process, and scale round process to round in try_into_value. The advantage of this method is. The process of converting from literal to value is kept as before, and validation and round are applied only to value, thereby simplifying the decimal operation process. The downside. Because logic for validation and round is added to the process of creating a row itself, the whole row operation may be slightly heavier.

If logic can be added to the row side, we will modify the code in the direction of applying precision and scale to decimal values that have already been converted from literal to value. If there are other better ways, that's even better.
