### PR TITLE
Rename StoreMut insert_data & update_data methods,

### DIFF
--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -134,7 +134,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                 .await
                 .try_self(storage)?;
 
-            storage.insert_data(target_table_name, rows).await
+            storage.append_data(target_table_name, rows).await
         }
         None => Ok((storage, ())),
     }

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -259,8 +259,8 @@ pub async fn execute<T: GStore + GStoreMut>(
             });
 
             match rows {
-                RowsData::Insert(rows) => storage.insert_data(table_name, rows).await,
-                RowsData::Update(rows) => storage.update_data(table_name, rows).await,
+                RowsData::Insert(rows) => storage.append_data(table_name, rows).await,
+                RowsData::Update(rows) => storage.insert_data(table_name, rows).await,
             }
             .map(|(storage, _)| (storage, Payload::Insert(num_rows)))
         }
@@ -309,7 +309,7 @@ pub async fn execute<T: GStore + GStoreMut>(
             let num_rows = rows.len();
 
             storage
-                .update_data(table_name, rows)
+                .insert_data(table_name, rows)
                 .await
                 .map(|(storage, _)| (storage, Payload::Update(num_rows)))
         }

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -181,8 +181,8 @@ pub async fn execute<T: GStore + GStoreMut>(
             ..
         } => {
             enum RowsData {
-                Insert(Vec<Row>),
-                Update(Vec<(Key, Row)>),
+                Append(Vec<Row>),
+                Insert(Vec<(Key, Row)>),
             }
 
             let (rows, num_rows, table_name) = try_block!(storage, {
@@ -251,16 +251,16 @@ pub async fn execute<T: GStore + GStoreMut>(
                             None => None,
                         })
                         .collect::<Result<Vec<_>>>()
-                        .map(RowsData::Update)?,
-                    None => RowsData::Insert(rows),
+                        .map(RowsData::Insert)?,
+                    None => RowsData::Append(rows),
                 };
 
                 Ok((rows, num_rows, table_name))
             });
 
             match rows {
-                RowsData::Insert(rows) => storage.append_data(table_name, rows).await,
-                RowsData::Update(rows) => storage.insert_data(table_name, rows).await,
+                RowsData::Append(rows) => storage.append_data(table_name, rows).await,
+                RowsData::Insert(rows) => storage.insert_data(table_name, rows).await,
             }
             .map(|(storage, _)| (storage, Payload::Insert(num_rows)))
         }

--- a/core/src/plan/mock.rs
+++ b/core/src/plan/mock.rs
@@ -91,14 +91,14 @@ impl StoreMut for MockStorage {
         Err((self, Error::StorageMsg(msg)))
     }
 
