### PR TITLE
[AST Builder] Implement Agggregate function `COUNT`

### DIFF
--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -23,7 +23,7 @@ pub use expr::{col, expr, nested, num, text, ExprNode};
 
 /// Available aggregate or normal SQL functions
 pub use expr::{
-    aggregate::{avg, max, min, sum, variance, AggregateNode},
+    aggregate::{avg, count, max, min, sum, variance, AggregateNode},
     function::{
         abs, acos, asin, atan, ceil, cos, floor, ifnull, left, log10, log2, pi, reverse, right,
         sin, tan, upper, FunctionNode,

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -105,7 +105,7 @@ fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(
         .map(Expr::Function)
 }
 
-fn translate_aggrecate_one_arg<T: FnOnce(Expr) -> Aggregate>(
+fn translate_aggregate_one_arg<T: FnOnce(Expr) -> Aggregate>(
     func: T,
     args: Vec<&SqlExpr>,
     name: String,
@@ -183,11 +183,11 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         .collect::<Result<Vec<_>>>()?;
 
     match name.as_str() {
-        "SUM" => translate_aggrecate_one_arg(Aggregate::Sum, args, name),
-        "MIN" => translate_aggrecate_one_arg(Aggregate::Min, args, name),
-        "MAX" => translate_aggrecate_one_arg(Aggregate::Max, args, name),
-        "AVG" => translate_aggrecate_one_arg(Aggregate::Avg, args, name),
-        "VARIANCE" => translate_aggrecate_one_arg(Aggregate::Variance, args, name),
+        "SUM" => translate_aggregate_one_arg(Aggregate::Sum, args, name),
+        "MIN" => translate_aggregate_one_arg(Aggregate::Min, args, name),
+        "MAX" => translate_aggregate_one_arg(Aggregate::Max, args, name),
+        "AVG" => translate_aggregate_one_arg(Aggregate::Avg, args, name),
+        "VARIANCE" => translate_aggregate_one_arg(Aggregate::Variance, args, name),
         "CONCAT" => {
             check_len_min(name, args.len(), 1)?;
             let exprs = args


### PR DESCRIPTION
## Task
Implementing aggregate function `COUNT` is a continuation of the previous work. #635 
enum Implemented by adding a new enum called `CountExprNode` to convert between `ExprNode` and `CountArgExpr`