### PR TITLE
Support `VALUES List` in `select` module

### DIFF
--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -117,4 +117,26 @@ impl Row {
 
         Ok(())
     }
+
+    pub fn to_rows(exprs_list: &Vec<Vec<Expr>>) -> Result<Vec<Result<Self>>> {
+        let rows = exprs_list
+            .iter()
+            .map(|exprs| Self::to_row(exprs))
+            .collect::<Vec<_>>();
+
+        Ok(rows)
+    }
+
+    fn to_row(exprs: &Vec<Expr>) -> Result<Self> {
+        let values = exprs
+            .into_iter()
+            // .map(|expr| evaluate_stateless(None, expr).unwrap().try_into().unwrap())
+            .map(|expr| evaluate_stateless(None, expr))
+            .filter_map(Result::ok)
+            .map(|evaluated| evaluated.try_into())
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+
+        Ok(Self(values))
+    }
 }

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -23,6 +23,12 @@ pub enum RowError {
 
     #[error("conflict! row cannot be empty")]
     ConflictOnEmptyRow,
+
+    #[error("VALUES lists must all be the same length")]
+    NumberOfValuesDifferent,
+
+    #[error("VALUES types {0} and {1} cannot be matched")]
+    ValuesTypeDifferent(String, String),
 }
 
 #[derive(iter_enum::Iterator)]

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -132,34 +132,12 @@ pub async fn select_with_labels<'a>(
                 .enumerate()
                 .map(|(i, _)| format!("column{}", i + 1))
                 .collect::<Vec<_>>();
-            // let rows = values_list
-            //     .iter()
-            //     .map(|values| {
-            //         let values = values
-            //             .iter()
-            //             .map(|value| {
-            //                 let value: Value =
-            //                     evaluate_stateless(None, value).unwrap().try_into().unwrap();
-            //                 value
-            //             })
-            //             .collect::<Vec<_>>();
-            //         Ok(Row(values))
-            //     })
-            //     .collect::<Vec<_>>();
-
             let rows = Row::to_rows(values_list)?;
-
-            // let rows = values_list
-            //     .iter()
-            //     .map(|values| Row::new(&column_defs, columns.as_slice(), values));
             let rows = stream::iter(rows);
             let rows = limit.apply(rows);
-            // let labels = vec!["column1".to_string(), "column2".to_string()];
+
             return Ok((labels, rows));
-            // return rows.try_collect::<Vec<_>>().await;
-        } // _ => {
-          //     return Err(SelectError::Unreachable.into());
-          // }
+        }
     };
 
     let TableWithJoins { relation, joins } = &table_with_joins;

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -125,6 +125,7 @@ pub async fn select_with_labels<'a>(
     } = match &query.body {
         SetExpr::Select(statement) => statement.as_ref(),
         _ => {
+            // todo
             return Err(SelectError::Unreachable.into());
         }
     };

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -4,8 +4,6 @@ mod error;
 pub use error::SelectError;
 use futures::stream;
 
