### PR TITLE
Support `ORDER BY` clause in `VALUES list`

### DIFF
--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -6,6 +6,7 @@ use {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Query {
     pub body: SetExpr,
+    pub order_by: Vec<OrderByExpr>,
     pub limit: Option<Expr>,
     pub offset: Option<Expr>,
 }
@@ -24,7 +25,6 @@ pub struct Select {
     pub selection: Option<Expr>,
     pub group_by: Vec<Expr>,
     pub having: Option<Expr>,
-    pub order_by: Vec<OrderByExpr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/ast_builder/select/mod.rs
+++ b/core/src/ast_builder/select/mod.rs
@@ -13,7 +13,7 @@ pub use {
 };
 
 use crate::{
-    ast::{Expr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins},
+    ast::{Expr, OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins},
     result::Result,
 };
 
@@ -29,6 +29,7 @@ pub struct NodeData {
     pub selection: Option<Expr>,
     pub group_by: Vec<Expr>,
     pub having: Option<Expr>,
+    pub order_by: Vec<OrderByExpr>,
     pub limit: Option<Expr>,
     pub offset: Option<Expr>,
 }
@@ -41,6 +42,7 @@ impl NodeData {
             selection,
             group_by,
             having,
+            order_by,
             offset,
             limit,
         } = self;
@@ -51,11 +53,11 @@ impl NodeData {
             selection,
             group_by,
             having,
-            order_by: vec![],
         };
 
         Query {
             body: SetExpr::Select(Box::new(select)),
+            order_by,
             offset,
             limit,
         }

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -75,6 +75,7 @@ impl Prebuild for SelectNode {
             selection,
             group_by: vec![],
             having: None,
+            order_by: vec![],
             offset: None,
             limit: None,
         })

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -160,7 +160,7 @@ fn rows_from(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
 fn sort_stateless(
     rows: Vec<Result<Row>>,
     labels: &Vec<String>,
-    order_by: &Vec<OrderByExpr>,
+    order_by: &[OrderByExpr],
 ) -> Result<Vec<Result<Row>>> {
     let sorted = rows
         .into_iter()

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -111,7 +111,7 @@ pub fn get_labels<'a>(
         .collect::<Result<_>>()
 }
 
-fn into_rows(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
+fn rows_from(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
     let first_len = exprs_list[0].len();
     let labels = (1..=first_len)
         .into_iter()
@@ -237,7 +237,7 @@ pub async fn select_with_labels<'a>(
         SetExpr::Select(statement) => statement.as_ref(),
         SetExpr::Values(Values(values_list)) => {
             let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-            let (rows, labels) = into_rows(values_list);
+            let (rows, labels) = rows_from(values_list);
             let rows = sort_stateless(rows, &labels, &query.order_by)?;
             let rows = stream::iter(rows);
             let rows = limit.apply(rows);

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -26,7 +26,6 @@ use {
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
     iter_enum::Iterator,
     std::{
-        cmp::Ordering,
         iter::{self, once},
         rc::Rc,
     },
@@ -171,7 +170,7 @@ fn sort_stateless(
                     let context = row.map(|row| (labels.as_slice(), row));
                     let value: Value = evaluate_stateless(context, expr)?.try_into()?;
 
-                    Ok((value, asc))
+                    Ok((value, *asc))
                 })
                 .collect::<Result<Vec<_>>>();
 
@@ -179,37 +178,7 @@ fn sort_stateless(
         })
         .collect::<Result<Vec<_>>>()
         .map(Vector::from)?
-        .sort_by(|(values_a, _), (values_b, _)| {
-            let pairs = values_a
-                .iter()
-                .map(|(a, _)| a)
-                .zip(values_b.iter())
-                .map(|(a, (b, asc))| (a, b, asc.unwrap_or(true)));
-
-            for (value_a, value_b, asc) in pairs {
-                let apply_asc = |ord: Ordering| if asc { ord } else { ord.reverse() };
-
-                match (value_a, value_b) {
-                    (Value::Null, Value::Null) => {}
-                    (Value::Null, _) => {
-                        return apply_asc(Ordering::Greater);
-                    }
-                    (_, Value::Null) => {
-                        return apply_asc(Ordering::Less);
-                    }
-                    _ => {}
-                };
-
-                match value_a.partial_cmp(value_b) {
-                    Some(ord) if ord != Ordering::Equal => {
-                        return apply_asc(ord);
-                    }
-                    _ => {}
-                }
-            }
-
-            Ordering::Equal
-        })
+        .sort_by(|(values_a, _), (values_b, _)| Sort::sort_by(values_a, values_b))
         .into_iter()
         .map(|(_, row)| row)
         .collect::<Vec<_>>();

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -170,7 +170,6 @@ pub async fn select_with_labels<'a>(
         projection,
         group_by,
         having,
-        order_by,
     } = match &query.body {
         SetExpr::Select(statement) => statement.as_ref(),
         SetExpr::Values(Values(values_list)) => {
@@ -241,7 +240,7 @@ pub async fn select_with_labels<'a>(
         None,
     ));
     let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-    let sort = Sort::new(storage, filter_context, order_by);
+    let sort = Sort::new(storage, filter_context, &query.order_by);
 
     let rows = join.apply(rows).await?;
     let rows = rows.try_filter_map(move |blend_context| {

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -1,8 +1,6 @@
 mod blend;
 mod error;
 
-use std::cmp::Ordering;
-
 pub use error::SelectError;
 
 use {
@@ -28,6 +26,7 @@ use {
     futures::stream::{self, StreamExt, TryStream, TryStreamExt},
     iter_enum::Iterator,
     std::{
+        cmp::Ordering,
         iter::{self, once},
         rc::Rc,
     },
@@ -111,7 +110,7 @@ pub fn get_labels<'a>(
         .collect::<Result<_>>()
 }
 
-fn rows_from(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
+fn rows_with_labels(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>) {
     let first_len = exprs_list[0].len();
     let labels = (1..=first_len)
         .into_iter()
@@ -237,7 +236,7 @@ pub async fn select_with_labels<'a>(
         SetExpr::Select(statement) => statement.as_ref(),
         SetExpr::Values(Values(values_list)) => {
             let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-            let (rows, labels) = rows_from(values_list);
+            let (rows, labels) = rows_with_labels(values_list);
             let rows = sort_stateless(rows, &labels, &query.order_by)?;
             let rows = stream::iter(rows);
             let rows = limit.apply(rows);

--- a/core/src/executor/sort.rs
+++ b/core/src/executor/sort.rs
@@ -82,40 +82,45 @@ impl<'a> Sort<'a> {
             .try_collect::<Vec<_>>()
             .await
             .map(Vector::from)?
-            .sort_by(|(values_a, _, _), (values_b, _, _)| {
-                let pairs = values_a
-                    .iter()
-                    .map(|(a, _)| a)
-                    .zip(values_b.iter())
-                    .map(|(a, (b, asc))| (a, b, asc.unwrap_or(true)));
-
-                for (value_a, value_b, asc) in pairs {
-                    let apply_asc = |ord: Ordering| if asc { ord } else { ord.reverse() };
-
-                    match (value_a, value_b) {
-                        (Value::Null, Value::Null) => {}
-                        (Value::Null, _) => {
-                            return apply_asc(Ordering::Greater);
-                        }
-                        (_, Value::Null) => {
-                            return apply_asc(Ordering::Less);
-                        }
-                        _ => {}
-                    };
-
-                    match value_a.partial_cmp(value_b) {
-                        Some(ord) if ord != Ordering::Equal => {
-                            return apply_asc(ord);
-                        }
-                        _ => {}
-                    }
-                }
-
-                Ordering::Equal
-            })
+            .sort_by(|(values_a, _, _), (values_b, _, _)| Self::sort_by(values_a, values_b))
             .into_iter()
             .map(|(_, aggregated, blend_context)| Ok((aggregated, blend_context)));
 
         Ok(Box::pin(stream::iter(rows)))
+    }
+
+    pub fn sort_by(
+        values_a: &[(Value, Option<bool>)],
+        values_b: &[(Value, Option<bool>)],
+    ) -> Ordering {
+        let pairs = values_a
+            .iter()
+            .map(|(a, _)| a)
+            .zip(values_b.iter())
+            .map(|(a, (b, asc))| (a, b, asc.unwrap_or(true)));
+
+        for (value_a, value_b, asc) in pairs {
+            let apply_asc = |ord: Ordering| if asc { ord } else { ord.reverse() };
+
+            match (value_a, value_b) {
+                (Value::Null, Value::Null) => {}
+                (Value::Null, _) => {
+                    return apply_asc(Ordering::Greater);
+                }
+                (_, Value::Null) => {
+                    return apply_asc(Ordering::Less);
+                }
+                _ => {}
+            };
+
+            match value_a.partial_cmp(value_b) {
+                Some(ord) if ord != Ordering::Equal => {
+                    return apply_asc(ord);
+                }
+                _ => {}
+            }
+        }
+
+        Ordering::Equal
     }
 }

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -44,6 +44,7 @@ pub fn check_expr(context: Option<Rc<Context<'_>>>, expr: &Expr) -> bool {
 fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
     let Query {
         body,
+        order_by,
         limit,
         offset,
     } = query;
@@ -61,6 +62,15 @@ fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
         return false;
     }
 
+    let order_by = order_by
+        .iter()
+        .map(|order_by| &order_by.expr)
+        .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
+        .all(identity);
+    if !order_by {
+        return false;
+    }
+
     limit
         .iter()
         .chain(offset.iter())
@@ -75,7 +85,6 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
         selection,
         group_by,
         having,
-        order_by,
     } = select;
 
     if !projection
@@ -126,7 +135,6 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
         .iter()
         .chain(group_by.iter())
         .chain(having.iter())
-        .chain(order_by.iter().map(|order_by| &order_by.expr))
         .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
         .all(identity)
 }

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -43,7 +43,7 @@ impl<'a> Planner<'a> for JoinPlanner<'a> {
 
                 SetExpr::Select(Box::new(select))
             }
-            SetExpr::Values(_) => query.body,
+            SetExpr::Values(_) => body,
         };
 
         Query {

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -246,6 +246,7 @@ mod tests {
             body: SetExpr::Select(Box::new(select)),
             limit: None,
             offset: None,
+            order_by: Vec::new(),
         })
     }
 
@@ -279,7 +280,6 @@ mod tests {
             selection: None,
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "primary key in lhs:\n{sql}");
 
@@ -298,7 +298,6 @@ mod tests {
             selection: None,
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "primary key in rhs:\n{sql}");
 
@@ -317,7 +316,6 @@ mod tests {
             selection: Some(expr("True")),
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "AND binary op:\n{sql}");
 
@@ -342,7 +340,6 @@ mod tests {
             selection: Some(expr("name IS NOT NULL AND True")),
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "AND binary op 2:\n{sql}");
 
@@ -376,7 +373,6 @@ mod tests {
             selection: Some(expr("name IS NOT NULL AND (True)")),
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "AND binary op 3:\n{sql}");
     }
@@ -417,7 +413,6 @@ mod tests {
             selection: None,
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "basic inner join:\n{sql}");
 
@@ -444,7 +439,6 @@ mod tests {
             selection: Some(expr("User.id = Badge.user_id")),
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "join but no primary key:\n{sql}");
 
@@ -469,10 +463,10 @@ mod tests {
                     selection: None,
                     group_by: Vec::new(),
                     having: None,
-                    order_by: Vec::new(),
                 })),
                 limit: None,
                 offset: None,
