### PR TITLE
Update aggregate structure

### DIFF
--- a/core/src/ast_builder/expr/aggregate.rs
+++ b/core/src/ast_builder/expr/aggregate.rs
@@ -1,7 +1,7 @@
 use {
     super::ExprNode,
     crate::{
-        ast::{Aggregate, CountArgExpr, Expr},
+        ast::{Aggregate, CountArgExpr},
         parse_sql::parse_expr,
         result::{Error, Result},
         translate::translate_expr,
@@ -53,46 +53,20 @@ impl TryFrom<CountArgExprNode> for CountArgExpr {
     }
 }
 
-impl TryFrom<AggregateNode> for Expr {
+impl TryFrom<AggregateNode> for Aggregate {
     type Error = Error;
 
     fn try_from(aggr_node: AggregateNode) -> Result<Self> {
         match aggr_node {
-            AggregateNode::Count(count_arg_expr_node) => count_arg_expr_node
-                .try_into()
-                .map(Aggregate::Count)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Sum(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Sum)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Min(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Min)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Max(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Max)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Avg(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Avg)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Variance(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Variance)
-                .map(Box::new)
-                .map(Expr::Aggregate),
-            AggregateNode::Stdev(expr_node) => expr_node
-                .try_into()
-                .map(Aggregate::Stdev)
-                .map(Box::new)
-                .map(Expr::Aggregate),
+            AggregateNode::Count(count_arg_expr_node) => {
+                count_arg_expr_node.try_into().map(Aggregate::Count)
+            }
+            AggregateNode::Sum(expr_node) => expr_node.try_into().map(Aggregate::Sum),
+            AggregateNode::Min(expr_node) => expr_node.try_into().map(Aggregate::Min),
+            AggregateNode::Max(expr_node) => expr_node.try_into().map(Aggregate::Max),
+            AggregateNode::Avg(expr_node) => expr_node.try_into().map(Aggregate::Avg),
+            AggregateNode::Variance(expr_node) => expr_node.try_into().map(Aggregate::Variance),
+            AggregateNode::Stdev(expr_node) => expr_node.try_into().map(Aggregate::Stdev),
         }
     }
 }

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -10,6 +10,8 @@ pub mod function;
 
 pub use nested::nested;
 
+use crate::ast::Aggregate;
+
 use {
     crate::{
         ast::{AstLiteral, BinaryOperator, DateTimeField, Expr, UnaryOperator},
@@ -102,7 +104,9 @@ impl TryFrom<ExprNode> for Expr {
             ExprNode::IsNotNull(expr) => Expr::try_from(*expr).map(Box::new).map(Expr::IsNotNull),
             ExprNode::Nested(expr) => Expr::try_from(*expr).map(Box::new).map(Expr::Nested),
             ExprNode::Function(func_expr) => Expr::try_from(*func_expr),
-            ExprNode::Aggregate(aggr_expr) => Expr::try_from(*aggr_expr),
+            ExprNode::Aggregate(aggr_expr) => Aggregate::try_from(*aggr_expr)
+                .map(Box::new)
+                .map(Expr::Aggregate),
         }
     }
 }

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -12,7 +12,7 @@ pub use nested::nested;
 
 use {
     crate::{
-        ast::{AstLiteral, BinaryOperator, DateTimeField, Expr, UnaryOperator, Aggregate},
+        ast::{Aggregate, AstLiteral, BinaryOperator, DateTimeField, Expr, UnaryOperator},
         parse_sql::parse_expr,
         result::{Error, Result},
         translate::translate_expr,

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -10,11 +10,9 @@ pub mod function;
 
 pub use nested::nested;
 
-use crate::ast::Aggregate;
-
 use {
     crate::{
-        ast::{AstLiteral, BinaryOperator, DateTimeField, Expr, UnaryOperator},
+        ast::{AstLiteral, BinaryOperator, DateTimeField, Expr, UnaryOperator, Aggregate},
         parse_sql::parse_expr,
         result::{Error, Result},
         translate::translate_expr,


### PR DESCRIPTION
## Description
1. previous structure of try_from function: converted `AggregateNode` to `Expr`
2. Intuitively, `AggregateNode` should be converted to enum `Aggregate`. changed try_from function `AggregateNode` =>`Aggregate` => `Expr`
