### PR TITLE
Scalar subquery should throw Error when more than one row returned

### DIFF
--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -60,4 +60,7 @@ pub enum EvaluateError {
 
     #[error("negative substring length not allowed")]
     NegativeSubstrLenNotAllowed,
+
+    #[error("subquery returns more than one row")]
+    MoreThanOneRowReturned,
 }

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -79,7 +79,7 @@ pub async fn evaluate<'a, T>(
                 0 => Err(EvaluateError::NestedSelectRowNotFound.into()),
                 1 => evaluations
                     .into_iter()
-                    .nth(0)
+                    .next()
                     .unwrap_or_else(|| Err(EvaluateError::NestedSelectRowNotFound.into())),
                 _ => Err(EvaluateError::MoreThanOneRowReturned.into()),
             }

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -75,14 +75,15 @@ pub async fn evaluate<'a, T>(
                 .take(2)
                 .try_collect::<Vec<_>>()
                 .await?;
-            match evaluations.len() {
-                0 => Err(EvaluateError::NestedSelectRowNotFound.into()),
-                1 => evaluations
-                    .into_iter()
-                    .next()
-                    .unwrap_or_else(|| Err(EvaluateError::NestedSelectRowNotFound.into())),
-                _ => Err(EvaluateError::MoreThanOneRowReturned.into()),
+
+            if evaluations.len() > 1 {
+                return Err(EvaluateError::MoreThanOneRowReturned.into());
             }
+
+            evaluations
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| Err(EvaluateError::NestedSelectRowNotFound.into()))
         }
         Expr::BinaryOp { op, left, right } => {
             let left = eval(left).await?;

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -9,6 +9,7 @@ test_case!(error, async move {
 
     run!("CREATE TABLE TableA (id INTEGER);");
     run!("INSERT INTO TableA (id) VALUES (1);");
+    run!("INSERT INTO TableA (id) VALUES (9);");
 
     let test_cases = vec![
         (
@@ -85,6 +86,10 @@ test_case!(error, async move {
         (
             EvaluateError::NestedSelectRowNotFound.into(),
             "SELECT * FROM TableA WHERE id = (SELECT id FROM TableA WHERE id = 2);",
+        ),
+        (
+            EvaluateError::MoreThanOneRowReturned.into(),
+            "select (select id from TableA) as id from TableA",
         ),
         (
             EvaluateError::ValueNotFound("noname".to_owned()).into(),

--- a/test-suite/src/ordering.rs
+++ b/test-suite/src/ordering.rs
@@ -35,7 +35,7 @@ test_case!(ordering, async move {
         (0, "SELECT * FROM Operator WHERE 3 > 3;"),
         (
             5,
-            "SELECT * FROM Operator o1 WHERE 3 > (SELECT min(id) FROM Operator WHERE o1.id < 100);",
+            "SELECT * FROM Operator o1 WHERE 3 > (SELECT MIN(id) FROM Operator WHERE o1.id < 100);",
         ),
         (2, "SELECT * FROM Operator WHERE name < \"Azzzzzzzzzz\";"),
         (1, "SELECT * FROM Operator WHERE name < \"Az\";"),

--- a/test-suite/src/ordering.rs
+++ b/test-suite/src/ordering.rs
@@ -35,7 +35,7 @@ test_case!(ordering, async move {
         (0, "SELECT * FROM Operator WHERE 3 > 3;"),
         (
             5,
-            "SELECT * FROM Operator o1 WHERE 3 > (SELECT id FROM Operator WHERE o1.id < 100);",
+            "SELECT * FROM Operator o1 WHERE 3 > (SELECT min(id) FROM Operator WHERE o1.id < 100);",
         ),
         (2, "SELECT * FROM Operator WHERE name < \"Azzzzzzzzzz\";"),
         (1, "SELECT * FROM Operator WHERE name < \"Az\";"),


### PR DESCRIPTION
To resolve #528 `Scalar subquery should throw Error when more than one row returned`,

## Implements
```rs
Expr::Subquery(query) => {
            let mut stream = select(storage, query, context.as_ref().map(Rc::clone))
                .await?
                .map_ok(|row| row.take_first_value().map(Evaluated::from));
            let first = stream
                .next()
                .await
                .unwrap_or_else(|| Err(EvaluateError::NestedSelectRowNotFound.into()))?;
            let second = stream.next().await;
            match second {
                Some(_) => Err(EvaluateError::MoreThanOneRowReturned.into()),
                None => first,
            }
        }
```
## Test Added
```rs
(
  EvaluateError::MoreThanOneRowReturned.into(),
  "select (select id from TableA) as id from TableA", // when TableA has 2 rows
)
```