### PR TITLE
Support `.columns TABLE` command in CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,3 +17,4 @@ clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"
 rustyline-derive = "0.6"
 comfy-table = "5"
+thiserror = "1.0"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,3 +1,5 @@
+use crate::command::CommandError;
+
 use {
     crate::{command::Command, helper::CliHelper, print::Print},
     gluesql_core::{
@@ -64,7 +66,11 @@ where
 
             let command = match Command::parse(&line) {
                 Ok(command) => command,
-                Err(_) => {
+                Err(CommandError::LackOfTable) => {
+                    println!("\n[error] should specify table. eg: .columns TableName\n");
+                    continue;
+                }
+                Err(CommandError::NotSupported) => {
                     println!("[error] command not supported: {}", line);
                     println!("\n  type .help to list all available commands.\n");
                     continue;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,9 @@
-use crate::command::CommandError;
-
 use {
-    crate::{command::Command, helper::CliHelper, print::Print},
+    crate::{
+        command::{Command, CommandError},
+        helper::CliHelper,
+        print::Print,
+    },
     gluesql_core::{
         prelude::Glue,
         store::{GStore, GStoreMut},

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -67,7 +67,7 @@ where
             let command = match Command::parse(&line) {
                 Ok(command) => command,
                 Err(CommandError::LackOfTable) => {
-                    println!("\n[error] should specify table. eg: .columns TableName\n");
+                    println!("[error] should specify table. eg: .columns TableName\n");
                     continue;
                 }
                 Err(CommandError::NotSupported) => {

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -1,3 +1,5 @@
+use {std::fmt::Debug, thiserror::Error as ThisError};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
     Help,
@@ -6,8 +8,16 @@ pub enum Command {
     ExecuteFromFile(String),
 }
 
+#[derive(ThisError, Debug, PartialEq)]
+pub enum CommandError {
+    #[error("should specify table")]
+    LackOfTable,
+    #[error("command not supported")]
+    NotSupported,
+}
+
 impl Command {
-    pub fn parse(line: &str) -> Result<Self, ()> {
+    pub fn parse(line: &str) -> Result<Self, CommandError> {
         let line = line.trim_start().trim_end_matches(|c| c == ' ' || c == ';');
         // We detect if the line is a command or not
         if line.starts_with('.') {
@@ -16,15 +26,15 @@ impl Command {
                 ".help" => Ok(Self::Help),
                 ".quit" => Ok(Self::Quit),
                 ".tables" => Ok(Self::Execute("SHOW TABLES".to_owned())),
-                ".columns" => match params.len() > 1 {
-                    true => Ok(Self::Execute(
-                        format!("SHOW COLUMNS FROM {}", params[1]).to_owned(),
+                ".columns" => match params.get(1) {
+                    Some(table_name) => Ok(Self::Execute(
+                        format!("SHOW COLUMNS FROM {}", table_name).to_owned(),
                     )),
-                    false => Err(()), // should throw another error
+                    None => Err(CommandError::LackOfTable),
                 },
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
                 ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
-                _ => Err(()),
+                _ => Err(CommandError::NotSupported),
             }
         } else {
             Ok(Self::Execute(line.to_owned()))
@@ -34,6 +44,8 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
+    use crate::command::CommandError;
+
     #[test]
     fn parse_command() {
         use super::Command;
@@ -51,16 +63,12 @@ mod tests {
             Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
             Command::parse(".columns Foo")
         );
-        assert_eq!(
-            Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
-            Command::parse(".columns")
-        );
-
+        assert_eq!(Err(CommandError::LackOfTable), Command::parse(".columns"));
         assert_eq!(
             Ok(Command::Execute("SHOW VERSION".to_owned())),
             Command::parse(".version")
         );
-        assert_eq!(Err(()), Command::parse(".foo"));
+        assert_eq!(Err(CommandError::NotSupported), Command::parse(".foo"));
         assert_eq!(
             Ok(Command::Execute("SELECT * FROM Foo".to_owned())),
             Command::parse("SELECT * FROM Foo;")

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -49,8 +49,13 @@ mod tests {
         );
         assert_eq!(
             Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
-            Command::parse(".column Foo")
+            Command::parse(".columns Foo")
         );
+        assert_eq!(
+            Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
+            Command::parse(".columns")
+        );
+
         assert_eq!(
             Ok(Command::Execute("SHOW VERSION".to_owned())),
             Command::parse(".version")

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -27,9 +27,9 @@ impl Command {
                 ".quit" => Ok(Self::Quit),
                 ".tables" => Ok(Self::Execute("SHOW TABLES".to_owned())),
                 ".columns" => match params.get(1) {
-                    Some(table_name) => Ok(Self::Execute(
-                        format!("SHOW COLUMNS FROM {}", table_name).to_owned(),
-                    )),
+                    Some(table_name) => {
+                        Ok(Self::Execute(format!("SHOW COLUMNS FROM {}", table_name)))
+                    }
                     None => Err(CommandError::LackOfTable),
                 },
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -16,6 +16,12 @@ impl Command {
                 ".help" => Ok(Self::Help),
                 ".quit" => Ok(Self::Quit),
                 ".tables" => Ok(Self::Execute("SHOW TABLES".to_owned())),
+                ".columns" => match params.len() > 1 {
+                    true => Ok(Self::Execute(
+                        format!("SHOW COLUMNS FROM {}", params[1]).to_owned(),
+                    )),
+                    false => Err(()), // should throw another error
+                },
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
                 ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
                 _ => Err(()),
@@ -40,6 +46,10 @@ mod tests {
         assert_eq!(
             Ok(Command::Execute("SHOW TABLES".to_owned())),
             Command::parse(".tables")
+        );
+        assert_eq!(
+            Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
+            Command::parse(".column Foo")
         );
         assert_eq!(
             Ok(Command::Execute("SHOW VERSION".to_owned())),

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -121,16 +121,16 @@ mod tests {
         let mut print = Print::new(Vec::new());
 
         let expected = "
-╭─────────────────────────────────────────╮
-│ command         description             │
-╞═════════════════════════════════════════╡
-│ .help           show help               │
-│ .quit           quit program            │
-│ .tables         show table names        │
-│ .columns TABLE  show table from TABLE   │
-│ .version        show version            │
-│ .execute FILE   execute SQL from a file │
-╰─────────────────────────────────────────╯";
+╭──────────────────────────────────────────╮
+│ command          description             │
+╞══════════════════════════════════════════╡
+│ .help            show help               │
+│ .quit            quit program            │
+│ .tables          show table names        │
+│ .columns TABLE   show columns from TABLE │
+│ .version         show version            │
+│ .execute FILE    execute SQL from a file │
+╰──────────────────────────────────────────╯";
         let found = {
             print.help().unwrap();
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -83,10 +83,11 @@ impl<W: Write> Print<W> {
 
     pub fn help(&mut self) -> Result<()> {
         const HEADER: [&str; 2] = ["command", "description"];
-        const CONTENT: [[&str; 2]; 5] = [
+        const CONTENT: [[&str; 2]; 6] = [
             [".help", "show help"],
             [".quit", "quit program"],
             [".tables", "show table names"],
+            [".columns TABLE", "show columns from TABLE"],
             [".version", "show version"],
             [".execute FILE", "execute SQL from a file"],
         ];
@@ -126,6 +127,7 @@ mod tests {
 │ .help           show help               │
 │ .quit           quit program            │
 │ .tables         show table names        │
+│ .columns TABLE  show table from TABLE   │
 │ .version        show version            │
 │ .execute FILE   execute SQL from a file │
 ╰─────────────────────────────────────────╯";


### PR DESCRIPTION
To resolve #735
## Goal
add .columns Table command in CLI as a alias of show columns from Table
```sql
gluesql> CREATE TABLE Foo(id INT, name TEXT);
gluesql> .columns Foo
╭──────────────╮
│ Field   Type │
╞══════════════╡
│ id      Int  │
│ name    Text │
╰──────────────╯
```
```sql
gluesql> .columns wrong
[error] table not found: wrong
```
```sql
gluesql> .columns
[error] should specify table. eg: .columns TableName
```
## Todo
- [x] create CommandError::LackOfTable
- [x] parse 2nd param
- If 2nd param does not exists => throw LackOfTable
- else..
  - [x] let .columns command executes `show columns from TABLE`