### PR TITLE
implement f32

### DIFF
--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -10,6 +10,7 @@ pub enum DataType {
     Int32,
     Int,
     Int128,
+    Float32,
     Float,
     Text,
     Bytea,

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -84,6 +84,7 @@ impl TryFrom<Value> for Key {
             Uuid(v) => Ok(Key::Uuid(v)),
             Decimal(v) => Ok(Key::Decimal(v)),
             Null => Ok(Key::None),
+            F32(_) => Err(KeyError::FloatTypeKeyNotSupported.into()),
             F64(_) => Err(KeyError::FloatTypeKeyNotSupported.into()),
             Map(_) => Err(KeyError::MapTypeKeyNotSupported.into()),
             List(_) => Err(KeyError::ListTypeKeyNotSupported.into()),

--- a/core/src/data/value/binary_op/f32.rs
+++ b/core/src/data/value/binary_op/f32.rs
@@ -1,0 +1,402 @@
+use {
+    super::TryBinaryOperator,
+    crate::{
+        data::{NumericBinaryOperator, ValueError},
+        prelude::Value,
+        result::Result,
+    },
+    rust_decimal::prelude::Decimal,
+    std::cmp::Ordering,
+    Value::*,
+};
+
+impl PartialEq<Value> for f32 {
+    fn eq(&self, other: &Value) -> bool {
+        let lhs = *self;
+
+        match *other {
+            I8(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            I16(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            I32(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            I64(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            I128(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            F32(rhs) => (lhs - rhs).abs() < f32::EPSILON,
+            F64(rhs) => (lhs - (rhs as f32)).abs() < f32::EPSILON,
+            Decimal(rhs) => Decimal::from_f32_retain(lhs)
+                .map(|x| rhs == x)
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+}
+
+impl PartialOrd<Value> for f32 {
+    fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
+        match *other {
+            I8(rhs) => self.partial_cmp(&(rhs as f32)),
+            I16(rhs) => self.partial_cmp(&(rhs as f32)),
+            I32(rhs) => self.partial_cmp(&(rhs as f32)),
+            I64(rhs) => self.partial_cmp(&(rhs as f32)),
+            I128(rhs) => self.partial_cmp(&(rhs as f32)),
+            F32(rhs) => self.partial_cmp(&rhs),
+            F64(rhs) => self.partial_cmp(&(rhs as f32)),
+            Decimal(rhs) => Decimal::from_f32_retain(*self)
+                .map(|x| x.partial_cmp(&rhs))
+                .unwrap_or(None),
+            _ => None,
+        }
+    }
+}
+
+impl TryBinaryOperator for f32 {
+    type Rhs = Value;
+
+    fn try_add(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => Ok(F32(lhs + rhs as f32)),
+            I16(rhs) => Ok(F32(lhs + rhs as f32)),
+            I32(rhs) => Ok(F32(lhs + rhs as f32)),
+            I64(rhs) => Ok(F32(lhs + rhs as f32)),
+            I128(rhs) => Ok(F32(lhs + rhs as f32)),
+            F32(rhs) => Ok(F32(lhs + rhs)),
+            F64(rhs) => Ok(F32(lhs + rhs as f32)),
+            Decimal(rhs) => Decimal::from_f32_retain(lhs)
+                .map(|x| Ok(Decimal(x + rhs)))
+                .unwrap_or_else(|| {
+                    Err(ValueError::FloatToDecimalConversionFailure(lhs.into()).into())
+                }),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F32(lhs),
+                operator: NumericBinaryOperator::Add,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_subtract(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => Ok(F32(lhs - rhs as f32)),
+            I16(rhs) => Ok(F32(lhs - rhs as f32)),
+            I32(rhs) => Ok(F32(lhs - rhs as f32)),
+            I64(rhs) => Ok(F32(lhs - rhs as f32)),
+            I128(rhs) => Ok(F32(lhs - rhs as f32)),
+            F32(rhs) => Ok(F32(lhs - rhs)),
+            F64(rhs) => Ok(F32(lhs - rhs as f32)),
+            Decimal(rhs) => Decimal::from_f32_retain(lhs)
+                .map(|x| Ok(Decimal(x - rhs)))
+                .unwrap_or_else(|| {
+                    Err(ValueError::FloatToDecimalConversionFailure(lhs.into()).into())
+                }),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F32(lhs),
+                operator: NumericBinaryOperator::Subtract,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_multiply(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => Ok(F32(lhs * rhs as f32)),
+            I16(rhs) => Ok(F32(lhs * rhs as f32)),
+            I32(rhs) => Ok(F32(lhs * rhs as f32)),
+            I64(rhs) => Ok(F32(lhs * rhs as f32)),
+            I128(rhs) => Ok(F32(lhs * rhs as f32)),
+            F32(rhs) => Ok(F32(lhs * rhs)),
+            F64(rhs) => Ok(F32(lhs * rhs as f32)),
+            Interval(rhs) => Ok(Interval(lhs as f64 * rhs)),
+            Decimal(rhs) => Decimal::from_f32_retain(lhs)
+                .map(|x| Ok(Decimal(x * rhs)))
+                .unwrap_or_else(|| {
+                    Err(ValueError::FloatToDecimalConversionFailure(lhs.into()).into())
+                }),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F32(lhs),
+                operator: NumericBinaryOperator::Multiply,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_divide(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => Ok(F32(lhs / rhs as f32)),
+            I16(rhs) => Ok(F32(lhs / rhs as f32)),
+            I32(rhs) => Ok(F32(lhs / rhs as f32)),
+            I64(rhs) => Ok(F32(lhs / rhs as f32)),
+            I128(rhs) => Ok(F32(lhs / rhs as f32)),
+            F32(rhs) => Ok(F32(lhs / rhs)),
+            F64(rhs) => Ok(F32(lhs / rhs as f32)),
+            Decimal(rhs) => Decimal::from_f32_retain(lhs)
+                .map(|x| Ok(Decimal(x * rhs)))
+                .unwrap_or_else(|| {
+                    Err(ValueError::FloatToDecimalConversionFailure(lhs.into()).into())
+                }),
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F32(lhs),
+                operator: NumericBinaryOperator::Divide,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn try_modulo(&self, rhs: &Self::Rhs) -> Result<Value> {
+        let lhs = *self;
+
+        match *rhs {
+            I8(rhs) => Ok(F32(lhs % rhs as f32)),
+            I16(rhs) => Ok(F32(lhs % rhs as f32)),
+            I32(rhs) => Ok(F32(lhs % rhs as f32)),
+            I64(rhs) => Ok(F32(lhs % rhs as f32)),
+            I128(rhs) => Ok(F32(lhs % rhs as f32)),
+            F32(rhs) => Ok(F32(lhs % rhs)),
+            F64(rhs) => Ok(F32(lhs % rhs as f32)),
+            Decimal(rhs) => match Decimal::from_f32_retain(lhs) {
+                Some(x) => x
+                    .checked_rem(rhs)
+                    .map(|y| Ok(Decimal(y)))
+                    .unwrap_or_else(|| {
+                        Err(ValueError::BinaryOperationOverflow {
+                            lhs: F32(lhs),
+                            operator: NumericBinaryOperator::Modulo,
+                            rhs: Decimal(rhs),
+                        }
+                        .into())
+                    }),
+                _ => Err(ValueError::FloatToDecimalConversionFailure(lhs.into()).into()),
+            },
+            Null => Ok(Null),
+            _ => Err(ValueError::NonNumericMathOperation {
+                lhs: F32(lhs),
+                operator: NumericBinaryOperator::Modulo,
+                rhs: rhs.clone(),
+            }
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{TryBinaryOperator, Value::*},
+        crate::data::{NumericBinaryOperator, ValueError},
+        rust_decimal::prelude::Decimal,
+        std::cmp::Ordering,
+    };
+
+    #[test]
+    fn eq() {
+        let base = 1.0_f32;
+
+        assert_eq!(base, I8(1));
+        assert_eq!(base, I16(1));
+        assert_eq!(base, I32(1));
+        assert_eq!(base, I64(1));
+        assert_eq!(base, I128(1));
+        assert_eq!(base, F32(1.0_f32));
+        assert_eq!(base, F64(1.0));
+        assert_eq!(base, Decimal(Decimal::from(1)));
+
+        assert_ne!(base, Bool(true));
+    }
+
+    #[test]
+    fn partial_cmp() {
+        let base = 1.0_f32;
+
+        assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F32(1.0)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
+        assert_eq!(
+            base.partial_cmp(&Decimal(Decimal::ONE)),
+            Some(Ordering::Equal)
+        );
+
+        assert_eq!(base.partial_cmp(&Bool(true)), None);
+    }
+
+    #[test]
+    fn try_add() {
+        let base = 1.0_f32;
+
+        assert!(matches!(base.try_add(&I8(1)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_add(&I16(1)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_add(&I32(1)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_add(&I64(1)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_add(&I128(1)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_add(&F32(1.0_f32)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON )
+        );
+        assert!(matches!(base.try_add(&F64(1.0)), Ok(F32(x)) if (x - 2.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_add(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::TWO)
+        );
+
+        assert_eq!(
+            base.try_add(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F32(1.0),
+                operator: NumericBinaryOperator::Add,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_subtract() {
+        let base = 1.0_f32;
+
+        assert!(matches!(base.try_subtract(&I8(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_subtract(&I16(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&I32(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&I64(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&I128(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&F32(1.0_f32)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&F64(1.0_f64)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::ZERO)
+        );
+
+        assert_eq!(
+            base.try_subtract(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F32(1.0),
+                operator: NumericBinaryOperator::Subtract,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_multiply() {
+        let base = 1.0_f32;
+
+        assert!(matches!(base.try_multiply(&I8(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_multiply(&I16(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&I32(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&I64(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&I128(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&F32(1.0)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&F64(1.0)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_multiply(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::ONE)
+        );
+
+        assert_eq!(
+            base.try_multiply(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F32(1.0),
+                operator: NumericBinaryOperator::Multiply,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_divide() {
+        let base = 1.0_f32;
+
+        assert!(matches!(base.try_divide(&I8(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_divide(&I16(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_divide(&I32(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_divide(&I64(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_divide(&I128(1)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_divide(&F32(1.0_f32)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_divide(&F64(1.0_f64)), Ok(F32(x)) if (x - 1.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_divide(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::ONE)
+        );
+
+        assert_eq!(
+            base.try_divide(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F32(1.0),
+                operator: NumericBinaryOperator::Divide,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+
+    #[test]
+    fn try_modulo() {
+        let base = 1.0_f32;
+
+        assert!(matches!(base.try_modulo(&I8(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_modulo(&I16(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_modulo(&I32(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_modulo(&I64(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(matches!(base.try_modulo(&I128(1)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON ));
+        assert!(
+            matches!(base.try_modulo(&F32(1.0_f32)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_modulo(&F64(1.0_f64)), Ok(F32(x)) if (x - 0.0).abs() < f32::EPSILON )
+        );
+        assert!(
+            matches!(base.try_modulo(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::ZERO)
+        );
+
+        assert_eq!(
+            base.try_modulo(&Bool(true)),
+            Err(ValueError::NonNumericMathOperation {
+                lhs: F32(1.0),
+                operator: NumericBinaryOperator::Modulo,
+                rhs: Bool(true)
+            }
+            .into())
+        );
+    }
+}

--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -20,6 +20,7 @@ impl PartialEq<Value> for f64 {
             I32(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I64(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I128(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
+            F32(rhs) => (lhs - rhs as f64).abs() < f64::EPSILON,
             F64(rhs) => (lhs - rhs).abs() < f64::EPSILON,
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| rhs == x)
@@ -37,6 +38,7 @@ impl PartialOrd<Value> for f64 {
             I32(rhs) => self.partial_cmp(&(rhs as f64)),
             I64(rhs) => self.partial_cmp(&(rhs as f64)),
             I128(rhs) => self.partial_cmp(&(rhs as f64)),
+            F32(rhs) => self.partial_cmp(&(rhs as f64)),
             F64(rhs) => self.partial_cmp(&rhs),
             Decimal(rhs) => Decimal::from_f64_retain(*self)
                 .map(|x| x.partial_cmp(&rhs))
@@ -58,6 +60,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs + rhs as f64)),
             I64(rhs) => Ok(F64(lhs + rhs as f64)),
             I128(rhs) => Ok(F64(lhs + rhs as f64)),
+            F32(rhs) => Ok(F64(lhs + rhs as f64)),
             F64(rhs) => Ok(F64(lhs + rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x + rhs)))
@@ -81,6 +84,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs - rhs as f64)),
             I64(rhs) => Ok(F64(lhs - rhs as f64)),
             I128(rhs) => Ok(F64(lhs - rhs as f64)),
+            F32(rhs) => Ok(F64(lhs - rhs as f64)),
             F64(rhs) => Ok(F64(lhs - rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x - rhs)))
@@ -104,6 +108,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs * rhs as f64)),
             I64(rhs) => Ok(F64(lhs * rhs as f64)),
             I128(rhs) => Ok(F64(lhs * rhs as f64)),
+            F32(rhs) => Ok(F64(lhs * rhs as f64)),
             F64(rhs) => Ok(F64(lhs * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
@@ -128,6 +133,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs / rhs as f64)),
             I64(rhs) => Ok(F64(lhs / rhs as f64)),
             I128(rhs) => Ok(F64(lhs / rhs as f64)),
+            F32(rhs) => Ok(F64(lhs / rhs as f64)),
             F64(rhs) => Ok(F64(lhs / rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x * rhs)))
@@ -151,6 +157,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs % rhs as f64)),
             I64(rhs) => Ok(F64(lhs % rhs as f64)),
             I128(rhs) => Ok(F64(lhs % rhs as f64)),
+            F32(rhs) => Ok(F64(lhs % rhs as f64)),
             F64(rhs) => Ok(F64(lhs % rhs)),
             Decimal(rhs) => match Decimal::from_f64_retain(lhs) {
                 Some(x) => x
@@ -195,6 +202,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, F32(1.0_f32));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::from(1)));
 
@@ -210,6 +218,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F32(1.0_f32)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
         assert_eq!(
             base.partial_cmp(&Decimal(Decimal::ONE)),
@@ -228,6 +237,9 @@ mod tests {
         assert!(matches!(base.try_add(&I32(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I64(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I128(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
+        assert!(
+            matches!(base.try_add(&F32(1.0_f32)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON )
+        );
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_add(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::TWO)
@@ -260,6 +272,9 @@ mod tests {
         );
         assert!(
             matches!(base.try_subtract(&I128(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
+        );
+        assert!(
+            matches!(base.try_subtract(&F32(1.0_f32)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
@@ -297,6 +312,9 @@ mod tests {
             matches!(base.try_multiply(&I128(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
         assert!(
+            matches!(base.try_multiply(&F32(1.0_f32)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
+        );
+        assert!(
             matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
         assert!(
@@ -324,6 +342,9 @@ mod tests {
         assert!(matches!(base.try_divide(&I64(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I128(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(
+            matches!(base.try_divide(&F32(1.0_f32)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
+        );
+        assert!(
             matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
         assert!(
@@ -350,6 +371,9 @@ mod tests {
         assert!(matches!(base.try_modulo(&I32(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I64(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I128(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
+        assert!(
+            matches!(base.try_modulo(&F32(1.0_f32)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
+        );
         assert!(
             matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );

--- a/core/src/data/value/binary_op/i128.rs
+++ b/core/src/data/value/binary_op/i128.rs
@@ -18,6 +18,7 @@ impl PartialEq<Value> for i128 {
             I32(other) => self == &(*other as i128),
             I64(other) => self == &(*other as i128),
             I128(other) => self == other,
+            F32(other) => ((*self as f32) - other).abs() < f32::EPSILON,
             F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
@@ -33,6 +34,7 @@ impl PartialOrd<Value> for i128 {
             I32(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I64(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I128(other) => PartialOrd::partial_cmp(self, other),
+            F32(other) => PartialOrd::partial_cmp(&(*self as f32), other),
             F64(other) => PartialOrd::partial_cmp(&(*self as f64), other),
             Decimal(other) => Decimal::from(*self).partial_cmp(other),
             _ => None,
@@ -103,6 +105,7 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 + rhs)),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) + rhs)),
             Null => Ok(Null),
@@ -174,6 +177,7 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 - rhs)),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) - rhs)),
 
@@ -244,6 +248,7 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 * rhs)),
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
@@ -316,6 +321,7 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 / rhs)),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) / rhs)),
             Null => Ok(Null),
@@ -386,6 +392,7 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 % rhs)),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) % rhs)),
             Null => Ok(Null),
@@ -676,6 +683,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, F32(1.0_f32));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -691,6 +699,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&F32(0.0_f32)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
@@ -698,6 +707,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F32(1.0_f32)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
@@ -705,6 +715,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&F32(2.0_f32)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -725,6 +736,9 @@ mod tests {
         assert_eq!(base.try_add(&I64(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
 
+        assert!(
+            matches!(base.try_add(&F32(1.0)), Ok(F32(x)) if (x - 2.0_f32).abs() < f32::EPSILON)
+        );
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
             base.try_add(&Decimal(Decimal::ONE)),
@@ -752,6 +766,9 @@ mod tests {
         assert_eq!(base.try_subtract(&I64(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
 
+        assert!(
+            matches!(base.try_subtract(&F32(1.0)), Ok(F32(x)) if (x - 0.0_f32).abs() < f32::EPSILON )
+        );
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
@@ -788,6 +805,9 @@ mod tests {
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I128(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
 
+        assert!(
+            matches!(base.try_multiply(&F32(1.0)), Ok(F32(x)) if (x - 3.0_f32).abs() < f32::EPSILON )
+        );
         assert!(
             matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 3.0).abs() < f64::EPSILON )
         );
@@ -826,6 +846,9 @@ mod tests {
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
 
         assert!(
+            matches!(base.try_divide(&F32(1.0)), Ok(F32(x)) if (x - 6.0_f32).abs() < f32::EPSILON )
+        );
+        assert!(
             matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 6.0).abs() < f64::EPSILON )
         );
 
@@ -861,6 +884,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I64(2)), Ok(I128(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
 
+        assert!(matches!(base.try_modulo(&F32(1.0)), Ok(F32(x)) if (x).abs() < f32::EPSILON ));
         assert!(matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x).abs() < f64::EPSILON ));
         assert_eq!(
             base.try_modulo(&Decimal(Decimal::ONE)),

--- a/core/src/data/value/binary_op/i32.rs
+++ b/core/src/data/value/binary_op/i32.rs
@@ -18,6 +18,7 @@ impl PartialEq<Value> for i32 {
             I32(other) => self == other,
             I64(other) => (*self as i64) == *other,
             I128(other) => (*self as i128) == *other,
+            F32(other) => ((*self as f32) - other).abs() < f32::EPSILON,
             F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
@@ -33,6 +34,7 @@ impl PartialOrd<Value> for i32 {
             I32(other) => PartialOrd::partial_cmp(self, other),
             I64(other) => PartialOrd::partial_cmp(&(*self as i64), other),
             I128(other) => PartialOrd::partial_cmp(&(*self as i128), other),
+            F32(other) => PartialOrd::partial_cmp(&(*self as f32), other),
             F64(other) => PartialOrd::partial_cmp(&(*self as f64), other),
             Decimal(other) => Decimal::from(*self).partial_cmp(other),
             _ => None,
@@ -102,6 +104,7 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 + rhs)),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) + rhs)),
             Null => Ok(Null),
@@ -173,6 +176,7 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 - rhs)),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) - rhs)),
 
@@ -243,6 +247,7 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 * rhs)),
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
@@ -315,6 +320,7 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 / rhs)),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) / rhs)),
             Null => Ok(Null),
@@ -385,6 +391,7 @@ impl TryBinaryOperator for i32 {
                     .into()
                 })
                 .map(I128),
+            F32(rhs) => Ok(F32(lhs as f32 % rhs)),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) % rhs)),
             Null => Ok(Null),
@@ -545,6 +552,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, F32(1.0_f32));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -560,6 +568,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&F32(0.0_f32)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
@@ -567,6 +576,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&F32(1.0_f32)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
@@ -574,6 +584,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&F32(2.0_f32)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -594,6 +605,9 @@ mod tests {
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
 
+        assert!(
+            matches!(base.try_add(&F32(1.0)), Ok(F32(x)) if (x - 2.0_f32).abs() < f32::EPSILON)
+        );
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
             base.try_add(&Decimal(Decimal::ONE)),
@@ -621,6 +635,9 @@ mod tests {
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
 
+        assert!(
+            matches!(base.try_subtract(&F32(1.0)), Ok(F32(x)) if (x - 0.0_f32).abs() < f32::EPSILON )
+        );
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
@@ -657,6 +674,9 @@ mod tests {
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
 
+        assert!(
+            matches!(base.try_multiply(&F32(1.0)), Ok(F32(x)) if (x - 3.0_f32).abs() < f32::EPSILON )
+        );
         assert!(
             matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 3.0).abs() < f64::EPSILON )
         );
@@ -695,6 +715,9 @@ mod tests {
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
 
         assert!(
+            matches!(base.try_divide(&F32(1.0)), Ok(F32(x)) if (x - 6.0_f32).abs() < f32::EPSILON )
+        );
+        assert!(
             matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 6.0).abs() < f64::EPSILON )
         );
 
@@ -730,6 +753,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
 
+        assert!(matches!(base.try_modulo(&F32(1.0)), Ok(F32(x)) if (x).abs() < f32::EPSILON ));
         assert!(matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x).abs() < f64::EPSILON ));
         assert_eq!(
             base.try_modulo(&Decimal(Decimal::ONE)),

--- a/core/src/data/value/binary_op/mod.rs
+++ b/core/src/data/value/binary_op/mod.rs
@@ -1,6 +1,7 @@
 use crate::{prelude::Value, result::Result};
 
 mod decimal;
+mod f32;
 mod f64;
 mod i128;
 mod i16;

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -23,6 +23,7 @@ impl From<&Value> for String {
             Value::I32(value) => value.to_string(),
             Value::I64(value) => value.to_string(),
             Value::I128(value) => value.to_string(),
+            Value::F32(value) => value.to_string(),
             Value::F64(value) => value.to_string(),
             Value::Date(value) => value.to_string(),
             Value::Timestamp(value) => value.to_string(),
@@ -77,6 +78,15 @@ impl TryFrom<&Value> for bool {
                 0 => false,
                 _ => return Err(ValueError::ImpossibleCast.into()),
             },
+            Value::F32(value) => {
+                if value.eq(&1.0_f32) {
+                    true
+                } else if value.eq(&0.0_f32) {
+                    false
+                } else {
+                    return Err(ValueError::ImpossibleCast.into());
+                }
+            }
             Value::F64(value) => {
                 if value.eq(&1.0) {
                     true
@@ -130,6 +140,7 @@ impl TryFrom<&Value> for i8 {
             Value::I32(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
+            Value::F32(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i8>()
@@ -165,6 +176,7 @@ impl TryFrom<&Value> for i16 {
             Value::I32(value) => *value as i16,
             Value::I64(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
+            Value::F32(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i16>()
@@ -200,6 +212,7 @@ impl TryFrom<&Value> for i32 {
             Value::I32(value) => *value,
             Value::I64(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
+            Value::F32(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i32>()
@@ -235,6 +248,7 @@ impl TryFrom<&Value> for i64 {
             Value::I32(value) => *value as i64,
             Value::I64(value) => *value,
             Value::I128(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
+            Value::F32(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i64>()
@@ -270,11 +284,48 @@ impl TryFrom<&Value> for i128 {
             Value::I32(value) => *value as i128,
             Value::I64(value) => *value as i128,
             Value::I128(value) => *value,
+            Value::F32(value) => value.to_i128().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i128().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i128>()
                 .map_err(|_| ValueError::ImpossibleCast)?,
             Value::Decimal(value) => value.to_i128().ok_or(ValueError::ImpossibleCast)?,
+            Value::Date(_)
+            | Value::Timestamp(_)
+            | Value::Time(_)
+            | Value::Interval(_)
+            | Value::Uuid(_)
+            | Value::Map(_)
+            | Value::List(_)
+            | Value::Bytea(_)
+            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+        })
+    }
+}
+
+impl TryFrom<&Value> for f32 {
+    type Error = Error;
+
+    fn try_from(v: &Value) -> Result<f32> {
+        Ok(match v {
+            Value::Bool(value) => {
+                if *value {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            Value::I8(value) => *value as f32,
+            Value::I16(value) => *value as f32,
+            Value::I32(value) => value.to_f32().ok_or(ValueError::ImpossibleCast)?,
+            Value::I64(value) => value.to_f32().ok_or(ValueError::ImpossibleCast)?,
+            Value::I128(value) => *value as f32,
+            Value::F32(value) => *value,
+            Value::F64(value) => *value as f32,
+            Value::Str(value) => value
+                .parse::<f32>()
+                .map_err(|_| ValueError::ImpossibleCast)?,
+            Value::Decimal(value) => value.to_f32().ok_or(ValueError::ImpossibleCast)?,
             Value::Date(_)
             | Value::Timestamp(_)
             | Value::Time(_)
@@ -305,6 +356,7 @@ impl TryFrom<&Value> for f64 {
             Value::I32(value) => value.to_f64().ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => value.to_f64().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => *value as f64,
+            Value::F32(value) => *value as f64,
             Value::F64(value) => *value,
             Value::Str(value) => value
                 .parse::<f64>()
@@ -340,6 +392,7 @@ impl TryFrom<&Value> for Decimal {
             Value::I32(value) => Decimal::from_i32(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => Decimal::from_i64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => Decimal::from_i128(*value).ok_or(ValueError::ImpossibleCast)?,
+            Value::F32(value) => Decimal::from_f32(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => Decimal::from_f64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => {
                 Decimal::from_str(value).map_err(|_| ValueError::ImpossibleCast)?
@@ -463,6 +516,7 @@ mod tests {
         test!(Value::I32(122), "122");
         test!(Value::I64(1234567890), "1234567890");
         test!(Value::I128(1234567890), "1234567890");
+        test!(Value::F32(123456.1_f32), "123456.1");
         test!(Value::F64(1234567890.0987), "1234567890.0987");
         test!(Value::Date(date(2021, 11, 20)), "2021-11-20");
         test!(
@@ -505,6 +559,10 @@ mod tests {
         test!(Value::I64(0), Ok(false));
         test!(Value::I128(1), Ok(true));
         test!(Value::I128(0), Ok(false));
+
+        test!(Value::F32(1.0_f32), Ok(true));
+        test!(Value::F32(0.0_f32), Ok(false));
+        test!(Value::F32(2.0_f32), Err(ValueError::ImpossibleCast.into()));
 
         test!(Value::F64(1.0), Ok(true));
         test!(Value::F64(0.0), Ok(false));
@@ -574,6 +632,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::F32(122.0_f32), Ok(122));
         test!(Value::F64(122.0), Ok(122));
         test!(Value::F64(122.9), Ok(122));
         test!(Value::Str("122".to_owned()), Ok(122));
@@ -613,6 +672,10 @@ mod tests {
         test!(Value::I32(128), Err(ValueError::ImpossibleCast.into()));
         test!(Value::I64(128), Err(ValueError::ImpossibleCast.into()));
         test!(Value::I128(128), Err(ValueError::ImpossibleCast.into()));
+        test!(
+            Value::F32(128.0_f32),
+            Err(ValueError::ImpossibleCast.into())
+        );
         test!(Value::F64(128.0), Err(ValueError::ImpossibleCast.into()));
     }
 
@@ -637,6 +700,8 @@ mod tests {
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
         test!(Value::I64(122), Ok(122));
+        test!(Value::F32(122.0_f32), Ok(122));
+        test!(Value::F32(122.1_f32), Ok(122));
         test!(Value::F64(122.0), Ok(122));
         test!(Value::F64(122.1), Ok(122));
         test!(Value::Str("122".to_owned()), Ok(122));
@@ -693,6 +758,8 @@ mod tests {
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
+        test!(Value::F32(1234567890.0_f32), Ok(1234567890.0_f32 as i32));
+        test!(Value::F32(1234567890.1_f32), Ok(1234567890.1_f32 as i32));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.1), Ok(1234567890));
         test!(Value::Str("1234567890".to_owned()), Ok(1234567890));
@@ -749,6 +816,8 @@ mod tests {
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
+        test!(Value::F32(1234567890.0_f32), Ok(1234567890.0_f32 as i64));
+        test!(Value::F32(1234567890.1_f32), Ok(1234567890.1_f32 as i64));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.1), Ok(1234567890));
         test!(Value::Str("1234567890".to_owned()), Ok(1234567890));
@@ -805,6 +874,8 @@ mod tests {
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
+        test!(Value::F32(1234567890.0_f32), Ok(1234567890.0_f32 as i128));
+        test!(Value::F32(1234567890.9_f32), Ok(1234567890.9_f32 as i128));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.9), Ok(1234567890));
         test!(Value::Str("1234567890".to_owned()), Ok(1234567890));
@@ -861,6 +932,7 @@ mod tests {
         test!(Value::I64(122), Ok(122.0));
         test!(Value::I128(122), Ok(122.0));
         test!(Value::I64(1234567890), Ok(1234567890.0));
+        test!(Value::F32(1234567890.1_f32), Ok(1234567890.1_f32 as f64));
         test!(Value::F64(1234567890.1), Ok(1234567890.1));
         test!(Value::Str("1234567890.1".to_owned()), Ok(1234567890.1));
         test!(

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -43,6 +43,7 @@ impl TryFrom<Value> for JsonValue {
             Value::I128(v) => JsonNumber::from_str(&v.to_string())
                 .map(JsonValue::Number)
                 .map_err(|_| ValueError::UnreachableJsonNumberParseFailure(v.to_string()).into()),
+            Value::F32(v) => Ok(JsonValue::Number(JsonNumber::from_f64(v as f64).unwrap())),
             Value::F64(v) => Ok(v.into()),
             Value::Decimal(v) => JsonNumber::from_str(&v.to_string())
                 .map(JsonValue::Number)

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -120,6 +120,7 @@ impl Value {
             Value::I32(_) => Some(DataType::Int32),
             Value::I64(_) => Some(DataType::Int),
             Value::I128(_) => Some(DataType::Int128),
+            Value::F32(_) => Some(DataType::Float32),
             Value::F64(_) => Some(DataType::Float),
             Value::Decimal(_) => Some(DataType::Decimal),
             Value::Bool(_) => Some(DataType::Boolean),


### PR DESCRIPTION
## Work
Implementation of issue [#623](https://github.com/gluesql/gluesql/issues/623)

## Need your help:  
There are some loss of information while casting, which is expected behavior in Rust.  
Should we endure this issue?  
E.g., value `1234567890` is casted to `1234568000`.