### PR TITLE
Introducing `CompositeType`

### DIFF
--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -17,4 +17,5 @@ pub enum DataType {
     Map,
     List,
     Decimal,
+    CustomType,
 }

--- a/core/src/data/custom_type.rs
+++ b/core/src/data/custom_type.rs
@@ -1,0 +1,16 @@
+use {
+    crate::prelude::DataType,
+    serde::{Deserialize, Serialize},
+};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CustomType {
+    name: String,
+    fields: Vec<CustomTypeField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct CustomTypeField {
+    name: String,
+    data_type: DataType,
+}

--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -1,4 +1,5 @@
 mod bigdecimal_ext;
+mod custom_type;
 mod interval;
 mod key;
 mod literal;
@@ -11,6 +12,7 @@ pub mod value;
 
 pub use {
     bigdecimal_ext::BigDecimalExt,
+    custom_type::CustomType,
     interval::{Interval, IntervalError},
     key::{Key, KeyError},
     literal::{Literal, LiteralError},

--- a/core/src/data/value/into.rs
+++ b/core/src/data/value/into.rs
@@ -29,6 +29,7 @@ impl From<&Value> for String {
             Value::List(_) => "[LIST]".to_owned(),
             Value::Decimal(value) => value.to_string(),
             Value::Null => String::from("NULL"),
+            Value::CustomType(_) => String::from("[CUSTOM_TYPE]"),
         }
     }
 }
@@ -88,7 +89,8 @@ impl TryInto<bool> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
-            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            | Value::Null
+            | Value::CustomType(_) => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -127,7 +129,8 @@ impl TryInto<i8> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
-            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            | Value::Null
+            | Value::CustomType(_) => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -166,7 +169,8 @@ impl TryInto<i64> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
-            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            | Value::Null
+            | Value::CustomType(_) => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -205,7 +209,8 @@ impl TryInto<f64> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
-            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            | Value::Null
+            | Value::CustomType(_) => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }
@@ -244,7 +249,8 @@ impl TryInto<Decimal> for &Value {
             | Value::Uuid(_)
             | Value::Map(_)
             | Value::List(_)
-            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+            | Value::Null
+            | Value::CustomType(_) => return Err(ValueError::ImpossibleCast.into()),
         })
     }
 }

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Interval, StringExt},
+    super::{CustomType, Interval, StringExt},
     crate::{ast::DataType, ast::DateTimeField, result::Result},
     binary_op::TryBinaryOperator,
     chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike},
@@ -37,6 +37,7 @@ pub enum Value {
     Uuid(u128),
     Map(HashMap<String, Value>),
     List(Vec<Value>),
+    CustomType(Box<CustomType>),
     Null,
 }
 
@@ -110,6 +111,7 @@ impl Value {
             Value::Uuid(_) => matches!(data_type, DataType::Uuid),
             Value::Map(_) => matches!(data_type, DataType::Map),
             Value::List(_) => matches!(data_type, DataType::List),
+            Value::CustomType(_) => matches!(data_type, DataType::CustomType),
             Value::Null => true,
         };
 


### PR DESCRIPTION
## Prepares entry layer for #596
Introduces new `CompositeType`, which allows you to compose various types into one.
This PR only implements the basic ingredients before the final goal of using `CREATE TYPE`.
### Expected usage when fully implemented
```sql
INSERT INTO Foo
  (id, name.id, name.order)
VALUES
  (1, 2, 3);

--- or

INSERT INTO Foo
  (id, name)
VALUES
  (1, { id: 2, order: 3 });
```
## Work In Progress 🚧 