### PR TITLE
Remove `Debug` macro from the generic requirements for key

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -5,15 +5,11 @@ use {
         store::{GStore, GStoreMut},
     },
     rustyline::{error::ReadlineError, Editor},
-    std::{
-        fmt::Debug,
-        io::{Result, Write},
-    },
+    std::io::{Result, Write},
 };
 
 pub struct Cli<T, U, W>
 where
-    T: Debug,
     U: GStore<T> + GStoreMut<T>,
     W: Write,
 {
@@ -23,7 +19,6 @@ where
 
 impl<T, U, W> Cli<T, U, W>
 where
-    T: Debug,
     U: GStore<T> + GStoreMut<T>,
     W: Write,
 {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -33,7 +33,7 @@ pub fn run() {
         run(MemoryStorage::default());
     }
 
-    fn run<T: Debug, U: GStore<T> + GStoreMut<T>>(storage: U) {
+    fn run<T, U: GStore<T> + GStoreMut<T>>(storage: U) {
         let output = std::io::stdout();
         let mut cli = Cli::new(storage, output);
 

--- a/core/src/executor/aggregate/mod.rs
+++ b/core/src/executor/aggregate/mod.rs
@@ -15,12 +15,12 @@ use {
         store::GStore,
     },
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
-    std::{fmt::Debug, pin::Pin, rc::Rc},
+    std::{pin::Pin, rc::Rc},
 };
 
 pub use {error::AggregateError, hash::GroupKey};
 
-pub struct Aggregator<'a, T: Debug> {
+pub struct Aggregator<'a, T> {
     storage: &'a dyn GStore<T>,
     fields: &'a [SelectItem],
     group_by: &'a [Expr],
@@ -31,7 +31,7 @@ pub struct Aggregator<'a, T: Debug> {
 type Applied<'a> = dyn TryStream<Ok = AggregateContext<'a>, Error = Error, Item = Result<AggregateContext<'a>>>
     + 'a;
 
-impl<'a, T: Debug> Aggregator<'a, T> {
+impl<'a, T> Aggregator<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         fields: &'a [SelectItem],

--- a/core/src/executor/alter/alter_table.rs
+++ b/core/src/executor/alter/alter_table.rs
@@ -8,7 +8,6 @@ use {
         result::{MutResult, TrySelf},
         store::{GStore, GStoreMut},
     },
-    std::fmt::Debug,
 };
 
 #[cfg(feature = "index")]
@@ -21,7 +20,7 @@ use {
     futures::stream::{self, TryStreamExt},
 };
 
-pub async fn alter_table<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn alter_table<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     name: &ObjectName,
     operation: &AlterTableOperation,

--- a/core/src/executor/alter/index.rs
+++ b/core/src/executor/alter/index.rs
@@ -8,10 +8,9 @@ use {
         result::MutResult,
         store::{GStore, GStoreMut},
     },
-    std::fmt::Debug,
 };
 
-pub async fn create_index<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn create_index<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     table_name: &ObjectName,
     index_name: &ObjectName,
@@ -70,7 +69,7 @@ fn validate_index_expr(columns: &[String], expr: &Expr) -> (bool, bool) {
     }
 }
 
-pub async fn drop_index<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn drop_index<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     table_name: &ObjectName,
     index_name: &ObjectName,

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -8,10 +8,9 @@ use {
         store::{GStore, GStoreMut},
     },
     futures::stream::{self, TryStreamExt},
-    std::fmt::Debug,
 };
 
-pub async fn create_table<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn create_table<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     name: &ObjectName,
     column_defs: &[ColumnDef],
@@ -81,7 +80,7 @@ pub async fn create_table<T: Debug, U: GStore<T> + GStoreMut<T>>(
     }
 }
 
-pub async fn drop_table<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn drop_table<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     table_names: &[ObjectName],
     if_exists: bool,

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -19,13 +19,13 @@ use {
         stream::{self, StreamExt, TryStreamExt},
     },
     im_rc::HashMap,
-    std::{borrow::Cow, fmt::Debug, rc::Rc},
+    std::{borrow::Cow, rc::Rc},
 };
 
 pub use {error::EvaluateError, evaluated::Evaluated, stateless::evaluate_stateless};
 
 #[async_recursion(?Send)]
-pub async fn evaluate<'a, T: Debug>(
+pub async fn evaluate<'a, T>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
@@ -193,7 +193,7 @@ pub async fn evaluate<'a, T: Debug>(
     }
 }
 
-async fn evaluate_function<'a, T: Debug>(
+async fn evaluate_function<'a, T>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -73,7 +73,7 @@ pub enum PayloadVariable {
 }
 
 #[cfg(feature = "transaction")]
