### PR TITLE
Remove unnecessary `Box`

### DIFF
--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -28,7 +28,7 @@ pub enum Statement {
     ShowColumns {
         table_name: ObjectName,
     },
-    /// SELECT
+    /// SELECT, VALUES
     Query(Query),
     /// INSERT
     Insert {

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -29,7 +29,7 @@ pub enum Statement {
         table_name: ObjectName,
     },
     /// SELECT
-    Query(Box<Query>),
+    Query(Query),
     /// INSERT
     Insert {
         /// TABLE
@@ -37,7 +37,7 @@ pub enum Statement {
         /// COLUMNS
         columns: Vec<String>,
         /// A SQL query that specifies what to insert
-        source: Box<Query>,
+        source: Query,
     },
     /// UPDATE
     Update {

--- a/core/src/ast_builder/select/mod.rs
+++ b/core/src/ast_builder/select/mod.rs
@@ -60,6 +60,6 @@ impl NodeData {
             limit,
         };
 
-        Statement::Query(Box::new(query))
+        Statement::Query(query)
     }
 }

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -13,9 +13,7 @@ use {
 
 pub fn plan(schema_map: &HashMap<String, Schema>, statement: Statement) -> Result<Statement> {
     match statement {
-        Statement::Query(query) => plan_query(schema_map, *query)
-            .map(Box::new)
-            .map(Statement::Query),
+        Statement::Query(query) => plan_query(schema_map, query).map(Statement::Query),
         _ => Ok(statement),
     }
 }

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -16,9 +16,9 @@ pub fn plan(schema_map: &HashMap<String, Schema>, statement: Statement) -> State
 
     match statement {
         Statement::Query(query) => {
-            let query = planner.query(None, *query);
+            let query = planner.query(None, query);
 
-            Statement::Query(Box::new(query))
+            Statement::Query(query)
         }
         _ => statement,
     }
@@ -590,11 +590,11 @@ mod tests {
     }
 
     fn select(select: Select) -> Statement {
-        Statement::Query(Box::new(Query {
+        Statement::Query(Query {
             body: SetExpr::Select(Box::new(select)),
             limit: None,
             offset: None,
-        }))
+        })
     }
 
     #[test]

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -34,7 +34,7 @@ use {
 
 pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
     match sql_statement {
-        SqlStatement::Query(query) => translate_query(query).map(Box::new).map(Statement::Query),
+        SqlStatement::Query(query) => translate_query(query).map(Statement::Query),
         SqlStatement::Insert {
             table_name,
             columns,
@@ -43,7 +43,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
         } => Ok(Statement::Insert {
             table_name: translate_object_name(table_name),
             columns: translate_idents(columns),
-            source: translate_query(source).map(Box::new)?,
+            source: translate_query(source)?,
         }),
         SqlStatement::Update {
             table,


### PR DESCRIPTION
related <https://github.com/sqlparser-rs/sqlparser-rs/pull/556>

> Previously, Query variant in enum Statement seemed to be used recursively, but this is not the case now.