### PR TITLE
Fix CLI --execute {file}.sql option to support CRLF line break,

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -100,7 +100,7 @@ where
     pub fn load<P: AsRef<Path>>(&mut self, filename: P) -> Result<()> {
         let mut sqls = String::new();
         File::open(filename)?.read_to_string(&mut sqls)?;
-        for sql in sqls.split(";\n").filter(|sql| !sql.trim().is_empty()) {
+        for sql in sqls.split(";").filter(|sql| !sql.trim().is_empty()) {
             match self.glue.execute(sql) {
                 Ok(payload) => self.print.payload(payload)?,
                 Err(e) => {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -100,7 +100,7 @@ where
     pub fn load<P: AsRef<Path>>(&mut self, filename: P) -> Result<()> {
         let mut sqls = String::new();
         File::open(filename)?.read_to_string(&mut sqls)?;
-        for sql in sqls.split(";").filter(|sql| !sql.trim().is_empty()) {
+        for sql in sqls.split(';').filter(|sql| !sql.trim().is_empty()) {
             match self.glue.execute(sql) {
                 Ok(payload) => self.print.payload(payload)?,
                 Err(e) => {


### PR DESCRIPTION
Replace ";\n" to ";" in --execute line splitting.

SQL files which are generated in Windows OS usually use CRLF symbol for line-break.
Current CLI `--execute` option was handling only the first statement and ignores the remainders.
Fix splitting symbol not to contain `\n` to resolve this issue.