### PR TITLE
Add INT(16) data type

### DIFF
--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -6,6 +6,7 @@ use strum_macros::Display;
 pub enum DataType {
     Boolean,
     Int8,
+    Int16,
     Int32,
     Int,
     Int128,

--- a/core/src/data/bigdecimal_ext.rs
+++ b/core/src/data/bigdecimal_ext.rs
@@ -2,6 +2,7 @@ use bigdecimal::BigDecimal;
 
 pub trait BigDecimalExt {
     fn to_i8(&self) -> Option<i8>;
+    fn to_i16(&self) -> Option<i16>;
     fn to_i32(&self) -> Option<i32>;
     fn to_i64(&self) -> Option<i64>;
     fn to_i128(&self) -> Option<i128>;
@@ -12,6 +13,10 @@ impl BigDecimalExt for BigDecimal {
     fn to_i8(&self) -> Option<i8> {
         self.is_integer()
             .then(|| bigdecimal::ToPrimitive::to_i8(self))?
+    }
+    fn to_i16(&self) -> Option<i16> {
+        self.is_integer()
+            .then(|| bigdecimal::ToPrimitive::to_i16(self))?
     }
     fn to_i32(&self) -> Option<i32> {
         self.is_integer()

--- a/core/src/data/interval/primitive.rs
+++ b/core/src/data/interval/primitive.rs
@@ -14,6 +14,17 @@ impl Mul<i8> for Interval {
     }
 }
 
+impl Mul<i16> for Interval {
+    type Output = Self;
+
+    fn mul(self, rhs: i16) -> Self {
+        match self {
+            Interval::Month(v) => Interval::Month(v * rhs as i32),
+            Interval::Microsecond(v) => Interval::Microsecond(v * rhs as i64),
+        }
+    }
+}
+
 impl Mul<i32> for Interval {
     type Output = Self;
 
@@ -66,6 +77,14 @@ impl Mul<Interval> for i8 {
     }
 }
 
+impl Mul<Interval> for i16 {
+    type Output = Interval;
+
+    fn mul(self, rhs: Interval) -> Interval {
+        rhs * self
+    }
+}
+
 impl Mul<Interval> for i32 {
     type Output = Interval;
 
@@ -102,6 +121,17 @@ impl Div<i8> for Interval {
     type Output = Self;
 
     fn div(self, rhs: i8) -> Self {
+        match self {
+            Interval::Month(v) => Interval::Month(v / rhs as i32),
+            Interval::Microsecond(v) => Interval::Microsecond(v / rhs as i64),
+        }
+    }
+}
+
+impl Div<i16> for Interval {
+    type Output = Self;
+
+    fn div(self, rhs: i16) -> Self {
         match self {
             Interval::Month(v) => Interval::Month(v / rhs as i32),
             Interval::Microsecond(v) => Interval::Microsecond(v / rhs as i64),
@@ -154,6 +184,17 @@ impl Div<f64> for Interval {
 }
 
 impl Div<Interval> for i8 {
+    type Output = Interval;
+
+    fn div(self, rhs: Interval) -> Interval {
+        match rhs {
+            Interval::Month(v) => Interval::Month(self as i32 / v),
+            Interval::Microsecond(v) => Interval::Microsecond(self as i64 / v),
+        }
+    }
+}
+
+impl Div<Interval> for i16 {
     type Output = Interval;
 
     fn div(self, rhs: Interval) -> Interval {
@@ -219,6 +260,9 @@ mod tests {
         assert_eq!(Month(2) * 3_i8, Month(6));
         assert_eq!(2_i8 * Month(3), Month(6));
 
+        assert_eq!(Month(2) * 3_i16, Month(6));
+        assert_eq!(2_i16 * Month(3), Month(6));
+
         assert_eq!(Month(2) * 3_i32, Month(6));
         assert_eq!(2_i32 * Month(3), Month(6));
 
@@ -233,6 +277,9 @@ mod tests {
 
         assert_eq!(Month(6) / 3_i8, Month(2));
         assert_eq!(6_i8 / Month(2), Month(3));
+
+        assert_eq!(Month(6) / 3_i16, Month(2));
+        assert_eq!(6_i16 / Month(2), Month(3));
 
         assert_eq!(Month(6) / 3_i32, Month(2));
         assert_eq!(6_i32 / Month(2), Month(3));
@@ -249,6 +296,9 @@ mod tests {
         assert_eq!(Microsecond(2) * 3_i8, Microsecond(6));
         assert_eq!(2_i8 * Microsecond(3), Microsecond(6));
 
+        assert_eq!(Microsecond(2) * 3_i16, Microsecond(6));
+        assert_eq!(2_i16 * Microsecond(3), Microsecond(6));
+
         assert_eq!(Microsecond(2) * 3_i32, Microsecond(6));
         assert_eq!(2_i32 * Microsecond(3), Microsecond(6));
 
@@ -260,6 +310,9 @@ mod tests {
 
         assert_eq!(Microsecond(6) / 3_i8, Microsecond(2));
         assert_eq!(6_i8 / Microsecond(2), Microsecond(3));
+
+        assert_eq!(Microsecond(6) / 3_i16, Microsecond(2));
+        assert_eq!(6_i16 / Microsecond(2), Microsecond(3));
 
         assert_eq!(Microsecond(6) / 3_i32, Microsecond(2));
         assert_eq!(6_i32 / Microsecond(2), Microsecond(3));

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -331,6 +331,21 @@ mod tests {
         assert_eq!(cmp(&n6, &n4), Ordering::Greater);
         assert_eq!(cmp(&n4, &null), Ordering::Less);
 
+        let n1 = I16(-100).to_cmp_be_bytes();
+        let n2 = I16(-10).to_cmp_be_bytes();
+        let n3 = I16(0).to_cmp_be_bytes();
+        let n4 = I16(3).to_cmp_be_bytes();
+        let n5 = I16(20).to_cmp_be_bytes();
+        let n6 = I16(100).to_cmp_be_bytes();
+
+        assert_eq!(cmp(&n1, &n2), Ordering::Less);
+        assert_eq!(cmp(&n3, &n2), Ordering::Greater);
+        assert_eq!(cmp(&n1, &n6), Ordering::Less);
+        assert_eq!(cmp(&n5, &n5), Ordering::Equal);
+        assert_eq!(cmp(&n4, &n5), Ordering::Less);
+        assert_eq!(cmp(&n6, &n4), Ordering::Greater);
+        assert_eq!(cmp(&n4, &null), Ordering::Less);
+
         let n1 = I32(-100).to_cmp_be_bytes();
         let n2 = I32(-10).to_cmp_be_bytes();
         let n3 = I32(0).to_cmp_be_bytes();

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -25,6 +25,7 @@ pub enum KeyError {
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub enum Key {
     I8(i8),
+    I16(i16),
     I32(i32),
     I64(i64),
     I128(i128),
@@ -44,6 +45,7 @@ impl PartialOrd for Key {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
             (Key::I8(l), Key::I8(r)) => Some(l.cmp(r)),
+            (Key::I16(l), Key::I16(r)) => Some(l.cmp(r)),
             (Key::I32(l), Key::I32(r)) => Some(l.cmp(r)),
             (Key::I64(l), Key::I64(r)) => Some(l.cmp(r)),
             (Key::Bool(l), Key::Bool(r)) => Some(l.cmp(r)),
@@ -69,6 +71,7 @@ impl TryFrom<Value> for Key {
         match value {
             Bool(v) => Ok(Key::Bool(v)),
             I8(v) => Ok(Key::I8(v)),
+            I16(v) => Ok(Key::I16(v)),
             I32(v) => Ok(Key::I32(v)),
             I64(v) => Ok(Key::I64(v)),
             I128(v) => Ok(Key::I128(v)),
@@ -111,6 +114,15 @@ impl Key {
                 }
             }
             Key::I8(v) => {
+                let sign = if *v >= 0 { 1 } else { 0 };
+
+                [VALUE, sign]
+                    .iter()
+                    .chain(v.to_be_bytes().iter())
+                    .copied()
+                    .collect::<Vec<_>>()
+            }
+            Key::I16(v) => {
                 let sign = if *v >= 0 { 1 } else { 0 };
 
                 [VALUE, sign]
@@ -232,6 +244,7 @@ mod tests {
         // Some
         assert_eq!(convert("True"), Ok(Key::Bool(true)));
         assert_eq!(convert("CAST(11 AS INT(8))"), Ok(Key::I8(11)));
+        assert_eq!(convert("CAST(11 AS INT(16))"), Ok(Key::I16(11)));
         assert_eq!(convert("CAST(11 AS INT(32))"), Ok(Key::I32(11)));
         assert_eq!(convert("2048"), Ok(Key::I64(2048)));
         assert_eq!(

--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -16,6 +16,7 @@ impl PartialEq<Value> for f64 {
 
         match *other {
             I8(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
+            I16(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I32(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I64(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I128(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
@@ -32,6 +33,7 @@ impl PartialOrd<Value> for f64 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match *other {
             I8(rhs) => self.partial_cmp(&(rhs as f64)),
+            I16(rhs) => self.partial_cmp(&(rhs as f64)),
             I32(rhs) => self.partial_cmp(&(rhs as f64)),
             I64(rhs) => self.partial_cmp(&(rhs as f64)),
             I128(rhs) => self.partial_cmp(&(rhs as f64)),
@@ -52,6 +54,7 @@ impl TryBinaryOperator for f64 {
 
         match *rhs {
             I8(rhs) => Ok(F64(lhs + rhs as f64)),
+            I16(rhs) => Ok(F64(lhs + rhs as f64)),
             I32(rhs) => Ok(F64(lhs + rhs as f64)),
             I64(rhs) => Ok(F64(lhs + rhs as f64)),
             I128(rhs) => Ok(F64(lhs + rhs as f64)),
@@ -74,6 +77,7 @@ impl TryBinaryOperator for f64 {
 
         match *rhs {
             I8(rhs) => Ok(F64(lhs - rhs as f64)),
+            I16(rhs) => Ok(F64(lhs - rhs as f64)),
             I32(rhs) => Ok(F64(lhs - rhs as f64)),
             I64(rhs) => Ok(F64(lhs - rhs as f64)),
             I128(rhs) => Ok(F64(lhs - rhs as f64)),
@@ -96,6 +100,7 @@ impl TryBinaryOperator for f64 {
 
         match *rhs {
             I8(rhs) => Ok(F64(lhs * rhs as f64)),
+            I16(rhs) => Ok(F64(lhs * rhs as f64)),
             I32(rhs) => Ok(F64(lhs * rhs as f64)),
             I64(rhs) => Ok(F64(lhs * rhs as f64)),
             I128(rhs) => Ok(F64(lhs * rhs as f64)),
@@ -119,6 +124,7 @@ impl TryBinaryOperator for f64 {
 
         match *rhs {
             I8(rhs) => Ok(F64(lhs / rhs as f64)),
+            I16(rhs) => Ok(F64(lhs / rhs as f64)),
             I32(rhs) => Ok(F64(lhs / rhs as f64)),
             I64(rhs) => Ok(F64(lhs / rhs as f64)),
             I128(rhs) => Ok(F64(lhs / rhs as f64)),
@@ -141,6 +147,7 @@ impl TryBinaryOperator for f64 {
 
         match *rhs {
             I8(rhs) => Ok(F64(lhs % rhs as f64)),
+            I16(rhs) => Ok(F64(lhs % rhs as f64)),
             I32(rhs) => Ok(F64(lhs % rhs as f64)),
             I64(rhs) => Ok(F64(lhs % rhs as f64)),
             I128(rhs) => Ok(F64(lhs % rhs as f64)),
@@ -184,6 +191,7 @@ mod tests {
         let base = 1.0_f64;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -198,6 +206,7 @@ mod tests {
         let base = 1.0_f64;
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
@@ -215,6 +224,7 @@ mod tests {
         let base = 1.0_f64;
 
         assert!(matches!(base.try_add(&I8(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_add(&I16(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I32(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I64(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I128(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
@@ -239,6 +249,9 @@ mod tests {
         let base = 1.0_f64;
 
         assert!(matches!(base.try_subtract(&I8(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
+        assert!(
+            matches!(base.try_subtract(&I16(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
+        );
         assert!(
             matches!(base.try_subtract(&I32(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
@@ -272,6 +285,9 @@ mod tests {
 
         assert!(matches!(base.try_multiply(&I8(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(
+            matches!(base.try_multiply(&I16(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
+        );
+        assert!(
             matches!(base.try_multiply(&I32(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
         assert!(
@@ -303,6 +319,7 @@ mod tests {
         let base = 1.0_f64;
 
         assert!(matches!(base.try_divide(&I8(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_divide(&I16(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I32(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I64(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I128(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
@@ -329,6 +346,7 @@ mod tests {
         let base = 1.0_f64;
 
         assert!(matches!(base.try_modulo(&I8(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_modulo(&I16(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I32(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I64(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I128(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));

--- a/core/src/data/value/binary_op/i128.rs
+++ b/core/src/data/value/binary_op/i128.rs
@@ -14,6 +14,7 @@ impl PartialEq<Value> for i128 {
     fn eq(&self, other: &Value) -> bool {
         match other {
             I8(other) => self == &(*other as i128),
+            I16(other) => self == &(*other as i128),
             I32(other) => self == &(*other as i128),
             I64(other) => self == &(*other as i128),
             I128(other) => self == other,
@@ -28,6 +29,7 @@ impl PartialOrd<Value> for i128 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match other {
             I8(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
+            I16(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I32(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I64(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I128(other) => PartialOrd::partial_cmp(self, other),
@@ -51,6 +53,18 @@ impl TryBinaryOperator for i128 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I128(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I128),
+
+            I16(rhs) => lhs
+                .checked_add(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
@@ -116,6 +130,17 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            I16(rhs) => lhs
+                .checked_sub(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I128),
             I32(rhs) => lhs
                 .checked_sub(rhs as i128)
                 .ok_or_else(|| {
@@ -170,6 +195,17 @@ impl TryBinaryOperator for i128 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I128(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I128),
+            I16(rhs) => lhs
+                .checked_mul(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
@@ -236,6 +272,17 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            I16(rhs) => lhs
+                .checked_div(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I128),
             I32(rhs) => lhs
                 .checked_div(rhs as i128)
                 .ok_or_else(|| {
@@ -290,6 +337,17 @@ impl TryBinaryOperator for i128 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I128(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I128),
+            I16(rhs) => lhs
+                .checked_rem(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
@@ -353,6 +411,7 @@ mod tests {
     #[test]
     fn test_extremes() {
         assert_eq!(I128(1), I8(1));
+        assert_eq!(I128(1), I16(1));
         assert_eq!(I128(1), I32(1));
         assert_eq!(I128(1), I64(1));
         assert_eq!(I128(1), I128(1));
@@ -370,6 +429,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: I8(1),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+        assert_eq!(
+            i128::MAX.try_add(&I16(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: I16(1),
                 operator: (NumericBinaryOperator::Add)
             }
             .into())
@@ -415,6 +483,15 @@ mod tests {
             .into())
         );
         assert_eq!(
+            i128::MIN.try_subtract(&I16(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MIN),
+                rhs: I16(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
             i128::MIN.try_subtract(&I32(1)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MIN),
@@ -445,6 +522,7 @@ mod tests {
 
         //try multiply
         assert_eq!(i128::MAX.try_multiply(&I8(1)), Ok(I128(i128::MAX)));
+        assert_eq!(i128::MAX.try_multiply(&I16(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I32(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I64(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I128(1)), Ok(I128(i128::MAX)));
@@ -454,6 +532,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: I8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            i128::MAX.try_multiply(&I16(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: I16(2),
                 operator: (NumericBinaryOperator::Multiply)
             }
             .into())
@@ -497,6 +584,15 @@ mod tests {
             .into())
         );
         assert_eq!(
+            i128::MAX.try_divide(&I16(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: I16(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
             i128::MAX.try_divide(&I32(0)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
@@ -526,6 +622,15 @@ mod tests {
 
         assert_eq!(
             i128::MAX.try_modulo(&I8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: I8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i128::MAX.try_modulo(&I16(0)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: I8(0),
@@ -567,6 +672,7 @@ mod tests {
         let base = 1_i128;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -581,12 +687,14 @@ mod tests {
         let base = 1_i128;
 
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
@@ -611,6 +719,7 @@ mod tests {
         let base = 1_i128;
 
         assert_eq!(base.try_add(&I8(1)), Ok(I128(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -637,6 +746,7 @@ mod tests {
         let base = 1_i128;
 
         assert_eq!(base.try_subtract(&I8(1)), Ok(I128(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -666,6 +776,7 @@ mod tests {
         let base = 3_i128;
 
         assert_eq!(base.try_multiply(&I8(2)), Ok(I128(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I128(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I128(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I128(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
@@ -701,6 +812,7 @@ mod tests {
         let base = 6_i128;
 
         assert_eq!(base.try_divide(&I8(2)), Ok(I128(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I128(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I128(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I128(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
@@ -735,6 +847,7 @@ mod tests {
         let base = 9_i128;
 
         assert_eq!(base.try_modulo(&I8(1)), Ok(I128(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I128(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I128(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I128(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));

--- a/core/src/data/value/binary_op/i128.rs
+++ b/core/src/data/value/binary_op/i128.rs
@@ -701,6 +701,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
@@ -782,6 +783,7 @@ mod tests {
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I128(-3)));
+        assert_eq!(base.try_multiply(&I16(-1)), Ok(I128(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I128(-3)));
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I128(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
@@ -818,6 +820,7 @@ mod tests {
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I128(-1)));
+        assert_eq!(base.try_divide(&I16(-6)), Ok(I128(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I128(-1)));
         assert_eq!(base.try_divide(&I64(-6)), Ok(I128(-1)));
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
@@ -853,6 +856,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I128(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I128(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I128(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I128(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));

--- a/core/src/data/value/binary_op/i16.rs
+++ b/core/src/data/value/binary_op/i16.rs
@@ -453,40 +453,40 @@ mod tests {
 
     #[test]
     fn test_extremes() {
-        assert_eq!(-1i8, I8(-1));
-        assert_eq!(0i8, I8(0));
-        assert_eq!(1i8, I8(1));
-        assert_eq!(i8::MAX, I8(i8::MAX));
-        assert_eq!(i8::MIN, I8(i8::MIN));
+        assert_eq!(-1i16, I16(-1));
+        assert_eq!(0i16, I16(0));
+        assert_eq!(1i16, I16(1));
+        assert_eq!(i16::MAX, I16(i16::MAX));
+        assert_eq!(i16::MIN, I16(i16::MIN));
 
         assert_eq!(
-            i8::MAX.try_add(&I8(1)),
+            i16::MAX.try_add(&I16(1)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
-                rhs: I8(1),
+                lhs: I16(i16::MAX),
+                rhs: I16(1),
                 operator: (NumericBinaryOperator::Add)
             }
             .into())
         );
 
-        assert_eq!(i8::MAX.try_add(&I32(1)), Ok(I32(i8::MAX as i32 + 1)));
-        assert_eq!(i8::MAX.try_add(&I64(1)), Ok(I64(i8::MAX as i64 + 1)));
-        assert_eq!(i8::MAX.try_add(&I128(1)), Ok(I128(i8::MAX as i128 + 1)));
+        assert_eq!(i16::MAX.try_add(&I32(1)), Ok(I32(i16::MAX as i32 + 1)));
+        assert_eq!(i16::MAX.try_add(&I64(1)), Ok(I64(i16::MAX as i64 + 1)));
+        assert_eq!(i16::MAX.try_add(&I128(1)), Ok(I128(i16::MAX as i128 + 1)));
 
         assert_eq!(
-            i8::MAX.try_add(&I8(i8::MAX)),
+            i16::MAX.try_add(&I16(i16::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
-                rhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
+                rhs: I16(i16::MAX),
                 operator: (NumericBinaryOperator::Add)
             }
             .into())
         );
 
         assert_eq!(
-            i8::MAX.try_add(&I32(i32::MAX)),
+            i16::MAX.try_add(&I32(i32::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I32(i32::MAX),
                 operator: (NumericBinaryOperator::Add)
             }
@@ -494,9 +494,9 @@ mod tests {
         );
 
         assert_eq!(
-            i8::MAX.try_add(&I64(i64::MAX)),
+            i16::MAX.try_add(&I64(i64::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I64(i64::MAX),
                 operator: (NumericBinaryOperator::Add)
             }
@@ -504,9 +504,9 @@ mod tests {
         );
 
         assert_eq!(
-            i8::MAX.try_add(&I128(i128::MAX)),
+            i16::MAX.try_add(&I128(i128::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Add)
             }
@@ -514,81 +514,103 @@ mod tests {
         );
 
         assert_eq!(
-            i8::MIN.try_subtract(&I8(1)),
+            i16::MIN.try_subtract(&I8(1)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
+                lhs: I16(i16::MIN),
                 rhs: I8(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i16::MIN.try_subtract(&I16(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I16(i16::MIN),
+                rhs: I16(1),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
 
         // these dont overflow since they are not i8 (ie, i32, i64, i128)
-        assert_eq!(i8::MIN.try_subtract(&I32(1)), Ok(I32(i8::MIN as i32 - 1)));
-        assert_eq!(i8::MIN.try_subtract(&I64(1)), Ok(I64(i8::MIN as i64 - 1)));
+        assert_eq!(i16::MIN.try_subtract(&I32(1)), Ok(I32(i16::MIN as i32 - 1)));
+        assert_eq!(i16::MIN.try_subtract(&I64(1)), Ok(I64(i16::MIN as i64 - 1)));
         assert_eq!(
-            i8::MIN.try_subtract(&I128(1)),
-            Ok(I128(i8::MIN as i128 - 1))
+            i16::MIN.try_subtract(&I128(1)),
+            Ok(I128(i16::MIN as i128 - 1))
         );
 
         assert_eq!(
-            i8::MIN.try_subtract(&I8(i8::MAX)),
+            i16::MIN.try_subtract(&I16(i16::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
-                rhs: I8(i8::MAX),
+                lhs: I16(i16::MIN),
+                rhs: I16(i16::MAX),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
         assert_eq!(
-            i8::MIN.try_subtract(&I32(i32::MAX)),
+            i16::MIN.try_subtract(&I32(i32::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
+                lhs: I16(i16::MIN),
                 rhs: I32(i32::MAX),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
         assert_eq!(
-            i8::MIN.try_subtract(&I64(i64::MAX)),
+            i16::MIN.try_subtract(&I64(i64::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
+                lhs: I16(i16::MIN),
                 rhs: I64(i64::MAX),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
         assert_eq!(
-            i8::MIN.try_subtract(&I128(i128::MAX)),
+            i16::MIN.try_subtract(&I128(i128::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
+                lhs: I16(i16::MIN),
                 rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
 
-        assert_eq!(i8::MAX.try_multiply(&I8(1)), Ok(I8(i8::MAX)));
-        assert_eq!(i8::MAX.try_multiply(&I32(1)), Ok(I32(i8::MAX as i32)));
+        assert_eq!(i16::MAX.try_multiply(&I8(1)), Ok(I16(i16::MAX)));
+        assert_eq!(i16::MAX.try_multiply(&I16(1)), Ok(I16(i16::MAX)));
+        assert_eq!(i16::MAX.try_multiply(&I32(1)), Ok(I32(i16::MAX as i32)));
         assert_eq!(
-            i8::MIN.try_subtract(&I128(i128::MAX)),
+            i16::MIN.try_subtract(&I128(i128::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MIN),
+                lhs: I16(i16::MIN),
                 rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
 
-        assert_eq!(i8::MAX.try_multiply(&I8(1)), Ok(I8(i8::MAX)));
-        assert_eq!(i8::MAX.try_multiply(&I64(1)), Ok(I64(i8::MAX as i64)));
-        assert_eq!(i8::MAX.try_multiply(&I128(1)), Ok(I128(i8::MAX as i128)));
+        assert_eq!(i16::MAX.try_multiply(&I8(1)), Ok(I16(i16::MAX)));
+        assert_eq!(i16::MAX.try_multiply(&I16(1)), Ok(I16(i16::MAX)));
+        assert_eq!(i16::MAX.try_multiply(&I32(1)), Ok(I32(i16::MAX as i32)));
+        assert_eq!(i16::MAX.try_multiply(&I64(1)), Ok(I64(i16::MAX as i64)));
+        assert_eq!(i16::MAX.try_multiply(&I128(1)), Ok(I128(i16::MAX as i128)));
 
         assert_eq!(
-            i8::MAX.try_multiply(&I8(2)),
+            i16::MAX.try_multiply(&I8(2)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            i16::MAX.try_multiply(&I16(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I16(i16::MAX),
+                rhs: I16(2),
                 operator: (NumericBinaryOperator::Multiply)
             }
             .into())
@@ -596,7 +618,7 @@ mod tests {
         assert_eq!(
             2i8.try_multiply(&I32(i32::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(2),
+                lhs: I16(2),
                 rhs: I32(i32::MAX),
                 operator: (NumericBinaryOperator::Multiply)
             }
@@ -605,7 +627,7 @@ mod tests {
         assert_eq!(
             2i8.try_multiply(&I64(i64::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(2),
+                lhs: I16(2),
                 rhs: I64(i64::MAX),
                 operator: (NumericBinaryOperator::Multiply)
             }
@@ -614,7 +636,7 @@ mod tests {
         assert_eq!(
             2i8.try_multiply(&I128(i128::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(2),
+                lhs: I16(2),
                 rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Multiply)
             }
@@ -624,7 +646,7 @@ mod tests {
         assert_eq!(
             2i8.try_multiply(&I128(i128::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(2),
+                lhs: I16(2),
                 rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Multiply)
             }
@@ -633,36 +655,45 @@ mod tests {
 
         //try_divide
         assert_eq!(
-            i8::MAX.try_divide(&I8(0)),
+            i16::MAX.try_divide(&I8(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I8(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_divide(&I32(0)),
+            i16::MAX.try_divide(&I16(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
+                rhs: I16(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i16::MAX.try_divide(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I16(i16::MAX),
                 rhs: I32(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_divide(&I64(0)),
+            i16::MAX.try_divide(&I64(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I64(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_divide(&I128(0)),
+            i16::MAX.try_divide(&I128(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I128(0),
                 operator: (NumericBinaryOperator::Divide)
             }
@@ -670,36 +701,45 @@ mod tests {
         );
 
         assert_eq!(
-            i8::MAX.try_modulo(&I8(0)),
+            i16::MAX.try_modulo(&I8(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I8(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_modulo(&I32(0)),
+            i16::MAX.try_modulo(&I16(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
+                rhs: I16(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i16::MAX.try_modulo(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I16(i16::MAX),
                 rhs: I32(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_modulo(&I64(0)),
+            i16::MAX.try_modulo(&I64(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I64(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())
         );
         assert_eq!(
-            i8::MAX.try_modulo(&I128(0)),
+            i16::MAX.try_modulo(&I128(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I8(i8::MAX),
+                lhs: I16(i16::MAX),
                 rhs: I128(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
@@ -712,6 +752,7 @@ mod tests {
         let base = 1_i16;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -726,18 +767,21 @@ mod tests {
         let base = 1_i16;
 
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
@@ -755,7 +799,8 @@ mod tests {
     fn try_add() {
         let base = 1_i16;
 
-        assert_eq!(base.try_add(&I8(1)), Ok(I8(2)));
+        assert_eq!(base.try_add(&I8(1)), Ok(I16(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I16(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -781,7 +826,8 @@ mod tests {
     fn try_subtract() {
         let base = 1_i16;
 
-        assert_eq!(base.try_subtract(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_subtract(&I8(1)), Ok(I16(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -808,10 +854,11 @@ mod tests {
 
     #[test]
     fn try_multiply() {
-        let base = 3_i8;
+        let base = 3_i16;
 
         // 3 * 2 = 6
-        assert_eq!(base.try_multiply(&I8(2)), Ok(I8(6)));
+        assert_eq!(base.try_multiply(&I8(2)), Ok(I16(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I16(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
@@ -834,7 +881,7 @@ mod tests {
         assert_eq!(
             base.try_multiply(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I8(base),
+                lhs: I16(base),
                 operator: NumericBinaryOperator::Multiply,
                 rhs: Bool(true)
             }
@@ -844,9 +891,10 @@ mod tests {
 
     #[test]
     fn try_divide() {
-        let base = 6_i8;
+        let base = 6_i16;
 
-        assert_eq!(base.try_divide(&I8(2)), Ok(I8(3)));
+        assert_eq!(base.try_divide(&I8(2)), Ok(I16(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I16(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
@@ -869,7 +917,7 @@ mod tests {
         assert_eq!(
             base.try_divide(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I8(base),
+                lhs: I16(base),
                 operator: NumericBinaryOperator::Divide,
                 rhs: Bool(true)
             }
@@ -879,14 +927,16 @@ mod tests {
 
     #[test]
     fn try_modulo() {
-        let base = 9_i8;
+        let base = 9_i16;
 
-        assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_modulo(&I8(1)), Ok(I16(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
-        assert_eq!(base.try_modulo(&I8(2)), Ok(I8(1)));
+        assert_eq!(base.try_modulo(&I8(2)), Ok(I16(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I16(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
@@ -900,7 +950,7 @@ mod tests {
         assert_eq!(
             base.try_modulo(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I8(base),
+                lhs: I16(base),
                 operator: NumericBinaryOperator::Modulo,
                 rhs: Bool(true)
             }

--- a/core/src/data/value/binary_op/i16.rs
+++ b/core/src/data/value/binary_op/i16.rs
@@ -1,0 +1,910 @@
+use {
+    super::TryBinaryOperator,
+    crate::{
+        data::{NumericBinaryOperator, ValueError},
+        prelude::Value,
+        result::Result,
+    },
+    rust_decimal::prelude::Decimal,
+    std::cmp::Ordering,
+    Value::*,
+};
+
+impl PartialEq<Value> for i16 {
+    fn eq(&self, other: &Value) -> bool {
+        let lhs = *self;
+
+        match other {
+            I8(rhs) => lhs == (*rhs as i16),
+            I16(rhs) => lhs == *rhs,
+            I32(rhs) => (lhs as i32) == *rhs,
+            I64(rhs) => (lhs as i64) == *rhs,
+            I128(rhs) => (lhs as i128) == *rhs,
+            F64(rhs) => ((lhs as f64) - rhs).abs() < f64::EPSILON,
+            Decimal(rhs) => Decimal::from(lhs) == *rhs,
+            _ => false,
+        }
+    }
+}
+
+impl PartialOrd<Value> for i16 {
+    fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
+        match other {
+            I8(rhs) => self.partial_cmp(&(*rhs as i16)),
+            I16(rhs) => self.partial_cmp(rhs),
+            I32(rhs) => (*self as i32).partial_cmp(rhs),
+            I64(rhs) => (*self as i64).partial_cmp(rhs),
+            I128(rhs) => (*self as i128).partial_cmp(rhs),
+            F64(rhs) => (*self as f64).partial_cmp(rhs),
+            Decimal(rhs) => Decimal::from(*self).partial_cmp(rhs),
+            _ => None,
+        }
+    }
+}
+
+impl TryBinaryOperator for i16 {
+    type Rhs = Value;
+
+    fn try_add(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => lhs
+                .checked_add(rhs as i16)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I16(rhs) => lhs
+                .checked_add(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I32(rhs) => (lhs as i32)
+                .checked_add(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I32(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I64(rhs) => (lhs as i64)
+                .checked_add(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I64(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I128(rhs) => (lhs as i128)
+                .checked_add(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I128),
+            F64(rhs) => Ok(F64(lhs as f64 + rhs)),
+            Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) + rhs)),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I16(lhs),
+                operator: NumericBinaryOperator::Add,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_subtract(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => lhs
+                .checked_sub(rhs as i16)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I16(rhs) => lhs
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I32(rhs) => (lhs as i32)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I32(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I64(rhs) => (lhs as i64)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I64(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I128(rhs) => (lhs as i128)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I128),
+            F64(rhs) => Ok(F64(lhs as f64 - rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I16(lhs),
+                operator: NumericBinaryOperator::Subtract,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_multiply(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => lhs
+                .checked_mul(rhs as i16)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I16(rhs) => lhs
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I32(rhs) => (lhs as i32)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I32(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I64(rhs) => (lhs as i64)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I64(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I128(rhs) => (lhs as i128)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I128),
+            F64(rhs) => Ok(F64(lhs as f64 * rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            Interval(rhs) => Ok(Interval(lhs * rhs)),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I16(lhs),
+                operator: NumericBinaryOperator::Multiply,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_divide(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => lhs
+                .checked_div(rhs as i16)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I16(rhs) => lhs
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I32(rhs) => (lhs as i32)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I32(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I64(rhs) => (lhs as i64)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I64(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I128(rhs) => (lhs as i128)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I128),
+            F64(rhs) => Ok(F64(lhs as f64 / rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I16(lhs),
+                operator: NumericBinaryOperator::Divide,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_modulo(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => lhs
+                .checked_rem(rhs as i16)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I16(rhs) => lhs
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I16),
+            I32(rhs) => (lhs as i32)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I32(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I64(rhs) => (lhs as i64)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I64(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I128(rhs) => (lhs as i128)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I128),
+            F64(rhs) => Ok(F64(lhs as f64 % rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I16(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: I16(lhs),
+                operator: NumericBinaryOperator::Modulo,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{TryBinaryOperator, Value::*},
+        crate::data::{NumericBinaryOperator, ValueError},
+        rust_decimal::prelude::Decimal,
+        std::cmp::Ordering,
+    };
+
+    #[test]
+    fn test_extremes() {
+        assert_eq!(-1i8, I8(-1));
+        assert_eq!(0i8, I8(0));
+        assert_eq!(1i8, I8(1));
+        assert_eq!(i8::MAX, I8(i8::MAX));
+        assert_eq!(i8::MIN, I8(i8::MIN));
+
+        assert_eq!(
+            i8::MAX.try_add(&I8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I8(1),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(i8::MAX.try_add(&I32(1)), Ok(I32(i8::MAX as i32 + 1)));
+        assert_eq!(i8::MAX.try_add(&I64(1)), Ok(I64(i8::MAX as i64 + 1)));
+        assert_eq!(i8::MAX.try_add(&I128(1)), Ok(I128(i8::MAX as i128 + 1)));
+
+        assert_eq!(
+            i8::MAX.try_add(&I8(i8::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I8(i8::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i8::MAX.try_add(&I32(i32::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I32(i32::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i8::MAX.try_add(&I64(i64::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I64(i64::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i8::MAX.try_add(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i8::MIN.try_subtract(&I8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I8(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+
+        // these dont overflow since they are not i8 (ie, i32, i64, i128)
+        assert_eq!(i8::MIN.try_subtract(&I32(1)), Ok(I32(i8::MIN as i32 - 1)));
+        assert_eq!(i8::MIN.try_subtract(&I64(1)), Ok(I64(i8::MIN as i64 - 1)));
+        assert_eq!(
+            i8::MIN.try_subtract(&I128(1)),
+            Ok(I128(i8::MIN as i128 - 1))
+        );
+
+        assert_eq!(
+            i8::MIN.try_subtract(&I8(i8::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I8(i8::MAX),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MIN.try_subtract(&I32(i32::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I32(i32::MAX),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MIN.try_subtract(&I64(i64::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I64(i64::MAX),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MIN.try_subtract(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+
+        assert_eq!(i8::MAX.try_multiply(&I8(1)), Ok(I8(i8::MAX)));
+        assert_eq!(i8::MAX.try_multiply(&I32(1)), Ok(I32(i8::MAX as i32)));
+        assert_eq!(
+            i8::MIN.try_subtract(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MIN),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+
+        assert_eq!(i8::MAX.try_multiply(&I8(1)), Ok(I8(i8::MAX)));
+        assert_eq!(i8::MAX.try_multiply(&I64(1)), Ok(I64(i8::MAX as i64)));
+        assert_eq!(i8::MAX.try_multiply(&I128(1)), Ok(I128(i8::MAX as i128)));
+
+        assert_eq!(
+            i8::MAX.try_multiply(&I8(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2i8.try_multiply(&I32(i32::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(2),
+                rhs: I32(i32::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2i8.try_multiply(&I64(i64::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(2),
+                rhs: I64(i64::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2i8.try_multiply(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(2),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            2i8.try_multiply(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(2),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+
+        //try_divide
+        assert_eq!(
+            i8::MAX.try_divide(&I8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I8(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_divide(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I32(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_divide(&I64(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I64(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_divide(&I128(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I128(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            i8::MAX.try_modulo(&I8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_modulo(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I32(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_modulo(&I64(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I64(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i8::MAX.try_modulo(&I128(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: I128(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn eq() {
+        let base = 1_i16;
+
+        assert_eq!(base, I8(1));
+        assert_eq!(base, I32(1));
+        assert_eq!(base, I64(1));
+        assert_eq!(base, I128(1));
+        assert_eq!(base, F64(1.0));
+        assert_eq!(base, Decimal(Decimal::ONE));
+
+        assert_ne!(base, Bool(true));
+    }
+
+    #[test]
+    fn partial_cmp() {
+        let base = 1_i16;
+
+        assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
+
+        assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
+
+        assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
+
+        assert_eq!(
+            base.partial_cmp(&Decimal(Decimal::ONE)),
+            Some(Ordering::Equal)
+        );
+
+        assert_eq!(base.partial_cmp(&Bool(true)), None);
+    }
+
+    #[test]
+    fn try_add() {
+        let base = 1_i16;
+
+        assert_eq!(base.try_add(&I8(1)), Ok(I8(2)));
+        assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
+        assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
+        assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
+
+        assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
+        assert_eq!(
+            base.try_add(&Decimal(Decimal::ONE)),
+            Ok(Decimal(Decimal::TWO))
+        );
+
+        assert_eq!(
+            base.try_add(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I16(base),
+                operator: NumericBinaryOperator::Add,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_subtract() {
+        let base = 1_i16;
+
+        assert_eq!(base.try_subtract(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
+        assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
+        assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
+
+        assert!(
+            matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
+        );
+
+        assert_eq!(
+            base.try_subtract(&Decimal(Decimal::ONE)),
+            Ok(Decimal(Decimal::ZERO))
+        );
+
+        assert_eq!(
+            base.try_subtract(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I16(base),
+                operator: NumericBinaryOperator::Subtract,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_multiply() {
+        let base = 3_i8;
+
+        // 3 * 2 = 6
+        assert_eq!(base.try_multiply(&I8(2)), Ok(I8(6)));
+        assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
+        assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
+        assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
+
+        assert_eq!(base.try_multiply(&I8(-1)), Ok(I8(-3)));
+        assert_eq!(base.try_multiply(&I32(-1)), Ok(I32(-3)));
+        assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
+        assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
+
+        assert!(
+            matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 3.0).abs() < f64::EPSILON )
+        );
+
+        let _result: Decimal = Decimal::from(3);
+        assert_eq!(
+            base.try_multiply(&Decimal(Decimal::ONE)),
+            Ok(Decimal(_result))
+        );
+
+        assert_eq!(
+            base.try_multiply(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(base),
+                operator: NumericBinaryOperator::Multiply,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_divide() {
+        let base = 6_i8;
+
+        assert_eq!(base.try_divide(&I8(2)), Ok(I8(3)));
+        assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
+        assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
+        assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
+
+        assert_eq!(base.try_divide(&I8(-6)), Ok(I8(-1)));
+        assert_eq!(base.try_divide(&I32(-6)), Ok(I32(-1)));
+        assert_eq!(base.try_divide(&I64(-6)), Ok(I64(-1)));
+        assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
+
+        assert!(
+            matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 6.0).abs() < f64::EPSILON )
+        );
+
+        let _decimal_result = Decimal::from(base);
+        assert_eq!(
+            base.try_divide(&Decimal(Decimal::ONE)),
+            Ok(Decimal(_decimal_result))
+        );
+
+        assert_eq!(
+            base.try_divide(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(base),
+                operator: NumericBinaryOperator::Divide,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_modulo() {
+        let base = 9_i8;
+
+        assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
+        assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
+        assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
+
+        assert_eq!(base.try_modulo(&I8(2)), Ok(I8(1)));
+        assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
+        assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
+        assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
+
+        assert!(matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x).abs() < f64::EPSILON ));
+        assert_eq!(
+            base.try_modulo(&Decimal(Decimal::ONE)),
+            Ok(Decimal(Decimal::ZERO))
+        );
+
+        assert_eq!(
+            base.try_modulo(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: I8(base),
+                operator: NumericBinaryOperator::Modulo,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+}

--- a/core/src/data/value/binary_op/i32.rs
+++ b/core/src/data/value/binary_op/i32.rs
@@ -14,6 +14,7 @@ impl PartialEq<Value> for i32 {
     fn eq(&self, other: &Value) -> bool {
         match other {
             I8(other) => self == &(*other as i32),
+            I16(other) => self == &(*other as i32),
             I32(other) => self == other,
             I64(other) => (*self as i64) == *other,
             I128(other) => (*self as i128) == *other,
@@ -28,6 +29,7 @@ impl PartialOrd<Value> for i32 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match other {
             I8(other) => PartialOrd::partial_cmp(self, &(*other as i32)),
+            I16(other) => PartialOrd::partial_cmp(self, &(*other as i32)),
             I32(other) => PartialOrd::partial_cmp(self, other),
             I64(other) => PartialOrd::partial_cmp(&(*self as i64), other),
             I128(other) => PartialOrd::partial_cmp(&(*self as i128), other),
@@ -51,6 +53,17 @@ impl TryBinaryOperator for i32 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I32(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I16(rhs) => lhs
+                .checked_add(rhs as i32)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I32(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
@@ -116,6 +129,17 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I32),
+            I16(rhs) => lhs
+                .checked_sub(rhs as i32)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I32(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I32),
             I32(rhs) => lhs
                 .checked_sub(rhs)
                 .ok_or_else(|| {
@@ -170,6 +194,17 @@ impl TryBinaryOperator for i32 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I32(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I16(rhs) => lhs
+                .checked_mul(rhs as i32)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I32(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
@@ -236,6 +271,17 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I32),
+            I16(rhs) => lhs
+                .checked_div(rhs as i32)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I32(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I32),
             I32(rhs) => lhs
                 .checked_div(rhs)
                 .ok_or_else(|| {
@@ -290,6 +336,17 @@ impl TryBinaryOperator for i32 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I32(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I32),
+            I16(rhs) => lhs
+                .checked_rem(rhs as i32)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I32(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
@@ -484,6 +541,7 @@ mod tests {
         let base = 1_i32;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -498,18 +556,21 @@ mod tests {
         let base = 1_i32;
 
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
@@ -528,6 +589,7 @@ mod tests {
         let base = 1_i32;
 
         assert_eq!(base.try_add(&I8(1)), Ok(I32(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -554,6 +616,7 @@ mod tests {
         let base = 1_i32;
 
         assert_eq!(base.try_subtract(&I8(1)), Ok(I32(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -583,6 +646,7 @@ mod tests {
         let base = 3_i32;
 
         assert_eq!(base.try_multiply(&I8(2)), Ok(I32(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
@@ -618,6 +682,7 @@ mod tests {
         let base = 6_i32;
 
         assert_eq!(base.try_divide(&I8(2)), Ok(I32(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
@@ -652,6 +717,7 @@ mod tests {
         let base = 9_i32;
 
         assert_eq!(base.try_modulo(&I8(1)), Ok(I32(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));

--- a/core/src/data/value/binary_op/i32.rs
+++ b/core/src/data/value/binary_op/i32.rs
@@ -652,6 +652,7 @@ mod tests {
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I32(-3)));
+        assert_eq!(base.try_multiply(&I16(-1)), Ok(I32(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I32(-3)));
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
@@ -688,6 +689,7 @@ mod tests {
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I32(-1)));
+        assert_eq!(base.try_divide(&I16(-6)), Ok(I32(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I32(-1)));
         assert_eq!(base.try_divide(&I64(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
@@ -723,6 +725,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I32(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));

--- a/core/src/data/value/binary_op/i64.rs
+++ b/core/src/data/value/binary_op/i64.rs
@@ -16,6 +16,7 @@ impl PartialEq<Value> for i64 {
 
         match *other {
             I8(rhs) => lhs == rhs as i64,
+            I16(rhs) => lhs == rhs as i64,
             I32(rhs) => lhs == rhs as i64,
             I64(rhs) => lhs == rhs,
             I128(rhs) => lhs as i128 == rhs,
@@ -30,6 +31,7 @@ impl PartialOrd<Value> for i64 {
     fn partial_cmp(&self, rhs: &Value) -> Option<Ordering> {
         match rhs {
             I8(rhs) => PartialOrd::partial_cmp(self, &(*rhs as i64)),
+            I16(rhs) => PartialOrd::partial_cmp(self, &(*rhs as i64)),
             I32(rhs) => PartialOrd::partial_cmp(self, &(*rhs as i64)),
             I64(rhs) => PartialOrd::partial_cmp(self, rhs),
             I128(rhs) => PartialOrd::partial_cmp(&(*self as i128), rhs),
@@ -53,6 +55,17 @@ impl TryBinaryOperator for i64 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I64(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I16(rhs) => lhs
+                .checked_add(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I64(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
@@ -128,6 +141,17 @@ impl TryBinaryOperator for i64 {
                     .into()
                 })
                 .map(I64),
+            I16(rhs) => lhs
+                .checked_sub(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I64(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I64),
             I32(rhs) => lhs
                 .checked_sub(rhs as i64)
                 .ok_or_else(|| {
@@ -193,6 +217,17 @@ impl TryBinaryOperator for i64 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I64(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I16(rhs) => lhs
+                .checked_mul(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I64(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
@@ -269,6 +304,17 @@ impl TryBinaryOperator for i64 {
                     .into()
                 })
                 .map(I64),
+            I16(rhs) => lhs
+                .checked_div(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I64(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I64),
             I32(rhs) => lhs
                 .checked_div(rhs as i64)
                 .ok_or_else(|| {
@@ -334,6 +380,17 @@ impl TryBinaryOperator for i64 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I64(lhs),
                         rhs: I8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I64),
+            I16(rhs) => lhs
+                .checked_rem(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I64(lhs),
+                        rhs: I16(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
@@ -633,6 +690,7 @@ mod tests {
         let base = 1_i64;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -647,18 +705,21 @@ mod tests {
         let base = 1_i64;
 
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
@@ -677,6 +738,7 @@ mod tests {
         let base = 1_i64;
 
         assert_eq!(base.try_add(&I8(1)), Ok(I64(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -703,6 +765,7 @@ mod tests {
         let base = 1_i64;
 
         assert_eq!(base.try_subtract(&I8(1)), Ok(I64(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -732,11 +795,13 @@ mod tests {
         let base = 3_i64;
 
         assert_eq!(base.try_multiply(&I8(2)), Ok(I64(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I64(-3)));
+        assert_eq!(base.try_multiply(&I16(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
@@ -767,11 +832,13 @@ mod tests {
         let base = 6_i64;
 
         assert_eq!(base.try_divide(&I8(2)), Ok(I64(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I64(-1)));
+        assert_eq!(base.try_divide(&I16(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I64(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
@@ -802,11 +869,13 @@ mod tests {
         let base = 9_i64;
 
         assert_eq!(base.try_modulo(&I8(1)), Ok(I64(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I64(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));

--- a/core/src/data/value/binary_op/i64.rs
+++ b/core/src/data/value/binary_op/i64.rs
@@ -479,6 +479,15 @@ mod tests {
             .into())
         );
         assert_eq!(
+            i64::MAX.try_add(&I16(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I64(i64::MAX),
+                rhs: I16(1),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+        assert_eq!(
             i64::MAX.try_add(&I32(1)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I64(i64::MAX),
@@ -519,6 +528,15 @@ mod tests {
             .into())
         );
         assert_eq!(
+            i64::MIN.try_subtract(&I16(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I64(i64::MIN),
+                rhs: I16(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
             i64::MIN.try_subtract(&I32(1)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I64(i64::MIN),
@@ -552,6 +570,7 @@ mod tests {
         );
 
         assert_eq!(i64::MAX.try_multiply(&I8(1)), Ok(I64(i64::MAX)));
+        assert_eq!(i64::MAX.try_multiply(&I16(1)), Ok(I64(i64::MAX)));
         assert_eq!(i64::MAX.try_multiply(&I32(1)), Ok(I64(i64::MAX)));
         assert_eq!(i64::MAX.try_multiply(&I64(1)), Ok(I64(i64::MAX)));
         assert_eq!(i64::MAX.try_multiply(&I128(1)), Ok(I128(i64::MAX as i128)));
@@ -565,12 +584,11 @@ mod tests {
             }
             .into())
         );
-
         assert_eq!(
-            i64::MAX.try_multiply(&I64(2)),
+            i64::MAX.try_multiply(&I16(2)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I64(i64::MAX),
-                rhs: I64(2),
+                rhs: I16(2),
                 operator: (NumericBinaryOperator::Multiply)
             }
             .into())
@@ -585,6 +603,15 @@ mod tests {
             .into())
         );
         assert_eq!(
+            i64::MAX.try_multiply(&I64(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I64(i64::MAX),
+                rhs: I64(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
             i64::MAX.try_multiply(&I128(2)),
             Ok(I128(2 * i64::MAX as i128))
         );
@@ -594,6 +621,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I64(i64::MAX),
                 rhs: I8(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i64::MAX.try_divide(&I16(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I64(i64::MAX),
+                rhs: I16(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
@@ -641,6 +677,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I64(i64::MAX),
                 rhs: I8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            i64::MAX.try_modulo(&I16(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I64(i64::MAX),
+                rhs: I16(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -14,6 +14,7 @@ impl PartialEq<Value> for i8 {
     fn eq(&self, other: &Value) -> bool {
         match other {
             I8(other) => self == other,
+            I16(other) => (*self as i16) == *other,
             I32(other) => (*self as i32) == *other,
             I64(other) => (*self as i64) == *other,
             I128(other) => (*self as i128) == *other,
@@ -28,6 +29,7 @@ impl PartialOrd<Value> for i8 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match other {
             I8(other) => self.partial_cmp(other),
+            I16(other) => (*self as i16).partial_cmp(other),
             I32(other) => (*self as i32).partial_cmp(other),
             I64(other) => (*self as i64).partial_cmp(other),
             I128(other) => (*self as i128).partial_cmp(other),
@@ -56,6 +58,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I8),
+            I16(rhs) => (lhs as i16)
+                .checked_add(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I16),
             I32(rhs) => (lhs as i32)
                 .checked_add(rhs)
                 .ok_or_else(|| {
@@ -116,6 +129,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I8),
+            I16(rhs) => (lhs as i16)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I16),
             I32(rhs) => (lhs as i32)
                 .checked_sub(rhs)
                 .ok_or_else(|| {
@@ -186,6 +210,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I8),
+            I16(rhs) => (lhs as i16)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I16),
             I32(rhs) => (lhs as i32)
                 .checked_mul(rhs)
                 .ok_or_else(|| {
@@ -257,6 +292,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I8),
+            I16(rhs) => (lhs as i16)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I16),
             I32(rhs) => (lhs as i32)
                 .checked_div(rhs)
                 .ok_or_else(|| {
@@ -327,6 +373,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I8),
+            I16(rhs) => (lhs as i16)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: I16(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I16),
             I32(rhs) => (lhs as i32)
                 .checked_rem(rhs)
                 .ok_or_else(|| {
@@ -653,6 +710,7 @@ mod tests {
         let base = 1_i8;
 
         assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
@@ -667,18 +725,21 @@ mod tests {
         let base = 1_i8;
 
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
@@ -697,6 +758,7 @@ mod tests {
         let base = 1_i8;
 
         assert_eq!(base.try_add(&I8(1)), Ok(I8(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I16(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -723,6 +785,7 @@ mod tests {
         let base = 1_i8;
 
         assert_eq!(base.try_subtract(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -753,11 +816,13 @@ mod tests {
 
         // 3 * 2 = 6
         assert_eq!(base.try_multiply(&I8(2)), Ok(I8(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I16(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I8(-3)));
+        assert_eq!(base.try_multiply(&I16(-1)), Ok(I16(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I32(-3)));
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
@@ -788,11 +853,13 @@ mod tests {
         let base = 6_i8;
 
         assert_eq!(base.try_divide(&I8(2)), Ok(I8(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I16(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I8(-1)));
+        assert_eq!(base.try_divide(&I16(-6)), Ok(I16(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I32(-1)));
         assert_eq!(base.try_divide(&I64(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
@@ -823,11 +890,13 @@ mod tests {
         let base = 9_i8;
 
         assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I8(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I16(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));

--- a/core/src/data/value/binary_op/mod.rs
+++ b/core/src/data/value/binary_op/mod.rs
@@ -3,6 +3,7 @@ use crate::{prelude::Value, result::Result};
 mod decimal;
 mod f64;
 mod i128;
+mod i16;
 mod i32;
 mod i64;
 mod i8;

--- a/core/src/data/value/into.rs
+++ b/core/src/data/value/into.rs
@@ -664,6 +664,61 @@ mod tests {
     }
 
     #[test]
+    fn try_into_i16() {
+        macro_rules! test {
+            ($from: expr, $to: expr) => {
+                assert_eq!($from.try_into() as Result<i16>, $to)
+            };
+        }
+        let timestamp = |y, m, d, hh, mm, ss, ms| {
+            chrono::NaiveDate::from_ymd(y, m, d).and_hms_milli(hh, mm, ss, ms)
+        };
+        let time = chrono::NaiveTime::from_hms_milli;
+        let date = chrono::NaiveDate::from_ymd;
+        test!(Value::Bool(true), Ok(1));
+        test!(Value::Bool(false), Ok(0));
+        test!(Value::I8(122), Ok(122));
+        test!(Value::I16(122), Ok(122));
+        test!(Value::I32(122), Ok(122));
+        test!(Value::I64(122), Ok(122));
+        test!(Value::I128(122), Ok(122));
+        test!(Value::I64(122), Ok(122));
+        test!(Value::F64(122.0), Ok(122));
+        test!(Value::F64(122.1), Ok(122));
+        test!(Value::Str("122".to_owned()), Ok(122));
+        test!(Value::Decimal(Decimal::new(122, 0)), Ok(122));
+        test!(
+            Value::Date(date(2021, 11, 20)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Timestamp(timestamp(2021, 11, 20, 10, 0, 0, 0)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Time(time(10, 0, 0, 0)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Interval(I::Month(1)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Uuid(195965723427462096757863453463987888808),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Map(HashMap::new()),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::List(Vec::new()),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(Value::Null, Err(ValueError::ImpossibleCast.into()));
+    }
+
+    #[test]
     fn try_into_i32() {
         macro_rules! test {
             ($from: expr, $to: expr) => {

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -126,6 +126,10 @@ mod tests {
         assert_eq!(Value::Bool(true).try_into(), Ok(JsonValue::Bool(true)));
         assert_eq!(Value::I8(16).try_into(), Ok(JsonValue::Number(16.into())));
         assert_eq!(
+            Value::I16(100).try_into(),
+            Ok(JsonValue::Number(100.into()))
+        );
+        assert_eq!(
             Value::I32(100).try_into(),
             Ok(JsonValue::Number(100.into()))
         );

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -37,6 +37,7 @@ impl TryFrom<Value> for JsonValue {
         match value {
             Value::Bool(v) => Ok(JsonValue::Bool(v)),
             Value::I8(v) => Ok(v.into()),
+            Value::I16(v) => Ok(v.into()),
             Value::I32(v) => Ok(v.into()),
             Value::I64(v) => Ok(v.into()),
             Value::I128(v) => JsonNumber::from_str(&v.to_string())

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -99,6 +99,7 @@ impl Value {
     pub fn is_zero(&self) -> bool {
         match self {
             Value::I8(v) => *v == 0,
+            Value::I16(v) => *v == 0,
             Value::I32(v) => *v == 0,
             Value::I64(v) => *v == 0,
             Value::I128(v) => *v == 0,
@@ -609,6 +610,14 @@ mod tests {
         assert_eq!(I8(0).partial_cmp(&I8(0)), Some(Ordering::Equal));
         assert_eq!(I8(0).partial_cmp(&I8(1)), Some(Ordering::Less));
 
+        assert_eq!(I16(0).partial_cmp(&I8(-1)), Some(Ordering::Greater));
+        assert_eq!(I16(0).partial_cmp(&I8(0)), Some(Ordering::Equal));
+        assert_eq!(I16(0).partial_cmp(&I8(1)), Some(Ordering::Less));
+
+        assert_eq!(I32(0).partial_cmp(&I8(-1)), Some(Ordering::Greater));
+        assert_eq!(I32(0).partial_cmp(&I8(0)), Some(Ordering::Equal));
+        assert_eq!(I32(0).partial_cmp(&I8(1)), Some(Ordering::Less));
+
         assert_eq!(I64(0).partial_cmp(&I8(-1)), Some(Ordering::Greater));
         assert_eq!(I64(0).partial_cmp(&I8(0)), Some(Ordering::Equal));
         assert_eq!(I64(0).partial_cmp(&I8(1)), Some(Ordering::Less));
@@ -622,6 +631,7 @@ mod tests {
     fn is_zero() {
         for i in -1..2 {
             assert_eq!(I8(i).is_zero(), i == 0);
+            assert_eq!(I16(i.into()).is_zero(), i == 0);
             assert_eq!(I32(i.into()).is_zero(), i == 0);
             assert_eq!(I64(i.into()).is_zero(), i == 0);
             assert_eq!(I128(i.into()).is_zero(), i == 0);
@@ -651,40 +661,53 @@ mod tests {
         let decimal = |n: i32| Decimal(n.into());
 
         test!(add I8(1),    I8(2)    => I8(3));
+        test!(add I8(1),    I16(2)    => I16(3));
         test!(add I8(1),    I32(2)   => I32(3));
         test!(add I8(1),    I64(2)   => I64(3));
         test!(add I8(1),    I128(2)  => I128(3));
 
+        test!(add I16(1),    I8(2)    => I16(3));
+        test!(add I16(1),    I16(2)    => I16(3));
+        test!(add I16(1),    I32(2)   => I32(3));
+        test!(add I16(1),    I64(2)   => I64(3));
+        test!(add I16(1),    I128(2)  => I128(3));
+
         test!(add I32(1),    I8(2)      => I32(3));
+        test!(add I32(1),    I16(2)      => I32(3));
         test!(add I32(1),    I32(2)     => I32(3));
         test!(add I32(1),    I64(2)     => I64(3));
         test!(add I32(1),    I128(2)    => I128(3));
 
         test!(add I64(1),    I8(2)      => I64(3));
+        test!(add I64(1),    I16(2)      => I64(3));
         test!(add I64(1),    I32(2)     => I64(3));
         test!(add I64(1),    I64(2)     => I64(3));
         test!(add I64(1),    I128(2)    => I128(3));
 
         test!(add I128(1),    I8(2)    => I128(3));
+        test!(add I128(1),    I16(2)    => I128(3));
         test!(add I128(1),    I32(2)    => I128(3));
         test!(add I128(1),    I64(2)   => I128(3));
         test!(add I128(1),    I128(2)  => I128(3));
 
         test!(add I8(1),    F64(2.0) => F64(3.0));
 
-        test!(add I32(1),   I64(2)   => I64(3));
-        test!(add I32(1),   I32(2)   => I32(3));
         test!(add I32(1),   I8(2)    => I32(3));
+        test!(add I32(1),   I16(2)    => I32(3));
+        test!(add I32(1),   I32(2)   => I32(3));
+        test!(add I32(1),   I64(2)   => I64(3));
         test!(add I32(1),   F64(2.0) => F64(3.0));
 
-        test!(add I64(1),   I64(2)   => I64(3));
-        test!(add I64(1),   I32(2)   => I64(3));
         test!(add I64(1),   I8(2)    => I64(3));
+        test!(add I64(1),   I16(2)    => I64(3));
+        test!(add I64(1),   I32(2)   => I64(3));
+        test!(add I64(1),   I64(2)   => I64(3));
         test!(add I64(1),   F64(2.0) => F64(3.0));
 
-        test!(add I128(1),   I64(2)   => I128(3));
-        test!(add I128(1),   I32(2)   => I128(3));
         test!(add I128(1),   I8(2)    => I128(3));
+        test!(add I128(1),   I16(2)    => I128(3));
+        test!(add I128(1),   I32(2)   => I128(3));
+        test!(add I128(1),   I64(2)   => I128(3));
         test!(add I128(1),   F64(2.0) => F64(3.0));
 
         test!(add F64(1.0), F64(2.0) => F64(3.0));
@@ -727,21 +750,25 @@ mod tests {
         test!(add mon!(1),    mon!(2)    => mon!(3));
 
         test!(subtract I8(3),    I8(2)    => I8(1));
+        test!(subtract I8(3),    I16(2)    => I8(1));
         test!(subtract I8(3),    I32(2)   => I32(1));
         test!(subtract I8(3),    I64(2)   => I64(1));
         test!(subtract I8(3),    I128(2)  => I128(1));
 
         test!(subtract I32(3),    I8(2)    => I32(1));
+        test!(subtract I32(3),    I16(2)    => I32(1));
         test!(subtract I32(3),    I32(2)   => I32(1));
         test!(subtract I32(3),    I64(2)   => I64(1));
         test!(subtract I32(3),    I128(2)  => I128(1));
 
         test!(subtract I64(3),    I8(2)    => I64(1));
+        test!(subtract I64(3),    I16(2)    => I64(1));
         test!(subtract I64(3),    I32(2)   => I64(1));
         test!(subtract I64(3),    I64(2)   => I64(1));
         test!(subtract I64(3),    I128(2)  => I128(1));
 
         test!(subtract I128(3),    I8(2)   => I128(1));
+        test!(subtract I128(3),    I16(2)   => I128(1));
         test!(subtract I128(3),    I32(2)  => I128(1));
         test!(subtract I128(3),    I64(2)  => I128(1));
         test!(subtract I128(3),    I128(2) => I128(1));
@@ -752,6 +779,7 @@ mod tests {
         test!(subtract I128(3),  F64(2.0) => F64(1.0));
 
         test!(subtract I32(3),   I8(2)    => I64(1));
+        test!(subtract I32(3),   I16(2)    => I64(1));
         test!(subtract I32(3),   I32(2)   => I32(1));
         test!(subtract I32(3),   I64(2)   => I64(1));
         test!(subtract I32(3),   I128(2)  => I128(1));
@@ -759,6 +787,7 @@ mod tests {
         test!(subtract I32(3),   F64(2.0) => F64(1.0));
 
         test!(subtract I64(3),   I8(2)    => I64(1));
+        test!(subtract I64(3),   I16(2)    => I64(1));
         test!(subtract I64(3),   I32(2)   => I64(1));
         test!(subtract I64(3),   I64(2)   => I64(1));
         test!(subtract I64(3),   I128(2)   => I64(1));
@@ -809,23 +838,28 @@ mod tests {
         test!(subtract mon!(1),  mon!(2)  => mon!(-1));
 
         test!(multiply I8(3),    I8(2)    => I8(6));
+        test!(multiply I8(3),    I16(2)    => I8(6));
         test!(multiply I8(3),    I32(2)    => I32(6));
         test!(multiply I8(3),    I64(2)   => I64(6));
         test!(multiply I8(3),    I128(2)  => I128(6));
 
         test!(multiply I64(3),    I8(2)    => I64(6));
+        test!(multiply I64(3),    I16(2)    => I64(6));
         test!(multiply I64(3),    I32(2)   => I64(6));
         test!(multiply I64(3),    I64(2)   => I64(6));
         test!(multiply I64(3),    I128(2)  => I128(6));
 
         test!(multiply I128(3),    I8(2)    => I128(6));
+        test!(multiply I128(3),    I16(2)    => I128(6));
         test!(multiply I128(3),    I32(2)    => I128(6));
         test!(multiply I128(3),    I64(2)   => I128(6));
         test!(multiply I128(3),    I128(2)  => I128(6));
 
         test!(multiply I8(3),    F64(2.0) => F64(6.0));
-
+        test!(multiply I16(3),    F64(2.0) => F64(6.0));
+        test!(multiply I32(3),    F64(2.0) => F64(6.0));
         test!(multiply I64(3),   F64(2.0) => F64(6.0));
+        test!(multiply I128(3),    F64(2.0) => F64(6.0));
 
         test!(multiply F64(3.0), F64(2.0) => F64(6.0));
         test!(multiply F64(3.0), I8(2)    => F64(6.0));
@@ -836,6 +870,7 @@ mod tests {
         test!(multiply decimal(3), decimal(2) => decimal(6));
 
         test!(multiply I8(3),    mon!(3)  => mon!(9));
+        test!(multiply I16(3),    mon!(3)  => mon!(9));
         test!(multiply I32(3),   mon!(3)  => mon!(9));
         test!(multiply I64(3),   mon!(3)  => mon!(9));
         test!(multiply I128(3),   mon!(3)  => mon!(9));
@@ -847,6 +882,7 @@ mod tests {
         test!(multiply mon!(3),  F64(2.0) => mon!(6));
 
         test!(divide I8(0),     I8(5)   => I8(0));
+        test!(divide I8(0),     I16(5)   => I8(0));
         test!(divide I8(0),     I32(5)  => I32(0));
         test!(divide I8(0),     I64(5)  => I64(0));
         test!(divide I8(0),     I128(5) => I128(0));
@@ -856,21 +892,25 @@ mod tests {
         );
 
         test!(divide I8(6),    I8(2)    => I8(3));
+        test!(divide I8(6),    I16(2)    => I8(3));
         test!(divide I8(6),    I32(2)    => I8(3));
         test!(divide I8(6),    I64(2)   => I64(3));
         test!(divide I8(6),    I128(2)  => I128(3));
 
         test!(divide I64(6),    I8(2)    => I64(3));
+        test!(divide I64(6),    I16(2)    => I64(3));
         test!(divide I64(6),    I32(2)    => I64(3));
         test!(divide I64(6),    I64(2)   => I64(3));
         test!(divide I64(6),    I128(2)  => I128(3));
 
         test!(divide I128(6),    I8(2)    => I128(3));
+        test!(divide I128(6),    I16(2)    => I128(3));
         test!(divide I128(6),    I32(2)    => I128(3));
         test!(divide I128(6),    I64(2)   => I128(3));
         test!(divide I128(6),    I128(2)  => I128(3));
 
         test!(divide I128(6),    I8(2)    => I128(3));
+        test!(divide I128(6),    I16(2)    => I128(3));
         test!(divide I128(6),    I32(2)    => I128(3));
         test!(divide I128(6),    I64(2)   => I128(3));
         test!(divide I128(6),    I128(2)  => I128(3));
@@ -881,18 +921,21 @@ mod tests {
         test!(divide I128(6),    F64(2.0) => F64(3.0));
 
         test!(divide F64(6.0), I8(2)    => F64(3.0));
+        test!(divide F64(6.0), I16(2)    => F64(3.0));
         test!(divide F64(6.0), I32(2)    => F64(3.0));
         test!(divide F64(6.0), I64(2)   => F64(3.0));
         test!(divide F64(6.0), I128(2)    => F64(3.0));
         test!(divide F64(6.0), F64(2.0) => F64(3.0));
 
         test!(divide mon!(6),  I8(2)    => mon!(3));
+        test!(divide mon!(6),  I16(2)    => mon!(3));
         test!(divide mon!(6),  I32(2)    => mon!(3));
         test!(divide mon!(6),  I64(2)   => mon!(3));
         test!(divide mon!(6),  I128(2)    => mon!(3));
         test!(divide mon!(6),  F64(2.0) => mon!(3));
 
         test!(modulo I8(6),    I8(4)    => I8(2));
+        test!(modulo I8(6),    I16(4)    => I8(2));
         test!(modulo I8(6),    I32(4)    => I8(2));
         test!(modulo I8(6),    I64(4)   => I64(2));
         test!(modulo I8(6),    I128(4)  => I128(2));
@@ -903,11 +946,13 @@ mod tests {
         );
 
         test!(modulo I64(6),    I8(4)    => I64(2));
+        test!(modulo I64(6),    I16(4)    => I64(2));
         test!(modulo I64(6),    I32(4)   => I64(2));
         test!(modulo I64(6),    I64(4)   => I64(2));
         test!(modulo I64(6),    I128(4)  => I128(2));
 
         test!(modulo I128(6),    I8(4)    => I128(2));
+        test!(modulo I128(6),    I16(4)    => I128(2));
         test!(modulo I128(6),    I32(4)    => I128(2));
         test!(modulo I128(6),    I64(4)   => I128(2));
         test!(modulo I128(6),    I128(4)  => I128(2));
@@ -921,6 +966,7 @@ mod tests {
         test!(modulo F64(6.0), I64(2)   => F64(0.0));
         test!(modulo F64(6.0), F64(2.0) => F64(0.0));
         test!(modulo I128(6),   I8(2)   => I128(0));
+        test!(modulo I128(6),   I16(2)   => I128(0));
         test!(modulo I128(6),   I32(2)   => I128(0));
         test!(modulo I128(6),   I64(2)   => I128(0));
         test!(modulo I128(6),   I128(2)   => I128(0));
@@ -937,6 +983,7 @@ mod tests {
         let ts = || Timestamp(NaiveDate::from_ymd(1989, 1, 1).and_hms(0, 0, 0));
 
         null_test!(add      I8(1),    Null);
+        null_test!(add      I16(1),    Null);
         null_test!(add      I32(1),   Null);
         null_test!(add      I64(1),   Null);
         null_test!(add      I128(1),   Null);
@@ -947,6 +994,7 @@ mod tests {
         null_test!(add      time(),   Null);
         null_test!(add      mon!(1),  Null);
         null_test!(subtract I8(1),    Null);
+        null_test!(subtract I16(1),    Null);
         null_test!(subtract I32(1),    Null);
         null_test!(subtract I64(1),   Null);
         null_test!(subtract I128(1),   Null);
@@ -957,6 +1005,7 @@ mod tests {
         null_test!(subtract time(),   Null);
         null_test!(subtract mon!(1),  Null);
         null_test!(multiply I8(1),    Null);
+        null_test!(multiply I16(1),    Null);
         null_test!(multiply I32(1),   Null);
         null_test!(multiply I64(1),   Null);
         null_test!(multiply I128(1),   Null);
@@ -964,6 +1013,7 @@ mod tests {
         null_test!(multiply decimal(1), Null);
         null_test!(multiply mon!(1),  Null);
         null_test!(divide   I8(1),    Null);
+        null_test!(divide   I16(1),    Null);
         null_test!(divide   I32(1),    Null);
         null_test!(divide   I64(1),   Null);
         null_test!(divide   I128(1),   Null);
@@ -971,6 +1021,7 @@ mod tests {
         null_test!(divide   decimal(1), Null);
         null_test!(divide   mon!(1),  Null);
         null_test!(modulo   I8(1),    Null);
+        null_test!(modulo   I16(1),    Null);
         null_test!(modulo   I32(1),    Null);
         null_test!(modulo   I64(1),   Null);
         null_test!(modulo   I128(1),   Null);
@@ -978,6 +1029,7 @@ mod tests {
         null_test!(modulo   decimal(1), Null);
 
         null_test!(add      Null, I8(1));
+        null_test!(add      Null, I16(1));
         null_test!(add      Null, I32(1));
         null_test!(add      Null, I64(1));
         null_test!(add      Null, I128(1));
@@ -987,6 +1039,7 @@ mod tests {
         null_test!(add      Null, date());
         null_test!(add      Null, ts());
         null_test!(subtract Null, I8(1));
+        null_test!(subtract Null, I16(1));
         null_test!(subtract Null, I32(1));
         null_test!(subtract Null, I64(1));
         null_test!(subtract Null, I128(1));
@@ -997,12 +1050,14 @@ mod tests {
         null_test!(subtract Null, time());
         null_test!(subtract Null, mon!(1));
         null_test!(multiply Null, I8(1));
+        null_test!(multiply Null, I16(1));
         null_test!(multiply Null, I32(1));
         null_test!(multiply Null, I64(1));
         null_test!(multiply Null, I128(1));
         null_test!(multiply Null, F64(1.0));
         null_test!(multiply Null, decimal(1));
         null_test!(divide   Null, I8(1));
+        null_test!(divide   Null, I16(1));
         null_test!(divide   Null, I32(1));
         null_test!(divide   Null, I64(1));
         null_test!(divide   Null, I128(1));
@@ -1049,6 +1104,7 @@ mod tests {
         cast!(Str("a".to_owned())   => Text         , Str("a".to_owned()));
         cast!(bytea                 => Bytea        , bytea);
         cast!(I8(1)                 => Int8         , I8(1));
+        cast!(I16(1)                 => Int16         , I16(1));
         cast!(I32(1)                => Int32        , I32(1));
         cast!(I64(1)                => Int          , I64(1));
         cast!(I128(1)               => Int128       , I128(1));
@@ -1060,6 +1116,7 @@ mod tests {
         cast!(Str("FALSE".to_owned())   => Boolean, Bool(false));
         cast!(I8(1)                     => Boolean, Bool(true));
         cast!(I8(0)                     => Boolean, Bool(false));
+        cast!(I16(0)                     => Boolean, Bool(false));
         cast!(I32(1)                     => Boolean, Bool(true));
         cast!(I32(0)                     => Boolean, Bool(false));
         cast!(I64(1)                    => Boolean, Bool(true));
@@ -1099,6 +1156,7 @@ mod tests {
         cast!(Bool(true)            => Float, F64(1.0));
         cast!(Bool(false)           => Float, F64(0.0));
         cast!(I8(1)                 => Float, F64(1.0));
+        cast!(I16(1)                 => Float, F64(1.0));
         cast!(I32(1)                => Float, F64(1.0));
         cast!(I64(1)                => Float, F64(1.0));
         cast!(I128(1)               => Float, F64(1.0));
@@ -1109,7 +1167,10 @@ mod tests {
         cast!(Bool(true)    => Text, Str("TRUE".to_owned()));
         cast!(Bool(false)   => Text, Str("FALSE".to_owned()));
         cast!(I8(11)        => Text, Str("11".to_owned()));
+        cast!(I16(11)        => Text, Str("11".to_owned()));
+        cast!(I32(11)        => Text, Str("11".to_owned()));
         cast!(I64(11)       => Text, Str("11".to_owned()));
+        cast!(I128(11)        => Text, Str("11".to_owned()));
         cast!(F64(1.0)      => Text, Str("1".to_owned()));
 
         let date = Value::Date(NaiveDate::from_ymd(2021, 5, 1));
@@ -1144,6 +1205,7 @@ mod tests {
         assert_eq!(a.concat(&Str("B".to_owned())), Str("AB".to_owned()));
         assert_eq!(a.concat(&Bool(true)), Str("ATRUE".to_owned()));
         assert_eq!(a.concat(&I8(1)), Str("A1".to_owned()));
+        assert_eq!(a.concat(&I16(1)), Str("A1".to_owned()));
         assert_eq!(a.concat(&I32(1)), Str("A1".to_owned()));
         assert_eq!(a.concat(&I64(1)), Str("A1".to_owned()));
         assert_eq!(a.concat(&I128(1)), Str("A1".to_owned()));
@@ -1173,6 +1235,7 @@ mod tests {
         assert!(Bool(true).validate_type(&D::Int).is_err());
         assert!(I8(1).validate_type(&D::Int8).is_ok());
         assert!(I8(1).validate_type(&D::Text).is_err());
+        assert!(I16(1).validate_type(&D::Text).is_err());
         assert!(I32(1).validate_type(&D::Int32).is_ok());
         assert!(I32(1).validate_type(&D::Text).is_err());
         assert!(I64(1).validate_type(&D::Int).is_ok());
@@ -1221,6 +1284,7 @@ mod tests {
     #[test]
     fn unary_minus() {
         assert_eq!(I8(1).unary_minus(), Ok(I8(-1)));
+        assert_eq!(I16(1).unary_minus(), Ok(I16(-1)));
         assert_eq!(I32(1).unary_minus(), Ok(I32(-1)));
         assert_eq!(I64(1).unary_minus(), Ok(I64(-1)));
         assert_eq!(I128(1).unary_minus(), Ok(I128(-1)));
@@ -1240,6 +1304,7 @@ mod tests {
     #[test]
     fn factorial() {
         assert_eq!(I8(5).unary_factorial(), Ok(I128(120)));
+        assert_eq!(I16(5).unary_factorial(), Ok(I128(120)));
         assert_eq!(I32(5).unary_factorial(), Ok(I128(120)));
         assert_eq!(I64(5).unary_factorial(), Ok(I128(120)));
         assert_eq!(I128(5).unary_factorial(), Ok(I128(120)));

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -199,6 +199,7 @@ impl Value {
 
         match (self, other) {
             (I8(a), b) => a.try_add(b),
+            (I16(a), b) => a.try_add(b),
             (I32(a), b) => a.try_add(b),
             (I64(a), b) => a.try_add(b),
             (I128(a), b) => a.try_add(b),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -25,6 +25,7 @@ pub use error::ValueError;
 pub enum Value {
     Bool(bool),
     I8(i8),
+    I16(i16),
     I32(i32),
     I64(i64),
     I128(i128),
@@ -46,6 +47,7 @@ impl PartialEq<Value> for Value {
     fn eq(&self, other: &Value) -> bool {
         match (self, other) {
             (Value::I8(l), _) => l == other,
+            (Value::I16(l), _) => l == other,
             (Value::I32(l), _) => l == other,
             (Value::I64(l), _) => l == other,
             (Value::I128(l), _) => l == other,
@@ -72,6 +74,7 @@ impl PartialOrd<Value> for Value {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match (self, other) {
             (Value::I8(l), _) => l.partial_cmp(other),
+            (Value::I16(l), _) => l.partial_cmp(other),
             (Value::I32(l), _) => l.partial_cmp(other),
             (Value::I64(l), _) => l.partial_cmp(other),
             (Value::I128(l), _) => l.partial_cmp(other),
@@ -108,6 +111,7 @@ impl Value {
     pub fn validate_type(&self, data_type: &DataType) -> Result<()> {
         let valid = match self {
             Value::I8(_) => matches!(data_type, DataType::Int8),
+            Value::I16(_) => matches!(data_type, DataType::Int16),
             Value::I32(_) => matches!(data_type, DataType::Int32),
             Value::I64(_) => matches!(data_type, DataType::Int),
             Value::I128(_) => matches!(data_type, DataType::Int128),
@@ -148,6 +152,7 @@ impl Value {
     pub fn cast(&self, data_type: &DataType) -> Result<Self> {
         match (data_type, self) {
             (DataType::Int8, Value::I8(_))
+            | (DataType::Int16, Value::I16(_))
             | (DataType::Int32, Value::I32(_))
             | (DataType::Int, Value::I64(_))
             | (DataType::Int128, Value::I128(_))
@@ -165,6 +170,7 @@ impl Value {
 
             (DataType::Boolean, value) => value.try_into().map(Value::Bool),
             (DataType::Int8, value) => value.try_into().map(Value::I8),
+            (DataType::Int16, value) => value.try_into().map(Value::I16),
             (DataType::Int32, value) => value.try_into().map(Value::I32),
             (DataType::Int, value) => value.try_into().map(Value::I64),
             (DataType::Int128, value) => value.try_into().map(Value::I128),
@@ -204,6 +210,7 @@ impl Value {
             (Time(a), Interval(b)) => b.add_time(a).map(Time),
             (Interval(a), Interval(b)) => a.add(b).map(Interval),
             (Null, I8(_))
+            | (Null, I16(_))
             | (Null, I32(_))
             | (Null, I64(_))
             | (Null, I128(_))
@@ -232,6 +239,7 @@ impl Value {
 
         match (self, other) {
             (I8(a), _) => a.try_subtract(other),
+            (I16(a), _) => a.try_subtract(other),
             (I32(a), _) => a.try_subtract(other),
             (I64(a), _) => a.try_subtract(other),
             (I128(a), _) => a.try_subtract(other),
@@ -257,6 +265,7 @@ impl Value {
             (Time(a), Interval(b)) => b.subtract_from_time(a).map(Time),
             (Interval(a), Interval(b)) => a.subtract(b).map(Interval),
             (Null, I8(_))
+            | (Null, I16(_))
             | (Null, I32(_))
             | (Null, I64(_))
             | (Null, I128(_))
@@ -285,19 +294,22 @@ impl Value {
 
         match (self, other) {
             (I8(a), _) => a.try_multiply(other),
+            (I16(a), _) => a.try_multiply(other),
             (I32(a), _) => a.try_multiply(other),
             (I64(a), _) => a.try_multiply(other),
             (I128(a), _) => a.try_multiply(other),
             (F64(a), _) => a.try_multiply(other),
             (Decimal(a), _) => a.try_multiply(other),
             (Interval(a), I8(b)) => Ok(Interval(*a * *b)),
+            (Interval(a), I16(b)) => Ok(Interval(*a * *b)),
             (Interval(a), I32(b)) => Ok(Interval(*a * *b)),
             (Interval(a), I64(b)) => Ok(Interval(*a * *b)),
             (Interval(a), I128(b)) => Ok(Interval(*a * *b)),
             (Interval(a), F64(b)) => Ok(Interval(*a * *b)),
             (Null, I8(_))
-            | (Null, I64(_))
+            | (Null, I16(_))
             | (Null, I32(_))
+            | (Null, I64(_))
             | (Null, I128(_))
             | (Null, F64(_))
             | (Null, Decimal(_))
@@ -322,17 +334,20 @@ impl Value {
 
         match (self, other) {
             (I8(a), _) => a.try_divide(other),
+            (I16(a), _) => a.try_divide(other),
             (I32(a), _) => a.try_divide(other),
             (I64(a), _) => a.try_divide(other),
             (I128(a), _) => a.try_divide(other),
             (F64(a), _) => a.try_divide(other),
             (Decimal(a), _) => a.try_divide(other),
             (Interval(a), I8(b)) => Ok(Interval(*a / *b)),
+            (Interval(a), I16(b)) => Ok(Interval(*a / *b)),
             (Interval(a), I32(b)) => Ok(Interval(*a / *b)),
             (Interval(a), I64(b)) => Ok(Interval(*a / *b)),
             (Interval(a), I128(b)) => Ok(Interval(*a / *b)),
             (Interval(a), F64(b)) => Ok(Interval(*a / *b)),
             (Null, I8(_))
+            | (Null, I16(_))
             | (Null, I32(_))
             | (Null, I64(_))
             | (Null, I128(_))
@@ -358,12 +373,14 @@ impl Value {
 
         match (self, other) {
             (I8(a), _) => a.try_modulo(other),
+            (I16(a), _) => a.try_modulo(other),
             (I32(a), _) => a.try_modulo(other),
             (I64(a), _) => a.try_modulo(other),
             (I128(a), _) => a.try_modulo(other),
             (F64(a), _) => a.try_modulo(other),
             (Decimal(a), _) => a.try_modulo(other),
             (Null, I8(_))
+            | (Null, I16(_))
             | (Null, I32(_))
             | (Null, I64(_))
             | (Null, I128(_))
@@ -387,7 +404,7 @@ impl Value {
         use Value::*;
 
         match self {
-            I8(_) | I32(_) | I64(_) | I128(_) | F64(_) | Interval(_) | Decimal(_) => {
+            I8(_) | I16(_) | I32(_) | I64(_) | I128(_) | F64(_) | Interval(_) | Decimal(_) => {
                 Ok(self.clone())
             }
             Null => Ok(Null),
@@ -400,6 +417,7 @@ impl Value {
 
         match self {
             I8(a) => Ok(I8(-a)),
+            I16(a) => Ok(I16(-a)),
             I32(a) => Ok(I32(-a)),
             I64(a) => Ok(I64(-a)),
             I128(a) => Ok(I128(-a)),
@@ -426,6 +444,7 @@ impl Value {
 
         match self {
             I8(a) => factorial_function(*a as i128).map(I128),
+            I16(a) => factorial_function(*a as i128).map(I128),
             I32(a) => factorial_function(*a as i128).map(I128),
             I64(a) => factorial_function(*a as i128).map(I128),
             I128(a) => factorial_function(*a).map(I128),
@@ -502,6 +521,7 @@ mod tests {
         assert_ne!(Null, Null);
         assert_eq!(Bool(true), Bool(true));
         assert_eq!(I8(1), I8(1));
+        assert_eq!(I16(1), I16(1));
         assert_eq!(I32(1), I32(1));
         assert_eq!(I64(1), I64(1));
         assert_eq!(I128(1), I128(1));

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -8,6 +8,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
     match sql_data_type {
         SqlDataType::Boolean => Ok(DataType::Boolean),
         SqlDataType::Int(Some(8)) => Ok(DataType::Int8),
+        SqlDataType::Int(Some(16)) => Ok(DataType::Int16),
         SqlDataType::Int(Some(32)) => Ok(DataType::Int32),
         SqlDataType::Int(Some(128)) => Ok(DataType::Int128),
         SqlDataType::Int(_) => Ok(DataType::Int),

--- a/test-suite/src/data_type/int16.rs
+++ b/test-suite/src/data_type/int16.rs
@@ -1,0 +1,88 @@
+use {
+    crate::*,
+    gluesql_core::{data::ValueError, prelude::Value::*},
+};
+
+test_case!(int16, async move {
+    run!(
+        "CREATE TABLE Item (
+        field_one INT(16),
+        field_two INT(16),
+    );"
+    );
+    run!("INSERT INTO Item VALUES (1, -1), (-2, 2), (3, 3), (-4, -4);");
+
+    let parse_i16 = |text: &str| -> i16 { text.parse().unwrap() };
+
+    test!(
+        Err(ValueError::FailedToParseNumber.into()),
+        "INSERT INTO Item VALUES (32768, 32768);"
+    );
+    test!(
+        Err(ValueError::FailedToParseNumber.into()),
+        "INSERT INTO Item VALUES (-32769, -32769);"
+    );
+
+    test!(
+        Ok(select!(
+            field_one        |  field_two
+            I16              |  I16;
+            1                   parse_i16("-1");
+            parse_i16("-2")     2;
+            3                   3;
+            parse_i16("-4")     parse_i16("-4")
+        )),
+        "SELECT field_one, field_two FROM Item"
+    );
+
+    test!(
+        Ok(select!(field_one I16; 1; 3)),
+        "SELECT field_one FROM Item WHERE field_one > 0"
+    );
+    test!(
+        Ok(select!(field_one I16; 1; 3)),
+        "SELECT field_one FROM Item WHERE field_one >= 0"
+    );
+
+    test!(
+        Ok(select!(field_one I16; -2)),
+        "SELECT field_one FROM Item WHERE field_one = -2"
+    );
+
+    test!(
+        Ok(select!(field_one I16; -2; -4)),
+        "SELECT field_one FROM Item WHERE field_one < 0"
+    );
+
+    test!(
+        Ok(select!(field_one I16; -2; -4)),
+        "SELECT field_one FROM Item WHERE field_one <= 0"
+    );
+
+    // test!(
+    //     Ok(select!(plus I16; 0; 0; 6; -8)),
+    //     "SELECT field_one + field_two AS plus FROM Item;"
+    // );
+
+    test!(
+        Ok(select!(sub I16; 2; -4; 0; 0)),
+        "SELECT field_one - field_two AS sub FROM Item;"
+    );
+
+    test!(
+        Ok(select!(mul I16; -1; -4; 9; 16)),
+        "SELECT field_one * field_two AS mul FROM Item;"
+    );
+
+    test!(
+        Ok(select!(div I16; -1; -1; 1; 1)),
+        "SELECT field_one / field_two AS div FROM Item;"
+    );
+
+    test!(
+        Ok(select!(modulo I16; 0; 0; 0; 0)),
+        "SELECT field_one % field_two AS modulo FROM Item;"
+    );
+
+    run!("DELETE FROM Item");
+});

--- a/test-suite/src/data_type/int16.rs
+++ b/test-suite/src/data_type/int16.rs
@@ -59,10 +59,10 @@ test_case!(int16, async move {
         "SELECT field_one FROM Item WHERE field_one <= 0"
     );
 
-    // test!(
-    //     Ok(select!(plus I16; 0; 0; 6; -8)),
-    //     "SELECT field_one + field_two AS plus FROM Item;"
-    // );
+    test!(
+        Ok(select!(plus I16; 0; 0; 6; -8)),
+        "SELECT field_one + field_two AS plus FROM Item;"
+    );
 
     test!(
         Ok(select!(sub I16; 2; -4; 0; 0)),

--- a/test-suite/src/data_type/mod.rs
+++ b/test-suite/src/data_type/mod.rs
@@ -2,6 +2,7 @@ pub mod bytea;
 pub mod date;
 pub mod decimal;
 pub mod int128;
+pub mod int16;
 pub mod int32;
 pub mod int64;
 pub mod int8;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -112,6 +112,7 @@ macro_rules! generate_store_tests {
         glue!(sql_types, data_type::sql_types::sql_types);
         glue!(showcolumns, showcolumns::showcolumns);
         glue!(int8, data_type::int8::int8);
+        glue!(int16, data_type::int16::int16);
         glue!(int32, data_type::int32::int32);
         glue!(int64, data_type::int64::int64);
         glue!(int128, data_type::int128::int128);


### PR DESCRIPTION
I am adding the `INT(16)` data type to the core and encountered one problem.

: [This commented test](https://github.com/yujong-lee/gluesql/blob/b2f28018cb9ee7274fc9c5f076f91aae0ed40aa0/test-suite/src/data_type/int16.rs#L62-L65) fails.


<img width="1328" alt="스크린샷 2022-07-10 오후 10 18 23" src="https://user-images.githubusercontent.com/61503739/178146900-c1140138-eb1c-4758-88b2-fa4784b32580.png">


Seems like it goes to [here](https://github.com/yujong-lee/gluesql/blob/b2f28018cb9ee7274fc9c5f076f91aae0ed40aa0/core/src/data/value/binary_op/i16.rs#L110-L114) rather than [here](https://github.com/yujong-lee/gluesql/blob/b2f28018cb9ee7274fc9c5f076f91aae0ed40aa0/core/src/data/value/binary_op/i16.rs#L63-L73) but I don't know why.

Can anyone guide me to figure this out?