### PR TITLE
Support CTAV(Create Table As Values)

### DIFF
--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -1,9 +1,10 @@
-use crate::ast::{ColumnOption, ColumnOptionDef};
-
 use {
     super::{validate, AlterError},
     crate::{
-        ast::{ColumnDef, ObjectName, Query, SetExpr, TableFactor, Values},
+        ast::{
+            ColumnDef, ColumnOption, ColumnOptionDef, ObjectName, Query, SetExpr, TableFactor,
+            Values,
+        },
         data::{get_name, Schema, TableError},
         executor::{evaluate_stateless, select::select},
         prelude::{DataType, Value},

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -1,7 +1,7 @@
 use {
     super::{validate, AlterError},
     crate::{
-        ast::{ColumnDef, ObjectName, Query, SetExpr, TableFactor},
+        ast::{ColumnDef, ObjectName, Query, SetExpr, TableFactor, Values},
         data::{get_name, Schema, TableError},
         executor::select::select,
         result::{Error, MutResult, TrySelf},
@@ -41,6 +41,10 @@ pub async fn create_table<T: GStore + GStoreMut>(
                     return Err(Error::Table(TableError::Unreachable));
                 }
             }
+            Some(Query {
+                body: SetExpr::Values(Values(values_list)),
+                ..
+            }) => todo!(),
             _ => column_defs.to_vec(),
         };
 

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -50,49 +50,41 @@ pub async fn create_table<T: GStore + GStoreMut>(
                 }
                 SetExpr::Values(Values(values_list)) => {
                     let first_len = values_list[0].len();
+                    let init_types = iter::repeat(None)
+                        .take(first_len)
+                        .collect::<Vec<Option<DataType>>>();
                     let column_types = values_list
                         .iter()
-                        .fold_while(
-                            Ok(iter::repeat(None)
-                                .take(first_len)
-                                .collect::<Vec<Option<DataType>>>()),
-                            |column_types, exprs| {
-                                let result = column_types.and_then(
-                                    |column_types| -> Result<(Vec<Option<DataType>>, bool)> {
-                                        let column_types = column_types
-                                            .iter()
-                                            .zip(exprs.iter())
-                                            .map(|(column_type, expr)| -> Result<_> {
-                                                let column_type = match column_type {
-                                                    Some(data_type) => Some(data_type.to_owned()),
-                                                    None => {
-                                                        let value: Value =
-                                                            evaluate_stateless(None, expr)?
-                                                                .try_into()?;
+                        .fold_while(Ok(init_types), |column_types, exprs| {
+                            let result = column_types.and_then(
+                                |column_types| -> Result<(Vec<Option<DataType>>, bool)> {
+                                    let column_types = column_types
+                                        .iter()
+                                        .zip(exprs.iter())
+                                        .map(|(column_type, expr)| -> Result<_> {
+                                            let column_type = match column_type {
+                                                Some(data_type) => Some(data_type.to_owned()),
+                                                None => evaluate_stateless(None, expr)
+                                                    .and_then(Value::try_from)?
+                                                    .get_type(),
+                                            };
 
-                                                        value.get_type()
-                                                    }
-                                                };
+                                            Ok(column_type)
+                                        })
+                                        .collect::<Result<Vec<Option<DataType>>>>()?;
 
-                                                Ok(column_type)
-                                            })
-                                            .collect::<Result<Vec<Option<DataType>>>>()?;
+                                    let has_none = column_types.iter().any(Option::is_none);
 
-                                        let has_none = column_types
-                                            .iter()
-                                            .any(|column_type| column_type.is_none());
+                                    Ok((column_types, has_none))
+                                },
+                            );
 
-                                        Ok((column_types, has_none))
-                                    },
-                                );
-
-                                match result {
-                                    Ok((column_types, true)) => Continue(Ok(column_types)),
-                                    Ok((column_types, false)) => Done(Ok(column_types)),
-                                    Err(error) => Done(Err(error)),
-                                }
-                            },
-                        )
+                            match result {
+                                Ok((column_types, true)) => Continue(Ok(column_types)),
+                                Ok((column_types, false)) => Done(Ok(column_types)),
+                                Err(error) => Done(Err(error)),
+                            }
+                        })
                         .into_inner();
 
                     let column_defs = column_types?

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -12,7 +12,7 @@ use {
         translate::TranslateError,
     },
     serde::Serialize,
-    std::fmt::Debug,
+    std::{fmt::Debug, ops::ControlFlow},
     thiserror::Error as ThisError,
 };
 
@@ -143,5 +143,18 @@ mod stringify {
         S: Serializer,
     {
         serializer.collect_str(value)
+    }
+}
+
+pub trait IntoControlFlow<T> {
+    fn into_control_flow(self) -> ControlFlow<Result<T>, T>;
+}
+
+impl<T> IntoControlFlow<T> for Result<T> {
+    fn into_control_flow(self) -> ControlFlow<Result<T>, T> {
+        match self {
+            Ok(v) => ControlFlow::Continue(v),
+            e => ControlFlow::Break(e),
+        }
     }
 }

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -2,10 +2,8 @@ use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
-        data::RowError,
-        data::{Literal, ValueError},
-        prelude::DataType,
-        prelude::Value::*,
+        data::{Literal, RowError, ValueError},
+        prelude::{DataType, Payload, Value::*},
     },
     std::borrow::Cow,
 };
@@ -86,6 +84,20 @@ test_case!(values, async move {
                 literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
             }
             .into()),
