### PR TITLE
Fix modulo binary op to handle zero divisor correctly

### DIFF
--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -713,6 +713,8 @@ mod tests {
         test!(divide mon!(6),  I64(2)   => mon!(3));
         test!(divide mon!(6),  F64(2.0) => mon!(3));
 
+        test!(modulo I8(6),    I8(4)    => I8(2));
+        test!(modulo I8(6),    I64(4)   => I64(2));
         assert_eq!(
             I8(5).modulo(&I8(0)),
             Err(ValueError::DivisorShouldNotBeZero.into())

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -314,7 +314,7 @@ impl Value {
     pub fn modulo(&self, other: &Value) -> Result<Value> {
         use Value::*;
 
-        if self.is_zero() {
+        if other.is_zero() {
             return Err(ValueError::DivisorShouldNotBeZero.into());
         }
 
@@ -664,6 +664,11 @@ mod tests {
         test!(divide mon!(6),  I8(2)    => mon!(3));
         test!(divide mon!(6),  I64(2)   => mon!(3));
         test!(divide mon!(6),  F64(2.0) => mon!(3));
+
+        assert_eq!(
+            I8(5).modulo(&I8(0)),
+            Err(ValueError::DivisorShouldNotBeZero.into())
+        );
 
         test!(modulo I64(6),   I64(2)   => I64(0));
         test!(modulo I64(6),   F64(2.0) => F64(0.0));


### PR DESCRIPTION
Should check that "other" is zero not the base number.  Also give a test to check for modulo zero.