-pub async fn execute_atomic<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn execute_atomic<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     statement: &Statement,
 ) -> MutResult<U, Payload> {
@@ -102,7 +102,7 @@ pub async fn execute_atomic<T: Debug, U: GStore<T> + GStoreMut<T>>(
     }
 }
 
-pub async fn execute<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn execute<T, U: GStore<T> + GStoreMut<T>>(
     storage: U,
     statement: &Statement,
 ) -> MutResult<U, Payload> {

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -18,10 +18,7 @@ pub enum FetchError {
     TableNotFound(String),
 }
 
-pub async fn fetch_columns<T: Debug>(
-    storage: &dyn GStore<T>,
-    table_name: &str,
-) -> Result<Vec<String>> {
+pub async fn fetch_columns<T>(storage: &dyn GStore<T>, table_name: &str) -> Result<Vec<String>> {
     Ok(storage
         .fetch_schema(table_name)
         .await?
@@ -32,7 +29,7 @@ pub async fn fetch_columns<T: Debug>(
         .collect::<Vec<String>>())
 }
 
-pub async fn fetch<'a, T: Debug>(
+pub async fn fetch<'a, T>(
     storage: &'a dyn GStore<T>,
     table_name: &'a str,
     columns: Rc<[String]>,

--- a/core/src/executor/filter.rs
+++ b/core/src/executor/filter.rs
@@ -10,17 +10,17 @@ use {
         store::GStore,
     },
     im_rc::HashMap,
-    std::{fmt::Debug, rc::Rc},
+    std::rc::Rc,
 };
 
-pub struct Filter<'a, T: Debug> {
+pub struct Filter<'a, T> {
     storage: &'a dyn GStore<T>,
     where_clause: Option<&'a Expr>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
 }
 
-impl<'a, T: Debug> Filter<'a, T> {
+impl<'a, T> Filter<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         where_clause: Option<&'a Expr>,
@@ -50,7 +50,7 @@ impl<'a, T: Debug> Filter<'a, T> {
     }
 }
 
-pub async fn check_expr<'a, T: Debug>(
+pub async fn check_expr<'a, T>(
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -10,11 +10,11 @@ use {
         store::GStore,
     },
     futures::stream::{self, once, Stream, StreamExt, TryStream, TryStreamExt},
-    std::{fmt::Debug, pin::Pin, rc::Rc},
+    std::{pin::Pin, rc::Rc},
     utils::OrStream,
 };
 
-pub struct Join<'a, T: Debug> {
+pub struct Join<'a, T> {
     storage: &'a dyn GStore<T>,
     join_clauses: &'a [AstJoin],
     join_columns: Vec<Rc<[String]>>,
@@ -25,7 +25,7 @@ type JoinItem<'a> = Rc<BlendContext<'a>>;
 type Joined<'a> =
     Pin<Box<dyn TryStream<Ok = JoinItem<'a>, Error = Error, Item = Result<JoinItem<'a>>> + 'a>>;
 
-impl<'a, T: Debug> Join<'a, T> {
+impl<'a, T> Join<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         join_clauses: &'a [AstJoin],
@@ -96,7 +96,7 @@ impl<'a, T: Debug> Join<'a, T> {
     }
 }
 
-async fn join<'a, T: Debug>(
+async fn join<'a, T>(
     storage: &'a dyn GStore<T>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     ast_join: &'a AstJoin,
@@ -146,7 +146,7 @@ async fn join<'a, T: Debug>(
     }
 }
 
-async fn fetch_joined<'a, T: Debug>(
+async fn fetch_joined<'a, T>(
     storage: &'a dyn GStore<T>,
     table_name: &'a str,
     table_alias: &'a str,

--- a/core/src/executor/select/blend.rs
+++ b/core/src/executor/select/blend.rs
@@ -12,16 +12,16 @@ use {
     },
     futures::stream::{self, StreamExt, TryStreamExt},
     im_rc::HashMap,
-    std::{fmt::Debug, rc::Rc},
+    std::rc::Rc,
 };
 
-pub struct Blend<'a, T: Debug> {
+pub struct Blend<'a, T> {
     storage: &'a dyn GStore<T>,
     filter_context: Option<Rc<FilterContext<'a>>>,
     fields: &'a [SelectItem],
 }
 
