### PR TITLE
Bump up `sqlparser` crate version from 0.11 to 0.13

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
+name = "gluesql-core"
+version = "0.10.2"
+edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
-documentation = "https://docs.rs/gluesql/"
-edition = "2021"
 license = "Apache-2.0"
-name = "gluesql-core"
 repository = "https://github.com/gluesql/gluesql"
-version = "0.10.2"
+documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-utils = {package = "gluesql-utils", path = "../utils", version = "0.10.2"}
+utils = { package = "gluesql-utils", path = "../utils", version = "0.10.2" }
 
-async-recursion = "1"
+regex = "1"
 async-trait = "0.1"
-bigdecimal = {version = "0.3", features = ["serde", "string-only"]}
+async-recursion = "1"
 cfg-if = "1"
-chrono = {version = "0.4", features = ["serde", "wasmbind"]}
 futures = "0.3"
+chrono = { version = "0.4", features = ["serde", "wasmbind"] }
+rust_decimal = { version = "1", features = ["serde-str"] }
 im-rc = "15"
 iter-enum = "1"
 itertools = "0.10"
-regex = "1"
-rust_decimal = {version = "1", features = ["serde-str"]}
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = {version = "0.13", features = ["serde", "bigdecimal"]}
-strum_macros = "0.23"
+sqlparser = { version = "0.13", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
-uuid = {version = "0.8", features = ["v4"]}
+strum_macros = "0.23"
+uuid = { version = "0.8", features = ["v4"] }
+bigdecimal = { version = "0.3", features = ["serde", "string-only"] }
 
 [features]
 # optional: ALTER TABLE

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name = "gluesql-core"
-version = "0.10.2"
-edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
-license = "Apache-2.0"
-repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
+edition = "2021"
+license = "Apache-2.0"
+name = "gluesql-core"
+repository = "https://github.com/gluesql/gluesql"
+version = "0.10.2"
 
 [dependencies]
-utils = { package = "gluesql-utils", path = "../utils", version = "0.10.2" }
+utils = {package = "gluesql-utils", path = "../utils", version = "0.10.2"}
 
-regex = "1"
-async-trait = "0.1"
 async-recursion = "1"
+async-trait = "0.1"
+bigdecimal = {version = "0.3", features = ["serde", "string-only"]}
 cfg-if = "1"
+chrono = {version = "0.4", features = ["serde", "wasmbind"]}
 futures = "0.3"
-chrono = { version = "0.4", features = ["serde", "wasmbind"] }
-rust_decimal = { version = "1", features = ["serde-str"] }
 im-rc = "15"
 iter-enum = "1"
 itertools = "0.10"
-serde = { version = "1", features = ["derive"] }
+regex = "1"
+rust_decimal = {version = "1", features = ["serde-str"]}
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
-sqlparser = { version = "0.11", features = ["serde", "bigdecimal"] }
-thiserror = "1.0"
+sqlparser = {version = "0.13", features = ["serde", "bigdecimal"]}
 strum_macros = "0.23"
-uuid = { version = "0.8", features = ["v4"] }
-bigdecimal = { version = "0.3", features = ["serde", "string-only"] }
+thiserror = "1.0"
+uuid = {version = "0.8", features = ["v4"]}
 
 [features]
 # optional: ALTER TABLE

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -14,6 +14,9 @@ pub enum TranslateError {
     #[error("unimplemented - join on update not supported")]
     JoinOnUpdateNotSupported,
 
+    #[error("unimplemented - compound identifier on update not supported: {0}")]
+    CompoundIndentOnUpdateNotSupported(String),
+
     #[error("too many params in drop index")]
     TooManyParamsInDropIndex,
 
@@ -85,4 +88,7 @@ pub enum TranslateError {
 
     #[error("unsupported alter table operation: {0}")]
     UnsupportedAlterTableOperation(String),
+
+    #[error("unsupported table factor: {0}")]
+    UnsupportedTableFactor(String),
 }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -11,6 +11,9 @@ pub enum TranslateError {
     #[error("unimplemented - composite index is not supported")]
     CompositeIndexNotSupported,
 
+    #[error("unimplemented - join on update not supported")]
+    JoinOnUpdateNotSupported,
+
     #[error("too many params in drop index")]
     TooManyParamsInDropIndex,
 
@@ -58,6 +61,9 @@ pub enum TranslateError {
 
     #[error("unreachable unary operator: {0}")]
     UnreachableUnaryOperator(String),
+
+    #[error("unreachable empty ident")]
+    UnreachableEmptyIdent,
 
     #[error("unsupported binary operator: {0}")]
     UnsupportedBinaryOperator(String),

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -15,7 +15,7 @@ pub enum TranslateError {
     JoinOnUpdateNotSupported,
 
     #[error("unimplemented - compound identifier on update not supported: {0}")]
-    CompoundIndentOnUpdateNotSupported(String),
+    CompoundIdentOnUpdateNotSupported(String),
 
     #[error("too many params in drop index")]
     TooManyParamsInDropIndex,

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -158,7 +158,7 @@ fn translate_assignment(sql_assignment: &SqlAssignment) -> Result<Assignment> {
 
     if id.len() > 1 {
         return Err(
-            TranslateError::CompoundIndentOnUpdateNotSupported(sql_assignment.to_string()).into(),
+            TranslateError::CompoundIdentOnUpdateNotSupported(sql_assignment.to_string()).into(),
         );
     }
 

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -14,6 +14,7 @@ pub use self::{
 
 #[cfg(feature = "alter-table")]
 use ddl::translate_alter_table_operation;
+use sqlparser::ast::{TableFactor, TableWithJoins};
 
 #[cfg(feature = "metadata")]
 use crate::ast::Variable;
@@ -44,12 +45,12 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             source: translate_query(source).map(Box::new)?,
         }),
         SqlStatement::Update {
-            table_name,
+            table,
             assignments,
             selection,
             ..
         } => Ok(Statement::Update {
-            table_name: translate_object_name(table_name),
+            table_name: translate_table_with_join(table)?,
             assignments: assignments
                 .iter()
                 .map(translate_assignment)
@@ -155,14 +156,32 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
 fn translate_assignment(sql_assignment: &SqlAssignment) -> Result<Assignment> {
     let SqlAssignment { id, value } = sql_assignment;
 
+    if id.len() > 1 {
+        return Err(TranslateError::JoinOnUpdateNotSupported.into());
+    }
+
     Ok(Assignment {
-        id: id.value.to_owned(),
+        id: id
+            .get(0)
+            .ok_or(TranslateError::UnreachableEmptyIdent)?
+            .value
+            .to_owned(),
         value: translate_expr(value)?,
     })
 }
 
 fn translate_object_name(sql_object_name: &SqlObjectName) -> ObjectName {
     ObjectName(translate_idents(&sql_object_name.0))
+}
+
+fn translate_table_with_join(table: &TableWithJoins) -> Result<ObjectName> {
+    if !table.joins.is_empty() {
+        return Err(TranslateError::JoinOnUpdateNotSupported.into());
+    }
+    match &table.relation {
+        TableFactor::Table { name, .. } => Ok(ObjectName(translate_idents(&name.0))),
+        _ => Err(TranslateError::JoinOnUpdateNotSupported.into()),
+    }
 }
 
 fn translate_idents(idents: &[SqlIdent]) -> Vec<String> {

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -71,6 +71,18 @@ test_case!(error, async move {
             "SELECT * FROM TableA CROSS JOIN TableA as A;",
         ),
         (
+            TranslateError::JoinOnUpdateNotSupported.into(),
+            "UPDATE TableA INNER JOIN TableA ON 1 = 1 SET 1 = 1",
+        ),
+        (
+            TranslateError::UnsupportedTableFactor("(SELECT * FROM TableA)".to_owned()).into(),
+            "UPDATE (SELECT * FROM TableA) SET 1 = 1",
+        ),
+        (
+            TranslateError::CompoundIdentOnUpdateNotSupported("TableA.id = 1".to_owned()).into(),
+            "UPDATE TableA SET TableA.id = 1 WHERE id = 1",
+        ),
+        (
             EvaluateError::NestedSelectRowNotFound.into(),
             "SELECT * FROM TableA WHERE id = (SELECT id FROM TableA WHERE id = 2);",
         ),


### PR DESCRIPTION
# Bump up `sqlparser` version.
## Changes made
Most of the changes are in `SqlStatement::Update` part,
- [x] `table` field is now `TableWithJoin` type, so I had to take `relation` field out of it and converted into `ObjectName`.
- [x] `SqlAssignment`'s `id` is now `Vec<Ident>` type, so I took only the first element's value.
## TODO's after implementing `Join`
- [ ] Remove `JoinOnUpdateNotSupported` error.