### PR TITLE
Add support SQL file read-and-execute

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -3,17 +3,26 @@ pub enum Command {
     Help,
     Quit,
     Execute(String),
+    ExecuteFromFile(String)
 }
 
 impl Command {
     pub fn parse(line: &str) -> Result<Self, ()> {
-        match line.trim_start().trim_end_matches(|c| c == ' ' || c == ';') {
-            ".help" => Ok(Self::Help),
-            ".quit" => Ok(Self::Quit),
-            ".tables" => Ok(Self::Execute("SHOW TABLES".to_owned())),
-            ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
-            _ if line.starts_with('.') => Err(()),
-            sql => Ok(Self::Execute(sql.to_owned())),
+        let line = line.trim_start().trim_end_matches(|c| c == ' ' || c == ';');
+        // We detect if the line is a command or not
+        if line.starts_with('.') {
+            let params: Vec<&str> = line.split_whitespace()
+                                        .collect();
+            match params[0] {
+                ".help" => Ok(Self::Help),
+                ".quit" => Ok(Self::Quit),
+                ".tables" => Ok(Self::Execute("SHOW TABLES".to_owned())),
+                ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
+                ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
+                _ => Err(()),
+            }
+        } else {
+            Ok(Self::Execute(line.to_owned()))
         }
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,6 +18,10 @@ struct Args {
     /// sled-storage path to load
     #[clap(short, long, parse(from_os_str))]
     path: Option<PathBuf>,
+
+    /// SQL file to execute
+    #[clap(short, long, parse(from_os_str))]
+    execute: Option<PathBuf>,
 }
 
 pub fn run() {
@@ -27,15 +31,22 @@ pub fn run() {
         let path = path.as_path().to_str().expect("wrong path");
 
         println!("[sled-storage] connected to {}", path);
-        run(SledStorage::new(path).expect("failed to load sled-storage"));
+        run(SledStorage::new(path).expect("failed to load sled-storage"), args.execute);
     } else {
         println!("[memory-storage] initialized");
-        run(MemoryStorage::default());
+        run(MemoryStorage::default(), args.execute);
     }
 
-    fn run<T, U: GStore<T> + GStoreMut<T>>(storage: U) {
+    fn run<T, U: GStore<T> + GStoreMut<T>>(storage: U, input: Option<PathBuf>) {
         let output = std::io::stdout();
         let mut cli = Cli::new(storage, output);
+
+        if let Some(path) = input {
+            
+            if let Err(e) = cli.load(path.as_path().to_str().expect("wrong path")) {
+                println!("[error] {}\n", e);
+            };
+        }
 
         if let Err(e) = cli.run() {
             eprintln!("{}", e);

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -57,11 +57,12 @@ impl<W: Write> Print<W> {
 
     pub fn help(&mut self) -> Result<()> {
         const HEADER: [&str; 2] = ["command", "description"];
-        const CONTENT: [[&str; 2]; 4] = [
+        const CONTENT: [[&str; 2]; 5] = [
             [".help", "show help"],
             [".quit", "quit program"],
             [".tables", "show table names"],
             [".version", "show version"],
+            [".execute FILE", "execute SQL from a file"],
         ];
 
         let mut table = get_table(HEADER);
@@ -92,14 +93,15 @@ mod tests {
         let mut print = Print::new(Vec::new());
 
         let expected = "
-╭─────────────────────────────╮
-│ command    description      │
-╞═════════════════════════════╡
-│ .help      show help        │
-│ .quit      quit program     │
-│ .tables    show table names │
-│ .version   show version     │
-╰─────────────────────────────╯";
+╭─────────────────────────────────────────╮
+│ command         description             │
+╞═════════════════════════════════════════╡
+│ .help           show help               │
+│ .quit           quit program            │
+│ .tables         show table names        │
+│ .version        show version            │
+│ .execute FILE   execute SQL from a file │
+╰─────────────────────────────────────────╯";
         let found = {
             print.help().unwrap();
 


### PR DESCRIPTION
### New
#### Add a functionality to read-and-execute SQL file in GlueSQL CLI
* Using with command line argument
* Using inside the GlueSQL CLI
### Demo
![a](https://user-images.githubusercontent.com/45305909/158263854-99c08d53-b77f-47ef-b2a3-d978dd1b7ddd.png)

