### PR TITLE
Support `Derived VALUES`

### DIFF
--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -5,7 +5,7 @@ use {
             ColumnDef, Expr, IndexItem, Join, Query, Select, SetExpr, TableAlias, TableFactor,
             TableWithJoins, Values,
         },
-        data::{get_alias, get_index, get_name, Key, Row, TableError, Value},
+        data::{get_alias, get_index, get_name, Key, Row, Value},
         executor::select::{get_labels, select},
         result::{Error, Result},
         store::GStore,

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -164,7 +164,7 @@ pub async fn fetch_relation_columns(
 ) -> Result<Vec<String>> {
     match table_factor {
         TableFactor::Table { name, .. } => {
-            let table_name = get_name(&name)?;
+            let table_name = get_name(name)?;
 
             fetch_columns(storage, table_name).await
         }
@@ -198,19 +198,14 @@ pub async fn fetch_relation_columns(
                 let alias_len = columns.len();
                 let labels = (alias_len + 1..=width)
                     .into_iter()
-                    .map(|i| format!("column{}", i))
-                    .collect::<Vec<_>>();
+                    .map(|i| format!("column{}", i));
                 let labels = match alias_len > width {
                     true => {
                         return Err(
                             FetchError::TooManyColumnAliases(name.into(), width, alias_len).into(),
                         )
                     }
-                    false => columns
-                        .to_owned()
-                        .into_iter()
-                        .chain(labels.into_iter())
-                        .collect::<Vec<_>>(),
+                    false => columns.iter().cloned().chain(labels).collect::<Vec<_>>(),
                 };
 
                 Ok(labels)

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -194,19 +194,20 @@ pub async fn fetch_relation_columns(
                 Ok(labels)
             }
             SetExpr::Values(Values(values_list)) => {
-                let width = values_list[0].len();
+                let total_len = values_list[0].len();
                 let alias_len = columns.len();
-                let labels = (alias_len + 1..=width)
+                if alias_len > total_len {
+                    return Err(FetchError::TooManyColumnAliases(
+                        name.into(),
+                        total_len,
+                        alias_len,
+                    )
+                    .into());
+                }
+                let labels = (alias_len + 1..=total_len)
                     .into_iter()
                     .map(|i| format!("column{}", i));
-                let labels = match alias_len > width {
-                    true => {
-                        return Err(
-                            FetchError::TooManyColumnAliases(name.into(), width, alias_len).into(),
-                        )
-                    }
-                    false => columns.iter().cloned().chain(labels).collect::<Vec<_>>(),
-                };
+                let labels = columns.iter().cloned().chain(labels).collect::<Vec<_>>();
 
                 Ok(labels)
             }

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -13,134 +13,143 @@ use {
 
 test_case!(values, async move {
     let test_cases = vec![
-                (
-                    "VALUES (1), (2), (3)",
-                    Ok(select!(
-                        column1;
-                        I64;
-                        1;
-                        2;
-                        3
-                    )),
-                ),
-                (
-                    "VALUES (1, 'a'), (2, 'b')",
-                    Ok(select!(
-                        column1 | column2;
-                        I64     | Str;
-                        1         "a".to_owned();
-                        2         "b".to_owned()
-                    )),
-                ),
-                (
-                    "VALUES (1), (2) limit 1",
-                    Ok(select!(
-                        column1;
-                        I64;
-                        1
-                    )),
-                ),
-                (
-                    "VALUES (1), (2) offset 1",
-                    Ok(select!(
-                        column1;
-                        I64;
-                        2
-                    )),
-                ),
-                (
-                    "VALUES (1, NULL), (2, NULL)",
-                    Ok(select_with_null!(
-                        column1 | column2;
-                        I64(1)    Null;
-                        I64(2)    Null
-                    )),
-                ),
-                (
-                    "VALUES (1), (2, 'b')",
-                    Err(RowError::NumberOfValuesDifferent.into()),
-                ),
-                (
-                    "VALUES (1, 'a'), (2)",
-                    Err(RowError::NumberOfValuesDifferent.into()),
-                ),
-                (
-                    "VALUES (1, 'a'), (2, 3)",
-                    Err(ValueError::IncompatibleLiteralForDataType {
-                        data_type: DataType::Text,
-                        literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
-                    }
-                    .into()),
-                ),
-                (
-                    "VALUES (1, 'a'), ('b', 'c')",
-                    Err(ValueError::IncompatibleLiteralForDataType {
-                        data_type: DataType::Int,
-                        literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
-                    }
-                    .into()),
-                ),
-                (
-                    "VALUES (1, NULL), (2, 'a'), (3, 4)",
-                    Err(ValueError::IncompatibleLiteralForDataType {
-                        data_type: DataType::Text,
-                        literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
-                    }
-                    .into()),
-                ),
-                (
-                    "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
-                    Ok(Payload::Create),
-                ),
-                (
-                    "SELECT * FROM TableFromValues",
-                    Ok(select_with_null!(
-                        column1 | column2         | column3    | column4 | column5;
-                        I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
-                        I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
-                    )),
-                ),
-                (
-                    "SHOW COLUMNS FROM TableFromValues",
-                    Ok(Payload::ShowColumns(vec![
-                        ("column1".into(), Int),
-                        ("column2".into(), Text),
-                        ("column3".into(), Boolean),
-                        ("column4".into(), Int),
-                        ("column5".into(), Text)])),
+                    (
+                        "VALUES (1), (2), (3)",
+                        Ok(select!(
+                            column1;
+                            I64;
+                            1;
+                            2;
+                            3
+                        )),
                     ),
                     (
-                    "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
-                    Ok(select!(
-                        column1 | column2;
-                        I64     | Str;
-                        1         "a".to_owned();
-                        2         "b".to_owned()
-                    )),
-                ),
-                (
-                    "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
-                    Ok(select!(
-                        id      | name;
-                        I64     | Str;
-                        1         "a".to_owned();
-                        2         "b".to_owned()
-                    )),
-                ),
-    (
-                "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)",
-                Ok(select!(
-                    id      | name;
-                    I64     | Str;
-                    1         "a".to_owned();
-                    2         "b".to_owned()
-                )),
-            ),
-(
-            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
-            Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
-        ),
-            ];
+                        "VALUES (1, 'a'), (2, 'b')",
+                        Ok(select!(
+                            column1 | column2;
+                            I64     | Str;
+                            1         "a".to_owned();
+                            2         "b".to_owned()
+                        )),
+                    ),
+                    (
+                        "VALUES (1), (2) limit 1",
+                        Ok(select!(
+                            column1;
+                            I64;
+                            1
+                        )),
+                    ),
+                    (
+                        "VALUES (1), (2) offset 1",
+                        Ok(select!(
+                            column1;
+                            I64;
+                            2
+                        )),
+                    ),
+                    (
+                        "VALUES (1, NULL), (2, NULL)",
+                        Ok(select_with_null!(
+                            column1 | column2;
+                            I64(1)    Null;
+                            I64(2)    Null
+                        )),
+                    ),
+                    (
+                        "VALUES (1), (2, 'b')",
+                        Err(RowError::NumberOfValuesDifferent.into()),
+                    ),
+                    (
+                        "VALUES (1, 'a'), (2)",
+                        Err(RowError::NumberOfValuesDifferent.into()),
+                    ),
+                    (
+                        "VALUES (1, 'a'), (2, 3)",
+                        Err(ValueError::IncompatibleLiteralForDataType {
+                            data_type: DataType::Text,
+                            literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
+                        }
+                        .into()),
+                    ),
+                    (
+                        "VALUES (1, 'a'), ('b', 'c')",
+                        Err(ValueError::IncompatibleLiteralForDataType {
+                            data_type: DataType::Int,
+                            literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
+                        }
+                        .into()),
+                    ),
+                    (
+                        "VALUES (1, NULL), (2, 'a'), (3, 4)",
+                        Err(ValueError::IncompatibleLiteralForDataType {
+                            data_type: DataType::Text,
+                            literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
+                        }
+                        .into()),
+                    ),
+                    (
+                        "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
+                        Ok(Payload::Create),
+                    ),
+                    (
+                        "SELECT * FROM TableFromValues",
+                        Ok(select_with_null!(
+                            column1 | column2         | column3    | column4 | column5;
+                            I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
+                            I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
+                        )),
+                    ),
+                    (
+                        "SHOW COLUMNS FROM TableFromValues",
+                        Ok(Payload::ShowColumns(vec![
+                            ("column1".into(), Int),
+                            ("column2".into(), Text),
+                            ("column3".into(), Boolean),
+                            ("column4".into(), Int),
+                            ("column5".into(), Text)])),
+                        ),
+                        (
+                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                        Ok(select!(
+                            column1 | column2;
+                            I64     | Str;
+                            1         "a".to_owned();
+                            2         "b".to_owned()
+                        )),
+                    ),
+                    (
+                        "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                        Ok(select!(
+                            id      | name;
+                            I64     | Str;
+                            1         "a".to_owned();
+                            2         "b".to_owned()
+                        )),
+                    ),
+                    (
+                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id)",
+                        Ok(select!(
+                            id      | column2;
+                            I64     | Str;
+                            1         "a".to_owned();
+                            2         "b".to_owned()
+                        )),
+                    ),
+                    (
+                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)",
+                        Ok(select!(
+                            id      | name;
+                            I64     | Str;
+                            1         "a".to_owned();
+                            2         "b".to_owned()
+                        )),
+                    ),
+                    (
+                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
+                        Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
+                    ),
+                ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -1,11 +1,10 @@
-use gluesql_core::executor::FetchError;
-
 use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType::{Boolean, Int, Text},
         data::{Literal, RowError, ValueError},
+        executor::FetchError,
         prelude::{DataType, Payload, Value::*},
     },
     std::borrow::Cow,

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -11,144 +11,144 @@ use {
 };
 
 test_case!(values, async move {
-    let test_cases = vec![
-                    (
-                        "VALUES (1), (2), (3)",
-                        Ok(select!(
-                            column1;
-                            I64;
-                            1;
-                            2;
-                            3
-                        )),
-                    ),
-                    (
-                        "VALUES (1, 'a'), (2, 'b')",
-                        Ok(select!(
-                            column1 | column2;
-                            I64     | Str;
-                            1         "a".to_owned();
-                            2         "b".to_owned()
-                        )),
-                    ),
-                    (
-                        "VALUES (1), (2) limit 1",
-                        Ok(select!(
-                            column1;
-                            I64;
-                            1
-                        )),
-                    ),
-                    (
-                        "VALUES (1), (2) offset 1",
-                        Ok(select!(
-                            column1;
-                            I64;
-                            2
-                        )),
-                    ),
-                    (
-                        "VALUES (1, NULL), (2, NULL)",
-                        Ok(select_with_null!(
-                            column1 | column2;
-                            I64(1)    Null;
-                            I64(2)    Null
-                        )),
-                    ),
-                    (
-                        "VALUES (1), (2, 'b')",
-                        Err(RowError::NumberOfValuesDifferent.into()),
-                    ),
-                    (
-                        "VALUES (1, 'a'), (2)",
-                        Err(RowError::NumberOfValuesDifferent.into()),
-                    ),
-                    (
-                        "VALUES (1, 'a'), (2, 3)",
-                        Err(ValueError::IncompatibleLiteralForDataType {
-                            data_type: DataType::Text,
-                            literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
-                        }
-                        .into()),
-                    ),
-                    (
-                        "VALUES (1, 'a'), ('b', 'c')",
-                        Err(ValueError::IncompatibleLiteralForDataType {
-                            data_type: DataType::Int,
-                            literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
-                        }
-                        .into()),
-                    ),
-                    (
-                        "VALUES (1, NULL), (2, 'a'), (3, 4)",
-                        Err(ValueError::IncompatibleLiteralForDataType {
-                            data_type: DataType::Text,
-                            literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
-                        }
-                        .into()),
-                    ),
-                    (
-                        "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
-                        Ok(Payload::Create),
-                    ),
-                    (
-                        "SELECT * FROM TableFromValues",
-                        Ok(select_with_null!(
-                            column1 | column2         | column3    | column4 | column5;
-                            I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
-                            I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
-                        )),
-                    ),
-                    (
-                        "SHOW COLUMNS FROM TableFromValues",
-                        Ok(Payload::ShowColumns(vec![
-                            ("column1".into(), Int),
-                            ("column2".into(), Text),
-                            ("column3".into(), Boolean),
-                            ("column4".into(), Int),
-                            ("column5".into(), Text)])),
-                        ),
-                        (
-                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
-                        Ok(select!(
-                            column1 | column2;
-                            I64     | Str;
-                            1         "a".to_owned();
-                            2         "b".to_owned()
-                        )),
-                    ),
-                    (
-                        "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
-                        Ok(select!(
-                            id      | name;
-                            I64     | Str;
-                            1         "a".to_owned();
-                            2         "b".to_owned()
-                        )),
-                    ),
-                    (
-                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id)",
-                        Ok(select!(
-                            id      | column2;
-                            I64     | Str;
-                            1         "a".to_owned();
-                            2         "b".to_owned()
-                        )),
-                    ),
-                    (
-                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)",
-                        Ok(select!(
-                            id      | name;
-                            I64     | Str;
-                            1         "a".to_owned();
-                            2         "b".to_owned()
-                        )),
-                    ),
-                    (
-                        "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
-                        Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
-                    ),
-                ];
+    let test_cases = [
+        (
+            "VALUES (1), (2), (3)",
+            Ok(select!(
+                column1;
+                I64;
+                1;
+                2;
+                3
+            )),
+        ),
+        (
+            "VALUES (1, 'a'), (2, 'b')",
+            Ok(select!(
+                column1 | column2;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+        ),
+        (
+            "VALUES (1), (2) limit 1",
+            Ok(select!(
+                column1;
+                I64;
+                1
+            )),
+        ),
+        (
+            "VALUES (1), (2) offset 1",
+            Ok(select!(
+                column1;
+                I64;
+                2
+            )),
+        ),
+        (
+            "VALUES (1, NULL), (2, NULL)",
+            Ok(select_with_null!(
+                column1 | column2;
+                I64(1)    Null;
+                I64(2)    Null
+            )),
+        ),
+        (
+            "VALUES (1), (2, 'b')",
+            Err(RowError::NumberOfValuesDifferent.into()),
+        ),
+        (
+            "VALUES (1, 'a'), (2)",
+            Err(RowError::NumberOfValuesDifferent.into()),
+        ),
+        (
+            "VALUES (1, 'a'), (2, 3)",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Text,
+                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
+            }
+            .into()),
+        ),
+        (
+            "VALUES (1, 'a'), ('b', 'c')",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Int,
+                literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
+            }
+            .into()),
+        ),
+        (
+            "VALUES (1, NULL), (2, 'a'), (3, 4)",
+            Err(ValueError::IncompatibleLiteralForDataType {
+                data_type: DataType::Text,
+                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
+            }
+            .into()),
+        ),
+        (
+            "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
+            Ok(Payload::Create),
+        ),
+        (
+            "SELECT * FROM TableFromValues",
+            Ok(select_with_null!(
+                column1 | column2         | column3    | column4 | column5;
+                I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
+                I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
+            )),
+        ),
+        (
+            "SHOW COLUMNS FROM TableFromValues",
+            Ok(Payload::ShowColumns(vec![
+                ("column1".into(), Int),
+                ("column2".into(), Text),
+                ("column3".into(), Boolean),
+                ("column4".into(), Int),
+                ("column5".into(), Text)])),
+            ),
+            (
+            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+            Ok(select!(
+                column1 | column2;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+        ),
+        (
+            "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+            Ok(select!(
+                id      | name;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+        ),
+        (
+            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id)",
+            Ok(select!(
+                id      | column2;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+        ),
+        (
+            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)",
+            Ok(select!(
+                id      | name;
+                I64     | Str;
+                1         "a".to_owned();
+                2         "b".to_owned()
+            )),
+        ),
+        (
+            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
+            Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
+        ),
+    ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -11,113 +11,122 @@ use {
 
 test_case!(values, async move {
     let test_cases = vec![
-            (
-                "VALUES (1), (2), (3)",
-                Ok(select!(
-                    column1;
-                    I64;
-                    1;
-                    2;
-                    3
-                )),
-            ),
-            (
-                "VALUES (1, 'a'), (2, 'b')",
-                Ok(select!(
-                    column1 | column2;
-                    I64     | Str;
-                    1         "a".to_owned();
-                    2         "b".to_owned()
-                )),
-            ),
-            (
-                "VALUES (1), (2) limit 1",
-                Ok(select!(
-                    column1;
-                    I64;
-                    1
-                )),
-            ),
-            (
-                "VALUES (1), (2) offset 1",
-                Ok(select!(
-                    column1;
-                    I64;
-                    2
-                )),
-            ),
-            (
-                "VALUES (1, NULL), (2, NULL)",
-                Ok(select_with_null!(
-                    column1 | column2;
-                    I64(1)    Null;
-                    I64(2)    Null
-                )),
-            ),
-            (
-                "VALUES (1), (2, 'b')",
-                Err(RowError::NumberOfValuesDifferent.into()),
-            ),
-            (
-                "VALUES (1, 'a'), (2)",
-                Err(RowError::NumberOfValuesDifferent.into()),
-            ),
-            (
-                "VALUES (1, 'a'), (2, 3)",
-                Err(ValueError::IncompatibleLiteralForDataType {
-                    data_type: DataType::Text,
-                    literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
-                }
-                .into()),
-            ),
-            (
-                "VALUES (1, 'a'), ('b', 'c')",
-                Err(ValueError::IncompatibleLiteralForDataType {
-                    data_type: DataType::Int,
-                    literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
-                }
-                .into()),
-            ),
-            (
-                "VALUES (1, NULL), (2, 'a'), (3, 4)",
-                Err(ValueError::IncompatibleLiteralForDataType {
-                    data_type: DataType::Text,
-                    literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
-                }
-                .into()),
-            ),
-            (
-                "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
-                Ok(Payload::Create),
-            ),
-            (
-                "SELECT * FROM TableFromValues",
-                Ok(select_with_null!(
-                    column1 | column2         | column3    | column4 | column5;
-                    I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
-                    I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
-                )),
-            ),
-            (
-                "SHOW COLUMNS FROM TableFromValues",
-                Ok(Payload::ShowColumns(vec![
-                    ("column1".into(), Int),
-                    ("column2".into(), Text),
-                    ("column3".into(), Boolean),
-                    ("column4".into(), Int),
-                    ("column5".into(), Text)])),
+                (
+                    "VALUES (1), (2), (3)",
+                    Ok(select!(
+                        column1;
+                        I64;
+                        1;
+                        2;
+                        3
+                    )),
                 ),
                 (
-                "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
-                Ok(select!(
-                    column1 | column2;
-                    I64     | Str;
-                    1         "a".to_owned();
-                    2         "b".to_owned()
-                )),
-            ),
-            (
-                "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                    "VALUES (1, 'a'), (2, 'b')",
+                    Ok(select!(
+                        column1 | column2;
+                        I64     | Str;
+                        1         "a".to_owned();
+                        2         "b".to_owned()
+                    )),
+                ),
+                (
+                    "VALUES (1), (2) limit 1",
+                    Ok(select!(
+                        column1;
+                        I64;
+                        1
+                    )),
+                ),
+                (
+                    "VALUES (1), (2) offset 1",
+                    Ok(select!(
+                        column1;
+                        I64;
+                        2
+                    )),
+                ),
+                (
+                    "VALUES (1, NULL), (2, NULL)",
+                    Ok(select_with_null!(
+                        column1 | column2;
+                        I64(1)    Null;
+                        I64(2)    Null
+                    )),
+                ),
+                (
+                    "VALUES (1), (2, 'b')",
+                    Err(RowError::NumberOfValuesDifferent.into()),
+                ),
+                (
+                    "VALUES (1, 'a'), (2)",
+                    Err(RowError::NumberOfValuesDifferent.into()),
+                ),
+                (
+                    "VALUES (1, 'a'), (2, 3)",
+                    Err(ValueError::IncompatibleLiteralForDataType {
+                        data_type: DataType::Text,
+                        literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
+                    }
+                    .into()),
+                ),
+                (
+                    "VALUES (1, 'a'), ('b', 'c')",
+                    Err(ValueError::IncompatibleLiteralForDataType {
+                        data_type: DataType::Int,
+                        literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
+                    }
+                    .into()),
+                ),
+                (
+                    "VALUES (1, NULL), (2, 'a'), (3, 4)",
+                    Err(ValueError::IncompatibleLiteralForDataType {
+                        data_type: DataType::Text,
+                        literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
+                    }
+                    .into()),
+                ),
+                (
+                    "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
+                    Ok(Payload::Create),
+                ),
+                (
+                    "SELECT * FROM TableFromValues",
+                    Ok(select_with_null!(
+                        column1 | column2         | column3    | column4 | column5;
+                        I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
+                        I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
+                    )),
+                ),
+                (
+                    "SHOW COLUMNS FROM TableFromValues",
+                    Ok(Payload::ShowColumns(vec![
+                        ("column1".into(), Int),
+                        ("column2".into(), Text),
+                        ("column3".into(), Boolean),
+                        ("column4".into(), Int),
+                        ("column5".into(), Text)])),
+                    ),
+                    (
+                    "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                    Ok(select!(
+                        column1 | column2;
+                        I64     | Str;
+                        1         "a".to_owned();
+                        2         "b".to_owned()
+                    )),
+                ),
+                (
+                    "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                    Ok(select!(
+                        id      | name;
+                        I64     | Str;
+                        1         "a".to_owned();
+                        2         "b".to_owned()
+                    )),
+                ),
+    (
+                "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)",
                 Ok(select!(
                     id      | name;
                     I64     | Str;
@@ -125,7 +134,8 @@ test_case!(values, async move {
                     2         "b".to_owned()
                 )),
             ),
-        ];
+
+            ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -1,3 +1,5 @@
+use gluesql_core::executor::FetchError;
+
 use {
     crate::*,
     bigdecimal::BigDecimal,
@@ -134,7 +136,10 @@ test_case!(values, async move {
                     2         "b".to_owned()
                 )),
             ),
-
+(
+            "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
+            Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
+        ),
             ];
     for (sql, expected) in test_cases {
         test!(expected, sql);

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -11,103 +11,121 @@ use {
 
 test_case!(values, async move {
     let test_cases = vec![
-        (
-            "VALUES (1), (2), (3)",
-            Ok(select!(
-                column1;
-                I64;
-                1;
-                2;
-                3
-            )),
-        ),
-        (
-            "VALUES (1, 'a'), (2, 'b')",
-            Ok(select!(
-                column1 | column2;
-                I64     | Str;
-                1         "a".to_owned();
-                2         "b".to_owned()
-            )),
-        ),
-        (
-            "VALUES (1), (2) limit 1",
-            Ok(select!(
-                column1;
-                I64;
-                1
-            )),
-        ),
-        (
-            "VALUES (1), (2) offset 1",
-            Ok(select!(
-                column1;
-                I64;
-                2
-            )),
-        ),
-        (
-            "VALUES (1, NULL), (2, NULL)",
-            Ok(select_with_null!(
-                column1 | column2;
-                I64(1)    Null;
-                I64(2)    Null
-            )),
-        ),
-        (
-            "VALUES (1), (2, 'b')",
-            Err(RowError::NumberOfValuesDifferent.into()),
-        ),
-        (
-            "VALUES (1, 'a'), (2)",
-            Err(RowError::NumberOfValuesDifferent.into()),
-        ),
-        (
-            "VALUES (1, 'a'), (2, 3)",
-            Err(ValueError::IncompatibleLiteralForDataType {
-                data_type: DataType::Text,
-                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
-            }
-            .into()),
-        ),
-        (
-            "VALUES (1, 'a'), ('b', 'c')",
-            Err(ValueError::IncompatibleLiteralForDataType {
-                data_type: DataType::Int,
-                literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
-            }
-            .into()),
-        ),
-        (
-            "VALUES (1, NULL), (2, 'a'), (3, 4)",
-            Err(ValueError::IncompatibleLiteralForDataType {
-                data_type: DataType::Text,
-                literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
-            }
-            .into()),
-        ),
-        (
-            "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
-            Ok(Payload::Create),
-        ),
-        (
-            "SELECT * FROM TableFromValues",
-            Ok(select_with_null!(
-                column1 | column2         | column3    | column4 | column5;
-                I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
-                I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
-            )),
-        ),
-        (
-            "SHOW COLUMNS FROM TableFromValues",
-            Ok(Payload::ShowColumns(vec![
-                ("column1".into(), Int), 
-                ("column2".into(), Text), 
-                ("column3".into(), Boolean), 
-                ("column4".into(), Int), 
-                ("column5".into(), Text)])),
-        ),
-    ];
+            (
+                "VALUES (1), (2), (3)",
+                Ok(select!(
+                    column1;
+                    I64;
+                    1;
+                    2;
+                    3
+                )),
+            ),
+            (
+                "VALUES (1, 'a'), (2, 'b')",
+                Ok(select!(
+                    column1 | column2;
+                    I64     | Str;
+                    1         "a".to_owned();
+                    2         "b".to_owned()
+                )),
+            ),
+            (
+                "VALUES (1), (2) limit 1",
+                Ok(select!(
+                    column1;
+                    I64;
+                    1
+                )),
+            ),
+            (
+                "VALUES (1), (2) offset 1",
+                Ok(select!(
+                    column1;
+                    I64;
+                    2
+                )),
+            ),
+            (
+                "VALUES (1, NULL), (2, NULL)",
+                Ok(select_with_null!(
+                    column1 | column2;
+                    I64(1)    Null;
+                    I64(2)    Null
+                )),
+            ),
+            (
+                "VALUES (1), (2, 'b')",
+                Err(RowError::NumberOfValuesDifferent.into()),
+            ),
+            (
+                "VALUES (1, 'a'), (2)",
+                Err(RowError::NumberOfValuesDifferent.into()),
+            ),
+            (
+                "VALUES (1, 'a'), (2, 3)",
+                Err(ValueError::IncompatibleLiteralForDataType {
+                    data_type: DataType::Text,
+                    literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(3)))),
+                }
+                .into()),
+            ),
+            (
+                "VALUES (1, 'a'), ('b', 'c')",
+                Err(ValueError::IncompatibleLiteralForDataType {
+                    data_type: DataType::Int,
+                    literal: format!("{:?}", Literal::Text(Cow::Owned("b".to_owned()))),
+                }
+                .into()),
+            ),
+            (
+                "VALUES (1, NULL), (2, 'a'), (3, 4)",
+                Err(ValueError::IncompatibleLiteralForDataType {
+                    data_type: DataType::Text,
+                    literal: format!("{:?}", Literal::Number(Cow::Owned(BigDecimal::from(4)))),
+                }
+                .into()),
+            ),
+            (
+                "CREATE TABLE TableFromValues AS VALUES (1, 'a', True, Null, Null), (2, 'b', False, 3, Null)",
+                Ok(Payload::Create),
+            ),
+            (
+                "SELECT * FROM TableFromValues",
+                Ok(select_with_null!(
+                    column1 | column2         | column3    | column4 | column5;
+                    I64(1)    Str("a".into())   Bool(true)   Null      Null   ;
+                    I64(2)    Str("b".into())   Bool(false)  I64(3)    Null
+                )),
+            ),
+            (
+                "SHOW COLUMNS FROM TableFromValues",
+                Ok(Payload::ShowColumns(vec![
+                    ("column1".into(), Int),
+                    ("column2".into(), Text),
+                    ("column3".into(), Boolean),
+                    ("column4".into(), Int),
+                    ("column5".into(), Text)])),
+                ),
+                (
+                "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                Ok(select!(
+                    column1 | column2;
+                    I64     | Str;
+                    1         "a".to_owned();
+                    2         "b".to_owned()
+                )),
+            ),
+            (
+                "SELECT column1 AS id, column2 AS name FROM (VALUES (1, 'a'), (2, 'b')) AS Derived",
+                Ok(select!(
+                    id      | name;
+                    I64     | Str;
+                    1         "a".to_owned();
+                    2         "b".to_owned()
+                )),
+            ),
+        ];
     for (sql, expected) in test_cases {
         test!(expected, sql);
     }


### PR DESCRIPTION
To resolve #418 
## Goal
- Basic Derived VALUES
```sql
SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived
 column1 | column2
---------+---------
       1 | a
       2 | b
```
- Derived VALUES with Column aliases
```sql
SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name)
 id | name
----+------
  1 | a
  2 | b
```
## Todo
- [x] implement Drived VALUES base
- [x] implement Drived VALUES with Column aliases
  - No Column aliases
  - Some Column aliases + original column name 
  - Only Column aliases
- [x] Throw error if the number of Column aliases exceeds columns