### PR TITLE
Fix `sled_multi_threaded` example code with threads of `INSERT` and `SELECT`,

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,3 +39,11 @@ jobs:
         run: cargo test --no-default-features --verbose
       - name: Run tests with all features
         run: cargo test --all-features --all-targets --verbose
+      - name: Run hello_world example code
+        run: cargo run --package gluesql --example hello_world
+      - name: Run api_usage example code
+        run: cargo run --package gluesql --example api_usage
+      - name: Run sled_multi_threaded example code
+        run: cargo run --package gluesql --example sled_multi_threaded
+      - name: Run using_config example code
+        run: cargo run --package gluesql --example using_config

--- a/examples/sled_multi_threaded.rs
+++ b/examples/sled_multi_threaded.rs
@@ -47,11 +47,12 @@ mod sled_multi_threaded {
             .expect("Something went wrong in the foo thread");
 
         let query = "SELECT name FROM greet";
-        let result = glue.execute(query).unwrap();
+        let payloads = glue.execute(query).unwrap();
+        assert_eq!(payloads.len(), 1);
 
-        let rows = match result {
-            Payload::Select { labels: _, rows } => rows,
-            _ => panic!("Unexpected result: {:?}", result),
+        let rows = match &payloads[0] {
+            Payload::Select { rows, .. } => rows,
+            _ => panic!("Unexpected result: {:?}", payloads),
         };
 
         let first_row = &rows[0];
@@ -61,7 +62,8 @@ mod sled_multi_threaded {
             value => panic!("Unexpected type: {:?}", value),
         };
 
-        println!("Hello {}!", to_greet); // Will typically output "Hello Foo!" but will sometimes output "Hello World!"; depends on which thread finished first.
+        // Will typically output "Hello Foo!" but will sometimes output "Hello World!"; depends on which thread finished first.
+        println!("Hello {}!", to_greet);
     }
 }
 

--- a/examples/sled_multi_threaded.rs
+++ b/examples/sled_multi_threaded.rs
@@ -22,27 +22,28 @@ mod sled_multi_threaded {
             SledStorage supports cloning, using this we can create copies of the storage for new threads;
               all we need to do is wrap it in glue again.
         */
-        let foo_storage = storage.clone();
-        let foo_thread = thread::spawn(move || {
-            let mut glue = Glue::new(foo_storage);
+        let insert_storage = storage.clone();
+        let insert_thread = thread::spawn(move || {
+            let mut glue = Glue::new(insert_storage);
             let query = "INSERT INTO greet (name) VALUES (\"Foo\")";
 
             glue.execute(query).unwrap();
         });
 
-        let world_storage = storage;
-        let world_thread = thread::spawn(move || {
-            let mut glue = Glue::new(world_storage);
-            let query = "INSERT INTO greet (name) VALUES (\"World\")";
+        let select_storage = storage;
+        let select_thread = thread::spawn(move || {
+            let mut glue = Glue::new(select_storage);
+            let query = "SELECT * FROM greet;";
 
-            glue.execute(query).unwrap();
+            let payloads = glue.execute(query).unwrap();
+            println!("{payloads:?}");
         });
 
-        world_thread
+        select_thread
             .join()
             .expect("Something went wrong in the world thread");
 
-        foo_thread
+        insert_thread
             .join()
             .expect("Something went wrong in the foo thread");
 


### PR DESCRIPTION
### Detail

1. You can check whether the example code can be executed in github actions.
2. Fix the broken sled example code after multiple query string is supported.