+        ),
+        (
+            "CREATE TABLE Tab AS VALUES (1, 'a', True), (2, 'b', False)",
+            Ok(Payload::Create),
+        ),
+        (
+            "SELECT * FROM Tab",
+            Ok(Payload::Create),
+            // Ok(select!(
+            //     column1 | column2    | column3;
+            //     I64     | Str        | Boolean;
+            //     1         "a".into() | True;
+            //     2         "b".into() | False
+            // )),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -2,6 +2,7 @@ use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
+        ast::DataType::{Boolean, Int, Text},
         data::{Literal, RowError, ValueError},
         prelude::{DataType, Payload, Value::*},
     },
@@ -97,19 +98,12 @@ test_case!(values, async move {
                 I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
             )),
         ),
+        (
+            "SHOW COLUMNS FROM TableFromValues",
+            Ok(Payload::ShowColumns(vec![("column1".into(), Int.into()), ("column2".into(), Text), ("column3".into(), Boolean), ("column4".into(), Int), ("column5".into(), Text)])),
+        ),
     ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }
-
-    type_match!(
-        &[
-            DataType::Int,
-            DataType::Text,
-            DataType::Boolean,
-            DataType::Int,
-            DataType::Text,
-        ],
-        "SELECT * FROM TableFromValues"
-    );
 });

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -100,7 +100,7 @@ test_case!(values, async move {
         ),
         (
             "SHOW COLUMNS FROM TableFromValues",
-            Ok(Payload::ShowColumns(vec![("column1".into(), Int.into()), ("column2".into(), Text), ("column3".into(), Boolean), ("column4".into(), Int), ("column5".into(), Text)])),
+            Ok(Payload::ShowColumns(vec![("column1".into(), Int), ("column2".into(), Text), ("column3".into(), Boolean), ("column4".into(), Int), ("column5".into(), Text)])),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -91,13 +91,12 @@ test_case!(values, async move {
         ),
         (
             "SELECT * FROM Tab",
-            Ok(Payload::Create),
-            // Ok(select!(
-            //     column1 | column2    | column3;
-            //     I64     | Str        | Boolean;
-            //     1         "a".into() | True;
-            //     2         "b".into() | False
-            // )),
+            Ok(select!(
+                column1 | column2    | column3;
+                I64     | Str        | Bool;
+                1         "a".into()   true;
+                2         "b".into()   false
+            )),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -86,20 +86,32 @@ test_case!(values, async move {
             .into()),
         ),
         (
-            "CREATE TABLE Tab AS VALUES (1, 'a', True), (2, 'b', False)",
+            "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
             Ok(Payload::Create),
         ),
         (
-            "SELECT * FROM Tab",
-            Ok(select!(
-                column1 | column2    | column3;
-                I64     | Str        | Bool;
-                1         "a".into()   true;
-                2         "b".into()   false
+            "SELECT * FROM TableFromValues",
+            Ok(select_with_null!(
+                column1 | column2         | column3    | column4 | column5;
+                I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
+                I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
             )),
         ),
     ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }
+});
+
+test_case!(type_match, async {
+    type_match!(
+        &[
+            DataType::Int,
+            DataType::Text,
+            DataType::Boolean,
+            DataType::Int,
+            DataType::Text,
+        ],
+        "SELECT * FROM TableFromValues"
+    );
 });

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -100,7 +100,12 @@ test_case!(values, async move {
         ),
         (
             "SHOW COLUMNS FROM TableFromValues",
-            Ok(Payload::ShowColumns(vec![("column1".into(), Int), ("column2".into(), Text), ("column3".into(), Boolean), ("column4".into(), Int), ("column5".into(), Text)])),
+            Ok(Payload::ShowColumns(vec![
+                ("column1".into(), Int), 
+                ("column2".into(), Text), 
+                ("column3".into(), Boolean), 
+                ("column4".into(), Int), 
+                ("column5".into(), Text)])),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -101,9 +101,7 @@ test_case!(values, async move {
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }
-});
 
-test_case!(type_match, async {
     type_match!(
         &[
             DataType::Int,


### PR DESCRIPTION
This is subsequent PR of #659 
## Goal
### Like Below, we will be able to create table with `Values List` !
```sql
postgres=# CREATE TABLE gluesql AS VALUES (1, null, TRUE, null), (2, 'b', FALSE, null);
SELECT 2
postgres=# select table_name, column_name, data_type from information_schema.columns where table_name = 'gluesql';
 table_name | column_name | data_type
------------+-------------+-----------
 gluesql    | column1     | integer
 gluesql    | column2     | text
 gluesql    | column3     | boolean
 gluesql    | column4     | text
```

## Todo
- [x] Create column names
Currently `CTAV` command runs with some bug it doesn't have column names, column types
```sql
gluesql> CREATE TABLE gluesql AS VALUES (1, null, TRUE, null), (2, 'b', FALSE, null);
gluesql> SELECT * FROM gluesql;
╭─────────────────────────╮
│                         │
╞═════════════════════════╡
│ 1   NULL   TRUE    NULL │
│ 2   b      FALSE   NULL │
╰─────────────────────────╯
```
- [x] Create column types
To create column types, we should know explicit type of all columns.
If all values are NULL in a specific column, we need a policy to get explicit type.
Note the last line of postgres example.
They converted NULL as TEXT
```sql
 gluesql    | column4     | text
```
  - [x] Convert NULL as TEXT after evaluating all Values