-impl<'a, T: Debug> Blend<'a, T> {
+impl<'a, T> Blend<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         filter_context: Option<Rc<FilterContext<'a>>>,

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -22,13 +22,13 @@ use {
     },
     futures::stream::{self, Stream, StreamExt, TryStream, TryStreamExt},
     iter_enum::Iterator,
-    std::{fmt::Debug, iter::once, rc::Rc},
+    std::{iter::once, rc::Rc},
 };
 
 #[cfg(feature = "index")]
 use {super::evaluate::evaluate, crate::ast::IndexItem};
 
-async fn fetch_blended<'a, T: Debug>(
+async fn fetch_blended<'a, T>(
     storage: &'a dyn GStore<T>,
     table: Table<'a>,
     columns: Rc<[String]>,
@@ -145,7 +145,7 @@ fn get_labels<'a>(
         .collect::<Result<_>>()
 }
 
-pub async fn select_with_labels<'a, T: Debug>(
+pub async fn select_with_labels<'a, T>(
     storage: &'a dyn GStore<T>,
     query: &'a Query,
     filter_context: Option<Rc<FilterContext<'a>>>,
@@ -255,7 +255,7 @@ pub async fn select_with_labels<'a, T: Debug>(
     Ok((labels, rows))
 }
 
-pub async fn select<'a, T: Debug>(
+pub async fn select<'a, T>(
     storage: &'a dyn GStore<T>,
     query: &'a Query,
     filter_context: Option<Rc<FilterContext<'a>>>,

--- a/core/src/executor/sort.rs
+++ b/core/src/executor/sort.rs
@@ -11,11 +11,11 @@ use {
     },
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
     im_rc::HashMap,
-    std::{cmp::Ordering, fmt::Debug, pin::Pin, rc::Rc},
+    std::{cmp::Ordering, pin::Pin, rc::Rc},
     utils::Vector,
 };
 
-pub struct Sort<'a, T: Debug> {
+pub struct Sort<'a, T> {
     storage: &'a dyn GStore<T>,
     context: Option<Rc<FilterContext<'a>>>,
     order_by: &'a [OrderByExpr],
@@ -26,7 +26,7 @@ type Item<'a> = Result<(
     Rc<BlendContext<'a>>,
 )>;
 
-impl<'a, T: Debug> Sort<'a, T> {
+impl<'a, T> Sort<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         context: Option<Rc<FilterContext<'a>>>,

--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -24,14 +24,14 @@ pub enum UpdateError {
     ConflictOnSchema,
 }
 
-pub struct Update<'a, T: Debug> {
+pub struct Update<'a, T> {
     storage: &'a dyn GStore<T>,
     table_name: &'a str,
     fields: &'a [Assignment],
     column_defs: &'a [ColumnDef],
 }
 
