### PR TITLE
Add more expression support to project,

### DIFF
--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -2,6 +2,7 @@ mod delete;
 mod expr;
 mod expr_list;
 mod select;
+mod select_item;
 mod select_item_list;
 mod table;
 
@@ -12,6 +13,7 @@ pub use {
         GroupByNode, HavingNode, LimitNode, LimitOffsetNode, OffsetLimitNode, OffsetNode,
         ProjectNode, SelectNode,
     },
+    select_item::SelectItemNode,
     select_item_list::SelectItemList,
     table::TableNode,
 };

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -120,7 +120,7 @@ impl Prebuild for ProjectNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{table, test};
+    use crate::ast_builder::{col, table, test};
 
     #[test]
     fn project() {
@@ -134,14 +134,17 @@ mod tests {
 
         let actual = table("Foo")
             .select()
-            .project("col1, col2")
+            .project(vec!["col1", "col2"])
             .project("col3")
-            .project("col4, col5, col6")
+            .project(vec!["col4".into(), col("col5")])
+            .project(col("col6"))
+            .project("col7 as hello")
             .build();
         let expected = "
             SELECT
                 col1, col2, col3,
-                col4, col5, col6
+                col4, col5, col6,
+                col7 as hello
             FROM
                 Foo
         ";
@@ -182,7 +185,7 @@ mod tests {
             .filter(r#"type = "cute""#)
             .group_by("age")
             .having("SUM(length) < 1000")
-            .project("age")
+            .project(col("age"))
             .project("SUM(length)")
             .build();
         let expected = r#"

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -1,0 +1,88 @@
+use {
+    super::ExprNode,
+    crate::{
+        ast::{Expr, SelectItem, ToSql},
+        parse_sql::parse_select_item,
+        result::{Error, Result},
+        translate::translate_select_item,
+    },
+};
+
+#[derive(Clone)]
+pub enum SelectItemNode {
+    SelectItem(SelectItem),
+    Expr(ExprNode),
+    Text(String),
+}
+
+impl From<SelectItem> for SelectItemNode {
+    fn from(select_item: SelectItem) -> Self {
+        Self::SelectItem(select_item)
+    }
+}
+
+impl From<ExprNode> for SelectItemNode {
+    fn from(expr_node: ExprNode) -> Self {
+        Self::Expr(expr_node)
+    }
+}
+
+impl From<&str> for SelectItemNode {
+    fn from(select_item: &str) -> Self {
+        Self::Text(select_item.to_owned())
+    }
+}
+
+impl TryFrom<SelectItemNode> for SelectItem {
+    type Error = Error;
+
+    fn try_from(select_item_node: SelectItemNode) -> Result<Self> {
+        match select_item_node {
+            SelectItemNode::SelectItem(select_item) => Ok(select_item),
+            SelectItemNode::Text(select_item) => {
+                parse_select_item(select_item).and_then(|item| translate_select_item(&item))
+            }
+            SelectItemNode::Expr(expr_node) => {
+                let expr = Expr::try_from(expr_node)?;
+                let label = expr.to_sql();
+
+                Ok(SelectItem::Expr { expr, label })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ast::SelectItem,
+        ast_builder::{col, SelectItemNode},
+        parse_sql::parse_select_item,
+        translate::translate_select_item,
+    };
+
+    fn test(actual: SelectItemNode, expected: &str) {
+        let parsed = &parse_select_item(expected).unwrap();
+        let expected = translate_select_item(parsed);
+        assert_eq!(actual.try_into(), expected);
+    }
+
+    #[test]
+    fn select_item() {
+        let actual = SelectItem::Wildcard.into();
+        let expected = "*";
+        test(actual, expected);
+
+        let actual = "Foo.*".into();
+        let expected = "Foo.*";
+        test(actual, expected);
+
+        let actual = "id as hello".into();
+        let expected = "id as hello";
+        test(actual, expected);
+
+        let actual = col("id").into();
+        let expected = "id";
+        test(actual, expected);
+    }
+}

--- a/core/src/ast_builder/select_item_list.rs
+++ b/core/src/ast_builder/select_item_list.rs
@@ -1,18 +1,40 @@
-use crate::{
-    ast::SelectItem,
-    parse_sql::parse_select_items,
-    result::{Error, Result},
-    translate::translate_select_item,
+use {
+    super::{ExprNode, SelectItemNode},
+    crate::{
+        ast::SelectItem,
+        parse_sql::parse_select_items,
+        result::{Error, Result},
+        translate::translate_select_item,
+    },
 };
 
 #[derive(Clone)]
 pub enum SelectItemList {
     Text(String),
+    SelectItems(Vec<SelectItemNode>),
 }
 
 impl From<&str> for SelectItemList {
     fn from(exprs: &str) -> Self {
         SelectItemList::Text(exprs.to_owned())
+    }
+}
+
+impl From<Vec<&str>> for SelectItemList {
+    fn from(select_items: Vec<&str>) -> Self {
+        SelectItemList::SelectItems(select_items.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<ExprNode> for SelectItemList {
+    fn from(expr_node: ExprNode) -> Self {
+        SelectItemList::SelectItems(vec![expr_node.into()])
+    }
+}
+
+impl From<Vec<ExprNode>> for SelectItemList {
+    fn from(expr_nodes: Vec<ExprNode>) -> Self {
+        SelectItemList::SelectItems(expr_nodes.into_iter().map(Into::into).collect())
     }
 }
 
@@ -25,6 +47,50 @@ impl TryFrom<SelectItemList> for Vec<SelectItem> {
                 .iter()
                 .map(translate_select_item)
                 .collect::<Result<Vec<_>>>(),
+            SelectItemList::SelectItems(items) => items
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>>>(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ast::SelectItem,
+        ast_builder::{col, SelectItemList},
+        parse_sql::parse_select_items,
+        result::Result,
+        translate::translate_select_item,
+    };
+
+    fn test(actual: SelectItemList, expected: &str) {
+        let parsed = parse_select_items(expected).unwrap();
+        let expected = parsed
+            .iter()
+            .map(translate_select_item)
+            .collect::<Result<Vec<SelectItem>>>();
+
+        assert_eq!(actual.try_into(), expected);
+    }
+
+    #[test]
+    fn select_item_list() {
+        let actual = "id, name".into();
+        let expected = "id, name";
+        test(actual, expected);
+
+        let actual = vec!["id", "name"].into();
+        let expected = "id, name";
+        test(actual, expected);
+
+        let actual = col("id").into();
+        let expected = "id";
+        test(actual, expected);
+
+        let actual = vec![col("id"), "name".into()].into();
+        let expected = "id, name";
+        test(actual, expected);
     }
 }

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -47,6 +47,16 @@ pub fn parse_comma_separated_exprs<Sql: AsRef<str>>(sql_exprs: Sql) -> Result<Ve
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
+pub fn parse_select_item<Sql: AsRef<str>>(sql_select_item: Sql) -> Result<SqlSelectItem> {
+    let tokens = Tokenizer::new(&DIALECT, sql_select_item.as_ref())
+        .tokenize()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
+
+    Parser::new(tokens, &DIALECT)
+        .parse_select_item()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))
+}
+
 pub fn parse_select_items<Sql: AsRef<str>>(sql_select_items: Sql) -> Result<Vec<SqlSelectItem>> {
     let tokens = Tokenizer::new(&DIALECT, sql_select_items.as_ref())
         .tokenize()


### PR DESCRIPTION
Add SelectItemNode to support more expr types not only SQL text
- AST itself, SQL text, ExprNode and Vec of each type.

e.g.
```rust
let actual = table("Foo")
    .select()
    .project(vec!["col1", "col2"])
    .project("col3")
    .project(vec!["col4".into(), col("col5")])
    .project(col("col6"))
    .project("col7 as hello")
    .build();
let expected = "
    SELECT
        col1, col2, col3,
        col4, col5, col6,
        col7 as hello
    FROM
        Foo
";
test(actual, expected);
```