### PR TITLE
cast 255 as int8, should return an error, but returns 127 instead (resolves issue #545)

### DIFF
--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -98,6 +98,9 @@ pub enum ValueError {
     #[error("literal cast failed to date: {0}")]
     LiteralCastToDateFailed(String),
 
+    #[error("literal cast failed to Int(8): {0}")]
+    LiteralCastToInt8Failed(String),
+
     #[error("literal cast failed to time: {0}")]
     LiteralCastToTimeFailed(String),
 

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -181,12 +181,10 @@ impl Value {
                 .parse::<i8>()
                 .map(Value::I8)
                 .map_err(|_| ValueError::LiteralCastFromTextToIntegerFailed(v.to_string()).into()),
-            (DataType::Int8, Literal::Number(v)) => v
-                .to_f64()
-                .map(|v| Value::I8(v.trunc() as i8))
-                .ok_or_else(|| {
-                    ValueError::UnreachableLiteralCastFromNumberToInteger(v.to_string()).into()
-                }),
+            (DataType::Int8, Literal::Number(v)) => match v.to_i8() {
+                Some(x) => Ok(Value::I8(x)),
+                None => Err(ValueError::LiteralCastToInt8Failed(v.to_string()).into()),
+            },
             (DataType::Int8, Literal::Boolean(v)) => {
                 let v = if *v { 1 } else { 0 };
 

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -55,6 +55,11 @@ test_case!(cast_literal, async move {
             Ok(select_with_null!(cast; Null)),
         ),
         (
+            r#"SELECT CAST(255 AS INT(8)) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastToInt8Failed("255".to_owned()).into()),
+        ),
+        
+        (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
             Ok(select!(cast F64; 1.1)),
         ),

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -58,7 +58,6 @@ test_case!(cast_literal, async move {
             r#"SELECT CAST(255 AS INT(8)) AS cast FROM Item"#,
             Err(ValueError::LiteralCastToInt8Failed("255".to_owned()).into()),
         ),
-        
         (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
             Ok(select!(cast F64; 1.1)),


### PR DESCRIPTION
Here's the error I found (this should probably produce an error, not insert 127 into an int(8) field).


```
gluesql> create table myi8 (id int(8));
gluesql> insert into myi8 values (1);
1 row inserted

gluesql> select cast(255 as int(8)) from myi8;
╭─────────────────────╮
│ CAST(255 AS INT(8)) │
╞═════════════════════╡
│ 127                 │
╰─────────────────────╯
gluesql>
```

This PR (resolves issue #545) implements the following result:

```
luesql> select cast(255 as int(8)) from dual;
[error] literal cast failed to Int(8): 255
```