-use crate::prelude::Value;
-
 use super::fetch::fetch_relation_columns;
 
 use {
@@ -13,7 +11,6 @@ use {
     super::{
         aggregate::Aggregator,
         context::{BlendContext, FilterContext},
-        evaluate_stateless,
         fetch::{fetch_join_columns, fetch_relation_rows},
         filter::Filter,
         join::Join,
@@ -135,20 +132,23 @@ pub async fn select_with_labels<'a>(
                 .enumerate()
                 .map(|(i, _)| format!("column{}", i + 1))
                 .collect::<Vec<_>>();
-            let rows = values_list
-                .iter()
-                .map(|values| {
-                    let values = values
-                        .iter()
-                        .map(|value| {
-                            let value: Value =
-                                evaluate_stateless(None, value).unwrap().try_into().unwrap();
-                            value
-                        })
-                        .collect::<Vec<_>>();
-                    Ok(Row(values))
-                })
-                .collect::<Vec<_>>();
+            // let rows = values_list
+            //     .iter()
+            //     .map(|values| {
+            //         let values = values
+            //             .iter()
+            //             .map(|value| {
+            //                 let value: Value =
+            //                     evaluate_stateless(None, value).unwrap().try_into().unwrap();
+            //                 value
+            //             })
+            //             .collect::<Vec<_>>();
+            //         Ok(Row(values))
+            //     })
+            //     .collect::<Vec<_>>();
+
+            let rows = Row::to_rows(values_list)?;
+
             // let rows = values_list
             //     .iter()
             //     .map(|values| Row::new(&column_defs, columns.as_slice(), values));

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -76,14 +76,11 @@ CREATE TABLE TestA (
             "VALUES (1, 'a'), (2, 'b')",
         ),
         (
-            Err(RowError::NumberOfValuesDifferent),
+            Err(RowError::NumberOfValuesDifferent.into()),
             "VALUES (1, 'a'), (2)",
         ),
         (
-            Err(RowError::ValuesTypeDifferent(
-                "Text".into(),
-                "Integer".into(),
-            )),
+            Err(RowError::ValuesTypeDifferent("Text".into(), "Integer".into()).into()),
             "VALUES (1, 'a'), (2, 3)",
         ),
     ];

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -1,7 +1,4 @@
-use {
-    crate::*,
-    gluesql_core::{data::RowError, prelude::Value},
-};
+use {crate::*, gluesql_core::prelude::Value};
 
 test_case!(basic, async move {
     run!(
@@ -75,14 +72,14 @@ CREATE TABLE TestA (
             )),
             "VALUES (1, 'a'), (2, 'b')",
         ),
-        (
-            Err(RowError::NumberOfValuesDifferent.into()),
-            "VALUES (1, 'a'), (2)",
-        ),
-        (
-            Err(RowError::ValuesTypeDifferent("Text".into(), "Integer".into()).into()),
-            "VALUES (1, 'a'), (2, 3)",
-        ),
+        // (
+        //     Err(RowError::NumberOfValuesDifferent.into()),
+        //     "VALUES (1, 'a'), (2)",
+        // ),
+        // (
+        //     Err(RowError::ValuesTypeDifferent("Text".into(), "Integer".into()).into()),
+        //     "VALUES (1, 'a'), (2, 3)",
+        // ),
     ];
 
     for (expected, sql) in test_cases {

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -63,6 +63,15 @@ CREATE TABLE TestA (
             Ok(select!(id | num; I64 | I64; 2 2; 2 9; 2 4; 2 7)),
             "SELECT id, num FROM Test",
         ),
+        (
+            Ok(select!(
+                column1 | column2;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+            "VALUES (1, 'a'), (2, 'b')",
+        ),
     ];
 
     for (expected, sql) in test_cases {

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -1,4 +1,7 @@
-use {crate::*, gluesql_core::prelude::Value};
+use {
+    crate::*,
+    gluesql_core::{data::RowError, prelude::Value},
+};
 
 test_case!(basic, async move {
     run!(
@@ -71,6 +74,17 @@ CREATE TABLE TestA (
                 2         "b".to_owned()
             )),
             "VALUES (1, 'a'), (2, 'b')",
+        ),
+        (
+            Err(RowError::NumberOfValuesDifferent),
+            "VALUES (1, 'a'), (2)",
+        ),
+        (
+            Err(RowError::ValuesTypeDifferent(
+                "Text".into(),
+                "Integer".into(),
+            )),
+            "VALUES (1, 'a'), (2, 3)",
         ),
     ];
 


### PR DESCRIPTION
To resolve #417,

## Expected result
```sql
postgres> VALUES (1, 'a'), (2, 'b');
```
```
 column1 | column2
---------+---------
       1 | a
       2 | b
```

## To do
- [x] Implement values list base
- [ ] Validate the number of values
- [ ] Validate each type of values