### PR TITLE
Draft: Implement ast_builder Select::Order_by

### DIFF
--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -2,6 +2,8 @@ mod delete;
 mod drop_table;
 mod expr;
 mod expr_list;
+mod order_by_expr;
+mod order_by_expr_list;
 mod select;
 mod select_item;
 mod select_item_list;
@@ -12,9 +14,11 @@ pub use {
     delete::DeleteNode,
     drop_table::DropTableNode,
     expr_list::ExprList,
+    order_by_expr::OrderByExprNode,
+    order_by_expr_list::OrderByExprList,
     select::{
         GroupByNode, HavingNode, LimitNode, LimitOffsetNode, OffsetLimitNode, OffsetNode,
-        ProjectNode, SelectNode,
+        OrderByNode, ProjectNode, SelectNode,
     },
     select_item::SelectItemNode,
     select_item_list::SelectItemList,

--- a/core/src/ast_builder/order_by_expr.rs
+++ b/core/src/ast_builder/order_by_expr.rs
@@ -1,0 +1,55 @@
+use {
+    super::ExprNode,
+    crate::{
+        ast::{Expr, OrderByExpr},
+        parse_sql::parse_order_by_expr,
+        result::{Error, Result},
+        translate::translate_order_by_expr,
+    },
+};
+
+#[derive(Clone)]
+pub enum OrderByExprNode {
+    OrderByExpr(OrderByExpr),
+    Expr(ExprNode),
+    Text(String),
+}
+
+impl From<OrderByExpr> for OrderByExprNode {
+    fn from(order_item: OrderByExpr) -> Self {
+        Self::OrderByExpr(order_item)
+    }
+}
+
+impl From<ExprNode> for OrderByExprNode {
+    fn from(expr_node: ExprNode) -> Self {
+        Self::Expr(expr_node)
+    }
+}
+
+impl From<&str> for OrderByExprNode {
+    fn from(select_item: &str) -> Self {
+        Self::Text(select_item.to_owned())
+    }
+}
+
+impl TryFrom<OrderByExprNode> for OrderByExpr {
+    type Error = Error;
+
+    fn try_from(order_by_expr_node: OrderByExprNode) -> Result<Self> {
+        match order_by_expr_node {
+            OrderByExprNode::OrderByExpr(order_by_expr) => Ok(order_by_expr),
+            OrderByExprNode::Text(order_by_expr) => {
+                parse_order_by_expr(order_by_expr).and_then(|item| translate_order_by_expr(&item))
+            }
+            OrderByExprNode::Expr(expr_node) => {
+                let expr = Expr::try_from(expr_node)?;
+
+                Ok(OrderByExpr { expr, asc: None })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/core/src/ast_builder/order_by_expr_list.rs
+++ b/core/src/ast_builder/order_by_expr_list.rs
@@ -1,0 +1,56 @@
+use {
+    super::{ExprNode, OrderByExprNode},
+    crate::{
+        ast::OrderByExpr,
+        parse_sql::parse_order_by_exprs,
+        result::{Error, Result},
+        translate::translate_order_by_expr,
+    },
+};
+
+#[derive(Clone)]
+pub enum OrderByExprList {
+    Text(String),
+    OrderByExprs(Vec<OrderByExprNode>),
+}
+
+impl From<&str> for OrderByExprList {
+    fn from(exprs: &str) -> Self {
+        OrderByExprList::Text(exprs.to_owned())
+    }
+}
+
+impl From<Vec<&str>> for OrderByExprList {
+    fn from(exprs: Vec<&str>) -> Self {
+        OrderByExprList::OrderByExprs(exprs.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<ExprNode> for OrderByExprList {
+    fn from(expr_node: ExprNode) -> Self {
+        OrderByExprList::OrderByExprs(vec![expr_node.into()])
+    }
+}
+
+impl From<Vec<ExprNode>> for OrderByExprList {
+    fn from(expr_nodes: Vec<ExprNode>) -> Self {
+        OrderByExprList::OrderByExprs(expr_nodes.into_iter().map(Into::into).collect())
+    }
+}
+
+impl TryFrom<OrderByExprList> for Vec<OrderByExpr> {
+    type Error = Error;
+
+    fn try_from(order_by_exprs: OrderByExprList) -> Result<Self> {
+        match order_by_exprs {
+            OrderByExprList::Text(exprs) => parse_order_by_exprs(exprs)?
+                .iter()
+                .map(translate_order_by_expr)
+                .collect::<Result<Vec<_>>>(),
+            OrderByExprList::OrderByExprs(exprs) => exprs
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>>>(),
+        }
+    }
+}

--- a/core/src/ast_builder/select/having.rs
+++ b/core/src/ast_builder/select/having.rs
@@ -1,3 +1,7 @@
+use crate::ast_builder::OrderByExprList;
+
+use super::OrderByNode;
+
 use {
     super::{NodeData, Prebuild},
     crate::{
@@ -46,6 +50,10 @@ impl HavingNode {
 
     pub fn limit<T: Into<ExprNode>>(self, expr: T) -> LimitNode {
         LimitNode::new(self, expr)
+    }
+
+    pub fn order_by<T: Into<OrderByExprList>>(self, expr_list: T) -> OrderByNode {
+        OrderByNode::new(self, expr_list)
     }
 
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {

--- a/core/src/ast_builder/select/limit.rs
+++ b/core/src/ast_builder/select/limit.rs
@@ -1,3 +1,5 @@
+use super::OrderByNode;
+
 use {
     super::{NodeData, Prebuild},
     crate::{
@@ -15,6 +17,7 @@ pub enum PrevNode {
     Select(SelectNode),
     GroupBy(GroupByNode),
     Having(HavingNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -23,6 +26,7 @@ impl Prebuild for PrevNode {
             Self::Select(node) => node.prebuild(),
             Self::GroupBy(node) => node.prebuild(),
             Self::Having(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -42,6 +46,12 @@ impl From<GroupByNode> for PrevNode {
 impl From<HavingNode> for PrevNode {
     fn from(node: HavingNode) -> Self {
         PrevNode::Having(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 
@@ -66,6 +76,8 @@ impl LimitNode {
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
         ProjectNode::new(self, select_items)
     }
+
+    // pub fn order_by<T: Into<>>(self, )
 
     pub fn build(self) -> Result<Statement> {
         self.prebuild().map(NodeData::build_stmt)

--- a/core/src/ast_builder/select/mod.rs
+++ b/core/src/ast_builder/select/mod.rs
@@ -4,16 +4,18 @@ mod limit;
 mod limit_offset;
 mod offset;
 mod offset_limit;
+mod order_by;
 mod project;
 mod root;
 
 pub use {
     group_by::GroupByNode, having::HavingNode, limit::LimitNode, limit_offset::LimitOffsetNode,
-    offset::OffsetNode, offset_limit::OffsetLimitNode, project::ProjectNode, root::SelectNode,
+    offset::OffsetNode, offset_limit::OffsetLimitNode, order_by::OrderByNode, project::ProjectNode,
+    root::SelectNode,
 };
 
 use crate::{
-    ast::{Expr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins},
+    ast::{Expr, OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins},
     result::Result,
 };
 
@@ -31,6 +33,7 @@ struct NodeData {
     pub having: Option<Expr>,
     pub limit: Option<Expr>,
     pub offset: Option<Expr>,
+    pub order_by: Vec<OrderByExpr>,
 }
 
 impl NodeData {
@@ -43,6 +46,7 @@ impl NodeData {
             having,
             offset,
             limit,
+            order_by,
         } = self;
 
         let select = Select {
@@ -51,7 +55,7 @@ impl NodeData {
             selection,
             group_by,
             having,
-            order_by: vec![],
+            order_by,
         };
 
         let query = Query {

--- a/core/src/ast_builder/select/offset.rs
+++ b/core/src/ast_builder/select/offset.rs
@@ -1,3 +1,5 @@
+use super::OrderByNode;
+
 use {
     super::{NodeData, Prebuild},
     crate::{
@@ -15,6 +17,7 @@ pub enum PrevNode {
     Select(SelectNode),
     GroupBy(GroupByNode),
     Having(HavingNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -23,6 +26,7 @@ impl Prebuild for PrevNode {
             Self::Select(node) => node.prebuild(),
             Self::GroupBy(node) => node.prebuild(),
             Self::Having(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -42,6 +46,12 @@ impl From<GroupByNode> for PrevNode {
 impl From<HavingNode> for PrevNode {
     fn from(node: HavingNode) -> Self {
         PrevNode::Having(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -80,7 +80,7 @@ impl Prebuild for OrderByNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{col, table, test, text};
+    use crate::ast_builder::{table, test};
 
     #[test]
     fn order_by() {

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -80,7 +80,7 @@ impl Prebuild for OrderByNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{table, test};
+    use crate::ast_builder::{col, table, test, text};
 
     #[test]
     fn order_by() {
@@ -111,9 +111,9 @@ mod tests {
 
         let actual = table("Bar")
             .select()
-            .order_by(vec!["name asc", "id desc"])
+            .order_by(vec!["name asc", "id desc", "country"])
             .build();
-        let expected = "SELECT * FROM Bar ORDER BY name asc, id desc";
+        let expected = "SELECT * FROM Bar ORDER BY name asc, id desc, country";
         test(actual, expected);
     }
 }

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -1,24 +1,21 @@
 use {
     super::{NodeData, Prebuild},
-    crate::{
-        ast::Statement,
-        ast_builder::{
-            ExprList, ExprNode, HavingNode, LimitNode, OffsetNode, OrderByExprList, OrderByNode,
-            ProjectNode, SelectItemList, SelectNode,
-        },
-        result::Result,
-    },
+    crate::{ast::Statement, ast_builder::*, result::Result},
 };
 
 #[derive(Clone)]
 pub enum PrevNode {
     Select(SelectNode),
+    Having(HavingNode),
+    GroupBy(GroupByNode),
 }
 
 impl Prebuild for PrevNode {
     fn prebuild(self) -> Result<NodeData> {
         match self {
             Self::Select(node) => node.prebuild(),
+            Self::Having(node) => node.prebuild(),
+            Self::GroupBy(node) => node.prebuild(),
         }
     }
 }
@@ -29,22 +26,30 @@ impl From<SelectNode> for PrevNode {
     }
 }
 
-#[derive(Clone)]
-pub struct GroupByNode {
-    prev_node: PrevNode,
-    expr_list: ExprList,
+impl From<HavingNode> for PrevNode {
+    fn from(node: HavingNode) -> Self {
+        PrevNode::Having(node)
+    }
 }
 
-impl GroupByNode {
-    pub fn new<N: Into<PrevNode>, T: Into<ExprList>>(prev_node: N, expr_list: T) -> Self {
+impl From<GroupByNode> for PrevNode {
+    fn from(node: GroupByNode) -> Self {
+        PrevNode::GroupBy(node)
+    }
+}
+
+#[derive(Clone)]
+pub struct OrderByNode {
+    prev_node: PrevNode,
+    expr_list: OrderByExprList,
+}
+
+impl OrderByNode {
+    pub fn new<N: Into<PrevNode>, T: Into<OrderByExprList>>(prev_node: N, expr_list: T) -> Self {
         Self {
             prev_node: prev_node.into(),
             expr_list: expr_list.into(),
         }
-    }
-
-    pub fn having<T: Into<ExprNode>>(self, expr: T) -> HavingNode {
-        HavingNode::new(self, expr)
     }
 
     pub fn offset<T: Into<ExprNode>>(self, expr: T) -> OffsetNode {
@@ -53,10 +58,6 @@ impl GroupByNode {
 
     pub fn limit<T: Into<ExprNode>>(self, expr: T) -> LimitNode {
         LimitNode::new(self, expr)
-    }
-
-    pub fn order_by<T: Into<OrderByExprList>>(self, expr_list: T) -> OrderByNode {
-        OrderByNode::new(self, expr_list)
     }
 
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
@@ -68,10 +69,10 @@ impl GroupByNode {
     }
 }
 
-impl Prebuild for GroupByNode {
+impl Prebuild for OrderByNode {
     fn prebuild(self) -> Result<NodeData> {
         let mut select_data = self.prev_node.prebuild()?;
-        select_data.group_by = self.expr_list.try_into()?;
+        select_data.order_by = self.expr_list.try_into()?;
 
         Ok(select_data)
     }
@@ -79,42 +80,40 @@ impl Prebuild for GroupByNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{col, table, test};
+    use crate::ast_builder::{table, test};
 
     #[test]
-    fn group_by() {
+    fn order_by() {
+        let actual = table("Foo").select().order_by(vec!["name asc"]).build();
+        let expected = "
+            SELECT * FROM Foo
+            ORDER BY name ASC
+        ";
+        test(actual, expected);
+
+        let actual = table("Foo")
+            .select()
+            .group_by("city")
+            .having("COUNT(name) < 100")
+            .order_by(vec!["name asc"])
+            .limit(3)
+            .offset(2)
+            .build();
+        let expected = "
+            SELECT * FROM Foo
+            GROUP BY city
+            HAVING COUNT(name) < 100
+            ORDER BY name ASC
+            LIMIT 3
+            OFFSET 2
+        ";
+        test(actual, expected);
+
         let actual = table("Bar")
             .select()
-            .filter(col("id").is_null())
-            .group_by("id, (a + name)")
+            .order_by(vec!["name asc", "id desc"])
             .build();
-        let expected = "
-            SELECT * FROM Bar
-            WHERE id IS NULL
-            GROUP BY id, (a + name)
-        ";
-        test(actual, expected);
-
-        let actual = table("Foo")
-            .select()
-            .filter("name IS NOT NULL")
-            .group_by(vec![col("id"), col("a").add(col("name"))])
-            .build();
-        let expected = "
-            SELECT * FROM Foo
-            WHERE name IS NOT NULL
-            GROUP BY id, a + name
-        ";
-        test(actual, expected);
-
-        let actual = table("Foo")
-            .select()
-            .group_by(vec!["id", "a + name"])
-            .build();
-        let expected = "
-            SELECT * FROM Foo
-            GROUP BY id, a + name
-        ";
+        let expected = "SELECT * FROM Bar ORDER BY name asc, id desc";
         test(actual, expected);
     }
 }

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -1,3 +1,5 @@
+use super::OrderByNode;
+
 use {
     super::{NodeData, Prebuild},
     crate::{
@@ -19,6 +21,7 @@ pub enum PrevNode {
     LimitOffset(LimitOffsetNode),
     Offset(OffsetNode),
     OffsetLimit(OffsetLimitNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -31,6 +34,7 @@ impl Prebuild for PrevNode {
             Self::LimitOffset(node) => node.prebuild(),
             Self::Offset(node) => node.prebuild(),
             Self::OffsetLimit(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -74,6 +78,12 @@ impl From<OffsetNode> for PrevNode {
 impl From<OffsetLimitNode> for PrevNode {
     fn from(node: OffsetLimitNode) -> Self {
         PrevNode::OffsetLimit(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -3,7 +3,8 @@ use {
     crate::{
         ast::{Expr, ObjectName, SelectItem, Statement, TableFactor, TableWithJoins},
         ast_builder::{
-            ExprList, ExprNode, GroupByNode, LimitNode, OffsetNode, ProjectNode, SelectItemList,
+            ExprList, ExprNode, GroupByNode, LimitNode, OffsetNode, OrderByExprList, OrderByNode,
+            ProjectNode, SelectItemList,
         },
         result::Result,
     },
@@ -49,6 +50,10 @@ impl SelectNode {
         ProjectNode::new(self, select_items)
     }
 
+    pub fn order_by<T: Into<OrderByExprList>>(self, order_list: T) -> OrderByNode {
+        OrderByNode::new(self, order_list)
+    }
+
     pub fn build(self) -> Result<Statement> {
         self.prebuild().map(NodeData::build_stmt)
     }
@@ -74,6 +79,7 @@ impl Prebuild for SelectNode {
             from,
             selection,
             group_by: vec![],
+            order_by: vec![],
             having: None,
             offset: None,
             limit: None,
@@ -116,6 +122,10 @@ mod tests {
             })
             .build();
         let expected = "SELECT * FROM Foo WHERE col1 > col2";
+        test(actual, expected);
+
+        let actual = table("Foo").select().group_by("Country, Age").build();
+        let expected = "SELECT * FROM Foo GROUP BY Country, Age";
         test(actual, expected);
     }
 }

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -2,8 +2,8 @@ use {
     crate::result::{Error, Result},
     sqlparser::{
         ast::{
-            Expr as SqlExpr, Query as SqlQuery, SelectItem as SqlSelectItem,
-            Statement as SqlStatement,
+            Expr as SqlExpr, OrderByExpr as SqlOrderByExpr, Query as SqlQuery,
+            SelectItem as SqlSelectItem, Statement as SqlStatement,
         },
         dialect::GenericDialect,
         parser::Parser,
@@ -64,6 +64,28 @@ pub fn parse_select_items<Sql: AsRef<str>>(sql_select_items: Sql) -> Result<Vec<
 
     Parser::new(tokens, &DIALECT)
         .parse_comma_separated(Parser::parse_select_item)
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))
+}
+
+pub fn parse_order_by_expr<Sql: AsRef<str>>(sql_orderby_expr: Sql) -> Result<SqlOrderByExpr> {
+    let tokens = Tokenizer::new(&DIALECT, sql_orderby_expr.as_ref())
+        .tokenize()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
+
+    Parser::new(tokens, &DIALECT)
+        .parse_order_by_expr()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))
+}
+
+pub fn parse_order_by_exprs<Sql: AsRef<str>>(
+    sql_orderby_exprs: Sql,
+) -> Result<Vec<SqlOrderByExpr>> {
+    let tokens = Tokenizer::new(&DIALECT, sql_orderby_exprs.as_ref())
+        .tokenize()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
+
+    Parser::new(tokens, &DIALECT)
+        .parse_comma_separated(Parser::parse_order_by_expr)
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 


### PR DESCRIPTION
## Description
Implementation of [#696](https://github.com/gluesql/gluesql/issues/696)

## Review Required:
- [ ] FSM structure
  - Currently, fsm is structure as:
  - {Select, Having, GroupBy} -> {OrderBy} -> {Offset, Limit, Project}

## Remaining Works:  
from Issue 696
- [ ] Support In Sub query Expression
- [ ] Support null first