+                order_by: Vec::new(),
             };
 
             select(Select {
@@ -492,7 +486,6 @@ mod tests {
                 }),
                 group_by: Vec::new(),
                 having: None,
-                order_by: Vec::new(),
             })
         };
         assert_eq!(actual, expected, "nested select:\n{sql}");
@@ -527,10 +520,10 @@ mod tests {
                     selection: None,
                     group_by: Vec::new(),
                     having: None,
-                    order_by: Vec::new(),
                 })),
                 limit: Some(expr("1")),
                 offset: None,
+                order_by: Vec::new(),
             };
 
             select(Select {
@@ -550,7 +543,6 @@ mod tests {
                 }),
                 group_by: Vec::new(),
                 having: None,
-                order_by: Vec::new(),
             })
         };
         assert_eq!(actual, expected, "name is not primary key:\n{sql}");
@@ -579,10 +571,10 @@ mod tests {
                     selection: Some(expr("id = id")),
                     group_by: Vec::new(),
                     having: None,
-                    order_by: Vec::new(),
                 })),
                 limit: None,
                 offset: None,
+                order_by: Vec::new(),
             };
 
             select(Select {
@@ -602,7 +594,6 @@ mod tests {
                 }),
                 group_by: Vec::new(),
                 having: None,
-                order_by: Vec::new(),
             })
         };
         assert_eq!(actual, expected, "ambiguous nested contexts:\n{sql}");
