### PR TITLE
Implement SledStorage export & import features

### DIFF
--- a/storages/sled-storage/src/error.rs
+++ b/storages/sled-storage/src/error.rs
@@ -23,6 +23,8 @@ pub enum StorageError {
     Str(#[from] str::Utf8Error),
     #[error(transparent)]
     SystemTime(#[from] time::SystemTimeError),
+    #[error(transparent)]
+    TryFromSlice(#[from] std::array::TryFromSliceError),
 }
 
 impl From<StorageError> for Error {
@@ -34,6 +36,7 @@ impl From<StorageError> for Error {
             Bincode(e) => Error::Storage(e),
             Str(e) => Error::Storage(Box::new(e)),
             SystemTime(e) => Error::Storage(Box::new(e)),
+            TryFromSlice(e) => Error::Storage(Box::new(e)),
             AlterTable(e) => e.into(),
             Index(e) => e.into(),
         }

--- a/storages/sled-storage/src/lib.rs
+++ b/storages/sled-storage/src/lib.rs
@@ -47,19 +47,24 @@ pub enum State {
 #[derive(Debug, Clone)]
 pub struct SledStorage {
     pub tree: Db,
+    pub id_offset: u64,
     pub state: State,
     /// transaction timeout in milliseconds
     pub tx_timeout: Option<u128>,
 }
 
+type ExportData<T> = (u64, Vec<(Vec<u8>, Vec<u8>, T)>);
+
 impl SledStorage {
     pub fn new(filename: &str) -> Result<Self> {
         let tree = sled::open(filename).map_err(err_into)?;
+        let id_offset = get_id_offset(&tree)?;
         let state = State::Idle;
         let tx_timeout = Some(DEFAULT_TX_TIMEOUT);
 
         Ok(Self {
             tree,
+            id_offset,
             state,
             tx_timeout,
         })
@@ -69,9 +74,34 @@ impl SledStorage {
         self.tx_timeout = tx_timeout;
     }
 
+    pub fn export(&self) -> Result<ExportData<impl Iterator<Item = Vec<Vec<u8>>>>> {
+        let id_offset = self.tree.generate_id().map_err(err_into)?;
+        let data = self.tree.export();
+
+        Ok((id_offset, data))
+    }
+
+    pub fn import(&mut self, export: ExportData<impl Iterator<Item = Vec<Vec<u8>>>>) -> Result<()> {
+        let (new_id_offset, data) = export;
+        let old_id_offset = get_id_offset(&self.tree)?;
+
+        self.tree.import(data);
+
+        if new_id_offset > old_id_offset {
+            self.tree
+                .insert("id_offset", &new_id_offset.to_be_bytes())
+                .map_err(err_into)?;
+
+            self.id_offset = new_id_offset;
+        }
+
+        Ok(())
+    }
+
     fn update_state(self, state: State) -> Self {
         Self {
             tree: self.tree,
+            id_offset: self.id_offset,
             state,
             tx_timeout: self.tx_timeout,
         }
@@ -83,15 +113,29 @@ impl TryFrom<Config> for SledStorage {
 
     fn try_from(config: Config) -> Result<Self> {
         let tree = config.open().map_err(err_into)?;
+        let id_offset = get_id_offset(&tree)?;
         let state = State::Idle;
         let tx_timeout = Some(DEFAULT_TX_TIMEOUT);
 
         Ok(Self {
             tree,
+            id_offset,
             state,
             tx_timeout,
         })
     }
+}
+
+fn get_id_offset(tree: &Db) -> Result<u64> {
+    tree.get("id_offset")
+        .map_err(err_into)?
+        .map(|id| {
+            id.as_ref()
+                .try_into()
+                .map_err(err_into)
+                .map(u64::from_be_bytes)
+        })
+        .unwrap_or(Ok(0))
 }
 
 fn fetch_schema(

--- a/storages/sled-storage/src/lock.rs
+++ b/storages/sled-storage/src/lock.rs
@@ -36,8 +36,8 @@ pub fn get_txdata_key(txid: u64) -> Vec<u8> {
         .collect::<Vec<_>>()
 }
 
-pub fn register(tree: &Db) -> Result<(u64, u128)> {
-    let txid = tree.generate_id().map_err(err_into)?;
+pub fn register(tree: &Db, id_offset: u64) -> Result<(u64, u128)> {
+    let txid = id_offset + tree.generate_id().map_err(err_into)?;
     let key = get_txdata_key(txid);
     let created_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/storages/sled-storage/src/store.rs
+++ b/storages/sled-storage/src/store.rs
@@ -16,9 +16,8 @@ impl Store<IVec> for SledStorage {
             State::Transaction {
                 txid, created_at, ..
             } => (txid, created_at, false),
-            State::Idle => {
-                lock::register(&self.tree).map(|(txid, created_at)| (txid, created_at, true))?
-            }
+            State::Idle => lock::register(&self.tree, self.id_offset)
+                .map(|(txid, created_at)| (txid, created_at, true))?,
         };
         let lock_txid = lock::fetch(&self.tree, txid, created_at, self.tx_timeout)?;
 

--- a/storages/sled-storage/src/store_mut.rs
+++ b/storages/sled-storage/src/store_mut.rs
@@ -144,6 +144,7 @@ impl StoreMut<IVec> for SledStorage {
     }
 
     async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
+        let id_offset = self.id_offset;
         let state = &self.state;
         let tx_timeout = self.tx_timeout;
         let tx_rows = &rows;
@@ -159,7 +160,7 @@ impl StoreMut<IVec> for SledStorage {
             let index_sync = IndexSync::new(tree, txid, table_name)?;
 
             for row in tx_rows.iter() {
-                let id = tree.generate_id()?;
+                let id = id_offset + tree.generate_id()?;
                 let id = id.to_be_bytes();
                 let prefix = format!("data/{}/", table_name);
 

--- a/storages/sled-storage/src/transaction.rs
+++ b/storages/sled-storage/src/transaction.rs
@@ -35,6 +35,7 @@ macro_rules! transaction {
             Ok(v) => {
                 let storage = Self {
                     tree: $self.tree,
+                    id_offset: $self.id_offset,
                     state: State::Idle,
                     tx_timeout: $self.tx_timeout,
                 };
@@ -64,7 +65,7 @@ impl Transaction for SledStorage {
 
                 Ok((self, autocommit))
             }
-            (State::Idle, _) => match lock::register(&self.tree) {
+            (State::Idle, _) => match lock::register(&self.tree, self.id_offset) {
                 Ok((txid, created_at)) => {
                     let state = State::Transaction {
                         txid,

--- a/storages/sled-storage/tests/export_and_import.rs
+++ b/storages/sled-storage/tests/export_and_import.rs
@@ -1,0 +1,53 @@
+use {
+    gluesql_core::{prelude::*, result::Error},
+    gluesql_sled_storage::SledStorage,
+    sled::Config,
+};
+
+#[test]
+fn export_and_import() {
+    let path1 = "tmp/export_and_import1";
+    let path2 = "tmp/export_and_import2";
+    let config1 = Config::default().path(path1).temporary(true);
+    let config2 = Config::default().path(path2).temporary(true);
+
+    let storage1 = SledStorage::try_from(config1).unwrap();
+    let mut glue1 = Glue::new(storage1);
+
+    glue1.execute("CREATE TABLE Foo (id INTEGER);").unwrap();
+    glue1
+        .execute("INSERT INTO Foo VALUES (1), (2), (3);")
+        .unwrap();
+
+    let data1 = glue1.execute("SELECT * FROM Foo;").unwrap();
+    let export = glue1.storage.unwrap().export().unwrap();
+
+    let mut storage2 = SledStorage::try_from(config2).unwrap();
+    storage2.import(export).unwrap();
+    let mut glue2 = Glue::new(storage2);
+
+    let data2 = glue2.execute("SELECT * FROM Foo;").unwrap();
+
+    assert_eq!(data1, data2);
+}
+
+#[test]
+fn invalid_id_offset() {
+    // value in "id_offset" key must have u64 big endian format data
+
+    let path1 = "tmp/import_error1";
+    let path2 = "tmp/import_error2";
+    let config1 = Config::default().path(path1).temporary(true);
+    let config2 = Config::default().path(path2).temporary(true);
+
+    let storage1 = SledStorage::try_from(config1).unwrap();
+    let export = storage1.export().unwrap();
+
+    let mut storage2 = SledStorage::try_from(config2).unwrap();
+    storage2
+        .tree
+        .insert("id_offset", "something wrong value")
+        .unwrap();
+
+    assert!(matches!(storage2.import(export), Err(Error::Storage(_))));
+}


### PR DESCRIPTION
Native export & import methods supported by Sled can cause problem if these are used for GlueSQL migration.
SledStorage wraps Sled export & import methods and provide its own ones.

@raindust
I also added a test case which you mentioned in the issue, thanks :)
Now you will be able to use `export` and `import` provided by `SledStorage` itself.
I'll soon to release v0.11 and this fix will be included.
ref. `storages/sled-storage/tests/export_and_import.rs`

fix #533 
