### PR TITLE
Release v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -25,11 +25,11 @@ all-features = true
 # opt-level = "s"
 
 [dependencies]
-gluesql-core = { path = "./core", version = "0.10.2" }
-cli = { package = "gluesql-cli", path = "./cli", version = "0.10.2", optional = true }
-test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.10.2", optional = true }
-memory-storage = { package = "gluesql_memory_storage", path = "./storages/memory-storage", version = "0.10.2", optional = true }
-sled-storage = { package = "gluesql_sled_storage", path = "./storages/sled-storage", version = "0.10.2", optional = true }
+gluesql-core = { path = "./core", version = "0.11.0" }
+cli = { package = "gluesql-cli", path = "./cli", version = "0.11.0", optional = true }
+test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.11.0", optional = true }
+memory-storage = { package = "gluesql_memory_storage", path = "./storages/memory-storage", version = "0.11.0", optional = true }
+sled-storage = { package = "gluesql_sled_storage", path = "./storages/sled-storage", version = "0.11.0", optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GlueSQL
 
 [![crates.io](https://img.shields.io/crates/v/gluesql.svg)](https://crates.io/crates/gluesql)
+[![npm](https://img.shields.io/npm/v/gluesql?color=red)](https://www.npmjs.com/package/gluesql)
 [![docs.rs](https://docs.rs/gluesql/badge.svg)](https://docs.rs/gluesql)
 [![LICENSE](https://img.shields.io/crates/l/gluesql.svg)](https://github.com/gluesql/gluesql/blob/main/LICENSE)
 ![Rust](https://github.com/gluesql/gluesql/workflows/Rust/badge.svg)
@@ -26,7 +27,7 @@ GlueSQL provides two reference storage options.
 * `Cargo.toml`
 ```toml
 [dependencies]
-gluesql = "0.10"
+gluesql = "0.11"
 ```
 
 * CLI application
@@ -65,7 +66,7 @@ fn main() {
 
 ```toml
 [dependencies.gluesql]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["alter-table", "index", "transaction", "metadata"]
 ```
@@ -131,6 +132,13 @@ pub trait Metadata {
 }
 ```
 
+## GlueSQL.js
+
+GlueSQL.js is a SQL database for web browsers and Node.js. It works as an embedded database and entirely runs in the browser. GlueSQL.js supports in-memory storage backend, but it will soon to have localStorage, sessionStorage and indexedDB backend supports.
+
+#### More info
+* [GlueSQL for web browsers and Node.js](https://github.com/gluesql/gluesql/tree/main/gluesql-js)
+
 ## SQL Features
 
 GlueSQL currently supports a limited subset of queries. It's being actively developed.
@@ -151,30 +159,6 @@ GlueSQL currently supports a limited subset of queries. It's being actively deve
 - Nested select, join, aggregations ...
 
 You can see tests for the currently supported queries in [test-suite/src/\*](https://github.com/gluesql/gluesql/tree/main/test-suite/src).
-
-## Use Cases
-
-### [GlueSQL-js](https://github.com/gluesql/gluesql-js)
-
-<https://github.com/gluesql/gluesql-js>
-Use SQL in web browsers!
-GlueSQL-js provides 3 storage options,
-
-- in-memory
-- localStorage
-- sessionStorage
-
-### [GlueSQL Sheets](https://sheets.gluesql.com)
-
-<https://sheets.gluesql.com>
-Turn **Google Sheets** into a SQL database!  
-It uses Google Sheets as a storage.  
-Data is stored and updated from Google Sheets.
-
-### Other expected use cases
-
-- Add SQL layer to NoSQL databases: Redis, CouchDB...
-- Build new SQL database management system
 
 ## Contribution
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-cli"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,9 +9,9 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.10.2", features = ["alter-table", "metadata"] }
-gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.10.2" }
-gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.10.2" }
+gluesql-core = { path = "../core", version = "0.11.0", features = ["alter-table", "metadata"] }
+gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.11.0" }
+gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.11.0" }
 
 clap = { version = "3.0.1", features = ["derive"] }
 rustyline = "9.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-core"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-utils = { package = "gluesql-utils", path = "../utils", version = "0.10.2" }
+utils = { package = "gluesql-utils", path = "../utils", version = "0.11.0" }
 
 regex = "1"
 async-trait = "0.1"

--- a/gluesql-js/README.md
+++ b/gluesql-js/README.md
@@ -23,7 +23,7 @@ npm install gluesql
 
 #### JavaScript modules
 ```javascript
-import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.10.2-rc.2/gluesql.js';
+import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.11.0/gluesql.js';
 ```
 
 ## Usage

--- a/gluesql-js/package.json
+++ b/gluesql-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.10.2-rc.2",
+  "version": "0.11.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "gluesql.js",
   "main": "gluesql.node.js",
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/gluesql/gluesql/issues"
   },
-  "homepage": "https://github.com/gluesql/gluesql#readme",
+  "homepage": "https://github.com/gluesql/gluesql/tree/main/gluesql-js#readme",
   "files": [
     "dist/bundler/gluesql.js",
     "dist/bundler/gluesql.js.map",

--- a/gluesql-js/web/Cargo.toml
+++ b/gluesql-js/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-js"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -35,8 +35,8 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 wee_alloc = { version = "0.4.5", optional = true }
 
-gluesql-core = { path = "../../core", version = "0.10.2" }
-memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.10.2" }
+gluesql-core = { path = "../../core", version = "0.11.0" }
+memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.11.0" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
@@ -44,5 +44,5 @@ wasm-bindgen-test = "0.3.13"
 [dev-dependencies.test-suite]
 package = "gluesql-test-suite"
 path = "../../test-suite"
-version = "0.10.2"
+version = "0.11.0"
 features = ["alter-table", "metadata"]

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_memory_storage"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.10.2", features = [
+gluesql-core = { path = "../../core", version = "0.11.0", features = [
 	"alter-table",
 	"index",
 	"transaction",
@@ -19,7 +19,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.10.2", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.11.0", features = [
 	"alter-table",
 	"index",
 	"transaction",

--- a/storages/sled-storage/Cargo.toml
+++ b/storages/sled-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_sled_storage"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,13 +9,13 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.10.2", features = [
+gluesql-core = { path = "../../core", version = "0.11.0", features = [
 	"index",
 	"transaction",
 	"alter-table",
 	"metadata",
 ] }
-utils = { package = "gluesql-utils", path = "../../utils", version = "0.10.2" }
+utils = { package = "gluesql-utils", path = "../../utils", version = "0.11.0" }
 async-trait = "0.1"
 iter-enum = "1"
 serde = { version = "1", features = ["derive"] }
@@ -24,7 +24,7 @@ bincode = "1"
 sled = "0.34"
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.10.2", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.11.0", features = [
 	"index",
 	"transaction",
 	"alter-table",

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-test-suite"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.10.2" }
+gluesql-core = { path = "../core", version = "0.11.0" }
 async-trait = "0.1"
 bigdecimal = "0.3"
 uuid = "0.8"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-utils"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"


### PR DESCRIPTION
Bump all workspace versions to v0.11.0
Update README.md & gluesql-js/README.md

- [x] Update README.md
- [x] Update workspace versions
- [x] Write release note
- [x] Publish to crates.io
- [x] Publish to npm (gluesql-js)