### PR TITLE
[Data] Add function `sqrt` for enum `Value`

### DIFF
--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -158,6 +158,12 @@ pub enum ValueError {
         rhs: Value,
         operator: NumericBinaryOperator,
     },
+
+    #[error("non numeric value in sqrt")]
+    SqrtOnNonNumeric,
+
+    #[error("negative numeric value in sqrt")]
+    SqrtOnNegativeNumeric,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -159,11 +159,8 @@ pub enum ValueError {
         operator: NumericBinaryOperator,
     },
 
-    #[error("non numeric value in sqrt")]
-    SqrtOnNonNumeric,
-
-    #[error("negative numeric value in sqrt")]
-    SqrtOnNegativeNumeric,
+    #[error("non numeric value in sqrt {0:?}")]
+    SqrtOnNonNumeric(Value),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -507,10 +507,8 @@ impl Value {
                 } else {
                     Err(ValueError::SqrtOnNegativeNumeric.into())
                 }
-            },
-            _ => {
-                Err(ValueError::SqrtOnNonNumeric.into())
             }
+            _ => Err(ValueError::SqrtOnNonNumeric.into()),
         }
     }
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -502,13 +502,10 @@ impl Value {
         match self {
             I8(_) | I16(_) | I64(_) | I128(_) | F64(_) => {
                 let a: f64 = self.try_into()?;
-                if a >= 0.0 {
-                    Ok(Value::F64(a.sqrt()))
-                } else {
-                    Err(ValueError::SqrtOnNegativeNumeric.into())
-                }
+                Ok(Value::F64(a.sqrt()))
             }
-            _ => Err(ValueError::SqrtOnNonNumeric.into()),
+            Null => Ok(Value::Null),
+            _ => Err(ValueError::SqrtOnNonNumeric(self.clone()).into()),
         }
     }
 
@@ -1341,10 +1338,10 @@ mod tests {
         assert_eq!(I64(9).sqrt(), Ok(F64(3.0)));
         assert_eq!(I128(9).sqrt(), Ok(F64(3.0)));
         assert_eq!(F64(9.0).sqrt(), Ok(F64(3.0)));
+        assert!(Null.sqrt().unwrap().is_null());
         assert_eq!(
-            F64(-9.0).sqrt(),
-            Err(ValueError::SqrtOnNegativeNumeric.into())
+            Str("9".to_string()).sqrt(),
+            Err(ValueError::SqrtOnNonNumeric(Str("9".to_string())).into())
         );
-        assert_eq!(Null.sqrt(), Err(ValueError::SqrtOnNonNumeric.into()));
     }
 }

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -497,6 +497,23 @@ impl Value {
         Ok(Value::I64(value))
     }
 
+    pub fn sqrt(&self) -> Result<Value> {
+        use Value::*;
+        match self {
+            I8(_) | I16(_) | I64(_) | I128(_) | F64(_) => {
+                let a: f64 = self.try_into()?;
+                if a >= 0.0 {
+                    Ok(Value::F64(a.sqrt()))
+                } else {
+                    Err(ValueError::SqrtOnNegativeNumeric.into())
+                }
+            },
+            _ => {
+                Err(ValueError::SqrtOnNonNumeric.into())
+            }
+        }
+    }
+
     /// Value to Big-Endian for comparison purpose
     pub fn to_cmp_be_bytes(&self) -> Result<Vec<u8>> {
         self.try_into().map(|key: Key| key.to_cmp_be_bytes())
@@ -1317,5 +1334,19 @@ mod tests {
             Str("5".to_string()).unary_factorial(),
             Err(ValueError::FactorialOnNonNumeric.into())
         );
+    }
+
+    #[test]
+    fn sqrt() {
+        assert_eq!(I8(9).sqrt(), Ok(F64(3.0)));
+        assert_eq!(I16(9).sqrt(), Ok(F64(3.0)));
+        assert_eq!(I64(9).sqrt(), Ok(F64(3.0)));
+        assert_eq!(I128(9).sqrt(), Ok(F64(3.0)));
+        assert_eq!(F64(9.0).sqrt(), Ok(F64(3.0)));
+        assert_eq!(
+            F64(-9.0).sqrt(),
+            Err(ValueError::SqrtOnNegativeNumeric.into())
+        );
+        assert_eq!(Null.sqrt(), Err(ValueError::SqrtOnNonNumeric.into()));
     }
 }

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -251,8 +251,8 @@ pub fn sign(name: String, n: Evaluated<'_>) -> Result<Value> {
     Ok(Value::I8(x.signum() as i8))
 }
 
-pub fn sqrt(name: String, n: Evaluated<'_>) -> Result<Value> {
-    Ok(Value::F64(eval_to_float!(name, n).sqrt()))
+pub fn sqrt(n: Evaluated<'_>) -> Result<Value> {
+    Value::sqrt(&n.try_into()?)
 }
 
 pub fn power(name: String, expr: Evaluated<'_>, power: Evaluated<'_>) -> Result<Value> {

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -298,7 +298,7 @@ async fn evaluate_function<'a>(
         // --- float ---
         Function::Abs(expr) => f::abs(name(), eval(expr).await?),
         Function::Sign(expr) => f::sign(name(), eval(expr).await?),
-        Function::Sqrt(expr) => f::sqrt(name(), eval(expr).await?),
+        Function::Sqrt(expr) => f::sqrt(eval(expr).await?),
         Function::Power { expr, power } => {
             let expr = eval(expr).await?;
             let power = eval(power).await?;

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -185,7 +185,7 @@ fn evaluate_function<'a>(
         }
 
         // --- float ---
-        Function::Sqrt(expr) => f::sqrt(name(), eval(expr)?),
+        Function::Sqrt(expr) => f::sqrt(eval(expr)?),
         Function::Power { expr, power } => {
             let expr = eval(expr)?;
             let power = eval(power)?;

--- a/test-suite/src/function/sqrt_power.rs
+++ b/test-suite/src/function/sqrt_power.rs
@@ -1,6 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
+        data::ValueError,
         executor::EvaluateError,
         prelude::{Payload, Value::*},
     },
@@ -45,7 +46,7 @@ test_case!(sqrt, async move {
         ),
         (
             "SELECT SQRT('string') AS sqrt FROM SingleItem",
-            Err(EvaluateError::FunctionRequiresFloatValue(String::from("SQRT")).into()),
+            Err(ValueError::SqrtOnNonNumeric(Str("string".to_string())).into()),
         ),
         (
             "SELECT SQRT(NULL) AS sqrt FROM SingleItem",


### PR DESCRIPTION
## Description
Implement to support evaluating sqrt between enum Value

https://doc.rust-lang.org/std/primitive.f64.html
- For real numbers less than or equal to 0, std::f64::sqrt() returns NaN. Therefore, for mistakes, the sqrt part does not process errors.
- It is not an error to pass real and null as arguments to the sqrt function, and non-numeric errors are handled for the rest of the types.
- Meanwhile, real numbers less than 0 are implemented to indicate an error in the result of the sql sqrt function.
  + This can result in having to handle error for NaN.
However, since NaN does not come as a result of expr parsing, it is independent of sqrt operations between enum `Values`.