### PR TITLE
Support variance aggregate function & update aggregate test

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -113,6 +113,7 @@ pub enum Aggregate {
     Max(Expr),
     Min(Expr),
     Avg(Expr),
+    Variance(Expr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/plan/expr/aggregate.rs
+++ b/core/src/plan/expr/aggregate.rs
@@ -9,6 +9,7 @@ impl Aggregate {
             | Aggregate::Max(expr)
             | Aggregate::Min(expr)
             | Aggregate::Avg(expr) => Some(expr),
+            Aggregate::Variance(expr) => Some(expr),
         }
     }
 }
@@ -52,6 +53,10 @@ mod tests {
         assert_eq!(actual.as_expr(), Some(&expected));
 
         let actual = parse("AVG(id)");
+        let expected = Expr::Identifier("id".to_owned());
+        assert_eq!(actual.as_expr(), Some(&expected));
+
+        let actual = parse("VARIANCE(id)");
         let expected = Expr::Identifier("id".to_owned());
         assert_eq!(actual.as_expr(), Some(&expected));
     }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -187,6 +187,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),
         "MAX" => translate_aggrecate_one_arg(Aggregate::Max, args, name),
         "AVG" => translate_aggrecate_one_arg(Aggregate::Avg, args, name),
+        "VARIANCE" => translate_aggrecate_one_arg(Aggregate::Variance, args, name),
         "CONCAT" => {
             check_len_min(name, args.len(), 1)?;
             let exprs = args

--- a/test-suite/src/aggregate.rs
+++ b/test-suite/src/aggregate.rs
@@ -57,6 +57,10 @@ test_case!(aggregate, async move {
             select_with_null!("AVG(age)"; Null),
         ),
         (
+            "SELECT VARIANCE(age) FROM Item",
+            select_with_null!("VARIANCE(age)"; Null),
+        ),
+        (
             "SELECT COUNT(age), COUNT(quantity) FROM Item",
             select!("COUNT(age)" | "COUNT(quantity)"; I64 | I64; 3 5),
         ),
@@ -64,8 +68,16 @@ test_case!(aggregate, async move {
             "SELECT AVG(id), AVG(quantity) FROM Item",
             select!(
                 "AVG(id)" | "AVG(quantity)"
-                I64       | I64;
-                3           9
+                F64       | F64;
+                3.0         9.4
+            ),
+        ),
+        (
+            "SELECT VARIANCE(id), VARIANCE(quantity) FROM Item",
+            select!(
+                "VARIANCE(id)" | "VARIANCE(quantity)"
+                F64            | F64;
+                2.0              74.64
             ),
         ),
     ];


### PR DESCRIPTION
1. Add variance aggregation function
2. modified `avg` aggregate test
The test that compared the existing average value as an integer is modified to a test that compares the decimal result.