### PR TITLE
Implement cast function in AST builder

### DIFF
--- a/core/src/ast_builder/data_type.rs
+++ b/core/src/ast_builder/data_type.rs
@@ -1,0 +1,37 @@
+use crate::{
+    ast::DataType,
+    parse_sql::parse_data_type,
+    result::{Error, Result},
+    translate::translate_data_type,
+};
+
+#[derive(Clone)]
+pub enum DataTypeNode {
+    DataType(DataType),
+    Text(String),
+}
+
+impl From<DataType> for DataTypeNode {
+    fn from(data_type: DataType) -> Self {
+        Self::DataType(data_type)
+    }
+}
+
+impl From<&str> for DataTypeNode {
+    fn from(data_type: &str) -> Self {
+        Self::Text(data_type.to_owned())
+    }
+}
+
+impl TryFrom<DataTypeNode> for DataType {
+    type Error = Error;
+
+    fn try_from(data_type: DataTypeNode) -> Result<Self> {
+        match data_type {
+            DataTypeNode::DataType(data_type) => Ok(data_type),
+            DataTypeNode::Text(data_type) => {
+                parse_data_type(data_type).and_then(|datatype| translate_data_type(&datatype))
+            }
+        }
+    }
+}

--- a/core/src/ast_builder/expr/cast.rs
+++ b/core/src/ast_builder/expr/cast.rs
@@ -1,0 +1,29 @@
+use {super::ExprNode, crate::ast_builder::DataTypeNode};
+
+impl ExprNode {
+    pub fn cast<T: Into<DataTypeNode>>(self, data_type: T) -> Self {
+        Self::Cast {
+            expr: Box::new(self),
+            data_type: data_type.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ast::DataType,
+        ast_builder::{col, test_expr},
+    };
+
+    #[test]
+    fn cast() {
+        let actual = col("date").cast(DataType::Int);
+        let expected = "CAST(date AS INTEGER)";
+        test_expr(actual, expected);
+
+        let actual = col("date").cast("INTEGER");
+        let expected = "CAST(date AS INTESER)";
+        test_expr(actual, expected);
+    }
+}

--- a/core/src/ast_builder/expr/cast.rs
+++ b/core/src/ast_builder/expr/cast.rs
@@ -23,7 +23,7 @@ mod tests {
         test_expr(actual, expected);
 
         let actual = col("date").cast("INTEGER");
-        let expected = "CAST(date AS INTESER)";
+        let expected = "CAST(date AS INTEGER)";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -5,12 +5,15 @@ mod unary_op;
 
 pub mod aggregate;
 pub mod between;
+pub mod cast;
 pub mod extract;
 pub mod function;
 pub mod in_list;
 pub mod in_subquery;
 
 pub use nested::nested;
+
+use super::DataTypeNode;
 
 use {
     crate::{
@@ -68,6 +71,10 @@ pub enum ExprNode {
     Nested(Box<ExprNode>),
     Function(Box<FunctionNode>),
     Aggregate(Box<AggregateNode>),
+    Cast {
+        expr: Box<ExprNode>,
+        data_type: DataTypeNode,
+    },
 }
 
 impl TryFrom<ExprNode> for Expr {
@@ -113,6 +120,11 @@ impl TryFrom<ExprNode> for Expr {
             ExprNode::Extract { field, expr } => {
                 let expr = Expr::try_from(*expr).map(Box::new)?;
                 Ok(Expr::Extract { field, expr })
+            }
+            ExprNode::Cast { expr, data_type } => {
+                let expr = Expr::try_from(*expr).map(Box::new)?;
+                let data_type = data_type.try_into()?;
+                Ok(Expr::Cast { expr, data_type })
             }
             ExprNode::IsNull(expr) => Expr::try_from(*expr).map(Box::new).map(Expr::IsNull),
             ExprNode::IsNotNull(expr) => Expr::try_from(*expr).map(Box::new).map(Expr::IsNotNull),

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -13,9 +13,8 @@ pub mod in_subquery;
 
 pub use nested::nested;
 
-use super::DataTypeNode;
-
 use {
+    super::DataTypeNode,
     crate::{
         ast::{
             Aggregate, AstLiteral, BinaryOperator, DateTimeField, Expr, Function, Query,

--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -1,3 +1,4 @@
+mod data_type;
 mod delete;
 mod drop_table;
 mod expr;
@@ -15,6 +16,7 @@ mod table;
 mod transaction;
 
 pub use {
+    data_type::DataTypeNode,
     delete::DeleteNode,
     drop_table::DropTableNode,
     expr_list::ExprList,

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -2,8 +2,8 @@ use {
     crate::result::{Error, Result},
     sqlparser::{
         ast::{
-            Expr as SqlExpr, OrderByExpr, Query as SqlQuery, SelectItem as SqlSelectItem,
-            Statement as SqlStatement,
+            DataType as SqlDataType, Expr as SqlExpr, OrderByExpr, Query as SqlQuery,
+            SelectItem as SqlSelectItem, Statement as SqlStatement,
         },
         dialect::GenericDialect,
         parser::Parser,
@@ -84,5 +84,15 @@ pub fn parse_order_by_expr<Sql: AsRef<str>>(sql_order_by_expr: Sql) -> Result<Or
 
     Parser::new(tokens, &DIALECT)
         .parse_order_by_expr()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))
+}
+
+pub fn parse_data_type<Sql: AsRef<str>>(sql_data_type: Sql) -> Result<SqlDataType> {
+    let tokens = Tokenizer::new(&DIALECT, sql_data_type.as_ref())
+        .tokenize()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
+
+    Parser::new(tokens, &DIALECT)
+        .parse_data_type()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -8,6 +8,7 @@ mod operator;
 mod query;
 
 pub use self::{
+    data_type::translate_data_type,
     error::TranslateError,
     expr::{translate_expr, translate_order_by_expr},
     query::{translate_query, translate_select_item},


### PR DESCRIPTION
## Description
implement `cast` function in AST_Builder

## Background
resolve #670 

## Test to pass
```rs
    #[test]
    fn cast() {
        let actual = col("date").cast(DataType::Int);
        let expected = "CAST(date AS INTEGER)";
        test_expr(actual, expected);

        let actual = col("date").cast("INTEGER");
        let expected = "CAST(date AS INTESER)";
        test_expr(actual, expected);
    }
```