### PR TITLE
Fix rust clippy gh action to check optional features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,22 +16,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: rustup component add clippy rustfmt
-      - name: Clippy
-        run: cargo clippy --no-default-features -- -D warnings
-      - name: Clippy (alter-table)
-        run: cargo clippy --no-default-features --features alter-table -- -D warnings
-      - name: Clippy (index)
-        run: cargo clippy --no-default-features --features index -- -D warnings
-      - name: Clippy (alter-table & index)
-        run: cargo clippy --no-default-features --features "alter-table index" -- -D warnings
-      - name: Clippy (alter-table & transaction)
-        run: cargo clippy --no-default-features --features "alter-table transaction" -- -D warnings
-      - name: Clippy (index & transaction)
-        run: cargo clippy --no-default-features --features "index transaction" -- -D warnings
-      - name: Clippy (alter-table & index & transaction)
-        run: cargo clippy --no-default-features --features "alter-table index transaction" -- -D warnings
-      - name: Clippy (all)
-        run: cargo clippy --all-features --all-targets -- -D warnings
+      - name: Clippy (root)
+        run: cargo clippy -- -D warnings
+      - name: Clippy (core)
+        run: |
+          cd core
+          cargo clippy --no-default-features -- -D warnings
+          cargo clippy --no-default-features --features alter-table -- -D warnings
+          cargo clippy --no-default-features --features index -- -D warnings
+          cargo clippy --no-default-features --features transaction -- -D warnings
+          cargo clippy --no-default-features --features "alter-table index" -- -D warnings
+          cargo clippy --no-default-features --features "alter-table transaction" -- -D warnings
+          cargo clippy --no-default-features --features "index transaction" -- -D warnings
+          cargo clippy --no-default-features --features "alter-table index transaction" -- -D warnings
+          cargo clippy --all-features --all-targets -- -D warnings
+          cd ../
       - name: Rustfmt
         run: cargo fmt -- --check
       - name: Build

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -8,7 +8,7 @@ use {
     },
     crate::{
         ast::{DataType, SetExpr, Statement, Values},
-        data::{get_name, Row, Schema, SchemaIndexOrd, Value},
+        data::{get_name, Row, Schema, Value},
         executor::limit::Limit,
         result::MutResult,
         store::{GStore, GStoreMut},
@@ -23,7 +23,10 @@ use {
 use super::alter::alter_table;
 
 #[cfg(feature = "index")]
-use super::alter::{create_index, drop_index};
+use {
+    super::alter::{create_index, drop_index},
+    crate::data::SchemaIndexOrd,
+};
 
 #[cfg(feature = "metadata")]
 use crate::{ast::Variable, result::TrySelf};
@@ -54,6 +57,8 @@ pub enum Payload {
     CreateIndex,
     #[cfg(feature = "index")]
     DropIndex,
+    #[cfg(feature = "index")]
+    ShowIndexes(Vec<(String, SchemaIndexOrd)>),
 
     #[cfg(feature = "transaction")]
     StartTransaction,
@@ -64,8 +69,6 @@ pub enum Payload {
 
     #[cfg(feature = "metadata")]
     ShowVariable(PayloadVariable),
-    #[cfg(feature = "index")]
-    ShowIndexes(Vec<(String, SchemaIndexOrd)>),
 }
 
 #[cfg(feature = "metadata")]
@@ -330,6 +333,7 @@ pub async fn execute<T, U: GStore<T> + GStoreMut<T>>(
 
             Ok((storage, Payload::ShowColumns(output)))
         }
+        #[cfg(feature = "index")]
         Statement::ShowIndexes(table_name) => {
             let table_name = match get_name(table_name) {
                 Ok(table_name) => table_name,


### PR DESCRIPTION
Clippy GitHub action was not working because all the features were activated by default because storages always use all the core features.
Fix rust.yml to run clippy in the core workspace for testing optional features.