### PR TITLE
Remove clippy warning in mac os 

### DIFF
--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -424,10 +424,10 @@ mod timeout_test {
 
     use crate::PATH_PREFIX;
 
-    pub const TX_TIMEOUT: Option<u128> = Some(200);
-    pub const TX_SLEEP_TICK: Duration = Duration::from_millis(201);
+    const TX_TIMEOUT: Option<u128> = Some(200);
+    const TX_SLEEP_TICK: Duration = Duration::from_millis(201);
 
-    pub fn sleep() {
+    fn sleep() {
         std::thread::sleep(TX_SLEEP_TICK);
     }
 

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -409,7 +409,7 @@ async fn sled_transaction_gc() {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-mod timeout_test {
+mod timeout_tests {
     use {
         gluesql_core::{
             executor::FetchError,

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -431,9 +431,8 @@ mod timeout_test {
         std::thread::sleep(TX_SLEEP_TICK);
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     #[tokio::test]
-    pub async fn sled_transaction_timeout_store() {
+    async fn sled_transaction_timeout_store() {
         let path = &format!("{}/transaction_timeout_store", PATH_PREFIX);
         fs::remove_dir_all(path).unwrap_or(());
 

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -15,7 +15,7 @@ use {
     gluesql_sled_storage::{self, SledStorage, State},
     std::{
         fs,
-        time::{SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     },
     test_suite::*,
 };
@@ -410,19 +410,7 @@ async fn sled_transaction_gc() {
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 mod timeout_tests {
-    use {
-        gluesql_core::{
-            executor::FetchError,
-            prelude::{Glue, Value::*},
-            result::Error,
-            store::StoreMut,
-        },
-        gluesql_sled_storage::SledStorage,
-        std::{fs, time::Duration},
-        test_suite::*,
-    };
-
-    use crate::PATH_PREFIX;
+    use super::*;
 
     const TX_TIMEOUT: Option<u128> = Some(200);
     const TX_SLEEP_TICK: Duration = Duration::from_millis(201);


### PR DESCRIPTION
## Description
As @ever0de pointed out, currently `cargo clippy` yields warning in mac os machine.
To resolve it, I made a small module named `timeout_test` to mark configuration easily - 