@@ -628,6 +619,7 @@ mod tests {
             ])),
             limit: None,
             offset: None,
+            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "values:\n{sql}");
 
@@ -646,7 +638,6 @@ mod tests {
             selection: Some(Expr::Nested(Box::new(expr("name")))),
             group_by: Vec::new(),
             having: None,
-            order_by: Vec::new(),
         });
         assert_eq!(actual, expected, "nested:\n{sql}");
     }

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -69,6 +69,7 @@ async fn scan_query(storage: &dyn Store, query: &Query) -> Result<Vec<Schema>> {
         body,
         limit,
         offset,
+        ..
     } = query;
 
     let schema_list = match body {
@@ -99,7 +100,6 @@ async fn scan_select(storage: &dyn Store, select: &Select) -> Result<Vec<Schema>
         selection,
         group_by,
         having,
-        order_by,
     } = select;
 
     let projection = stream::iter(projection)
@@ -116,11 +116,7 @@ async fn scan_select(storage: &dyn Store, select: &Select) -> Result<Vec<Schema>
 
     let from = scan_table_with_joins(storage, from).await?;
 
-    let exprs = selection
-        .iter()
-        .chain(group_by.iter())
-        .chain(having.iter())
-        .chain(order_by.iter().map(|order_by| &order_by.expr));
+    let exprs = selection.iter().chain(group_by.iter()).chain(having.iter());
 
     Ok(stream::iter(exprs)
         .then(|expr| scan_expr(storage, expr))

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -32,6 +32,15 @@ test_case!(values, async move {
             )),
         ),
         (
+            "VALUES (1, 'a'), (2, 'b') ORDER BY column1 DESC",
+            Ok(select!(
+                column1 | column2;
+                I64     | Str;
+                2         "b".to_owned();
+                1         "a".to_owned()
+            )),
+        ),
+        (
             "VALUES (1), (2) limit 1",
             Ok(select!(
                 column1;


### PR DESCRIPTION
This is subsequent PR of #648 
## Goal
- Support `ORDER BY` clause in `VALUES list`
```sql
gluesql> VALUES (1, 'a'), (2, 'b') ORDER BY column1 DESC;
 column1 | column2
---------+---------
       2 | b
       1 | a
```

## Todo
- [x] move order_by property from `select` to `query`
- [x] implement values-orderby
- [x] refactor implementation as sort_stateless() for future reuse 