### PR TITLE
Implements trigonometric functions in ast_builder

### DIFF
--- a/core/src/ast_builder/expr/function.rs
+++ b/core/src/ast_builder/expr/function.rs
@@ -10,6 +10,13 @@ use {
 pub enum FunctionNode {
     Abs(ExprNode),
     Floor(ExprNode),
+    Asin(ExprNode),
+    Acos(ExprNode),
+    Atan(ExprNode),
+    Sin(ExprNode),
+    Cos(ExprNode),
+    Tan(ExprNode),
+    Pi,
 }
 
 impl TryFrom<FunctionNode> for Expr {
@@ -27,6 +34,37 @@ impl TryFrom<FunctionNode> for Expr {
                 .map(Function::Floor)
                 .map(Box::new)
                 .map(Expr::Function),
+            FunctionNode::Asin(expr_node) => expr_node
+                .try_into()
+                .map(Function::Asin)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Acos(expr_node) => expr_node
+                .try_into()
+                .map(Function::Acos)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Atan(expr_node) => expr_node
+                .try_into()
+                .map(Function::Atan)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Sin(expr_node) => expr_node
+                .try_into()
+                .map(Function::Sin)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Cos(expr_node) => expr_node
+                .try_into()
+                .map(Function::Cos)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Tan(expr_node) => expr_node
+                .try_into()
+                .map(Function::Tan)
+                .map(Box::new)
+                .map(Expr::Function),
+            FunctionNode::Pi => Ok(Expr::Function(Box::new(Function::Pi()))),
         }
     }
 }
@@ -38,19 +76,59 @@ impl ExprNode {
     pub fn floor(self) -> ExprNode {
         floor(self)
     }
+    pub fn asin(self) -> ExprNode {
+        asin(self)
+    }
+    pub fn acos(self) -> ExprNode {
+        acos(self)
+    }
+    pub fn atan(self) -> ExprNode {
+        atan(self)
+    }
+    pub fn sin(self) -> ExprNode {
+        sin(self)
+    }
+    pub fn cos(self) -> ExprNode {
+        cos(self)
+    }
+    pub fn tan(self) -> ExprNode {
+        tan(self)
+    }
 }
 
 pub fn abs<T: Into<ExprNode>>(expr: T) -> ExprNode {
     ExprNode::Function(Box::new(FunctionNode::Abs(expr.into())))
 }
-
 pub fn floor<T: Into<ExprNode>>(expr: T) -> ExprNode {
     ExprNode::Function(Box::new(FunctionNode::Floor(expr.into())))
+}
+pub fn asin<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Asin(expr.into())))
+}
+pub fn acos<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Acos(expr.into())))
+}
+pub fn atan<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Atan(expr.into())))
+}
+pub fn sin<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Sin(expr.into())))
+}
+pub fn cos<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Cos(expr.into())))
+}
+pub fn tan<T: Into<ExprNode>>(expr: T) -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Tan(expr.into())))
+}
+pub fn pi() -> ExprNode {
+    ExprNode::Function(Box::new(FunctionNode::Pi))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{abs, col, expr, floor, test_expr};
+    use crate::ast_builder::{
+        abs, acos, asin, atan, col, cos, expr, floor, pi, sin, tan, test_expr,
+    };
 
     #[test]
     fn function_abs() {
@@ -71,6 +149,68 @@ mod tests {
 
         let actual = expr("base - 10").floor();
         let expected = "FLOOR(base - 10)";
+        test_expr(actual, expected);
+    }
+
+    #[test]
+    fn function_trigonometrics() {
+        // asin
+        let actual = asin(col("num"));
+        let expected = "ASIN(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").asin();
+        let expected = "ASIN(num)";
+        test_expr(actual, expected);
+
+        // acos
+        let actual = acos(col("num"));
+        let expected = "ACOS(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").acos();
+        let expected = "ACOS(num)";
+        test_expr(actual, expected);
+
+        // atan
+        let actual = atan(col("num"));
+        let expected = "ATAN(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").atan();
+        let expected = "ATAN(num)";
+        test_expr(actual, expected);
+
+        // sin
+        let actual = sin(col("num"));
+        let expected = "SIN(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").sin();
+        let expected = "SIN(num)";
+        test_expr(actual, expected);
+
+        // cos
+        let actual = cos(col("num"));
+        let expected = "COS(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").cos();
+        let expected = "COS(num)";
+        test_expr(actual, expected);
+
+        // tan
+        let actual = tan(col("num"));
+        let expected = "TAN(num)";
+        test_expr(actual, expected);
+
+        let actual = col("num").tan();
+        let expected = "TAN(num)";
+        test_expr(actual, expected);
+
+        // pi
+        let actual = pi();
+        let expected = "PI()";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -22,7 +22,7 @@ pub use expr::{col, expr, nested, num, text, ExprNode};
 /// Available aggregate or normal SQL functions
 pub use expr::{
     aggregate::{max, sum, AggregateNode},
-    function::{abs, floor, FunctionNode},
+    function::{abs, acos, asin, atan, cos, floor, pi, sin, tan, FunctionNode},
 };
 
 /// Entry point function to build statement


### PR DESCRIPTION
This pull request resolves #624, implementing `asin`, `acos`, `atan`, `sin`, `cos`, `tan`, `pi` for `ast_builder`.

Thanks!