### PR TITLE
Replace bool::then to bool::then_some

### DIFF
--- a/core/src/executor/aggregate/mod.rs
+++ b/core/src/executor/aggregate/mod.rs
@@ -124,7 +124,7 @@ impl<'a> Aggregator<'a> {
                                 having,
                             )
                             .await
-                            .map(|pass| pass.then(|| (aggregated, next)))
+                            .map(|pass| pass.then_some((aggregated, next)))
                             .transpose()
                         }
                     }

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -68,7 +68,7 @@ pub fn evaluate_stateless<'a>(
 
                     eval(expr).map_or_else(
                         |error| Some(Err(error)),
-                        |evaluated| (target == &evaluated).then(|| Ok(!negated)),
+                        |evaluated| (target == &evaluated).then_some(Ok(!negated)),
                     )
                 })
                 .take(1)

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -53,7 +53,7 @@ pub async fn fetch<'a>(
 
                 check_expr(storage, Some(Rc::new(context)), None, expr)
                     .await
-                    .map(|pass| pass.then(|| (columns, key, row)))
+                    .map(|pass| pass.then_some((columns, key, row)))
             }
         });
 

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -268,7 +268,7 @@ impl<'a> JoinExecutor<'a> {
                     match where_clause {
                         Some(expr) => check_expr(storage, Some(filter_context), None, expr)
                             .await
-                            .map(|pass| pass.then(|| (hash_key, row))),
+                            .map(|pass| pass.then_some((hash_key, row))),
                         None => Ok(Some((hash_key, row))),
                     }
                 }

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -251,7 +251,7 @@ pub async fn select_with_labels<'a>(
             filter
                 .check(Rc::clone(&blend_context))
                 .await
-                .map(|pass| pass.then(|| blend_context))
+                .map(|pass| pass.then_some(blend_context))
         }
     });
 

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -388,7 +388,7 @@ fn search_index_op(
 ) -> Planned {
     if let Some(index_name) = indexes
         .find(left.as_ref())
-        .and_then(|index_name| is_stateless(right.as_ref()).then(|| index_name))
+        .and_then(|index_name| is_stateless(right.as_ref()).then_some(index_name))
     {
         Planned::IndexedExpr {
             index_name,
@@ -398,7 +398,7 @@ fn search_index_op(
         }
     } else if let Some(index_name) = indexes
         .find(right.as_ref())
-        .and_then(|index_name| is_stateless(left.as_ref()).then(|| index_name))
+        .and_then(|index_name| is_stateless(left.as_ref()).then_some(index_name))
     {
         Planned::IndexedExpr {
             index_name,

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -398,7 +398,7 @@ impl AlterTable for SledStorage {
                     .0
                     .into_iter()
                     .enumerate()
-                    .filter_map(|(i, v)| (i != column_index).then(|| v))
+                    .filter_map(|(i, v)| (i != column_index).then_some(v))
                     .collect());
 
                 let (snapshot, _) = snapshot.update(txid, row);
@@ -419,7 +419,7 @@ impl AlterTable for SledStorage {
             let column_defs = column_defs
                 .into_iter()
                 .enumerate()
-                .filter_map(|(i, v)| (i != column_index).then(|| v))
+                .filter_map(|(i, v)| (i != column_index).then_some(v))
                 .collect::<Vec<ColumnDef>>();
 
             let temp_key = key::temp_schema(txid, &table_name);

--- a/storages/sled-storage/src/snapshot.rs
+++ b/storages/sled-storage/src/snapshot.rs
@@ -71,7 +71,7 @@ impl<T: Clone> Snapshot<T> {
             })
             .collect::<Vec<_>>();
 
-        (!items.is_empty()).then(|| Snapshot(items))
+        (!items.is_empty()).then_some(Snapshot(items))
     }
 
     pub fn extract(self, txid: u64, lock_txid: Option<u64>) -> Option<T> {
@@ -132,6 +132,6 @@ impl<T: Clone> Snapshot<T> {
             })
             .collect::<Vec<_>>();
 
-        (!items.is_empty()).then(|| Self(items))
+        (!items.is_empty()).then_some(Self(items))
     }
 }


### PR DESCRIPTION
`bool::then_some` is now available in stable rust 1.62.
Replace some `bool::then` codes to `bool::then_some` which does not require closures

ref. https://doc.rust-lang.org/std/primitive.bool.html#method.then_some