### PR TITLE
Correct the plural of index from `indexes` to `indices`

### DIFF
--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -22,7 +22,7 @@ pub struct SchemaIndex {
 pub struct Schema {
     pub table_name: String,
     pub column_defs: Vec<ColumnDef>,
-    pub indexes: Vec<SchemaIndex>,
+    pub indices: Vec<SchemaIndex>,
 }
 
 pub trait ColumnDefExt {

--- a/core/src/executor/alter/alter_table.rs
+++ b/core/src/executor/alter/alter_table.rs
@@ -56,8 +56,8 @@ pub async fn alter_table<T, U: GStore<T> + GStoreMut<T>>(
         } => {
             #[cfg(feature = "index")]
             let storage = {
-                let indexes = match storage.fetch_schema(table_name).await {
-                    Ok(Some(Schema { indexes, .. })) => indexes,
+                let indices = match storage.fetch_schema(table_name).await {
+                    Ok(Some(Schema { indices, .. })) => indices,
                     Ok(None) => {
                         return Err((
                             storage,
@@ -69,12 +69,12 @@ pub async fn alter_table<T, U: GStore<T> + GStoreMut<T>>(
                     }
                 };
 
-                let indexes = indexes
+                let indices = indices
                     .iter()
                     .filter(|SchemaIndex { expr, .. }| find_column(expr, column_name))
                     .map(Ok);
 
-                stream::iter(indexes)
+                stream::iter(indices)
                     .try_fold(storage, |storage, SchemaIndex { name, .. }| async move {
                         storage
                             .drop_index(table_name, name)

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -43,7 +43,7 @@ pub async fn create_table<T, U: GStore<T> + GStoreMut<T>>(
         let schema = Schema {
             table_name: target_table_name.to_string(),
             column_defs: target_columns_defs,
-            indexes: vec![],
+            indices: vec![],
         };
 
         for column_def in &schema.column_defs {

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -52,7 +52,7 @@ impl AlterTable for SledStorage {
             let (old_snapshot, old_schema) = schema_snapshot.delete(txid);
             let Schema {
                 column_defs,
-                indexes,
+                indices,
                 ..
             } = old_schema
                 .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_string()).into())
@@ -61,7 +61,7 @@ impl AlterTable for SledStorage {
             let new_schema = Schema {
                 table_name: new_table_name.to_string(),
                 column_defs,
-                indexes,
+                indices,
             };
 
             bincode::serialize(&old_snapshot)
@@ -157,7 +157,7 @@ impl AlterTable for SledStorage {
 
             let Schema {
                 column_defs,
-                indexes,
+                indices,
                 ..
             } = snapshot
                 .get(txid, None)
@@ -184,7 +184,7 @@ impl AlterTable for SledStorage {
             let schema = Schema {
                 table_name: table_name.to_string(),
                 column_defs,
-                indexes,
+                indices,
             };
             let (snapshot, _) = snapshot.update(txid, schema);
             let value = bincode::serialize(&snapshot)
@@ -234,7 +234,7 @@ impl AlterTable for SledStorage {
             let Schema {
                 table_name,
                 column_defs,
-                indexes,
+                indices,
             } = schema_snapshot
                 .get(txid, None)
                 .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_string()).into())
@@ -307,7 +307,7 @@ impl AlterTable for SledStorage {
             let schema = Schema {
                 table_name,
                 column_defs,
-                indexes,
+                indices,
             };
             let (schema_snapshot, _) = schema_snapshot.update(txid, schema);
             let schema_value = bincode::serialize(&schema_snapshot)
@@ -361,7 +361,7 @@ impl AlterTable for SledStorage {
             let Schema {
                 table_name,
                 column_defs,
-                indexes,
+                indices,
             } = schema_snapshot
                 .get(txid, None)
                 .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_string()).into())
@@ -427,7 +427,7 @@ impl AlterTable for SledStorage {
             let schema = Schema {
                 table_name,
                 column_defs,
-                indexes,
+                indices,
             };
             let (schema_snapshot, _) = schema_snapshot.update(txid, schema);
             let schema_value = bincode::serialize(&schema_snapshot)

--- a/storages/sled-storage/src/index_mut.rs
+++ b/storages/sled-storage/src/index_mut.rs
@@ -66,13 +66,13 @@ impl IndexMut for SledStorage {
             let (schema_snapshot, schema) = schema_snapshot.delete(txid);
             let Schema {
                 column_defs,
-                indexes,
+                indices,
                 ..
             } = schema
                 .ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()).into())
                 .map_err(ConflictableTransactionError::Abort)?;
 
-            if indexes.iter().any(|index| index.name == index_name) {
+            if indices.iter().any(|index| index.name == index_name) {
                 return Err(IndexError::IndexNameAlreadyExists(index_name.to_owned()).into())
                     .map_err(ConflictableTransactionError::Abort);
             }
@@ -83,7 +83,7 @@ impl IndexMut for SledStorage {
                 order: SchemaIndexOrd::Both,
             };
 
-            let indexes = indexes
+            let indices = indices
                 .into_iter()
                 .chain(once(index.clone()))
                 .collect::<Vec<_>>();
@@ -91,7 +91,7 @@ impl IndexMut for SledStorage {
             let schema = Schema {
                 table_name: table_name.to_owned(),
                 column_defs,
-                indexes,
+                indices,
             };
 
             let index_sync = IndexSync::from_schema(tree, txid, &schema);
@@ -141,13 +141,13 @@ impl IndexMut for SledStorage {
             let (schema_snapshot, schema) = schema_snapshot.delete(txid);
             let Schema {
                 column_defs,
-                indexes,
+                indices,
                 ..
             } = schema
                 .ok_or_else(|| IndexError::ConflictTableNotFound(table_name.to_owned()).into())
                 .map_err(ConflictableTransactionError::Abort)?;
 
-            let (index, indexes): (Vec<_>, _) = indexes
+            let (index, indices): (Vec<_>, _) = indices
                 .into_iter()
                 .partition(|index| index.name == index_name);
 
@@ -162,7 +162,7 @@ impl IndexMut for SledStorage {
             let schema = Schema {
                 table_name: table_name.to_owned(),
                 column_defs,
-                indexes,
+                indices,
             };
 
             let index_sync = IndexSync::from_schema(tree, txid, &schema);

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -38,7 +38,7 @@ macro_rules! test_idx {
     ($glue: ident $sql: literal, $idx: expr, $result: expr) => {
         let statement = $glue.plan($sql).await.unwrap();
 
-        test_indexes(&statement, Some($idx));
+        test_indices(&statement, Some($idx));
         assert_eq!($glue.execute_stmt(statement), $result);
     };
 }

--- a/test-suite/src/alter/drop_indexed.rs
+++ b/test-suite/src/alter/drop_indexed.rs
@@ -61,7 +61,7 @@ CREATE TABLE Test (
     "#
     );
 
-    // create indexes
+    // create indices
     run!("CREATE INDEX idx_name ON Test (num + 1)");
     run!("CREATE INDEX idx_id ON Test (id)");
     run!("CREATE INDEX idx_typed_string ON Test ((id))");
@@ -69,7 +69,7 @@ CREATE TABLE Test (
     run!("CREATE INDEX idx_unary_op ON Test (-id);");
     run!("CREATE INDEX idx_cast ON Test (CAST(id AS TEXT));");
 
-    // check indexes working
+    // check indices working
     test!(
         Err(AlterError::IdentifierNotFound(expr!("100")).into()),
         "CREATE INDEX idx_literal ON Test (100)"
@@ -163,5 +163,5 @@ CREATE TABLE Test (
     );
 
     // Only idx_name remains.
-    assert_eq!(1, schema!("Test").indexes.len());
+    assert_eq!(1, schema!("Test").indices.len());
 });


### PR DESCRIPTION
# Indexes -> Indices
Just a tiny spelling correction.
The plural of the `index` should be `indices`.

## Reference
https://www.merriam-webster.com/dictionary/indices
