### PR TITLE
Migrate sqlparser-rs version from v0.13 to v0.14,

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.13", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.14", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.23"
 uuid = { version = "0.8", features = ["v4"] }

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -9,8 +9,6 @@ use {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Expr {
     Identifier(String),
-    Wildcard,
-    QualifiedWildcard(Vec<String>),
     CompoundIdentifier(Vec<String>),
     IsNull(Box<Expr>),
     IsNotNull(Box<Expr>),

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -108,9 +108,15 @@ pub enum Function {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Aggregate {
-    Count(Expr),
+    Count(CountArgExpr),
     Sum(Expr),
     Max(Expr),
     Min(Expr),
     Avg(Expr),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CountArgExpr {
+    Expr(Expr),
+    Wildcard,
 }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -10,7 +10,7 @@ pub use ast_literal::{AstLiteral, DateTimeField, TrimWhereField};
 pub use data_type::DataType;
 pub use ddl::*;
 pub use expr::Expr;
-pub use function::{Aggregate, Function};
+pub use function::{Aggregate, CountArgExpr, Function};
 pub use operator::*;
 pub use query::*;
 

--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -1,7 +1,7 @@
 use {
     super::{error::AggregateError, hash::GroupKey},
     crate::{
-        ast::{Aggregate, Expr},
+        ast::{Aggregate, CountArgExpr, Expr},
         data::Value,
         executor::context::BlendContext,
         result::Result,
@@ -27,8 +27,12 @@ impl<'a> AggrValue {
         let value = value.clone();
 
         match aggr {
-            Aggregate::Count(expr) => AggrValue::Count {
-                wildcard: matches!(expr, Expr::Wildcard),
+            Aggregate::Count(CountArgExpr::Wildcard) => AggrValue::Count {
+                wildcard: true,
+                count: 1,
+            },
+            Aggregate::Count(CountArgExpr::Expr(_)) => AggrValue::Count {
+                wildcard: false,
                 count: 1,
             },
             Aggregate::Sum(_) => AggrValue::Sum(value),
@@ -192,8 +196,8 @@ impl<'a> State<'a> {
         };
 
         let value = match aggr {
-            Aggregate::Count(Expr::Wildcard) => &Value::Null,
-            Aggregate::Count(expr)
+            Aggregate::Count(CountArgExpr::Wildcard) => &Value::Null,
+            Aggregate::Count(CountArgExpr::Expr(expr))
             | Aggregate::Sum(expr)
             | Aggregate::Min(expr)
             | Aggregate::Max(expr)

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -46,9 +46,6 @@ pub enum EvaluateError {
     #[error("unsupported stateless expression: {0:#?}")]
     UnsupportedStatelessExpr(Expr),
 
-    #[error("unreachable wildcard expression")]
-    UnreachableWildcardExpr,
-
     #[error("unreachable empty context")]
     UnreachableEmptyContext,
 

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -174,9 +174,6 @@ pub async fn evaluate<'a, T>(
 
             Ok(Evaluated::from(Value::Bool(!v)))
         }
-        Expr::Wildcard | Expr::QualifiedWildcard(_) => {
-            Err(EvaluateError::UnreachableWildcardExpr.into())
-        }
         Expr::Case {
             operand,
             when_then,

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -101,9 +101,6 @@ pub fn evaluate_stateless<'a>(
 
             Ok(Evaluated::from(Value::Bool(!v)))
         }
-        Expr::Wildcard | Expr::QualifiedWildcard(_) => {
-            Err(EvaluateError::UnreachableWildcardExpr.into())
-        }
         Expr::Function(func) => evaluate_function(context, func),
         _ => Err(EvaluateError::UnsupportedStatelessExpr(expr.clone()).into()),
     }

--- a/core/src/plan/expr/aggregate.rs
+++ b/core/src/plan/expr/aggregate.rs
@@ -1,13 +1,14 @@
-use crate::ast::{Aggregate, Expr};
+use crate::ast::{Aggregate, CountArgExpr, Expr};
 
 impl Aggregate {
-    pub fn as_expr(&self) -> &Expr {
+    pub fn as_expr(&self) -> Option<&Expr> {
         match self {
-            Aggregate::Count(expr)
+            Aggregate::Count(CountArgExpr::Wildcard) => None,
+            Aggregate::Count(CountArgExpr::Expr(expr))
             | Aggregate::Sum(expr)
             | Aggregate::Max(expr)
             | Aggregate::Min(expr)
-            | Aggregate::Avg(expr) => expr,
+            | Aggregate::Avg(expr) => Some(expr),
         }
     }
 }
@@ -32,24 +33,26 @@ mod tests {
 
     #[test]
     fn as_expr() {
+        assert_eq!(parse("COUNT(*)").as_expr(), None);
+
         let actual = parse("COUNT(id)");
         let expected = Expr::Identifier("id".to_owned());
-        assert_eq!(actual.as_expr(), &expected);
+        assert_eq!(actual.as_expr(), Some(&expected));
 
         let actual = parse("SUM(id)");
         let expected = Expr::Identifier("id".to_owned());
-        assert_eq!(actual.as_expr(), &expected);
+        assert_eq!(actual.as_expr(), Some(&expected));
 
         let actual = parse("MAX(id)");
         let expected = Expr::Identifier("id".to_owned());
-        assert_eq!(actual.as_expr(), &expected);
+        assert_eq!(actual.as_expr(), Some(&expected));
 
         let actual = parse("MIN(id)");
         let expected = Expr::Identifier("id".to_owned());
-        assert_eq!(actual.as_expr(), &expected);
+        assert_eq!(actual.as_expr(), Some(&expected));
 
         let actual = parse("AVG(id)");
         let expected = Expr::Identifier("id".to_owned());
-        assert_eq!(actual.as_expr(), &expected);
+        assert_eq!(actual.as_expr(), Some(&expected));
     }
 }

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -170,8 +170,6 @@ impl<'a> Planner<'a> {
     fn subquery_expr(&self, outer_context: Option<Rc<Context<'a>>>, expr: Expr) -> Expr {
         match expr {
             Expr::Identifier(_)
-            | Expr::Wildcard
-            | Expr::QualifiedWildcard(_)
             | Expr::CompoundIdentifier(_)
             | Expr::Literal(_)
             | Expr::TypedString { .. } => expr,

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -45,6 +45,12 @@ pub enum TranslateError {
     #[error("named function arg is not supported")]
     NamedFunctionArgNotSupported,
 
+    #[error("wildcard function arg is not accepted")]
+    WildcardFunctionArgNotAccepted,
+
+    #[error("qualified wildcard is not supported - COUNT({0})")]
+    QualifiedWildcardInCountNotSupported(String),
+
     #[error("order by - NULLS (FIRST | LAST) is not supported")]
     OrderByNullsFirstOrLastNotSupported,
 

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -20,8 +20,6 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             Some(_) => Ok(Expr::Literal(AstLiteral::QuotedString(ident.value.clone()))),
             None => Ok(Expr::Identifier(ident.value.clone())),
         },
-        SqlExpr::Wildcard => Ok(Expr::Wildcard),
-        SqlExpr::QualifiedWildcard(idents) => Ok(Expr::QualifiedWildcard(translate_idents(idents))),
         SqlExpr::CompoundIdentifier(idents) => {
             Ok(Expr::CompoundIdentifier(translate_idents(idents)))
         }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -4,12 +4,12 @@ use {
         TranslateError,
     },
     crate::{
-        ast::{Aggregate, Expr, Function, ObjectName, TrimWhereField},
+        ast::{Aggregate, CountArgExpr, Expr, Function, ObjectName, TrimWhereField},
         result::Result,
     },
     sqlparser::ast::{
         Expr as SqlExpr, Function as SqlFunction, FunctionArg as SqlFunctionArg,
-        TrimWhereField as SqlTrimWhereField,
+        FunctionArgExpr as SqlFunctionArgExpr, TrimWhereField as SqlTrimWhereField,
     },
 };
 
@@ -144,17 +144,49 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
         names[0].to_uppercase()
     };
-    let args = args
+
+    let function_args = args
         .iter()
         .map(|arg| match arg {
             SqlFunctionArg::Named { .. } => {
                 Err(TranslateError::NamedFunctionArgNotSupported.into())
             }
-            SqlFunctionArg::Unnamed(expr) => Ok(expr),
+            SqlFunctionArg::Unnamed(arg_expr) => Ok(arg_expr),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if name.as_str() == "COUNT" {
+        check_len(name, args.len(), 1)?;
+
+        let count_arg = match function_args[0] {
+            SqlFunctionArgExpr::Expr(expr) => CountArgExpr::Expr(translate_expr(expr)?),
+            SqlFunctionArgExpr::QualifiedWildcard(idents) => {
+                let ObjectName(idents) = translate_object_name(idents);
+                let idents = format!("{}.*", idents.join("."));
+
+                return Err(TranslateError::QualifiedWildcardInCountNotSupported(idents).into());
+            }
+            SqlFunctionArgExpr::Wildcard => CountArgExpr::Wildcard,
+        };
+
+        return Ok(Expr::Aggregate(Box::new(Aggregate::Count(count_arg))));
+    }
+
+    let args = function_args
+        .iter()
+        .map(|function_arg| match function_arg {
+            SqlFunctionArgExpr::Expr(expr) => Ok(expr),
+            SqlFunctionArgExpr::Wildcard | SqlFunctionArgExpr::QualifiedWildcard(_) => {
+                Err(TranslateError::WildcardFunctionArgNotAccepted.into())
+            }
         })
         .collect::<Result<Vec<_>>>()?;
 
     match name.as_str() {
+        "SUM" => translate_aggrecate_one_arg(Aggregate::Sum, args, name),
+        "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),
+        "MAX" => translate_aggrecate_one_arg(Aggregate::Max, args, name),
+        "AVG" => translate_aggrecate_one_arg(Aggregate::Avg, args, name),
         "CONCAT" => {
             check_len_min(name, args.len(), 1)?;
             let exprs = args
@@ -278,11 +310,6 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "RTRIM" => {
             translate_function_trim(|expr, chars| Function::Rtrim { expr, chars }, args, name)
         }
-        "COUNT" => translate_aggrecate_one_arg(Aggregate::Count, args, name),
-        "SUM" => translate_aggrecate_one_arg(Aggregate::Sum, args, name),
-        "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),
-        "MAX" => translate_aggrecate_one_arg(Aggregate::Max, args, name),
-        "AVG" => translate_aggrecate_one_arg(Aggregate::Avg, args, name),
         "DIV" => {
             check_len(name, args.len(), 2)?;
 

--- a/test-suite/src/aggregate.rs
+++ b/test-suite/src/aggregate.rs
@@ -1,4 +1,7 @@
-use {crate::*, gluesql_core::prelude::Value::*};
+use {
+    crate::*,
+    gluesql_core::{executor::AggregateError, prelude::Value::*, translate::TranslateError},
+};
 
 test_case!(aggregate, async move {
     run!(
@@ -69,7 +72,6 @@ test_case!(aggregate, async move {
         test!(Ok(expected), sql);
     }
 
-    use gluesql_core::executor::AggregateError;
     let error_cases = vec![
         (
             AggregateError::UnsupportedCompoundIdentifier(expr!("id.name.ok")).into(),
@@ -82,6 +84,14 @@ test_case!(aggregate, async move {
         (
             AggregateError::ValueNotFound("num".to_owned()).into(),
             "SELECT SUM(num) FROM Item;",
+        ),
+        (
+            TranslateError::QualifiedWildcardInCountNotSupported("Foo.*".to_owned()).into(),
+            "SELECT COUNT(Foo.*) FROM Item;",
+        ),
+        (
+            TranslateError::WildcardFunctionArgNotAccepted.into(),
+            "SELECT SUM(*) FROM Item;",
         ),
     ];
 


### PR DESCRIPTION
In v0.14, function arg takes FunctionArgExpr, not Expr.
Remove `Expr::Wildcard` and `Expr::QualifiedWildcard`.
Add `CountArgExpr` enum, only `COUNT` aggregate function takes wildcard expression.