-    async fn insert_data(self, _table_name: &str, _rows: Vec<Row>) -> MutResult<Self, ()> {
-        let msg = "[MockStorage] insert_data is not supported".to_owned();
+    async fn append_data(self, _table_name: &str, _rows: Vec<Row>) -> MutResult<Self, ()> {
+        let msg = "[MockStorage] append_data is not supported".to_owned();
 
         Err((self, Error::StorageMsg(msg)))
     }
 
-    async fn update_data(self, _table_name: &str, _rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
-        let msg = "[MockStorage] update_data is not supported".to_owned();
+    async fn insert_data(self, _table_name: &str, _rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
+        let msg = "[MockStorage] insert_data is not supported".to_owned();
 
         Err((self, Error::StorageMsg(msg)))
     }
@@ -172,8 +172,8 @@ mod tests {
         assert!(block_on(storage.fetch_data("Foo", &Key::None)).is_err());
         assert!(block_on(storage.fetch_schema("__Err__")).is_err());
         let storage = test(storage.delete_schema("Foo"));
+        let storage = test(storage.append_data("Foo", Vec::new()));
         let storage = test(storage.insert_data("Foo", Vec::new()));
-        let storage = test(storage.update_data("Foo", Vec::new()));
         let storage = test(storage.delete_data("Foo", Vec::new()));
 
         #[cfg(feature = "alter-table")]

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -92,9 +92,9 @@ where
 
     async fn delete_schema(self, table_name: &str) -> MutResult<Self, ()>;
 
-    async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()>;
+    async fn append_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()>;
 
-    async fn update_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()>;
+    async fn insert_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()>;
 
     async fn delete_data(self, table_name: &str, keys: Vec<Key>) -> MutResult<Self, ()>;
 }

--- a/storages/memory-storage/src/lib.rs
+++ b/storages/memory-storage/src/lib.rs
@@ -70,7 +70,7 @@ impl MemoryStorage {
         self.items.remove(table_name);
     }
 
-    pub fn insert_data(&mut self, table_name: &str, rows: Vec<Row>) {
+    pub fn append_data(&mut self, table_name: &str, rows: Vec<Row>) {
         if let Some(item) = self.items.get_mut(table_name) {
             for row in rows {
                 self.id_counter += 1;
@@ -80,7 +80,7 @@ impl MemoryStorage {
         }
     }
 
-    pub fn update_data(&mut self, table_name: &str, rows: Vec<(Key, Row)>) {
+    pub fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, Row)>) {
         if let Some(item) = self.items.get_mut(table_name) {
             for (key, row) in rows {
                 item.rows.insert(key, row);
@@ -115,18 +115,18 @@ impl StoreMut for MemoryStorage {
         Ok((storage, ()))
     }
 
-    async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
+    async fn append_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
         let mut storage = self;
 
-        MemoryStorage::insert_data(&mut storage, table_name, rows);
+        MemoryStorage::append_data(&mut storage, table_name, rows);
 
         Ok((storage, ()))
     }
 
-    async fn update_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
+    async fn insert_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
         let mut storage = self;
 
-        MemoryStorage::update_data(&mut storage, table_name, rows);
+        MemoryStorage::insert_data(&mut storage, table_name, rows);
 
         Ok((storage, ()))
     }

--- a/storages/shared-memory-storage/src/lib.rs
+++ b/storages/shared-memory-storage/src/lib.rs
@@ -86,20 +86,20 @@ impl StoreMut for SharedMemoryStorage {
         Ok((self, ()))
     }
 
-    async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
+    async fn append_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
         let database = Arc::clone(&self.database);
         let mut database = database.write().await;
 
-        MemoryStorage::insert_data(&mut database, table_name, rows);
+        MemoryStorage::append_data(&mut database, table_name, rows);
 
         Ok((self, ()))
     }
 
-    async fn update_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
+    async fn insert_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
         let database = Arc::clone(&self.database);
         let mut database = database.write().await;
 
-        MemoryStorage::update_data(&mut database, table_name, rows);
+        MemoryStorage::insert_data(&mut database, table_name, rows);
 
         Ok((self, ()))
     }

--- a/storages/sled-storage/src/store_mut.rs
+++ b/storages/sled-storage/src/store_mut.rs
@@ -143,7 +143,7 @@ impl StoreMut for SledStorage {
             .await
     }
 
-    async fn insert_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
+    async fn append_data(self, table_name: &str, rows: Vec<Row>) -> MutResult<Self, ()> {
         let id_offset = self.id_offset;
         let state = &self.state;
         let tx_timeout = self.tx_timeout;
@@ -183,11 +183,11 @@ impl StoreMut for SledStorage {
             Ok(TxPayload::Success)
         });
 
-        self.check_and_retry(tx_result, |storage| storage.insert_data(table_name, rows))
+        self.check_and_retry(tx_result, |storage| storage.append_data(table_name, rows))
             .await
     }
 
-    async fn update_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
+    async fn insert_data(self, table_name: &str, rows: Vec<(Key, Row)>) -> MutResult<Self, ()> {
         let state = &self.state;
         let tx_timeout = self.tx_timeout;
         let tx_rows = &rows;
@@ -245,7 +245,7 @@ impl StoreMut for SledStorage {
             Ok(TxPayload::Success)
         });
 
-        self.check_and_retry(tx_result, |storage| storage.update_data(table_name, rows))
+        self.check_and_retry(tx_result, |storage| storage.insert_data(table_name, rows))
             .await
     }
 

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -398,7 +398,7 @@ async fn sled_transaction_gc() {
         glue1
             .storage
             .unwrap()
-            .update_data("NewGarlic", vec![])
+            .insert_data("NewGarlic", vec![])
             .await
             .map(|(_, v)| v)
             .map_err(|(_, e)| e),
@@ -447,7 +447,7 @@ mod timeout_tests {
                 .storage
                 .clone()
                 .unwrap()
-                .update_data("TxGarlic", vec![])
+                .insert_data("TxGarlic", vec![])
                 .await
                 .map(|(_, v)| v)
                 .map_err(|(_, e)| e),


### PR DESCRIPTION
StoreMut::insert_data -> append_data
StoreMut::update_data -> insert_data

Our custom storage makers use Rust lang to build their own storages.
It would be better to follow the method names which are commonly used by standard libraries
e.g.
[Vec::append](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.append)
[Vec::insert](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.insert)