### PR TITLE
Support `.spool FilePath` command in CLI

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -32,7 +32,7 @@ where
 {
     pub fn new(storage: T, output: W) -> Self {
         let glue = Glue::new(storage);
-        let print = Print::new(output);
+        let print = Print::new(output, None);
 
         Self { glue, print }
     }
@@ -72,6 +72,10 @@ where
                     println!("[error] should specify table. eg: .columns TableName\n");
                     continue;
                 }
+                Err(CommandError::LackOfFile) => {
+                    println!("[error] should specify file path.\n");
+                    continue;
+                }
                 Err(CommandError::NotSupported) => {
                     println!("[error] command not supported: {}", line);
                     println!("\n  type .help to list all available commands.\n");
@@ -98,6 +102,9 @@ where
                     if let Err(e) = self.load(&filename) {
                         println!("[error] {}\n", e);
                     }
+                }
+                Command::SpoolOn(path) => {
+                    self.print.spool_on(path)?;
                 }
             }
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -106,6 +106,9 @@ where
                 Command::SpoolOn(path) => {
                     self.print.spool_on(path)?;
                 }
+                Command::SpoolOff => {
+                    self.print.spool_off();
+                }
             }
         }
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -39,7 +39,7 @@ impl Command {
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
                 ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
                 ".spool" => match params.get(1) {
-                    Some(&arg) if arg == "off" => Ok(Self::SpoolOff),
+                    Some(&"off") => Ok(Self::SpoolOff),
                     Some(path) => Ok(Self::SpoolOn(path.to_string())),
                     None => Err(CommandError::LackOfFile),
                 },

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -7,6 +7,7 @@ pub enum Command {
     Execute(String),
     ExecuteFromFile(String),
     SpoolOn(String),
+    SpoolOff,
 }
 
 #[derive(ThisError, Debug, PartialEq)]
@@ -38,6 +39,7 @@ impl Command {
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
                 ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
                 ".spool" => match params.get(1) {
+                    Some(&arg) if arg == "off" => Ok(Self::SpoolOff),
                     Some(path) => Ok(Self::SpoolOn(path.to_string())),
                     None => Err(CommandError::LackOfFile),
                 },

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -82,5 +82,11 @@ mod tests {
             Ok(Command::Execute("SELECT * FROM Foo".to_owned())),
             Command::parse("SELECT * FROM Foo;")
         );
+        assert_eq!(
+            Ok(Command::SpoolOn("query.log".into())),
+            Command::parse(".spool query.log")
+        );
+        assert_eq!(Ok(Command::SpoolOff), Command::parse(".spool off"));
+        assert_eq!(Err(CommandError::LackOfFile), Command::parse(".spool"));
     }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -6,12 +6,15 @@ pub enum Command {
     Quit,
     Execute(String),
     ExecuteFromFile(String),
+    SpoolOn(String),
 }
 
 #[derive(ThisError, Debug, PartialEq)]
 pub enum CommandError {
     #[error("should specify table")]
     LackOfTable,
+    #[error("should specify file path")]
+    LackOfFile,
     #[error("command not supported")]
     NotSupported,
 }
@@ -34,6 +37,10 @@ impl Command {
                 },
                 ".version" => Ok(Self::Execute("SHOW VERSION".to_owned())),
                 ".execute" if params.len() == 2 => Ok(Self::ExecuteFromFile(params[1].to_owned())),
+                ".spool" => match params.get(1) {
+                    Some(path) => Ok(Self::SpoolOn(path.to_string())),
+                    None => Err(CommandError::LackOfFile),
+                },
                 _ => Err(CommandError::NotSupported),
             }
         } else {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -18,13 +18,6 @@ pub struct Print<W: Write> {
 }
 
 impl<W: Write> Print<W> {
-    pub fn spool_on<P: AsRef<Path>>(&mut self, filename: P) -> Result<()> {
-        let file = File::create(filename)?;
-        self.spool_file = Some(file);
-
-        Ok(())
-    }
-
     pub fn new(output: W, spool_file: Option<File>) -> Self {
         Print { output, spool_file }
     }
@@ -115,6 +108,17 @@ impl<W: Write> Print<W> {
         }
 
         writeln!(self.output, "{}\n", table)
+    }
+
+    pub fn spool_on<P: AsRef<Path>>(&mut self, filename: P) -> Result<()> {
+        let file = File::create(filename)?;
+        self.spool_file = Some(file);
+
+        Ok(())
+    }
+
+    pub fn spool_off(&mut self) -> () {
+        self.spool_file = None;
     }
 }
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -93,13 +93,14 @@ impl<W: Write> Print<W> {
 
     pub fn help(&mut self) -> Result<()> {
         const HEADER: [&str; 2] = ["command", "description"];
-        const CONTENT: [[&str; 2]; 6] = [
+        const CONTENT: [[&str; 2]; 7] = [
             [".help", "show help"],
             [".quit", "quit program"],
             [".tables", "show table names"],
             [".columns TABLE", "show columns from TABLE"],
             [".version", "show version"],
             [".execute FILE", "execute SQL from a file"],
+            [".spool FILE|off", "spool to file or off"],
         ];
 
         let mut table = get_table(HEADER);
@@ -143,16 +144,17 @@ mod tests {
         let mut print = Print::new(Vec::new(), None);
 
         let expected = "
-╭──────────────────────────────────────────╮
-│ command          description             │
-╞══════════════════════════════════════════╡
-│ .help            show help               │
-│ .quit            quit program            │
-│ .tables          show table names        │
-│ .columns TABLE   show columns from TABLE │
-│ .version         show version            │
-│ .execute FILE    execute SQL from a file │
-╰──────────────────────────────────────────╯";
+╭───────────────────────────────────────────╮
+│ command           description             │
+╞═══════════════════════════════════════════╡
+│ .help             show help               │
+│ .quit             quit program            │
+│ .tables           show table names        │
+│ .columns TABLE    show columns from TABLE │
+│ .version          show version            │
+│ .execute FILE     execute SQL from a file │
+│ .spool FILE|off   spool to file or off    │
+╰───────────────────────────────────────────╯";
         let found = {
             print.help().unwrap();
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -28,13 +28,8 @@ impl<W: Write> Print<W> {
 
     pub fn payload(&mut self, payload: &Payload) -> Result<()> {
         let mut affected = |n: usize, msg: &str| -> Result<()> {
-            writeln!(
-                self.output,
-                "{} row{} {}\n",
-                n,
-                if n > 1 { "s" } else { "" },
-                msg
-            )
+            let payload = format!("{} row{} {}", n, if n > 1 { "s" } else { "" }, msg);
+            self.write(payload)
         };
 
         match payload {
@@ -84,11 +79,11 @@ impl<W: Write> Print<W> {
         Ok(())
     }
 
-    fn write(&mut self, table: impl Display) -> Result<()> {
+    fn write(&mut self, payload: impl Display) -> Result<()> {
         if let Some(file) = &self.spool_file {
-            writeln!(file.to_owned(), "{}\n", table)?;
+            writeln!(file.to_owned(), "{}\n", payload)?;
         };
-        writeln!(self.output, "{}\n", table)
+        writeln!(self.output, "{}\n", payload)
     }
 
     pub fn help(&mut self) -> Result<()> {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -118,7 +118,7 @@ impl<W: Write> Print<W> {
         Ok(())
     }
 
-    pub fn spool_off(&mut self) -> () {
+    pub fn spool_off(&mut self) {
         self.spool_file = None;
     }
 }


### PR DESCRIPTION
To resolve #747 
## Goal
`Spool` is the easiest way to export data.
```sql
gluesql> .spool query.log
gluesql> VALUES (1), (2);
╭─────────╮
│ column1 │
╞═════════╡
│ 1       │
│ 2       │
╰─────────╯

gluesql> .spool off
gluesql> .quit
```
```
$> cat query.log
╭─────────╮
│ column1 │
╞═════════╡
│ 1       │
│ 2       │
╰─────────╯
```

## Todo
- [x] Add Command::SpoolOn, CommandError::LackOfFile
- [x] Add Command::SpoolOff
- [x] if Some(spool_file), write to spool_file whenver print payload
## Q
- Should we test the contents of created spool_file ?
## In Next PR
### Support granular options
- set header on | off
- set tabular on | off
- set echo on | off (show executed query or not)