### PR TITLE
Support `limit`, `offset` clause in Insert into values ~

### DIFF
--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -9,10 +9,11 @@ use {
     crate::{
         ast::{SetExpr, Statement, Values},
         data::{get_name, Row, Schema, Value},
-        result::{MutResult, Result},
+        executor::limit::Limit,
+        result::MutResult,
         store::{GStore, GStoreMut},
     },
-    futures::stream::TryStreamExt,
+    futures::stream::{self, TryStreamExt},
     serde::Serialize,
     std::{fmt::Debug, rc::Rc},
     thiserror::Error as ThisError,
@@ -182,10 +183,15 @@ pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
                 let column_validation = ColumnValidation::All(Rc::clone(&column_defs));
 
                 let rows = match &source.body {
-                    SetExpr::Values(Values(values_list)) => values_list
-                        .iter()
-                        .map(|values| Row::new(&column_defs, columns, values))
-                        .collect::<Result<Vec<Row>>>()?,
+                    SetExpr::Values(Values(values_list)) => {
+                        let limit = Limit::new(source.limit.as_ref(), source.offset.as_ref())?;
+                        let rows = values_list
+                            .iter()
+                            .map(|values| Row::new(&column_defs, columns, values));
+                        let rows = stream::iter(rows);
+                        let rows = limit.apply(rows);
+                        rows.try_collect::<Vec<_>>().await?
+                    }
                     SetExpr::Select(_) => {
                         select(&storage, source, None)
                             .await?

--- a/test-suite/src/limit.rs
+++ b/test-suite/src/limit.rs
@@ -53,28 +53,59 @@ test_case!(limit, async move {
             ),
         ),
         (
-            "INSERT INTO Test SELECT * FROM Test OFFSET 1;",
+            "CREATE TABLE InsertTest (
+                case_no INTEGER,
+                id INTEGER
+            )",
+            Payload::Create,
+        ),
+        (
+            "INSERT INTO InsertTest SELECT 1, id FROM Test OFFSET 1;",
             Payload::Insert(7),
         ),
         (
-            "INSERT INTO Test SELECT * FROM Test LIMIT 1;",
+            "SELECT id FROM InsertTest WHERE case_no = 1",
+            select!(id; I64; 2; 3; 4; 5; 6; 7; 8),
+        ),
+        (
+            "INSERT INTO InsertTest SELECT 2, id FROM Test LIMIT 1;",
             Payload::Insert(1),
         ),
         (
-            "INSERT INTO Test SELECT * FROM Test ORDER BY id LIMIT 1 OFFSET 1;",
+            "SELECT id FROM InsertTest WHERE case_no = 2",
+            select!(id; I64; 1),
+        ),
+        (
+            "INSERT INTO InsertTest SELECT 3, id FROM Test ORDER BY id LIMIT 1 OFFSET 1;",
             Payload::Insert(1),
         ),
         (
-            "INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 1;",
+            "SELECT id FROM InsertTest WHERE case_no = 3",
+            select!(id; I64; 2),
+        ),
+        (
+            "INSERT INTO InsertTest VALUES (4, 1), (4, 2), (4, 3), (4, 4) LIMIT 1;",
             Payload::Insert(1),
         ),
         (
-            "INSERT INTO Test VALUES (1), (2), (3), (4) OFFSET 1;",
+            "SELECT id FROM InsertTest WHERE case_no = 4",
+            select!(id; I64; 1),
+        ),
+        (
+            "INSERT INTO InsertTest VALUES (5, 1), (5, 2), (5, 3), (5, 4) OFFSET 1;",
             Payload::Insert(3),
         ),
         (
-            "INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 3 OFFSET 2;",
+            "SELECT id FROM InsertTest WHERE case_no = 5",
+            select!(id; I64; 2; 3; 4),
+        ),
+        (
+            "INSERT INTO InsertTest VALUES (6, 1), (6, 2), (6, 3), (6, 4) LIMIT 3 OFFSET 2;",
             Payload::Insert(2),
+        ),
+        (
+            "SELECT id FROM InsertTest WHERE case_no = 6",
+            select!(id; I64; 3; 4),
         ),
     ];
 

--- a/test-suite/src/limit.rs
+++ b/test-suite/src/limit.rs
@@ -64,6 +64,18 @@ test_case!(limit, async move {
             "INSERT INTO Test SELECT * FROM Test ORDER BY id LIMIT 1 OFFSET 1;",
             Payload::Insert(1),
         ),
+        (
+            "INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 1;",
+            Payload::Insert(1),
+        ),
+        (
+            "INSERT INTO Test VALUES (1), (2), (3), (4) OFFSET 1;",
+            Payload::Insert(3),
+        ),
+        (
+            "INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 3 OFFSET 2;",
+            Payload::Insert(2),
+        ),
     ];
 
     for (sql, expected) in test_cases {


### PR DESCRIPTION
### `limit` and `offset` were not supported at insert values clause.
### Now It is possible to execute below queries.
```sql
INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 1; 
-- 1 rows inserted.
INSERT INTO Test VALUES (1), (2), (3), (4) OFFSET 1;
-- 3 rows inserted.
INSERT INTO Test VALUES (1), (2), (3), (4) LIMIT 3 OFFSET 2;
-- 2 rows inserted.
```