### PR TITLE
Enhance `Values List` to validate column type

### DIFF
--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -26,6 +26,9 @@ pub enum RowError {
 
     #[error("VALUES lists must all be the same length")]
     NumberOfValuesDifferent,
+
+    #[error("VALUES types {0} and {1} cannot be matched")]
+    ValuesTypeDifferent(String, String),
 }
 
 #[derive(iter_enum::Iterator)]

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -26,9 +26,6 @@ pub enum RowError {
 
     #[error("VALUES lists must all be the same length")]
     NumberOfValuesDifferent,
-
-    #[error("VALUES types {0} and {1} cannot be matched")]
-    ValuesTypeDifferent(String, String),
 }
 
 #[derive(iter_enum::Iterator)]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -542,8 +542,7 @@ impl Value {
 mod tests {
     use {
         super::{Interval, Value::*},
-        crate::data::value::uuid::parse_uuid,
-        crate::data::ValueError,
+        crate::data::{value::uuid::parse_uuid, ValueError},
         rust_decimal::Decimal,
     };
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -109,6 +109,29 @@ impl Value {
         }
     }
 
+    pub fn get_type(&self) -> Option<DataType> {
+        match self {
+            Value::I8(_) => Some(DataType::Int8),
+            Value::I16(_) => Some(DataType::Int16),
+            Value::I32(_) => Some(DataType::Int32),
+            Value::I64(_) => Some(DataType::Int),
+            Value::I128(_) => Some(DataType::Int128),
+            Value::F64(_) => Some(DataType::Float),
+            Value::Decimal(_) => Some(DataType::Decimal),
+            Value::Bool(_) => Some(DataType::Boolean),
+            Value::Str(_) => Some(DataType::Text),
+            Value::Bytea(_) => Some(DataType::Bytea),
+            Value::Date(_) => Some(DataType::Date),
+            Value::Timestamp(_) => Some(DataType::Timestamp),
+            Value::Time(_) => Some(DataType::Time),
+            Value::Interval(_) => Some(DataType::Interval),
+            Value::Uuid(_) => Some(DataType::Uuid),
+            Value::Map(_) => Some(DataType::Map),
+            Value::List(_) => Some(DataType::List),
+            Value::Null => None,
+        }
+    }
+
     pub fn validate_type(&self, data_type: &DataType) -> Result<()> {
         let valid = match self {
             Value::I8(_) => matches!(data_type, DataType::Int8),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -1369,7 +1369,7 @@ mod tests {
     }
 
     #[test]
-    fn values() {
+    fn get_type() {
         use {
             super::Value,
             crate::{ast::DataType as D, data::Interval as I},

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -1341,4 +1341,41 @@ mod tests {
             Err(ValueError::FactorialOnNonNumeric.into())
         );
     }
+
+    #[test]
+    fn values() {
+        use {
+            super::Value,
+            crate::{ast::DataType as D, data::Interval as I},
+            chrono::{NaiveDate, NaiveTime},
+        };
+        let decimal = Decimal(rust_decimal::Decimal::ONE);
+        let date = Date(NaiveDate::from_ymd(2021, 5, 1));
+        let timestamp = Timestamp(NaiveDate::from_ymd(2021, 5, 1).and_hms(12, 34, 50));
+        let time = Time(NaiveTime::from_hms(12, 30, 11));
+        let interval = Interval(I::hours(5));
+        let uuid = Uuid(parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap());
+        let map = Value::parse_json_map(r#"{ "a": 10 }"#).unwrap();
+        let list = Value::parse_json_list(r#"[ true ]"#).unwrap();
+        let bytea = Bytea(hex::decode("9001").unwrap());
+
+        assert_eq!(I8(1).get_type(), Some(D::Int8));
+        assert_eq!(I16(1).get_type(), Some(D::Int16));
+        assert_eq!(I32(1).get_type(), Some(D::Int32));
+        assert_eq!(I64(1).get_type(), Some(D::Int));
+        assert_eq!(I128(1).get_type(), Some(D::Int128));
+        assert_eq!(F64(1.1).get_type(), Some(D::Float));
+        assert_eq!(decimal.get_type(), Some(D::Decimal));
+        assert_eq!(Bool(true).get_type(), Some(D::Boolean));
+        assert_eq!(Str('1'.into()).get_type(), Some(D::Text));
+        assert_eq!(bytea.get_type(), Some(D::Bytea));
+        assert_eq!(date.get_type(), Some(D::Date));
+        assert_eq!(timestamp.get_type(), Some(D::Timestamp));
+        assert_eq!(time.get_type(), Some(D::Time));
+        assert_eq!(interval.get_type(), Some(D::Interval));
+        assert_eq!(uuid.get_type(), Some(D::Uuid));
+        assert_eq!(map.get_type(), Some(D::Map));
+        assert_eq!(list.get_type(), Some(D::List));
+        assert_eq!(Null.get_type(), None);
+    }
 }

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -139,7 +139,7 @@ pub async fn select_with_labels<'a>(
                 .map(|expr| {
                     evaluate_stateless(None, expr)
                         .and_then(|evaluated| evaluated.try_into())
-                        .and_then(|value: Value| Ok(value.get_type()))
+                        .map(|value: Value| value.get_type())
                 })
                 .collect::<Result<Vec<_>>>()?;
 
@@ -154,7 +154,7 @@ pub async fn select_with_labels<'a>(
 
             for exprs in values_list {
                 let null_indexes = get_null_indexes(&column_types);
-                if null_indexes.len() == 0 {
+                if null_indexes.is_empty() {
                     break;
                 };
                 exprs

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -183,8 +183,8 @@ pub async fn select_with_labels<'a>(
                     }
                     let values = exprs
                         .iter()
+                        .map(|expr| evaluate_stateless(None, expr))
                         .zip(column_types.iter())
-                        .map(|(expr, column_type)| (evaluate_stateless(None, expr), column_type))
                         .map(|(result, column_type)| {
                             result.and_then(|evaluated| match column_type {
                                 Some(data_type) => evaluated.try_into_value(data_type, true),

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -3,6 +3,8 @@ mod error;
 
 pub use error::SelectError;
 
+use crate::prelude::{DataType, Value};
+
 use super::{evaluate_stateless, fetch::fetch_relation_columns};
 
 use {
@@ -131,6 +133,14 @@ pub async fn select_with_labels<'a>(
                 .into_iter()
                 .map(|i| format!("column{}", i))
                 .collect::<Vec<_>>();
+            let first_types = values_list[0]
+                .iter()
+                .map(|expr| {
+                    evaluate_stateless(None, expr)
+                        .and_then(|evaluated| evaluated.try_into())
+                        .and_then(|value: Value| Ok(value.get_type()))
+                })
+                .collect::<Result<Vec<_>>>()?;
             let rows = values_list
                 .iter()
                 .map(|exprs| {

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -3,16 +3,13 @@ mod error;
 
 pub use error::SelectError;
 
-use crate::prelude::Value;
-
-use super::{evaluate_stateless, fetch::fetch_relation_columns};
-
 use {
     self::blend::Blend,
     super::{
         aggregate::Aggregator,
         context::{BlendContext, FilterContext},
-        fetch::{fetch_join_columns, fetch_relation_rows},
+        evaluate_stateless,
+        fetch::{fetch_join_columns, fetch_relation_columns, fetch_relation_rows},
         filter::Filter,
         join::Join,
         limit::Limit,
@@ -21,6 +18,7 @@ use {
     crate::{
         ast::{Query, Select, SelectItem, SetExpr, TableWithJoins, Values},
         data::{get_alias, get_name, Row, RowError},
+        prelude::{DataType, Value},
         result::{Error, Result},
         store::GStore,
     },
@@ -143,33 +141,33 @@ pub async fn select_with_labels<'a>(
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            // let get_null_indexes = |types: &Vec<Option<DataType>>| -> Vec<usize> {
-            //     types
-            //         .iter()
-            //         .enumerate()
-            //         .filter(|(_, t)| t.is_none())
-            //         .map(|(i, _)| i)
-            //         .collect::<Vec<_>>()
-            // };
+            let get_null_indexes = |types: &Vec<Option<DataType>>| -> Vec<usize> {
+                types
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, t)| t.is_none())
+                    .map(|(i, _)| i)
+                    .collect::<Vec<_>>()
+            };
 
-            // for exprs in values_list {
-            //     let null_indexes = get_null_indexes(&column_types);
-            //     if null_indexes.is_empty() {
-            //         break;
-            //     };
-            //     exprs
-            //         .iter()
-            //         .enumerate()
-            //         .filter(|(i, _)| null_indexes.contains(i))
-            //         .try_for_each(|(i, expr)| -> Result<()> {
-            //             let value: Value = evaluate_stateless(None, expr)?.try_into()?;
-            //             if let Some(data_type) = value.get_type() {
-            //                 column_types[i] = Some(data_type);
-            //             }
+            for exprs in values_list {
+                let null_indexes = get_null_indexes(&column_types);
+                if null_indexes.is_empty() {
+                    break;
+                };
+                exprs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| null_indexes.contains(i))
+                    .try_for_each(|(i, expr)| -> Result<()> {
+                        let value: Value = evaluate_stateless(None, expr)?.try_into()?;
+                        if let Some(data_type) = value.get_type() {
+                            column_types[i] = Some(data_type);
+                        }
 
-            //             Ok(())
-            //         })?;
-            // }
+                        Ok(())
+                    })?;
+            }
 
             let rows = values_list
                 .iter()
@@ -184,19 +182,10 @@ pub async fn select_with_labels<'a>(
                         .map(|(result, column_type)| {
                             result.and_then(|evaluated| match column_type {
                                 Some(data_type) => evaluated.try_into_value(data_type, true),
-                                None => evaluated.try_into(), // Ok(Value::Null),
+                                None => evaluated.try_into(),
                             })
                         })
                         .collect::<Result<Vec<_>>>()?;
-
-                    column_types = column_types
-                        .iter()
-                        .zip(values.iter())
-                        .map(|(column_type, value)| match (column_type, value) {
-                            (None, value) => value.get_type(),
-                            _ => column_type.to_owned(),
-                        })
-                        .collect::<Vec<_>>();
 
                     Ok(Row(values))
                 })

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -1,11 +1,7 @@
 mod blend;
 mod error;
 
-use std::iter;
-
 pub use error::SelectError;
-
-use crate::ast::Expr;
 
 use {
     self::blend::Blend,
@@ -20,7 +16,7 @@ use {
         sort::Sort,
     },
     crate::{
-        ast::{Query, Select, SelectItem, SetExpr, TableWithJoins, Values},
+        ast::{Expr, Query, Select, SelectItem, SetExpr, TableWithJoins, Values},
         data::{get_alias, get_name, Row, RowError},
         prelude::{DataType, Value},
         result::{Error, Result},
@@ -29,7 +25,10 @@ use {
     async_recursion::async_recursion,
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
     iter_enum::Iterator,
-    std::{iter::once, rc::Rc},
+    std::{
+        iter::{self, once},
+        rc::Rc,
+    },
 };
 
 pub fn get_labels<'a>(

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -109,14 +109,14 @@ pub fn get_labels<'a>(
         .collect::<Result<_>>()
 }
 
-fn into_rows(exprs_list: &Vec<Vec<Expr>>) -> (Vec<Result<Row>>, Vec<String>) {
+fn into_rows(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
     let first_len = exprs_list[0].len();
     let labels = (1..=first_len)
         .into_iter()
         .map(|i| format!("column{}", i))
         .collect::<Vec<_>>();
     let rows = exprs_list
-        .into_iter()
+        .iter()
         .scan(
             iter::repeat(None)
                 .take(first_len)

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -193,6 +193,16 @@ pub async fn select_with_labels<'a>(
                         })
                         .collect::<Result<Vec<_>>>()?;
 
+                    // below cannot handle VALUES (Null), (Some) case
+                    // column_types = column_types
+                    //     .iter()
+                    //     .zip(values.iter())
+                    //     .map(|(column_type, value)| match (column_type, value) {
+                    //         (None, value) => value.get_type(),
+                    //         _ => column_type.to_owned(),
+                    //     })
+                    //     .collect::<Vec<_>>();
+
                     Ok(Row(values))
                 })
                 .collect::<Vec<_>>();

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -33,22 +33,6 @@ test_case!(values, async move {
             )),
         ),
         (
-            "VALUES (1), (2, 'b')",
-            Err(RowError::NumberOfValuesDifferent.into()),
-        ),
-        (
-            "VALUES (1, 'a'), (2)",
-            Err(RowError::NumberOfValuesDifferent.into()),
-        ),
-        // (
-        //     "VALUES (1, 'a'), (2, 3)",
-        //     Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
-        // ),
-        // (
-        //     "VALUES (1, 'a'), ('b', 'c')",
-        //     Err(RowError::ValuesTypeDifferent("Int".into(), "Str".into()).into()),
-        // ),
-        (
             "VALUES (1), (2) limit 1",
             Ok(select!(
                 column1;
@@ -65,11 +49,36 @@ test_case!(values, async move {
             )),
         ),
         (
-            "VALUES (1, NULL)",
+            "VALUES (1, NULL), (2, NULL)",
             Ok(select_with_null!(
                 column1 | column2;
-                I64(1)    Null
+                I64(1)    Null;
+                I64(2)    Null
             )),
+        ),
+        (
+            "VALUES (1), (2, 'b')",
+            Err(RowError::NumberOfValuesDifferent.into()),
+        ),
+        (
+            "VALUES (1, 'a'), (2)",
+            Err(RowError::NumberOfValuesDifferent.into()),
+        ),
+        (
+            "VALUES (1, 'a'), (2, 3)",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Text,
+                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
+            }
+            .into()),
+        ),
+        (
+            "VALUES (1, 'a'), ('b', 'c')",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Int,
+                literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
+            }
+            .into()),
         ),
         (
             "VALUES (1, NULL), (2, 'a'), (3, 4)",

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -33,6 +33,14 @@ test_case!(values, async move {
             Err(RowError::NumberOfValuesDifferent.into()),
         ),
         (
+            "VALUES (1, 'a'), (2, 3)",
+            Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
+        ),
+        (
+            "VALUES (1, 'a'), ('b', 'c')",
+            Err(RowError::ValuesTypeDifferent("Int".into(), "Str".into()).into()),
+        ),
+        (
             "VALUES (1), (2) limit 1",
             Ok(select!(
                 column1;

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -32,14 +32,14 @@ test_case!(values, async move {
             "VALUES (1, 'a'), (2)",
             Err(RowError::NumberOfValuesDifferent.into()),
         ),
-        (
-            "VALUES (1, 'a'), (2, 3)",
-            Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
-        ),
-        (
-            "VALUES (1, 'a'), ('b', 'c')",
-            Err(RowError::ValuesTypeDifferent("Int".into(), "Str".into()).into()),
-        ),
+        // (
+        //     "VALUES (1, 'a'), (2, 3)",
+        //     Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
+        // ),
+        // (
+        //     "VALUES (1, 'a'), ('b', 'c')",
+        //     Err(RowError::ValuesTypeDifferent("Int".into(), "Str".into()).into()),
+        // ),
         (
             "VALUES (1), (2) limit 1",
             Ok(select!(
@@ -55,6 +55,17 @@ test_case!(values, async move {
                 I64;
                 2
             )),
+        ),
+        (
+            "VALUES (1, NULL)",
+            Ok(select_with_null!(
+                column1 | column2;
+                I64(1)    Null
+            )),
+        ),
+        (
+            "VALUES (1, NULL), (2, 'a'), (3, 4)",
+            Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -1,3 +1,11 @@
+use std::borrow::Cow;
+
+use bigdecimal::BigDecimal;
+use gluesql_core::{
+    data::{Literal, ValueError},
+    prelude::DataType,
+};
+
 use {
     crate::*,
     gluesql_core::{data::RowError, prelude::Value::*},
@@ -65,7 +73,11 @@ test_case!(values, async move {
         ),
         (
             "VALUES (1, NULL), (2, 'a'), (3, 4)",
-            Err(RowError::ValuesTypeDifferent("Str".into(), "Int".into()).into()),
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Text,
+                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
+            }
+            .into()),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -1,14 +1,13 @@
-use std::borrow::Cow;
-
-use bigdecimal::BigDecimal;
-use gluesql_core::{
-    data::{Literal, ValueError},
-    prelude::DataType,
-};
-
 use {
     crate::*,
-    gluesql_core::{data::RowError, prelude::Value::*},
+    bigdecimal::BigDecimal,
+    gluesql_core::{
+        data::RowError,
+        data::{Literal, ValueError},
+        prelude::DataType,
+        prelude::Value::*,
+    },
+    std::borrow::Cow,
 };
 
 test_case!(values, async move {


### PR DESCRIPTION
This is subsequent PR of #648 

## Goal
- `Values List` does not have schema so that there is no minimum validation for each column types yet
- If there is no `NULL`, the first row will create column types
- If there is `NULL` at first row, the next row having type will create colum type

## Todo
- [x] get mutable `column_types` base
- [x] get indexes of None
- [x] if new row has type at those indexes, renew `column_types`
- [x] if there is no None in `column_types`, break
- [x] validate and cast type with try_info_value

## In Next PR
- Handle when specific column has NULL at all rows
  - It seems like postgres also converts NULL to TEXT for accomplishing `CreateTableAsValues`
```sql
postgres=# create table tb_values as values (1, null, null), (2, null, 3);
SELECT 2
postgres=# select column_name, data_type from information_schema.columns where table_name = 'tb_values';
 column_name | data_type 
-------------+-----------
 column1     | integer
 column2     | text
 column3     | integer
``` 
-  refactor `values_list into row` with row::new
  - split common codes
  - blend `column_defs` from `column_types`, `labels`