### PR TITLE
resolve issue #424

### DIFF
--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -16,5 +16,5 @@ pub use {
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
     string_ext::{StringExt, StringExtError},
     table::{get_name, Table, TableError},
-    value::{Value, ValueError},
+    value::{NumericBinaryOperator, Value, ValueError},
 };

--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -1,6 +1,10 @@
 use {
     super::TryBinaryOperator,
-    crate::{data::ValueError, prelude::Value, result::Result},
+    crate::{
+        data::{NumericBinaryOperator, ValueError},
+        prelude::Value,
+        result::Result,
+    },
     std::cmp::Ordering,
     Value::*,
 };
@@ -42,7 +46,7 @@ impl TryBinaryOperator for f64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: F64(lhs),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -59,7 +63,7 @@ impl TryBinaryOperator for f64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: F64(lhs),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -77,7 +81,7 @@ impl TryBinaryOperator for f64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: F64(lhs),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -94,7 +98,7 @@ impl TryBinaryOperator for f64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: F64(lhs),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -111,7 +115,7 @@ impl TryBinaryOperator for f64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: F64(lhs),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -123,7 +127,7 @@ impl TryBinaryOperator for f64 {
 mod tests {
     use {
         super::{TryBinaryOperator, Value::*},
-        crate::data::ValueError,
+        crate::data::{NumericBinaryOperator, ValueError},
         std::cmp::Ordering,
     };
 
@@ -161,7 +165,7 @@ mod tests {
             base.try_add(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: F64(1.0),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: Bool(true)
             }
             .into())
@@ -184,7 +188,7 @@ mod tests {
             base.try_subtract(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: F64(1.0),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: Bool(true)
             }
             .into())
@@ -207,7 +211,7 @@ mod tests {
             base.try_multiply(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: F64(1.0),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: Bool(true)
             }
             .into())
@@ -228,7 +232,7 @@ mod tests {
             base.try_divide(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: F64(1.0),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: Bool(true)
             }
             .into())
@@ -249,7 +253,7 @@ mod tests {
             base.try_modulo(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: F64(1.0),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: Bool(true)
             }
             .into())

--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -5,6 +5,19 @@ use {
     Value::*,
 };
 
+impl PartialEq<Value> for f64 {
+    fn eq(&self, other: &Value) -> bool {
+        let lhs = *self;
+
+        match *other {
+            I8(rhs) => lhs == rhs as f64,
+            I64(rhs) => lhs == rhs as f64,
+            F64(rhs) => lhs == rhs,
+            _ => false,
+        }
+    }
+}
+
 impl PartialOrd<Value> for f64 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match *other {
@@ -27,7 +40,12 @@ impl TryBinaryOperator for f64 {
             I64(rhs) => Ok(F64(lhs + rhs as f64)),
             F64(rhs) => Ok(F64(lhs + rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::AddOnNonNumeric(F64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F64(lhs),
+                operator: "+".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -39,7 +57,12 @@ impl TryBinaryOperator for f64 {
             I64(rhs) => Ok(F64(lhs - rhs as f64)),
             F64(rhs) => Ok(F64(lhs - rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::SubtractOnNonNumeric(F64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F64(lhs),
+                operator: "-".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -52,7 +75,12 @@ impl TryBinaryOperator for f64 {
             F64(rhs) => Ok(F64(lhs * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::MultiplyOnNonNumeric(F64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F64(lhs),
+                operator: "*".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -64,7 +92,12 @@ impl TryBinaryOperator for f64 {
             I64(rhs) => Ok(F64(lhs / rhs as f64)),
             F64(rhs) => Ok(F64(lhs / rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::DivideOnNonNumeric(F64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F64(lhs),
+                operator: "/".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -76,7 +109,12 @@ impl TryBinaryOperator for f64 {
             I64(rhs) => Ok(F64(lhs % rhs as f64)),
             F64(rhs) => Ok(F64(lhs % rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::ModuloOnNonNumeric(F64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F64(lhs),
+                operator: "%".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 }
@@ -121,7 +159,12 @@ mod tests {
 
         assert_eq!(
             base.try_add(&Bool(true)),
-            Err(ValueError::AddOnNonNumeric(F64(1.0), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F64(1.0),
+                operator: "+".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -139,7 +182,12 @@ mod tests {
 
         assert_eq!(
             base.try_subtract(&Bool(true)),
-            Err(ValueError::SubtractOnNonNumeric(F64(1.0), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F64(1.0),
+                operator: "-".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -157,7 +205,12 @@ mod tests {
 
         assert_eq!(
             base.try_multiply(&Bool(true)),
-            Err(ValueError::MultiplyOnNonNumeric(F64(1.0), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F64(1.0),
+                operator: "*".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -173,7 +226,12 @@ mod tests {
 
         assert_eq!(
             base.try_divide(&Bool(true)),
-            Err(ValueError::DivideOnNonNumeric(F64(1.0), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F64(1.0),
+                operator: "/".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -189,7 +247,12 @@ mod tests {
 
         assert_eq!(
             base.try_modulo(&Bool(true)),
-            Err(ValueError::ModuloOnNonNumeric(F64(1.0), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F64(1.0),
+                operator: "%".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 }

--- a/core/src/data/value/binary_op/i64.rs
+++ b/core/src/data/value/binary_op/i64.rs
@@ -1,6 +1,10 @@
 use {
     super::TryBinaryOperator,
-    crate::{data::ValueError, prelude::Value, result::Result},
+    crate::{
+        data::{NumericBinaryOperator, ValueError},
+        prelude::Value,
+        result::Result,
+    },
     std::cmp::Ordering,
     Value::*,
 };
@@ -42,7 +46,7 @@ impl TryBinaryOperator for i64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I64(lhs),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -59,7 +63,7 @@ impl TryBinaryOperator for i64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I64(lhs),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -77,7 +81,7 @@ impl TryBinaryOperator for i64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I64(lhs),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -94,7 +98,7 @@ impl TryBinaryOperator for i64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I64(lhs),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -111,7 +115,7 @@ impl TryBinaryOperator for i64 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I64(lhs),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -123,7 +127,7 @@ impl TryBinaryOperator for i64 {
 mod tests {
     use {
         super::{TryBinaryOperator, Value::*},
-        crate::data::ValueError,
+        crate::data::{NumericBinaryOperator, ValueError},
         std::cmp::Ordering,
     };
 
@@ -161,7 +165,7 @@ mod tests {
             base.try_add(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I64(1),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: Bool(true)
             }
             .into())
@@ -182,7 +186,7 @@ mod tests {
             base.try_subtract(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I64(1),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: Bool(true)
             }
             .into())
@@ -203,7 +207,7 @@ mod tests {
             base.try_multiply(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I64(1),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: Bool(true)
             }
             .into())
@@ -222,7 +226,7 @@ mod tests {
             base.try_divide(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I64(1),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: Bool(true)
             }
             .into())
@@ -243,7 +247,7 @@ mod tests {
             base.try_modulo(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I64(1),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: Bool(true)
             }
             .into())

--- a/core/src/data/value/binary_op/i64.rs
+++ b/core/src/data/value/binary_op/i64.rs
@@ -5,6 +5,19 @@ use {
     Value::*,
 };
 
+impl PartialEq<Value> for i64 {
+    fn eq(&self, other: &Value) -> bool {
+        let lhs = *self;
+
+        match *other {
+            I8(rhs) => lhs == rhs as i64,
+            I64(rhs) => lhs == rhs,
+            F64(rhs) => lhs as f64 == rhs,
+            _ => false,
+        }
+    }
+}
+
 impl PartialOrd<Value> for i64 {
     fn partial_cmp(&self, rhs: &Value) -> Option<Ordering> {
         match rhs {
@@ -27,7 +40,12 @@ impl TryBinaryOperator for i64 {
             I64(rhs) => Ok(I64(lhs + rhs)),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::AddOnNonNumeric(I64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I64(lhs),
+                operator: "+".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -39,7 +57,12 @@ impl TryBinaryOperator for i64 {
             I64(rhs) => Ok(I64(lhs - rhs)),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::SubtractOnNonNumeric(I64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I64(lhs),
+                operator: "-".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -52,7 +75,12 @@ impl TryBinaryOperator for i64 {
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::MultiplyOnNonNumeric(I64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I64(lhs),
+                operator: "*".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -64,7 +92,12 @@ impl TryBinaryOperator for i64 {
             I64(rhs) => Ok(I64(lhs / rhs)),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::DivideOnNonNumeric(I64(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I64(lhs),
+                operator: "/".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -76,20 +109,12 @@ impl TryBinaryOperator for i64 {
             I64(rhs) => Ok(I64(lhs % rhs)),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::ModuloOnNonNumeric(I64(lhs), rhs.clone()).into()),
-        }
-    }
-}
-
-impl PartialEq<Value> for f64 {
-    fn eq(&self, other: &Value) -> bool {
-        let lhs = *self;
-
-        match *other {
-            I8(rhs) => lhs == rhs as f64,
-            I64(rhs) => lhs == rhs as f64,
-            F64(rhs) => lhs == rhs,
-            _ => false,
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I64(lhs),
+                operator: "%".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 }
@@ -134,7 +159,12 @@ mod tests {
 
         assert_eq!(
             base.try_add(&Bool(true)),
-            Err(ValueError::AddOnNonNumeric(I64(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I64(1),
+                operator: "+".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -150,7 +180,12 @@ mod tests {
 
         assert_eq!(
             base.try_subtract(&Bool(true)),
-            Err(ValueError::SubtractOnNonNumeric(I64(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I64(1),
+                operator: "-".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -166,7 +201,12 @@ mod tests {
 
         assert_eq!(
             base.try_multiply(&Bool(true)),
-            Err(ValueError::MultiplyOnNonNumeric(I64(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I64(1),
+                operator: "*".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -180,7 +220,12 @@ mod tests {
 
         assert_eq!(
             base.try_divide(&Bool(true)),
-            Err(ValueError::DivideOnNonNumeric(I64(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I64(1),
+                operator: "/".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -196,7 +241,12 @@ mod tests {
 
         assert_eq!(
             base.try_modulo(&Bool(true)),
-            Err(ValueError::ModuloOnNonNumeric(I64(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I64(1),
+                operator: "%".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 }

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -48,7 +48,12 @@ impl TryBinaryOperator for i8 {
             I64(rhs) => Ok(I64(lhs as i64 + rhs)),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::AddOnNonNumeric(I8(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I8(lhs),
+                operator: "+".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -70,7 +75,12 @@ impl TryBinaryOperator for i8 {
             I64(rhs) => Ok(I64(lhs as i64 - rhs)),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::SubtractOnNonNumeric(I8(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I8(lhs),
+                operator: "-".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -93,7 +103,12 @@ impl TryBinaryOperator for i8 {
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::MultiplyOnNonNumeric(I8(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I8(lhs),
+                operator: "*".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -115,7 +130,12 @@ impl TryBinaryOperator for i8 {
             I64(rhs) => Ok(I64(lhs as i64 / rhs)),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::DivideOnNonNumeric(I8(lhs), rhs.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I8(lhs),
+                operator: "/".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 
@@ -127,20 +147,12 @@ impl TryBinaryOperator for i8 {
             I64(rhs) => Ok(I64(lhs as i64 % rhs)),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Null => Ok(Null),
-            _ => Err(ValueError::ModuloOnNonNumeric(I8(lhs), rhs.clone()).into()),
-        }
-    }
-}
-
-impl PartialEq<Value> for i64 {
-    fn eq(&self, other: &Value) -> bool {
-        let lhs = *self;
-
-        match *other {
-            I8(rhs) => lhs == rhs as i64,
-            I64(rhs) => lhs == rhs,
-            F64(rhs) => lhs as f64 == rhs,
-            _ => false,
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I8(lhs),
+                operator: "%".to_string(),
+                rhs: rhs.clone(),
+            }
+            .into()),
         }
     }
 }
@@ -185,7 +197,12 @@ mod tests {
 
         assert_eq!(
             base.try_add(&Bool(true)),
-            Err(ValueError::AddOnNonNumeric(I8(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(1),
+                operator: "+".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -201,7 +218,12 @@ mod tests {
 
         assert_eq!(
             base.try_subtract(&Bool(true)),
-            Err(ValueError::SubtractOnNonNumeric(I8(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(1),
+                operator: "-".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -217,7 +239,12 @@ mod tests {
 
         assert_eq!(
             base.try_multiply(&Bool(true)),
-            Err(ValueError::MultiplyOnNonNumeric(I8(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(1),
+                operator: "*".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -233,7 +260,12 @@ mod tests {
 
         assert_eq!(
             base.try_divide(&Bool(true)),
-            Err(ValueError::DivideOnNonNumeric(I8(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(1),
+                operator: "/".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 
@@ -249,7 +281,12 @@ mod tests {
 
         assert_eq!(
             base.try_modulo(&Bool(true)),
-            Err(ValueError::ModuloOnNonNumeric(I8(1), Bool(true)).into())
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(1),
+                operator: "%".to_string(),
+                rhs: Bool(true)
+            }
+            .into())
         );
     }
 }

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -44,7 +44,7 @@ impl TryBinaryOperator for i8 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I8(lhs),
                         rhs: I8(rhs),
-                        operator: '+',
+                        operator: NumericBinaryOperator::Add,
                     }
                     .into()
                 })
@@ -71,7 +71,7 @@ impl TryBinaryOperator for i8 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I8(lhs),
                         rhs: I8(rhs),
-                        operator: '-',
+                        operator: NumericBinaryOperator::Subtract,
                     }
                     .into()
                 })
@@ -98,7 +98,7 @@ impl TryBinaryOperator for i8 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I8(lhs),
                         rhs: I8(rhs),
-                        operator: '*',
+                        operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
                 })
@@ -126,7 +126,7 @@ impl TryBinaryOperator for i8 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I8(lhs),
                         rhs: I8(rhs),
-                        operator: '/',
+                        operator: NumericBinaryOperator::Divide,
                     }
                     .into()
                 })

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -1,6 +1,10 @@
 use {
     super::TryBinaryOperator,
-    crate::{data::ValueError, prelude::Value, result::Result},
+    crate::{
+        data::{NumericBinaryOperator, ValueError},
+        prelude::Value,
+        result::Result,
+    },
     std::cmp::Ordering,
     Value::*,
 };
@@ -50,7 +54,7 @@ impl TryBinaryOperator for i8 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I8(lhs),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -77,7 +81,7 @@ impl TryBinaryOperator for i8 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I8(lhs),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -105,7 +109,7 @@ impl TryBinaryOperator for i8 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I8(lhs),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -132,7 +136,7 @@ impl TryBinaryOperator for i8 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I8(lhs),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -149,7 +153,7 @@ impl TryBinaryOperator for i8 {
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: I8(lhs),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: rhs.clone(),
             }
             .into()),
@@ -161,7 +165,7 @@ impl TryBinaryOperator for i8 {
 mod tests {
     use {
         super::{TryBinaryOperator, Value::*},
-        crate::data::ValueError,
+        crate::data::{NumericBinaryOperator, ValueError},
         std::cmp::Ordering,
     };
 
@@ -199,7 +203,7 @@ mod tests {
             base.try_add(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I8(1),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: Bool(true)
             }
             .into())
@@ -220,7 +224,7 @@ mod tests {
             base.try_subtract(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I8(1),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: Bool(true)
             }
             .into())
@@ -241,7 +245,7 @@ mod tests {
             base.try_multiply(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I8(1),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: Bool(true)
             }
             .into())
@@ -262,7 +266,7 @@ mod tests {
             base.try_divide(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I8(1),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: Bool(true)
             }
             .into())
@@ -283,7 +287,7 @@ mod tests {
             base.try_modulo(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
                 lhs: I8(1),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: Bool(true)
             }
             .into())

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -2,6 +2,7 @@ use {
     crate::{ast::DataType, ast::DateTimeField, data::Value},
     serde::Serialize,
     std::fmt::Debug,
+    strum_macros::Display,
     thiserror::Error,
 };
 
@@ -37,11 +38,11 @@ pub enum ValueError {
     #[error("failed to parse Decimal: {0}")]
     FailedToParseDecimal(String),
 
-    #[error("non-numeric values {lhs:?} {operator:?} {rhs:?}")]
+    #[error("non-numeric values {lhs:?} {operator} {rhs:?}")]
     NonNumericMathOperation {
         lhs: Value,
         rhs: Value,
-        operator: String,
+        operator: NumericBinaryOperator,
     },
 
     #[error("the divisor should not be zero")]
@@ -149,4 +150,18 @@ pub enum ValueError {
         /// ['+', '-', '*', '/']
         operator: char,
     },
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Display)]
+pub enum NumericBinaryOperator {
+    #[strum(to_string = "+")]
+    Add,
+    #[strum(to_string = "-")]
+    Subtract,
+    #[strum(to_string = "*")]
+    Multiply,
+    #[strum(to_string = "/")]
+    Divide,
+    #[strum(to_string = "%")]
+    Modulo,
 }

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -147,8 +147,7 @@ pub enum ValueError {
     BinaryOperationOverflow {
         lhs: Value,
         rhs: Value,
-        /// ['+', '-', '*', '/']
-        operator: char,
+        operator: NumericBinaryOperator,
     },
 }
 

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -37,23 +37,15 @@ pub enum ValueError {
     #[error("failed to parse Decimal: {0}")]
     FailedToParseDecimal(String),
 
-    #[error("add on non-numeric values: {0:?} + {1:?}")]
-    AddOnNonNumeric(Value, Value),
-
-    #[error("subtract on non-numeric values: {0:?} - {1:?}")]
-    SubtractOnNonNumeric(Value, Value),
-
-    #[error("multiply on non-numeric values: {0:?} * {1:?}")]
-    MultiplyOnNonNumeric(Value, Value),
-
-    #[error("divide on non-numeric values: {0:?} / {1:?}")]
-    DivideOnNonNumeric(Value, Value),
+    #[error("non-numeric values {lhs:?} {operator:?} {rhs:?}")]
+    NonNumericMathOperation {
+        lhs: Value,
+        rhs: Value,
+        operator: String,
+    },
 
     #[error("the divisor should not be zero")]
     DivisorShouldNotBeZero,
-
-    #[error("modulo on non-numeric values: {0:?} % {1:?}")]
-    ModuloOnNonNumeric(Value, Value),
 
     #[error("{0} type cannot be grouped by")]
     GroupByNotSupported(String),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -195,7 +195,12 @@ impl Value {
             | (Time(_), Null)
             | (Interval(_), Null)
             | (Null, Null) => Ok(Null),
-            _ => Err(ValueError::AddOnNonNumeric(self.clone(), other.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: self.clone(),
+                operator: "+".to_string(),
+                rhs: other.clone(),
+            }
+            .into()),
         }
     }
 
@@ -241,7 +246,12 @@ impl Value {
             | (Time(_), Null)
             | (Interval(_), Null)
             | (Null, Null) => Ok(Null),
-            _ => Err(ValueError::SubtractOnNonNumeric(self.clone(), other.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: self.clone(),
+                operator: "-".to_string(),
+                rhs: other.clone(),
+            }
+            .into()),
         }
     }
 
@@ -264,7 +274,12 @@ impl Value {
             | (Decimal(_), Null)
             | (Interval(_), Null)
             | (Null, Null) => Ok(Null),
-            _ => Err(ValueError::MultiplyOnNonNumeric(self.clone(), other.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: self.clone(),
+                operator: "*".to_string(),
+                rhs: other.clone(),
+            }
+            .into()),
         }
     }
 
@@ -290,7 +305,12 @@ impl Value {
             | (Interval(_), Null)
             | (Decimal(_), Null)
             | (Null, Null) => Ok(Null),
-            _ => Err(ValueError::DivideOnNonNumeric(self.clone(), other.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: self.clone(),
+                operator: "/".to_string(),
+                rhs: other.clone(),
+            }
+            .into()),
         }
     }
 
@@ -312,7 +332,12 @@ impl Value {
             | (Null, Decimal(_))
             | (Decimal(_), Null)
             | (Null, Null) => Ok(Null),
-            _ => Err(ValueError::ModuloOnNonNumeric(self.clone(), other.clone()).into()),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: self.clone(),
+                operator: "%".to_string(),
+                rhs: other.clone(),
+            }
+            .into()),
         }
     }
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -21,6 +21,7 @@ mod selector;
 mod unique_key;
 mod uuid;
 
+pub use error::NumericBinaryOperator;
 pub use error::ValueError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,7 +198,7 @@ impl Value {
             | (Null, Null) => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: self.clone(),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: other.clone(),
             }
             .into()),
@@ -248,7 +249,7 @@ impl Value {
             | (Null, Null) => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: self.clone(),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: other.clone(),
             }
             .into()),
@@ -276,7 +277,7 @@ impl Value {
             | (Null, Null) => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: self.clone(),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: other.clone(),
             }
             .into()),
@@ -307,7 +308,7 @@ impl Value {
             | (Null, Null) => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: self.clone(),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: other.clone(),
             }
             .into()),
@@ -334,7 +335,7 @@ impl Value {
             | (Null, Null) => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: self.clone(),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: other.clone(),
             }
             .into()),

--- a/test-suite/src/arithmetic.rs
+++ b/test-suite/src/arithmetic.rs
@@ -75,23 +75,48 @@ test_case!(arithmetic, async move {
 
     let test_cases = vec![
         (
-            ValueError::AddOnNonNumeric(Value::Str("A".to_owned()), Value::I64(1)).into(),
+            ValueError::NonNumericMathOperation {
+                lhs: Value::Str("A".to_owned()),
+                operator: "+".to_string(),
+                rhs: Value::I64(1),
+            }
+            .into(),
             "SELECT * FROM Arith WHERE name + id < 1",
         ),
         (
-            ValueError::SubtractOnNonNumeric(Value::Str("A".to_owned()), Value::I64(1)).into(),
+            ValueError::NonNumericMathOperation {
+                lhs: Value::Str("A".to_owned()),
+                operator: "-".to_string(),
+                rhs: Value::I64(1),
+            }
+            .into(),
             "SELECT * FROM Arith WHERE name - id < 1",
         ),
         (
-            ValueError::MultiplyOnNonNumeric(Value::Str("A".to_owned()), Value::I64(1)).into(),
+            ValueError::NonNumericMathOperation {
+                lhs: Value::Str("A".to_owned()),
+                operator: "*".to_string(),
+                rhs: Value::I64(1),
+            }
+            .into(),
             "SELECT * FROM Arith WHERE name * id < 1",
         ),
         (
-            ValueError::DivideOnNonNumeric(Value::Str("A".to_owned()), Value::I64(1)).into(),
+            ValueError::NonNumericMathOperation {
+                lhs: Value::Str("A".to_owned()),
+                operator: "/".to_string(),
+                rhs: Value::I64(1),
+            }
+            .into(),
             "SELECT * FROM Arith WHERE name / id < 1",
         ),
         (
-            ValueError::ModuloOnNonNumeric(Value::Str("A".to_owned()), Value::I64(1)).into(),
+            ValueError::NonNumericMathOperation {
+                lhs: Value::Str("A".to_owned()),
+                operator: "%".to_string(),
+                rhs: Value::I64(1),
+            }
+            .into(),
             "SELECT * FROM Arith WHERE name % id < 1",
         ),
         (

--- a/test-suite/src/arithmetic.rs
+++ b/test-suite/src/arithmetic.rs
@@ -2,7 +2,7 @@ use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
-        data::{Literal, LiteralError, ValueError},
+        data::{Literal, LiteralError, NumericBinaryOperator, ValueError},
         executor::{EvaluateError, UpdateError},
         prelude::Value::{self, *},
     },
@@ -77,7 +77,7 @@ test_case!(arithmetic, async move {
         (
             ValueError::NonNumericMathOperation {
                 lhs: Value::Str("A".to_owned()),
-                operator: "+".to_string(),
+                operator: NumericBinaryOperator::Add,
                 rhs: Value::I64(1),
             }
             .into(),
@@ -86,7 +86,7 @@ test_case!(arithmetic, async move {
         (
             ValueError::NonNumericMathOperation {
                 lhs: Value::Str("A".to_owned()),
-                operator: "-".to_string(),
+                operator: NumericBinaryOperator::Subtract,
                 rhs: Value::I64(1),
             }
             .into(),
@@ -95,7 +95,7 @@ test_case!(arithmetic, async move {
         (
             ValueError::NonNumericMathOperation {
                 lhs: Value::Str("A".to_owned()),
-                operator: "*".to_string(),
+                operator: NumericBinaryOperator::Multiply,
                 rhs: Value::I64(1),
             }
             .into(),
@@ -104,7 +104,7 @@ test_case!(arithmetic, async move {
         (
             ValueError::NonNumericMathOperation {
                 lhs: Value::Str("A".to_owned()),
-                operator: "/".to_string(),
+                operator: NumericBinaryOperator::Divide,
                 rhs: Value::I64(1),
             }
             .into(),
@@ -113,7 +113,7 @@ test_case!(arithmetic, async move {
         (
             ValueError::NonNumericMathOperation {
                 lhs: Value::Str("A".to_owned()),
-                operator: "%".to_string(),
+                operator: NumericBinaryOperator::Modulo,
                 rhs: Value::I64(1),
             }
             .into(),


### PR DESCRIPTION
This PR removes the ArithmeticNonNumeric enum error codes for a single NonNumericMathOperation error code with a lhs, operator and rhs args.   See issue #424 for more info. 