### PR TITLE
Add BYTEA data type support

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ sqlparser = { version = "0.17", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.24"
 bigdecimal = { version = "0.3", features = ["serde", "string-only"] }
+hex = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
 version = "0.8.2"

--- a/core/src/ast/ast_literal.rs
+++ b/core/src/ast/ast_literal.rs
@@ -8,6 +8,7 @@ pub enum AstLiteral {
     Boolean(bool),
     Number(BigDecimal),
     QuotedString(String),
+    HexString(String),
     Interval {
         value: String,
         leading_field: Option<DateTimeField>,

--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -9,6 +9,7 @@ pub enum DataType {
     Int,
     Float,
     Text,
+    Bytea,
     Date,
     Timestamp,
     Time,

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -28,6 +28,7 @@ pub enum Key {
     I64(i64),
     Bool(bool),
     Str(String),
+    Bytea(Vec<u8>),
     Date(NaiveDate),
     Timestamp(NaiveDateTime),
     Time(NaiveTime),
@@ -43,6 +44,8 @@ impl PartialOrd for Key {
             (Key::I8(l), Key::I8(r)) => Some(l.cmp(r)),
             (Key::I64(l), Key::I64(r)) => Some(l.cmp(r)),
             (Key::Bool(l), Key::Bool(r)) => Some(l.cmp(r)),
+            (Key::Str(l), Key::Str(r)) => Some(l.cmp(r)),
+            (Key::Bytea(l), Key::Bytea(r)) => Some(l.cmp(r)),
             (Key::Date(l), Key::Date(r)) => Some(l.cmp(r)),
             (Key::Timestamp(l), Key::Timestamp(r)) => Some(l.cmp(r)),
             (Key::Time(l), Key::Time(r)) => Some(l.cmp(r)),
@@ -65,6 +68,7 @@ impl TryFrom<Value> for Key {
             I8(v) => Ok(Key::I8(v)),
             I64(v) => Ok(Key::I64(v)),
             Str(v) => Ok(Key::Str(v)),
+            Bytea(v) => Ok(Key::Bytea(v)),
             Date(v) => Ok(Key::Date(v)),
             Timestamp(v) => Ok(Key::Timestamp(v)),
             Time(v) => Ok(Key::Time(v)),
@@ -116,6 +120,10 @@ mod tests {
         assert_eq!(
             convert(r#""Hello World""#),
             Ok(Key::Str("Hello World".to_owned()))
+        );
+        assert_eq!(
+            convert("X'1234'"),
+            Ok(Key::Bytea(hex::decode("1234").unwrap())),
         );
         assert!(matches!(convert(r#"DATE "2022-03-03""#), Ok(Key::Date(_))));
         assert!(matches!(convert(r#"TIME "12:30:00""#), Ok(Key::Time(_))));

--- a/core/src/data/value/big_endian.rs
+++ b/core/src/data/value/big_endian.rs
@@ -46,6 +46,7 @@ impl Value {
                 .chain(v.as_bytes().iter())
                 .copied()
                 .collect::<Vec<_>>(),
+            Value::Bytea(v) => v.to_vec(),
             Value::Date(date) => [VALUE]
                 .iter()
                 .chain(date.num_days_from_ce().to_be_bytes().iter())
@@ -190,6 +191,20 @@ mod tests {
         let n3 = Str("aaa".to_owned()).to_cmp_be_bytes().unwrap();
         let n4 = Str("aaz".to_owned()).to_cmp_be_bytes().unwrap();
         let n5 = Str("c".to_owned()).to_cmp_be_bytes().unwrap();
+
+        assert_eq!(cmp(&n2, &n2), Ordering::Equal);
+        assert_eq!(cmp(&n1, &n2), Ordering::Less);
+        assert_eq!(cmp(&n3, &n1), Ordering::Greater);
+        assert_eq!(cmp(&n2, &n3), Ordering::Greater);
+        assert_eq!(cmp(&n3, &n4), Ordering::Less);
+        assert_eq!(cmp(&n5, &n4), Ordering::Greater);
+        assert_eq!(cmp(&n1, &null), Ordering::Less);
+
+        let n1 = Bytea(n1).to_cmp_be_bytes().unwrap();
+        let n2 = Bytea(n2).to_cmp_be_bytes().unwrap();
+        let n3 = Bytea(n3).to_cmp_be_bytes().unwrap();
+        let n4 = Bytea(n4).to_cmp_be_bytes().unwrap();
+        let n5 = Bytea(n5).to_cmp_be_bytes().unwrap();
 
         assert_eq!(cmp(&n2, &n2), Ordering::Equal);
         assert_eq!(cmp(&n1, &n2), Ordering::Less);

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -41,6 +41,9 @@ pub enum ValueError {
     #[error("failed to parse Decimal: {0}")]
     FailedToParseDecimal(String),
 
+    #[error("failed to parse hex string: {0}")]
+    FailedToParseHexString(String),
+
     #[error("non-numeric values {lhs:?} {operator} {rhs:?}")]
     NonNumericMathOperation {
         lhs: Value,

--- a/core/src/data/value/into.rs
+++ b/core/src/data/value/into.rs
@@ -16,6 +16,7 @@ impl From<&Value> for String {
     fn from(v: &Value) -> Self {
         match v {
             Value::Str(value) => value.to_string(),
+            Value::Bytea(value) => hex::encode(value),
             Value::Bool(value) => (if *value { "TRUE" } else { "FALSE" }).to_string(),
             Value::I8(value) => value.to_string(),
             Value::I64(value) => value.to_string(),
@@ -88,6 +89,7 @@ impl TryInto<bool> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
+            | Value::Bytea(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -127,6 +129,7 @@ impl TryInto<i8> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
+            | Value::Bytea(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -166,6 +169,7 @@ impl TryInto<i64> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
+            | Value::Bytea(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -205,6 +209,7 @@ impl TryInto<f64> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
+            | Value::Bytea(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -244,6 +249,7 @@ impl TryInto<Decimal> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
+            | Value::Bytea(_)
             | Value::Null => return Err(ValueError::ImpossibleCast.into()),
         })
     }
@@ -340,6 +346,7 @@ mod tests {
         let time = chrono::NaiveTime::from_hms_milli;
         let date = chrono::NaiveDate::from_ymd;
         test!(Value::Str("text".to_owned()), "text");
+        test!(Value::Bytea(hex::decode("1234").unwrap()), "1234");
         test!(Value::Bool(true), "TRUE");
         test!(Value::I8(122), "122");
         test!(Value::I64(1234567890), "1234567890");

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -43,6 +43,7 @@ impl TryFrom<Value> for JsonValue {
                 .map(JsonValue::Number)
                 .map_err(|_| ValueError::UnreachableJsonNumberParseFailure(v.to_string()).into()),
             Value::Str(v) => Ok(v.into()),
+            Value::Bytea(v) => Ok(hex::encode(v).into()),
             Value::Date(v) => Ok(v.to_string().into()),
             Value::Timestamp(v) => Ok(DateTime::<Utc>::from_utc(v, Utc).to_string().into()),
             Value::Time(v) => Ok(v.to_string().into()),
@@ -134,6 +135,10 @@ mod tests {
         assert_eq!(
             Value::Str("abc".to_owned()).try_into(),
             Ok(JsonValue::String("abc".to_owned()))
+        );
+        assert_eq!(
+            Value::Bytea(hex::decode("a1b2").unwrap()).try_into(),
+            Ok(JsonValue::String("a1b2".to_owned()))
         );
         assert_eq!(
             Value::Date(NaiveDate::from_ymd(2020, 1, 3)).try_into(),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -30,6 +30,7 @@ pub enum Value {
     F64(f64),
     Decimal(Decimal),
     Str(String),
+    Bytea(Vec<u8>),
     Date(NaiveDate),
     Timestamp(NaiveDateTime),
     Time(NaiveTime),
@@ -49,6 +50,7 @@ impl PartialEq<Value> for Value {
             (Value::Decimal(l), Value::Decimal(r)) => l == r,
             (Value::Bool(l), Value::Bool(r)) => l == r,
             (Value::Str(l), Value::Str(r)) => l == r,
+            (Value::Bytea(l), Value::Bytea(r)) => l == r,
             (Value::Date(l), Value::Date(r)) => l == r,
             (Value::Date(l), Value::Timestamp(r)) => &l.and_hms(0, 0, 0) == r,
             (Value::Timestamp(l), Value::Date(r)) => l == &r.and_hms(0, 0, 0),
@@ -72,6 +74,7 @@ impl PartialOrd<Value> for Value {
             (Value::Decimal(l), Value::Decimal(r)) => Some(l.cmp(r)),
             (Value::Bool(l), Value::Bool(r)) => Some(l.cmp(r)),
             (Value::Str(l), Value::Str(r)) => Some(l.cmp(r)),
+            (Value::Bytea(l), Value::Bytea(r)) => Some(l.cmp(r)),
             (Value::Date(l), Value::Date(r)) => Some(l.cmp(r)),
             (Value::Date(l), Value::Timestamp(r)) => Some(l.and_hms(0, 0, 0).cmp(r)),
             (Value::Timestamp(l), Value::Date(r)) => Some(l.cmp(&r.and_hms(0, 0, 0))),
@@ -103,6 +106,7 @@ impl Value {
             Value::Decimal(_) => matches!(data_type, DataType::Decimal),
             Value::Bool(_) => matches!(data_type, DataType::Boolean),
             Value::Str(_) => matches!(data_type, DataType::Text),
+            Value::Bytea(_) => matches!(data_type, DataType::Bytea),
             Value::Date(_) => matches!(data_type, DataType::Date),
             Value::Timestamp(_) => matches!(data_type, DataType::Timestamp),
             Value::Time(_) => matches!(data_type, DataType::Time),
@@ -140,6 +144,7 @@ impl Value {
             | (DataType::Decimal, Value::Decimal(_))
             | (DataType::Boolean, Value::Bool(_))
             | (DataType::Text, Value::Str(_))
+            | (DataType::Bytea, Value::Bytea(_))
             | (DataType::Date, Value::Date(_))
             | (DataType::Timestamp, Value::Timestamp(_))
             | (DataType::Time, Value::Time(_))
@@ -442,6 +447,7 @@ mod tests {
         use super::Interval;
         use chrono::{NaiveDateTime, NaiveTime};
         let decimal = |n: i32| Decimal(n.into());
+        let bytea = |v: &str| Bytea(hex::decode(v).unwrap());
 
         assert_ne!(Null, Null);
         assert_eq!(Bool(true), Bool(true));
@@ -451,6 +457,7 @@ mod tests {
         assert_eq!(F64(1.0), I64(1));
         assert_eq!(F64(6.11), F64(6.11));
         assert_eq!(Str("Glue".to_owned()), Str("Glue".to_owned()));
+        assert_eq!(bytea("1004"), bytea("1004"));
         assert_eq!(Interval::Month(1), Interval::Month(1));
         assert_eq!(
             Time(NaiveTime::from_hms(12, 30, 11)),
@@ -511,6 +518,14 @@ mod tests {
             Decimal(one).partial_cmp(&Decimal(two)),
             Some(Ordering::Less)
         );
+
+        let bytea = |v: &str| Bytea(hex::decode(v).unwrap());
+        assert_eq!(bytea("12").partial_cmp(&bytea("20")), Some(Ordering::Less));
+        assert_eq!(
+            bytea("9123").partial_cmp(&bytea("9122")),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(bytea("10").partial_cmp(&bytea("10")), Some(Ordering::Equal));
     }
 
     #[test]
@@ -824,10 +839,13 @@ mod tests {
             };
         }
 
+        let bytea = Value::Bytea(hex::decode("0abc").unwrap());
+
         // Same as
         cast!(Bool(true)            => Boolean      , Bool(true));
         cast!(Str("a".to_owned())   => Text         , Str("a".to_owned()));
-        cast!(I8(1)                 => Int8          , I8(1));
+        cast!(bytea                 => Bytea        , bytea);
+        cast!(I8(1)                 => Int8         , I8(1));
         cast!(I64(1)                => Int          , I64(1));
         cast!(F64(1.0)              => Float        , F64(1.0));
         cast!(Value::Uuid(123)      => Uuid         , Value::Uuid(123));
@@ -923,6 +941,7 @@ mod tests {
         let uuid = Uuid(parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap());
         let map = Value::parse_json_map(r#"{ "a": 10 }"#).unwrap();
         let list = Value::parse_json_list(r#"[ true ]"#).unwrap();
+        let bytea = Bytea(hex::decode("9001").unwrap());
 
         assert!(Bool(true).validate_type(&D::Boolean).is_ok());
         assert!(Bool(true).validate_type(&D::Int).is_err());
@@ -940,6 +959,8 @@ mod tests {
             .is_err());
         assert!(Str("a".to_owned()).validate_type(&D::Text).is_ok());
         assert!(Str("a".to_owned()).validate_type(&D::Int).is_err());
+        assert!(bytea.validate_type(&D::Bytea).is_ok());
+        assert!(bytea.validate_type(&D::Uuid).is_err());
         assert!(date.validate_type(&D::Date).is_ok());
         assert!(date.validate_type(&D::Text).is_err());
         assert!(timestamp.validate_type(&D::Timestamp).is_ok());

--- a/core/src/translate/ast_literal.rs
+++ b/core/src/translate/ast_literal.rs
@@ -13,9 +13,8 @@ pub fn translate_ast_literal(sql_value: &SqlValue) -> Result<AstLiteral> {
     Ok(match sql_value {
         SqlValue::Boolean(v) => AstLiteral::Boolean(*v),
         SqlValue::Number(v, _) => AstLiteral::Number(v.clone()),
-        SqlValue::SingleQuotedString(v) | SqlValue::HexStringLiteral(v) => {
-            AstLiteral::QuotedString(v.clone())
-        }
+        SqlValue::SingleQuotedString(v) => AstLiteral::QuotedString(v.clone()),
+        SqlValue::HexStringLiteral(v) => AstLiteral::HexString(v.clone()),
         SqlValue::Interval {
             value,
             leading_field,

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -11,6 +11,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Int(_) => Ok(DataType::Int),
         SqlDataType::Float(_) => Ok(DataType::Float),
         SqlDataType::Text => Ok(DataType::Text),
+        SqlDataType::Bytea => Ok(DataType::Bytea),
         SqlDataType::Date => Ok(DataType::Date),
         SqlDataType::Timestamp => Ok(DataType::Timestamp),
         SqlDataType::Time => Ok(DataType::Time),

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -15,6 +15,7 @@ bigdecimal = "0.3"
 uuid = "0.8"
 chrono = "0.4"
 rust_decimal = "1"
+hex = "0.4"
 
 [features]
 alter-table = ["gluesql-core/alter-table"]

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -57,8 +57,8 @@ test_case!(create_table, async move {
             Err(TranslateError::UnsupportedDataType("SOMEWHAT".to_owned()).into()),
         ),
         (
-            "CREATE TABLE Gluery (id BYTEA);",
-            Err(TranslateError::UnsupportedDataType("BYTEA".to_owned()).into()),
+            "CREATE TABLE Gluery (id BLOB);",
+            Err(TranslateError::UnsupportedDataType("BLOB".to_owned()).into()),
         ),
         (
             "CREATE TABLE Gluery (id INTEGER CHECK (true));",

--- a/test-suite/src/data_type/bytea.rs
+++ b/test-suite/src/data_type/bytea.rs
@@ -1,0 +1,53 @@
+use {
+    crate::*,
+    bigdecimal::BigDecimal,
+    gluesql_core::{
+        ast::DataType,
+        data::{Literal, LiteralError, ValueError},
+        executor::Payload,
+        prelude::Value::Bytea,
+    },
+    std::borrow::Cow,
+};
+
+test_case!(bytea, async move {
+    let bytea = |v| hex::decode(v).unwrap();
+
+    let test_cases = vec![
+        ("CREATE TABLE Bytea (key BYTEA)", Ok(Payload::Create)),
+        (
+            "INSERT INTO Bytea VALUES
+                (X'123456'),
+                ('ab0123'),
+                (X'936DA0');
+            ",
+            Ok(Payload::Insert(3)),
+        ),
+        (
+            "SELECT * FROM Bytea",
+            Ok(select!(
+                key
+                Bytea;
+                bytea("123456");
+                bytea("ab0123");
+                bytea("936DA0")
+            )),
+        ),
+        (
+            "INSERT INTO Bytea VALUES (0)",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Bytea,
+                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(0)))),
+            }
+            .into()),
+        ),
+        (
+            r#"INSERT INTO Bytea VALUES (X'123')"#,
+            Err(LiteralError::FailedToDecodeHexString("123".to_string()).into()),
+        ),
+    ];
+
+    for (sql, expected) in test_cases.into_iter() {
+        test!(expected, sql);
+    }
+});

--- a/test-suite/src/data_type/mod.rs
+++ b/test-suite/src/data_type/mod.rs
@@ -1,3 +1,4 @@
+pub mod bytea;
 pub mod date;
 pub mod decimal;
 pub mod int8;

--- a/test-suite/src/data_type/uuid.rs
+++ b/test-suite/src/data_type/uuid.rs
@@ -25,8 +25,8 @@ test_case!(uuid, async move {
             .into()),
         ),
         (
-            r#"INSERT INTO UUID VALUES (X'123')"#,
-            Err(ValueError::FailedToParseUUID("123".to_string()).into()),
+            r#"INSERT INTO UUID VALUES (X'1234')"#,
+            Err(ValueError::FailedToParseUUID("1234".to_string()).into()),
         ),
         (
             r#"INSERT INTO UUID VALUES ('NOT_UUID')"#,

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -116,6 +116,7 @@ macro_rules! generate_store_tests {
         glue!(interval, data_type::interval::interval);
         glue!(list, data_type::list::list);
         glue!(map, data_type::map::map);
+        glue!(bytea, data_type::bytea::bytea);
         glue!(synthesize, synthesize::synthesize);
         glue!(validate_unique, validate::unique::unique);
         glue!(validate_types, validate::types::types);


### PR DESCRIPTION
BYTEA type value has format of Vec<u8> which is for storing binary data.
Currently, hexadecimal string values are only accepted for inserting BYTEA values using SQL.
Rather than BLOB (binary large object), BYTEA name has used.
BLOB implies "large" but BYTEA is just a kind of byte array and it fits better for current use.

ref. https://www.postgresql.org/docs/current/datatype-binary.html