### PR TITLE
Fix PartialEq between f64 and other numeric types

### DIFF
--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -15,9 +15,9 @@ impl PartialEq<Value> for f64 {
         let lhs = *self;
 
         match *other {
-            I8(rhs) => lhs == rhs as f64,
-            I64(rhs) => lhs == rhs as f64,
-            F64(rhs) => lhs == rhs,
+            I8(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
+            I64(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
+            F64(rhs) => (lhs - rhs).abs() < f64::EPSILON,
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| rhs == x)
                 .unwrap_or(false),

--- a/core/src/data/value/binary_op/i64.rs
+++ b/core/src/data/value/binary_op/i64.rs
@@ -17,7 +17,7 @@ impl PartialEq<Value> for i64 {
         match *other {
             I8(rhs) => lhs == rhs as i64,
             I64(rhs) => lhs == rhs,
-            F64(rhs) => lhs as f64 == rhs,
+            F64(rhs) => ((lhs as f64) - rhs).abs() < f64::EPSILON,
             Decimal(rhs) => Decimal::from(lhs) == rhs,
             _ => false,
         }

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -15,7 +15,7 @@ impl PartialEq<Value> for i8 {
         match other {
             I8(other) => self == other,
             I64(other) => (*self as i64) == *other,
-            F64(other) => &(*self as f64) == other,
+            F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
         }


### PR DESCRIPTION
see [https://rust-lang.github.io/rust-clippy/master/#float_cmp](https://rust-lang.github.io/rust-clippy/master/#float_cmp)