### PR TITLE
Implement ast_builder binary::gte&lte&or

### DIFF
--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -45,12 +45,24 @@ impl ExprNode {
         self.binary_op(BinaryOperator::Gt, other)
     }
 
+    pub fn gte<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::GtEq, other)
+    }
+
     pub fn lt<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Lt, other)
     }
 
+    pub fn lte<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::LtEq, other)
+    }
+
     pub fn and<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::And, other)
+    }
+
+    pub fn or<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::Or, other)
     }
 }
 
@@ -92,12 +104,24 @@ mod tests {
         let expected = "id > Bar.id";
         test_expr(actual, expected);
 
+        let actual = col("id").gte(col("Bar.id"));
+        let expected = "id >= Bar.id";
+        test_expr(actual, expected);
+
         let actual = col("id").lt(col("Bar.id"));
         let expected = "id < Bar.id";
         test_expr(actual, expected);
 
+        let actual = col("id").lte(col("Bar.id"));
+        let expected = "id <= Bar.id";
+        test_expr(actual, expected);
+
         let actual = (col("id").gt(num(10))).and(col("id").lt(num(20)));
         let expected = "id > 10 AND id < 20";
+        test_expr(actual, expected);
+
+        let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
+        let expected = "id > 10 OR id < 20";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -49,16 +49,8 @@ impl ExprNode {
         self.binary_op(BinaryOperator::GtEq, other)
     }
 
-    pub fn lt<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::Lt, other)
-    }
-
     pub fn lte<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::LtEq, other)
-    }
-
-    pub fn and<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::And, other)
     }
 
     pub fn or<T: Into<Self>>(self, other: T) -> Self {
@@ -108,16 +100,8 @@ mod tests {
         let expected = "id >= Bar.id";
         test_expr(actual, expected);
 
-        let actual = col("id").lt(col("Bar.id"));
-        let expected = "id < Bar.id";
-        test_expr(actual, expected);
-
         let actual = col("id").lte(col("Bar.id"));
         let expected = "id <= Bar.id";
-        test_expr(actual, expected);
-
-        let actual = (col("id").gt(num(10))).and(col("id").lt(num(20)));
-        let expected = "id > 10 AND id < 20";
         test_expr(actual, expected);
 
         let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -44,6 +44,14 @@ impl ExprNode {
     pub fn gt<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Gt, other)
     }
+
+    pub fn lt<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::Lt, other)
+    }
+
+    pub fn and<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::And, other)
+    }
 }
 
 #[cfg(test)]
@@ -82,6 +90,14 @@ mod tests {
 
         let actual = col("id").gt(col("Bar.id"));
         let expected = "id > Bar.id";
+        test_expr(actual, expected);
+
+        let actual = col("id").lt(col("Bar.id"));
+        let expected = "id < Bar.id";
+        test_expr(actual, expected);
+
+        let actual = (col("id").gt(num(10))).and(col("id").lt(num(20)));
+        let expected = "id > 10 AND id < 20";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -24,7 +24,11 @@ impl SelectNode {
     }
 
     pub fn filter<T: Into<ExprNode>>(mut self, expr: T) -> Self {
-        self.filter_expr = Some(expr.into());
+        if let Some(exprs) = self.filter_expr {
+            self.filter_expr = Some(exprs.and(expr));
+        } else {
+            self.filter_expr = Some(expr.into());
+        }
 
         self
     }
@@ -92,6 +96,15 @@ mod tests {
 
         let actual = table("Bar").select().filter("id IS NULL").build();
         let expected = "SELECT * FROM Bar WHERE id IS NULL";
+        test(actual, expected);
+
+        let actual = table("Bar")
+            .select()
+            .filter("id IS NULL")
+            .filter("id > 10")
+            .filter("id < 20")
+            .build();
+        let expected = "SELECT * FROM Bar WHERE id IS NULL AND id > 10 AND id < 20";
         test(actual, expected);
 
         let actual = table("Foo")


### PR DESCRIPTION
## Description
Implement `gte`, `lte`, `or` binary operator at ast_builder. Related to [#624](https://github.com/gluesql/gluesql/issues/614)

## Example
```rust
#[test]
fn binary_op() {
        let actual = col("id").gte(col("Bar.id"));
        let expected = "id >= Bar.id";
        test_expr(actual, expected);

        let actual = col("id").lte(col("Bar.id"));
        let expected = "id <= Bar.id";
        test_expr(actual, expected);

        let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
        let expected = "id > 10 OR id < 20";
        test_expr(actual, expected);
}
```