-impl<'a, T: Debug> Update<'a, T> {
+impl<'a, T> Update<'a, T> {
     pub fn new(
         storage: &'a dyn GStore<T>,
         table_name: &'a str,

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -89,7 +89,7 @@ impl UniqueConstraint {
     }
 }
 
-pub async fn validate_unique<T: Debug>(
+pub async fn validate_unique<T>(
     storage: &impl Store<T>,
     table_name: &str,
     column_validation: ColumnValidation,

--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -9,15 +9,15 @@ use {
         translate::translate,
     },
     futures::executor::block_on,
-    std::{fmt::Debug, marker::PhantomData},
+    std::marker::PhantomData,
 };
 
-pub struct Glue<T: Debug, U: GStore<T> + GStoreMut<T>> {
+pub struct Glue<T, U: GStore<T> + GStoreMut<T>> {
     _marker: PhantomData<T>,
     pub storage: Option<U>,
 }
 
-impl<T: Debug, U: GStore<T> + GStoreMut<T>> Glue<T, U> {
+impl<T, U: GStore<T> + GStoreMut<T>> Glue<T, U> {
     pub fn new(storage: U) -> Self {
         let storage = Some(storage);
 

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -9,11 +9,10 @@ use {
         store::Store,
     },
     async_recursion::async_recursion,
-    std::fmt::Debug,
     utils::Vector,
 };
 
-pub async fn plan<T: Debug>(storage: &dyn Store<T>, statement: Statement) -> Result<Statement> {
+pub async fn plan<T>(storage: &dyn Store<T>, statement: Statement) -> Result<Statement> {
     match statement {
         Statement::Query(query) => plan_query(storage, *query)
             .await
@@ -53,7 +52,7 @@ impl Indexes {
     }
 }
 
-async fn plan_query<T: Debug>(storage: &dyn Store<T>, query: Query) -> Result<Query> {
+async fn plan_query<T>(storage: &dyn Store<T>, query: Query) -> Result<Query> {
     let Query {
         body,
         limit,
@@ -145,7 +144,7 @@ async fn plan_query<T: Debug>(storage: &dyn Store<T>, query: Query) -> Result<Qu
     }
 }
 
-async fn plan_select<T: Debug>(
+async fn plan_select<T>(
     storage: &dyn Store<T>,
     indexes: &Indexes,
     select: Select,
@@ -226,7 +225,7 @@ enum Planned {
 }
 
 #[async_recursion(?Send)]
-async fn plan_index<T: Debug>(
+async fn plan_index<T>(
     storage: &dyn Store<T>,
     indexes: &Indexes,
     selection: Expr,

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -110,11 +110,11 @@ pub trait TrySelf<V>
 where
     Self: Sized,
 {
-    fn try_self<T: Debug, U: GStore<T> + GStoreMut<T>>(self, storage: U) -> MutResult<U, V>;
+    fn try_self<T, U: GStore<T> + GStoreMut<T>>(self, storage: U) -> MutResult<U, V>;
 }
 
 impl<V> TrySelf<V> for Result<V> {
-    fn try_self<T: Debug, U: GStore<T> + GStoreMut<T>>(self, storage: U) -> MutResult<U, V> {
+    fn try_self<T, U: GStore<T> + GStoreMut<T>>(self, storage: U) -> MutResult<U, V> {
         match self {
             Ok(v) => Ok((storage, v)),
             Err(e) => Err((storage, e)),

--- a/core/src/store/index.rs
+++ b/core/src/store/index.rs
@@ -39,7 +39,7 @@ pub enum IndexError {
 }
 
 #[async_trait(?Send)]
-pub trait Index<T: Debug> {
+pub trait Index<T> {
     async fn scan_indexed_data(
         &self,
         table_name: &str,
@@ -50,7 +50,7 @@ pub trait Index<T: Debug> {
 }
 
 #[async_trait(?Send)]
-pub trait IndexMut<T: Debug>
+pub trait IndexMut<T>
 where
     Self: Sized,
 {

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -31,33 +31,33 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(all(feature = "metadata", feature = "index"))] {
-        pub trait GStore<T: Debug>: Store<T> + Metadata + Index<T> {}
+        pub trait GStore<T>: Store<T> + Metadata + Index<T> {}
     } else if #[cfg(feature = "metadata")] {
-        pub trait GStore<T: Debug>: Store<T> + Metadata {}
+        pub trait GStore<T>: Store<T> + Metadata {}
     } else if #[cfg(feature = "index")] {
-        pub trait GStore<T: Debug>: Store<T> + Index<T> {}
+        pub trait GStore<T>: Store<T> + Index<T> {}
     } else {
-        pub trait GStore<T: Debug>: Store<T> {}
+        pub trait GStore<T>: Store<T> {}
     }
 }
 
 cfg_if! {
     if #[cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + AlterTable + Transaction {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + AlterTable + Transaction {}
     } else if #[cfg(all(feature = "alter-table", feature = "index"))] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + AlterTable {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + AlterTable {}
     } else if #[cfg(all(feature = "alter-table", feature = "transaction"))] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + Transaction + AlterTable {}
+        pub trait GStoreMut<T>: StoreMut<T> + Transaction + AlterTable {}
     } else if #[cfg(all(feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> + Transaction {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + Transaction {}
     } else if #[cfg(feature = "alter-table")] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + AlterTable {}
+        pub trait GStoreMut<T>: StoreMut<T> + AlterTable {}
     } else if #[cfg(feature = "index")] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + IndexMut<T> {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> {}
     } else if #[cfg(feature = "transaction")] {
-        pub trait GStoreMut<T: Debug>: StoreMut<T> + Transaction {}
+        pub trait GStoreMut<T>: StoreMut<T> + Transaction {}
     } else {
-        pub trait GStoreMut<T: Debug>: Store<T> + StoreMut<T> {}
+        pub trait GStoreMut<T>: Store<T> + StoreMut<T> {}
     }
 }
 
@@ -67,14 +67,13 @@ use {
         result::{MutResult, Result},
     },
     async_trait::async_trait,
-    std::fmt::Debug,
 };
 
 pub type RowIter<T> = Box<dyn Iterator<Item = Result<(T, Row)>>>;
 
 /// By implementing `Store` trait, you can run `SELECT` query.
 #[async_trait(?Send)]
-pub trait Store<T: Debug> {
+pub trait Store<T> {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>>;
 
     async fn scan_data(&self, table_name: &str) -> Result<RowIter<T>>;
@@ -83,7 +82,7 @@ pub trait Store<T: Debug> {
 /// By implementing `StoreMut` trait,
 /// you can run `INSERT`, `CREATE TABLE`, `DELETE`, `UPDATE` and `DROP TABLE` queries.
 #[async_trait(?Send)]
-pub trait StoreMut<T: Debug>
+pub trait StoreMut<T>
 where
     Self: Sized,
 {

--- a/storages/sled-storage/src/snapshot.rs
+++ b/storages/sled-storage/src/snapshot.rs
@@ -13,7 +13,7 @@ struct SnapshotItem<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Snapshot<T>(Vec<SnapshotItem<T>>);
 
-impl<T: Debug + Clone> Snapshot<T> {
+impl<T: Clone> Snapshot<T> {
     pub fn new(txid: u64, data: T) -> Self {
         Self(vec![SnapshotItem {
             data,

--- a/storages/sled-storage/src/transaction.rs
+++ b/storages/sled-storage/src/transaction.rs
@@ -21,7 +21,7 @@ use {
         },
         IVec,
     },
-    std::{fmt::Debug, result::Result as StdResult},
+    std::result::Result as StdResult,
 };
 
 macro_rules! transaction {
@@ -166,7 +166,7 @@ impl SledStorage {
                 .collect::<Result<Vec<_>>>()
         };
 
-        fn rollback_items<T: Debug + Clone + Serialize + DeserializeOwned>(
+        fn rollback_items<T: Clone + Serialize + DeserializeOwned>(
             tree: &TransactionalTree,
             txid: u64,
             items: &[(IVec, IVec)],

--- a/test-suite/src/tester.rs
+++ b/test-suite/src/tester.rs
@@ -8,7 +8,7 @@ use {
         store::{GStore, GStoreMut},
         translate::translate_expr,
     },
-    std::{cell::RefCell, fmt::Debug, rc::Rc},
+    std::{cell::RefCell, rc::Rc},
 };
 
 pub fn expr(sql: &str) -> Expr {
@@ -86,7 +86,7 @@ pub fn test(expected: Result<Payload>, found: Result<Payload>) {
     }
 }
 
-pub async fn run<T: Debug, U: GStore<T> + GStoreMut<T>>(
+pub async fn run<T, U: GStore<T> + GStoreMut<T>>(
     cell: Rc<RefCell<Option<U>>>,
     sql: &str,
     indexes: Option<Vec<IndexItem>>,
@@ -234,7 +234,7 @@ pub fn type_match(expected: &[DataType], found: Result<Payload>) {
 /// Actual test cases are in [test-suite/src/](https://github.com/gluesql/gluesql/blob/main/test-suite/src/),
 /// not in `/tests/`.
 #[async_trait]
-pub trait Tester<T: Debug, U: GStore<T> + GStoreMut<T>> {
+pub trait Tester<T, U: GStore<T> + GStoreMut<T>> {
     fn new(namespace: &str) -> Self;
 
     fn get_cell(&mut self) -> Rc<RefCell<Option<U>>>;

--- a/tests/glue.rs
+++ b/tests/glue.rs
@@ -1,14 +1,11 @@
 #![cfg(any(feature = "memory-storage", feature = "sled-storage"))]
-use {
-    gluesql_core::{
-        executor::Payload,
-        prelude::{Glue, Value},
-        store::{GStore, GStoreMut},
-    },
-    std::fmt::Debug,
+use gluesql_core::{
+    executor::Payload,
+    prelude::{Glue, Value},
+    store::{GStore, GStoreMut},
 };
 
-fn basic<T: Debug, U: GStore<T> + GStoreMut<T>>(mut glue: Glue<T, U>) {
+fn basic<T, U: GStore<T> + GStoreMut<T>>(mut glue: Glue<T, U>) {
     assert_eq!(
         glue.execute("DROP TABLE IF EXISTS api_test"),
         Ok(Payload::DropTable)
@@ -53,7 +50,7 @@ fn basic<T: Debug, U: GStore<T> + GStoreMut<T>>(mut glue: Glue<T, U>) {
     );
 }
 
-async fn basic_async<T: Debug, U: GStore<T> + GStoreMut<T>>(mut glue: Glue<T, U>) {
+async fn basic_async<T, U: GStore<T> + GStoreMut<T>>(mut glue: Glue<T, U>) {
     assert_eq!(
         glue.execute_async("DROP TABLE IF EXISTS api_test").await,
         Ok(Payload::DropTable)


### PR DESCRIPTION
We don't need to require the `Debug` macro for the Generic type `T` we use as `Key`. 
because the `Debug` macro is not used internally.