### PR TITLE
Feature implementation - Unary Factorial operation for (unsigned) `INT8` type

### DIFF
--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -348,6 +348,9 @@ impl Value {
         use Value::*;
 
         let factorial_function = |a: i64| -> Result<i64> {
+            if a.is_negative() {
+                return Err(ValueError::FactorialOnNegativeNumeric.into());
+            }
             (1..(a + 1))
                 .into_iter()
                 .try_fold(1i64, |mul, x| mul.checked_mul(x))
@@ -355,8 +358,8 @@ impl Value {
         };
 
         match self {
-            I64(a) if *a >= 0 => factorial_function(*a).map(I64),
-            I64(_) => Err(ValueError::FactorialOnNegativeNumeric.into()),
+            I8(a) => factorial_function(*a as i64).map(I64),
+            I64(a) => factorial_function(*a).map(I64),
             F64(_) => Err(ValueError::FactorialOnNonInteger.into()),
             Null => Ok(Null),
             _ => Err(ValueError::FactorialOnNonNumeric.into()),

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -8,18 +8,18 @@ test_case!(unary_operator, async move {
 
     let test_cases = vec![
         (
-            "CREATE TABLE Test (v1 INT, v2 FLOAT, v3 TEXT, v4 INT, v5 INT)",
+            "CREATE TABLE Test (v1 INT, v2 FLOAT, v3 TEXT, v4 INT, v5 INT, v6 INT(8))",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Test VALUES (10, 10.5, "hello", -5, 1000)"#,
+            r#"INSERT INTO Test VALUES (10, 10.5, "hello", -5, 1000, 20)"#,
             Ok(Payload::Insert(1)),
         ),
         (
-            "SELECT -v1 as v1, -v2 as v2, v3, -v4 as v4 FROM Test",
+            "SELECT -v1 as v1, -v2 as v2, v3, -v4 as v4, -v6 as v6 FROM Test",
             Ok(select_with_null!(
-                v1      |   v2          |   v3                      |   v4;
-                I64(-10)    F64(-10.5)      Str("hello".to_owned())     I64(5)
+                v1      |   v2          |   v3                      |   v4      |  v6;
+                I64(-10)    F64(-10.5)      Str("hello".to_owned())     I64(5)     I8(-20)
             )),
         ),
         (
@@ -84,6 +84,14 @@ test_case!(unary_operator, async move {
         ),
         (
             "SELECT v5! as v5 FROM Test",
+            Err(ValueError::FactorialOverflow.into()),
+        ),
+        (
+            "SELECT (-v6)! as v6 FROM Test",
+            Err(ValueError::FactorialOnNegativeNumeric.into()),
+        ),
+        (
+            "SELECT (v6 * 100)! as v6 FROM Test",
             Err(ValueError::FactorialOverflow.into()),
         ),
         (


### PR DESCRIPTION
# This implements the issue #431 
This PR implements the unary factorial operator to process `INT8` typed numeric data. 
Error handling is same as ones of `INT64`.