### PR TITLE
Minor improvements

### DIFF
--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -27,7 +27,7 @@ impl<T, U: GStore<T> + GStoreMut<T>> Glue<T, U> {
         }
     }
 
-    pub async fn plan(&self, sql: &str) -> Result<Statement> {
+    pub async fn plan<Sql: AsRef<str>>(&self, sql: Sql) -> Result<Statement> {
         let parsed = parse(sql)?;
         let statement = translate(&parsed[0])?;
         let storage = self.storage.as_ref().unwrap();
@@ -39,7 +39,7 @@ impl<T, U: GStore<T> + GStoreMut<T>> Glue<T, U> {
         block_on(self.execute_stmt_async(statement))
     }
 
-    pub fn execute(&mut self, sql: &str) -> Result<Payload> {
+    pub fn execute<Sql: AsRef<str>>(&mut self, sql: Sql) -> Result<Payload> {
         let statement = block_on(self.plan(sql))?;
 
         self.execute_stmt(statement)
@@ -62,7 +62,7 @@ impl<T, U: GStore<T> + GStoreMut<T>> Glue<T, U> {
         }
     }
 
-    pub async fn execute_async(&mut self, sql: &str) -> Result<Payload> {
+    pub async fn execute_async<Sql: AsRef<str>>(&mut self, sql: Sql) -> Result<Payload> {
         let statement = self.plan(sql).await?;
 
         self.execute_stmt_async(statement).await

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -8,15 +8,15 @@ use {
     },
 };
 
-pub fn parse(sql: &str) -> Result<Vec<SqlStatement>> {
+pub fn parse<Sql: AsRef<str>>(sql: Sql) -> Result<Vec<SqlStatement>> {
     let dialect = GenericDialect {};
 
-    Parser::parse_sql(&dialect, sql).map_err(|e| Error::Parser(format!("{:#?}", e)))
+    Parser::parse_sql(&dialect, sql.as_ref()).map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
-pub fn parse_query(sql_expr: &str) -> Result<SqlQuery> {
+pub fn parse_query<Sql: AsRef<str>>(sql_expr: Sql) -> Result<SqlQuery> {
     let dialect = GenericDialect {};
-    let tokens = Tokenizer::new(&dialect, sql_expr)
+    let tokens = Tokenizer::new(&dialect, sql_expr.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
@@ -25,9 +25,9 @@ pub fn parse_query(sql_expr: &str) -> Result<SqlQuery> {
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
-pub fn parse_expr(sql_expr: &str) -> Result<SqlExpr> {
+pub fn parse_expr<Sql: AsRef<str>>(sql_expr: Sql) -> Result<SqlExpr> {
     let dialect = GenericDialect {};
-    let tokens = Tokenizer::new(&dialect, sql_expr)
+    let tokens = Tokenizer::new(&dialect, sql_expr.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
@@ -36,9 +36,9 @@ pub fn parse_expr(sql_expr: &str) -> Result<SqlExpr> {
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
-pub fn parse_interval(sql_interval: &str) -> Result<SqlExpr> {
+pub fn parse_interval<Sql: AsRef<str>>(sql_interval: Sql) -> Result<SqlExpr> {
     let dialect = GenericDialect {};
-    let tokens = Tokenizer::new(&dialect, sql_interval)
+    let tokens = Tokenizer::new(&dialect, sql_interval.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -8,10 +8,10 @@ use {
     },
 };
 
-pub fn parse<Sql: AsRef<str>>(sql: Sql) -> Result<Vec<SqlStatement>> {
-    let dialect = GenericDialect {};
+const DIALECT: GenericDialect = GenericDialect {};
 
-    Parser::parse_sql(&dialect, sql.as_ref()).map_err(|e| Error::Parser(format!("{:#?}", e)))
+pub fn parse<Sql: AsRef<str>>(sql: Sql) -> Result<Vec<SqlStatement>> {
+    Parser::parse_sql(&DIALECT, sql.as_ref()).map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
 pub fn parse_query<Sql: AsRef<str>>(sql_expr: Sql) -> Result<SqlQuery> {
@@ -26,23 +26,21 @@ pub fn parse_query<Sql: AsRef<str>>(sql_expr: Sql) -> Result<SqlQuery> {
 }
 
 pub fn parse_expr<Sql: AsRef<str>>(sql_expr: Sql) -> Result<SqlExpr> {
-    let dialect = GenericDialect {};
-    let tokens = Tokenizer::new(&dialect, sql_expr.as_ref())
+    let tokens = Tokenizer::new(&DIALECT, sql_expr.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
-    Parser::new(tokens, &dialect)
+    Parser::new(tokens, &DIALECT)
         .parse_expr()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
 pub fn parse_interval<Sql: AsRef<str>>(sql_interval: Sql) -> Result<SqlExpr> {
-    let dialect = GenericDialect {};
-    let tokens = Tokenizer::new(&dialect, sql_interval.as_ref())
+    let tokens = Tokenizer::new(&DIALECT, sql_interval.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
-    Parser::new(tokens, &dialect)
+    Parser::new(tokens, &DIALECT)
         .parse_literal_interval()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }


### PR DESCRIPTION
- It seems that receiving a variable that implements `AsRef<str>` would have a better experience for the user than receiving only the `&str` type
- I create a dialect every time I parse a sql statement, but it doesn't seem to be necessary.
    - It would be nice to make this for the user to choose later.