### PR TITLE
feat(ast_build): implement binary operations (modulo, like, ilike. not_like, not_ilike)

### DIFF
--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -76,6 +76,10 @@ impl ExprNode {
     pub fn ilike<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::ILike, other)
     }
+
+    pub fn not_like<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::NotLike, other)
+    }
 }
 
 #[cfg(test)]
@@ -146,6 +150,10 @@ mod tests {
 
         let actual = col("name").ilike(text("a%"));
         let expected = "name ILIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").not_like(text("a%"));
+        let expected = "name NOT LIKE 'a%'";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -72,6 +72,10 @@ impl ExprNode {
     pub fn like<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Like, other)
     }
+
+    pub fn ilike<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::ILike, other)
+    }
 }
 
 #[cfg(test)]
@@ -138,6 +142,10 @@ mod tests {
 
         let actual = col("name").like(text("a%"));
         let expected = "name LIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").ilike(text("a%"));
+        let expected = "name ILIKE 'a%'";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -29,6 +29,10 @@ impl ExprNode {
         self.binary_op(BinaryOperator::Divide, other)
     }
 
+    pub fn modulo<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::Modulo, other)
+    }
+
     pub fn concat<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::StringConcat, other)
     }
@@ -86,6 +90,10 @@ mod tests {
 
         let actual = col("amount").div(30);
         let expected = "amount / 30";
+        test_expr(actual, expected);
+
+        let actual = col("amount").modulo(30);
+        let expected = "amount % 30";
         test_expr(actual, expected);
 
         let actual = text("hello").concat(r#""world""#);

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -68,6 +68,10 @@ impl ExprNode {
     pub fn or<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Or, other)
     }
+
+    pub fn like<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::Like, other)
+    }
 }
 
 #[cfg(test)]
@@ -130,6 +134,10 @@ mod tests {
 
         let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
         let expected = "id > 10 OR id < 20";
+        test_expr(actual, expected);
+
+        let actual = col("name").like(text("a%"));
+        let expected = "name LIKE 'a%'";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -80,6 +80,10 @@ impl ExprNode {
     pub fn not_like<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::NotLike, other)
     }
+
+    pub fn not_ilike<T: Into<Self>>(self, other: T) -> Self {
+        self.binary_op(BinaryOperator::NotILike, other)
+    }
 }
 
 #[cfg(test)]
@@ -154,6 +158,10 @@ mod tests {
 
         let actual = col("name").not_like(text("a%"));
         let expected = "name NOT LIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").not_ilike(text("a%"));
+        let expected = "name NOT ILIKE 'a%'";
         test_expr(actual, expected);
     }
 }


### PR DESCRIPTION
Hello, implemented AST builders for Binary Operators `Modulo`, `Like`, `ILike`, `NotLike`, `NotILike`.

I didn't implement XOR because the test below failed when I implemented it. 

```rust
let actual = (col("id").gt(num(10))).xor(col("id").lt(num(20)));
let expected = "id > 10 XOR id < 20"; // id > (10 XOR id) < 20
test_expr(actual, expected); 
// thread 'ast_builder::expr::binary_op::tests::binary_op' panicked at 'assertion failed: `(left == right)`
// left: `Ok(BinaryOp { left: BinaryOp { left: Identifier("id"), op: Gt, right: Literal(Number(BigDecimal("10"))) }, op: Xor, right: BinaryOp { left: Identifier("id"), op: Lt, right: Literal(Number(BigDecimal("20"))) } })`,
// right: `Ok(BinaryOp { left: BinaryOp { left: Identifier("id"), op: Gt, right: BinaryOp { left: Literal(Number(BigDecimal("10"))), op: Xor, right: Identifier("id") } }, op: Lt, right: Literal(Number(BigDecimal("20"))) })`',
```

Please leave an RC if there's any problem, suggestion or conflict at main branch.

Thank you.

This PR closes #685