### PR TITLE
Remove unused generic in `IndexMut`

### DIFF
--- a/core/src/store/index.rs
+++ b/core/src/store/index.rs
@@ -50,7 +50,7 @@ pub trait Index<T> {
 }
 
 #[async_trait(?Send)]
-pub trait IndexMut<T>
+pub trait IndexMut
 where
     Self: Sized,
 {

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -43,17 +43,17 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + AlterTable + Transaction {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut + AlterTable + Transaction {}
     } else if #[cfg(all(feature = "alter-table", feature = "index"))] {
-        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + AlterTable {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut + AlterTable {}
     } else if #[cfg(all(feature = "alter-table", feature = "transaction"))] {
         pub trait GStoreMut<T>: StoreMut<T> + Transaction + AlterTable {}
     } else if #[cfg(all(feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> + Transaction {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut + Transaction {}
     } else if #[cfg(feature = "alter-table")] {
         pub trait GStoreMut<T>: StoreMut<T> + AlterTable {}
     } else if #[cfg(feature = "index")] {
-        pub trait GStoreMut<T>: StoreMut<T> + IndexMut<T> {}
+        pub trait GStoreMut<T>: StoreMut<T> + IndexMut {}
     } else if #[cfg(feature = "transaction")] {
         pub trait GStoreMut<T>: StoreMut<T> + Transaction {}
     } else {

--- a/storages/memory-storage/src/index.rs
+++ b/storages/memory-storage/src/index.rs
@@ -25,7 +25,7 @@ impl Index<Key> for MemoryStorage {
 }
 
 #[async_trait(?Send)]
-impl IndexMut<Key> for MemoryStorage {
+impl IndexMut for MemoryStorage {
     async fn create_index(
         self,
         _table_name: &str,

--- a/storages/sled-storage/src/index_mut.rs
+++ b/storages/sled-storage/src/index_mut.rs
@@ -14,11 +14,8 @@ use {
         result::{Error, MutResult, Result, TrySelf},
         store::{IndexError, IndexMut, Store},
     },
-    sled::{
-        transaction::{
-            ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
-        },
-        IVec,
+    sled::transaction::{
+        ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
     },
     std::iter::once,
 };
@@ -39,7 +36,7 @@ fn fetch_schema(
 }
 
 #[async_trait(?Send)]
-impl IndexMut<IVec> for SledStorage {
+impl IndexMut for SledStorage {
     async fn create_index(
         self,
         table_name: &str,


### PR DESCRIPTION
`IndexMut` trait does not require the `T` generic for the Key value.