### PR TITLE
Fix SledStorage export & import multiple times bug,

### DIFF
--- a/storages/sled-storage/src/lib.rs
+++ b/storages/sled-storage/src/lib.rs
@@ -75,7 +75,7 @@ impl SledStorage {
     }
 
     pub fn export(&self) -> Result<ExportData<impl Iterator<Item = Vec<Vec<u8>>>>> {
-        let id_offset = self.tree.generate_id().map_err(err_into)?;
+        let id_offset = self.id_offset + self.tree.generate_id().map_err(err_into)?;
         let data = self.tree.export();
 
         Ok((id_offset, data))

--- a/storages/sled-storage/tests/export_and_import.rs
+++ b/storages/sled-storage/tests/export_and_import.rs
@@ -32,6 +32,42 @@ fn export_and_import() {
 }
 
 #[test]
+fn export_and_import_multiple_times() {
+    let path1 = "tmp/repeated_export_and_import1";
+    let path2 = "tmp/repeated_export_and_import2";
+    let path3 = "tmp/repeated_export_and_import3";
+    let config1 = Config::default().path(path1).temporary(true);
+    let config2 = Config::default().path(path2).temporary(true);
+    let config3 = Config::default().path(path3).temporary(true);
+
+    let storage1 = SledStorage::try_from(config1).unwrap();
+    let mut glue1 = Glue::new(storage1);
+
+    glue1.execute("CREATE TABLE Foo (id INTEGER);").unwrap();
+    glue1
+        .execute("INSERT INTO Foo VALUES (1), (2), (3);")
+        .unwrap();
+
+    let data1 = glue1.execute("SELECT * FROM Foo;").unwrap();
+    let export = glue1.storage.unwrap().export().unwrap();
+
+    let mut storage2 = SledStorage::try_from(config2).unwrap();
+    storage2.import(export).unwrap();
+    let mut glue2 = Glue::new(storage2);
+
+    let data2 = glue2.execute("SELECT * FROM Foo;").unwrap();
+    let export2 = glue2.storage.unwrap().export().unwrap();
+    assert_eq!(data1, data2);
+
+    let mut storage3 = SledStorage::try_from(config3).unwrap();
+    storage3.import(export2).unwrap();
+    let mut glue3 = Glue::new(storage3);
+
+    let data3 = glue3.execute("SELECT * FROM Foo;").unwrap();
+    assert_eq!(data1, data3);
+}
+
+#[test]
 fn invalid_id_offset() {
     // value in "id_offset" key must have u64 big endian format data
 


### PR DESCRIPTION
Fix SledStorage export id_offset calculation to use existing id_offset.
Add corresponding export & import integration test, thanks to @raindust

Thanks a lot for providing proper test case to generate the bug @raindust
So I was able to directly dig into the issue and do easy-fix.

resolve #603 
