### PR TITLE
refactor(ast_build): reorder binary_op functions and tests

### DIFF
--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -33,28 +33,28 @@ impl ExprNode {
         self.binary_op(BinaryOperator::StringConcat, other)
     }
 
-    pub fn eq<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::Eq, other)
-    }
-
-    pub fn neq<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::NotEq, other)
-    }
-
     pub fn gt<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Gt, other)
-    }
-
-    pub fn gte<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::GtEq, other)
     }
 
     pub fn lt<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Lt, other)
     }
 
+    pub fn gte<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::GtEq, other)
+    }
+
     pub fn lte<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::LtEq, other)
+    }
+
+    pub fn eq<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::Eq, other)
+    }
+
+    pub fn neq<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::NotEq, other)
     }
 
     pub fn and<T: Into<Self>>(self, other: T) -> Self {
@@ -92,16 +92,12 @@ mod tests {
         let expected = "'hello' || 'world'";
         test_expr(actual, expected);
 
-        let actual = col("id").eq(10);
-        let expected = "id = 10";
-        test_expr(actual, expected);
-
-        let actual = col("id").neq("'abcde'");
-        let expected = r#"id != "abcde""#;
-        test_expr(actual, expected);
-
         let actual = col("id").gt(col("Bar.id"));
         let expected = "id > Bar.id";
+        test_expr(actual, expected);
+
+        let actual = col("id").lt(col("Bar.id"));
+        let expected = "id < Bar.id";
         test_expr(actual, expected);
 
         let actual = col("id").gte(col("Bar.id"));
@@ -112,16 +108,20 @@ mod tests {
         let expected = "id <= Bar.id";
         test_expr(actual, expected);
 
-        let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
-        let expected = "id > 10 OR id < 20";
+        let actual = col("id").eq(10);
+        let expected = "id = 10";
         test_expr(actual, expected);
 
-        let actual = col("id").lt(col("Bar.id"));
-        let expected = "id < Bar.id";
+        let actual = col("id").neq("'abcde'");
+        let expected = r#"id != "abcde""#;
         test_expr(actual, expected);
 
         let actual = (col("id").gt(num(10))).and(col("id").lt(num(20)));
         let expected = "id > 10 AND id < 20";
+        test_expr(actual, expected);
+
+        let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
+        let expected = "id > 10 OR id < 20";
         test_expr(actual, expected);
     }
 }


### PR DESCRIPTION
Hello, cleansed the `ast_builder::expr::binary_op` by reordering the functions and tests to match the order of `BinaryOperator` at `ast::operator`. 

- The order: `Plus`, `Minus`, `Multiply`, `Divide`, `Modulo`, `StringConcat`, `Gt`, `Lt`, `GtEq`, `LtEq`, `Eq`, `NotEq`, `And`, `Or`, `Xor`, `Like`, `ILike`, `NotLike`, `NotILike`.

Please leave an RC if there's any problem, suggestion or conflict at main branch.

Thank you.

This PR closes #678