### PR TITLE
Update SledStorage scan_(indexed)_data key not to contain table prefix,

### DIFF
--- a/storages/sled-storage/src/index_mut.rs
+++ b/storages/sled-storage/src/index_mut.rs
@@ -14,11 +14,8 @@ use {
         result::{Error, MutResult, Result, TrySelf},
         store::{IndexError, IndexMut, Store},
     },
-    sled::{
-        transaction::{
-            ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
-        },
-        IVec,
+    sled::transaction::{
+        ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,
     },
     std::iter::once,
 };
@@ -105,7 +102,7 @@ impl IndexMut for SledStorage {
                 .map_err(ConflictableTransactionError::Abort)?;
 
             for (data_key, row) in rows.iter() {
-                let data_key = IVec::from(data_key.to_cmp_be_bytes());
+                let data_key = key::data(table_name, data_key.to_cmp_be_bytes());
 
                 index_sync.insert_index(&index, &data_key, row)?;
             }
@@ -178,7 +175,7 @@ impl IndexMut for SledStorage {
                 .map_err(ConflictableTransactionError::Abort)?;
 
             for (data_key, row) in rows.iter() {
-                let data_key = IVec::from(data_key.to_cmp_be_bytes());
+                let data_key = key::data(table_name, data_key.to_cmp_be_bytes());
 
                 index_sync.delete_index(&index, &data_key, row)?;
             }

--- a/storages/sled-storage/src/key.rs
+++ b/storages/sled-storage/src/key.rs
@@ -4,6 +4,20 @@ const TEMP_DATA: &str = "temp_data/";
 const TEMP_SCHEMA: &str = "temp_schema/";
 const TEMP_INDEX: &str = "temp_index/";
 
+pub fn data_prefix(table_name: &str) -> String {
+    format!("data/{table_name}/")
+}
+
+pub fn data(table_name: &str, key: Vec<u8>) -> IVec {
+    let key = data_prefix(table_name)
+        .into_bytes()
+        .into_iter()
+        .chain(key.into_iter())
+        .collect::<Vec<_>>();
+
+    IVec::from(key)
+}
+
 macro_rules! prefix {
     ($txid: ident, $prefix: ident) => {
         $prefix

--- a/storages/sled-storage/src/store.rs
+++ b/storages/sled-storage/src/store.rs
@@ -1,5 +1,5 @@
 use {
-    super::{err_into, lock, SledStorage, Snapshot, State},
+    super::{err_into, key, lock, SledStorage, Snapshot, State},
     async_trait::async_trait,
     gluesql_core::{
         data::{Key, Row, Schema},
@@ -50,16 +50,17 @@ impl Store for SledStorage {
         };
         let lock_txid = lock::fetch(&self.tree, txid, created_at, self.tx_timeout)?;
 
-        let prefix = format!("data/{}/", table_name);
+        let prefix = key::data_prefix(table_name);
+        let prefix_len = prefix.len();
         let result_set = self
             .tree
             .scan_prefix(prefix.as_bytes())
             .map(move |item| {
                 let (key, value) = item.map_err(err_into)?;
-                let key = Key::Bytea(key.to_vec());
+                let key = key.subslice(prefix_len, key.len() - prefix_len).to_vec();
                 let snapshot: Snapshot<Row> = bincode::deserialize(&value).map_err(err_into)?;
                 let row = snapshot.extract(txid, lock_txid);
-                let item = row.map(|row| (key, row));
+                let item = row.map(|row| (Key::Bytea(key), row));
 
                 Ok(item)
             })


### PR DESCRIPTION
prev.
Key info fetched from SledStorage scan_data & scan_indexed_data had
format of {table_name} + {data identifier}.
However, all store mut traits which handles data keys provide table_name info
so it is unnecessary for the fetched keys to have {table_name} info.

changes.
Remove {table_name} prefix info from the keys fetched from
Store::scan_data & Index::scan_indexed_data.
Apply key format changes to store mut trait impl codes.