### PR TITLE
Simplify lifetime uses in data/literal binary operators

### DIFF
--- a/core/src/data/literal.rs
+++ b/core/src/data/literal.rs
@@ -133,7 +133,7 @@ impl<'a> Literal<'a> {
         }
     }
 
-    pub fn add<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+    pub fn add(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
         match (self, other) {
             (Number(l), Number(r)) => Ok(Number(Cow::Owned(l.as_ref() + r.as_ref()))),
             (Interval(l), Interval(r)) => l.add(r).map(Interval),
@@ -150,7 +150,7 @@ impl<'a> Literal<'a> {
         }
     }
 
-    pub fn subtract<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+    pub fn subtract(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
         match (self, other) {
             (Number(l), Number(r)) => Ok(Number(Cow::Owned(l.as_ref() - r.as_ref()))),
             (Interval(l), Interval(r)) => l.subtract(r).map(Interval),
@@ -167,7 +167,7 @@ impl<'a> Literal<'a> {
         }
     }
 
-    pub fn multiply<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+    pub fn multiply(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
         match (self, other) {
             (Number(l), Number(r)) => Ok(Number(Cow::Owned(l.as_ref() * r.as_ref()))),
             (Number(l), Interval(r)) | (Interval(r), Number(l)) => {
@@ -192,7 +192,7 @@ impl<'a> Literal<'a> {
         }
     }
 
-    pub fn divide<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+    pub fn divide(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
         match (self, other) {
             (Number(l), Number(r)) => {
                 if *r.as_ref() == 0.into() {
@@ -224,7 +224,7 @@ impl<'a> Literal<'a> {
         }
     }
 
-    pub fn modulo<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
+    pub fn modulo(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
         match (self, other) {
             (Number(l), Number(r)) => {
                 if *r.as_ref() == 0.into() {


### PR DESCRIPTION
Replace `'b` to `'static`, make it to use more narrow lifetimes.

e.g.
```rust
// from
pub fn add<'b>(&self, other: &Literal<'a>) -> Result<Literal<'b>> {
 ..
}

// to
pub fn add(&self, other: &Literal<'a>) -> Result<Literal<'static>> {
 ..
}
```
