### PR TITLE
upgrade to Sqlparser 0.18

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.17", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.18", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.24"
 bigdecimal = { version = "0.3", features = ["serde", "string-only"] }


### PR DESCRIPTION
Sqlparser has released version 0.18.  This PR uses the new release.