### PR TITLE
[Test Suite] Merge use crates into one

### DIFF
--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -2,7 +2,10 @@
 
 use {
     crate::*,
-    gluesql_core::{data::Value::*, prelude::Payload, store::AlterTableError},
+    gluesql_core::{
+        ast::*, data::Value::*, executor::AlterError, executor::EvaluateError, prelude::Payload,
+        store::AlterTableError, translate::TranslateError,
+    },
 };
 
 test_case!(alter_table_rename, async move {
@@ -36,9 +39,6 @@ test_case!(alter_table_rename, async move {
 });
 
 test_case!(alter_table_add_drop, async move {
-    use gluesql_core::{
-        ast::*, executor::AlterError, executor::EvaluateError, store::*, translate::TranslateError,
-    };
     let test_cases = [
         ("CREATE TABLE Foo (id INTEGER);", Ok(Payload::Create)),
         ("INSERT INTO Foo VALUES (1), (2);", Ok(Payload::Insert(2))),

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -1,14 +1,14 @@
 use {
     crate::*,
-    gluesql_core::data::value::Value::{Null, Str, I64},
-};
-
-test_case!(create_table, async move {
-    use gluesql_core::{
+    gluesql_core::{
+        data::value::Value::{Null, Str, I64},
         executor::{AlterError, EvaluateError},
         prelude::Payload,
         translate::TranslateError,
-    };
+    },
+};
+
+test_case!(create_table, async move {
     let test_cases = [
         (
             r#"

--- a/test-suite/src/alter/drop_table.rs
+++ b/test-suite/src/alter/drop_table.rs
@@ -2,6 +2,7 @@ use {
     crate::*,
     gluesql_core::{
         executor::{AlterError, FetchError, Payload},
+        prelude::Value::*,
         translate::TranslateError,
     },
 };
@@ -21,8 +22,6 @@ CREATE TABLE DropTable (
     for sql in sqls {
         run!(sql);
     }
-
-    use gluesql_core::prelude::Value::*;
 
     let sqls = [
         (

--- a/test-suite/src/blend.rs
+++ b/test-suite/src/blend.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(blend, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::{EvaluateError, SelectError},
         prelude::Value::*,
-    };
+    },
+};
 
+test_case!(blend, async move {
     let create_sqls: [&str; 2] = [
         "
         CREATE TABLE BlendUser (

--- a/test-suite/src/case.rs
+++ b/test-suite/src/case.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(case, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(case, async move {
     let test_cases = [
         (
             "CREATE TABLE Item (id INTEGER, name TEXT);",

--- a/test-suite/src/concat.rs
+++ b/test-suite/src/concat.rs
@@ -1,8 +1,6 @@
-use crate::*;
+use {crate::*, gluesql_core::prelude::Value::*};
 
 test_case!(concat, async move {
-    use gluesql_core::prelude::Value::*;
-
     run!(
         "
         CREATE TABLE Concat (

--- a/test-suite/src/data_type/date.rs
+++ b/test-suite/src/data_type/date.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use {crate::*, gluesql_core::prelude::Value::*};
 
 test_case!(date, async move {
     run!(
@@ -18,8 +18,6 @@ INSERT INTO DateLog VALUES
     (3, "2021-05-01", "2021-05-01");
 "#
     );
-
-    use gluesql_core::prelude::Value::*;
 
     macro_rules! date {
         ($date: expr) => {

--- a/test-suite/src/data_type/interval.rs
+++ b/test-suite/src/data_type/interval.rs
@@ -1,7 +1,12 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        data::{Interval as I, IntervalError},
+        prelude::Value::*,
+    },
+};
 
 test_case!(interval, async move {
-    use gluesql_core::data::IntervalError;
     run!(
         r#"
 CREATE TABLE IntervalLog (
@@ -23,9 +28,6 @@ INSERT INTO IntervalLog VALUES
     (7, INTERVAL "-1000-11" YEAR TO MONTH,    INTERVAL "-30:11" MINUTE TO SECOND);
 "#
     );
-
-    use gluesql_core::data::Interval as I;
-    use gluesql_core::prelude::Value::*;
 
     test!(
         Ok(select!(

--- a/test-suite/src/data_type/time.rs
+++ b/test-suite/src/data_type/time.rs
@@ -1,8 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    chrono::{NaiveDate, NaiveTime},
+    gluesql_core::data::{IntervalError, ValueError},
+    gluesql_core::prelude::Value::*,
+};
 
 test_case!(time, async move {
-    use gluesql_core::data::{IntervalError, ValueError};
-
     run!(
         r#"
 CREATE TABLE TimeLog (
@@ -20,9 +23,6 @@ INSERT INTO TimeLog VALUES
     (3, "PM 2:59", "9:00:00 AM");
 "#
     );
-
-    use chrono::{NaiveDate, NaiveTime};
-    use gluesql_core::prelude::Value::*;
 
     let t = NaiveTime::from_hms_milli;
     let i = |h, m, s, ms| {

--- a/test-suite/src/data_type/timestamp.rs
+++ b/test-suite/src/data_type/timestamp.rs
@@ -1,7 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{data::ValueError, prelude::Value::*},
+};
 
 test_case!(timestamp, async move {
-    use gluesql_core::data::ValueError;
     run!(
         r#"
 CREATE TABLE TimestampLog (
@@ -25,8 +27,6 @@ INSERT INTO TimestampLog VALUES
             $timestamp.parse().unwrap()
         };
     }
-
-    use gluesql_core::prelude::Value::*;
 
     test!(
         Ok(select!(

--- a/test-suite/src/default.rs
+++ b/test-suite/src/default.rs
@@ -1,14 +1,13 @@
-use crate::*;
+use {
+    crate::*,
+    chrono::NaiveDate,
+    gluesql_core::{
+        executor::EvaluateError,
+        prelude::{Payload, Value::*},
+    },
+};
 
 test_case!(default, async move {
-    use {
-        chrono::NaiveDate,
-        gluesql_core::{
-            executor::EvaluateError,
-            prelude::{Payload, Value::*},
-        },
-    };
-
     let test_cases = [
         (
             "CREATE TABLE Test (

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -1,13 +1,14 @@
-use crate::*;
-
-test_case!(error, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         data::RowError,
         executor::{EvaluateError, ExecuteError, FetchError},
         plan::PlanError,
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(error, async move {
     run!("CREATE TABLE TableA (id INTEGER);");
     run!("INSERT INTO TableA (id) VALUES (1);");
     run!("INSERT INTO TableA (id) VALUES (9);");

--- a/test-suite/src/filter.rs
+++ b/test-suite/src/filter.rs
@@ -1,12 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    bigdecimal::BigDecimal,
+    gluesql_core::data::*,
+    std::{borrow::Cow, str::FromStr},
+};
 
 test_case!(filter, async move {
-    use {
-        bigdecimal::BigDecimal,
-        gluesql_core::data::*,
-        std::{borrow::Cow, str::FromStr},
-    };
-
     let create_sqls = [
         "
         CREATE TABLE Boss (

--- a/test-suite/src/function/abs.rs
+++ b/test-suite/src/function/abs.rs
@@ -1,9 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
+    },
+};
 
 test_case!(abs, async move {
-    use gluesql_core::{
-        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
-    };
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id integer, int8 int(8), dec decimal)",

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -1,5 +1,6 @@
 use {
     crate::*,
+    chrono::{NaiveDate, NaiveTime},
     gluesql_core::{
         data::Interval as I,
         data::ValueError,
@@ -13,8 +14,6 @@ use {
 };
 
 test_case!(cast_literal, async move {
-    use chrono::{NaiveDate, NaiveTime};
-
     let test_cases = [
         ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
         (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),

--- a/test-suite/src/function/ceil.rs
+++ b/test-suite/src/function/ceil.rs
@@ -1,9 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
+    },
+};
 
 test_case!(ceil, async move {
-    use gluesql_core::{
-        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
-    };
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT CEIL(0.5))",

--- a/test-suite/src/function/concat.rs
+++ b/test-suite/src/function/concat.rs
@@ -1,9 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{prelude::Value::*, translate::TranslateError},
+};
 
 test_case!(concat, async move {
-    use gluesql_core::prelude::Value::*;
-    use gluesql_core::translate::TranslateError;
-
     run!(
         "
         CREATE TABLE Concat (

--- a/test-suite/src/function/degrees.rs
+++ b/test-suite/src/function/degrees.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(degrees, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(degrees, async move {
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id FLOAT DEFAULT DEGREES(90))",

--- a/test-suite/src/function/div_mod.rs
+++ b/test-suite/src/function/div_mod.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(div_mod, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(div_mod, async move {
     let eval_div = |dividend, divisor| (dividend / divisor) as i64;
     let eval_mod = |dividend, divisor| dividend % divisor;
     let test_cases = [

--- a/test-suite/src/function/exp_log.rs
+++ b/test-suite/src/function/exp_log.rs
@@ -51,8 +51,6 @@ test_case!(log2, async move {
 });
 
 test_case!(log10, async move {
-    use gluesql_core::prelude::Value::{Null, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT LOG10(100))",
@@ -97,8 +95,6 @@ test_case!(log10, async move {
 });
 
 test_case!(ln, async move {
-    use gluesql_core::prelude::Value::{Null, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT LN(10))",
@@ -143,8 +139,6 @@ test_case!(ln, async move {
 });
 
 test_case!(log, async move {
-    use gluesql_core::prelude::Value::{Null, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT LOG(2, 64))",
@@ -197,8 +191,6 @@ test_case!(log, async move {
 });
 
 test_case!(exp, async move {
-    use gluesql_core::prelude::Value::{Null, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT EXP(3.3))",

--- a/test-suite/src/function/floor.rs
+++ b/test-suite/src/function/floor.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(floor, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(floor, async move {
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT FLOOR(3.3))",

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(gcd_lcm, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
-    };
+    },
+};
 
+test_case!(gcd_lcm, async move {
     let test_cases = [
         (
             r#"

--- a/test-suite/src/function/generate_uuid.rs
+++ b/test-suite/src/function/generate_uuid.rs
@@ -1,8 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{ast::DataType, prelude::Payload, translate::TranslateError},
+};
 
 test_case!(generate_uuid, async move {
-    use gluesql_core::{ast::DataType, prelude::Payload, translate::TranslateError};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id UUID DEFAULT GENERATE_UUID())",

--- a/test-suite/src/function/ifnull.rs
+++ b/test-suite/src/function/ifnull.rs
@@ -1,9 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    chrono::{NaiveDate, NaiveDateTime, NaiveTime},
+    gluesql_core::{executor::Payload, prelude::Value::*},
+    rust_decimal::Decimal,
+};
 
 test_case!(ifnull, async move {
-    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-    use gluesql_core::{executor::Payload, prelude::Value::*};
-    use rust_decimal::Decimal;
     let test_cases = [
         (
             r#"CREATE TABLE SingleItem (id integer null, int8 int(8) null, dec decimal null, 

--- a/test-suite/src/function/left_right.rs
+++ b/test-suite/src/function/left_right.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(left_right, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(left_right, async move {
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT LEFT("abc", 1))"#,

--- a/test-suite/src/function/lpad_rpad.rs
+++ b/test-suite/src/function/lpad_rpad.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(lpad_rpad, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(lpad_rpad, async move {
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT LPAD("a", 5) || LPAD("b", 3))"#,

--- a/test-suite/src/function/ltrim_rtrim.rs
+++ b/test-suite/src/function/ltrim_rtrim.rs
@@ -1,14 +1,15 @@
-use crate::*;
-
-test_case!(ltrim_rtrim, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{
             Payload,
             Value::{self, *},
         },
-    };
+    },
+};
 
+test_case!(ltrim_rtrim, async move {
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT RTRIM(LTRIM("   abc   ")))"#,

--- a/test-suite/src/function/math_function.rs
+++ b/test-suite/src/function/math_function.rs
@@ -70,8 +70,6 @@ test_case!(sin, async move {
 });
 
 test_case!(cos, async move {
-    use gluesql_core::prelude::Value::{self, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT COS(3.141592))",
@@ -131,8 +129,6 @@ test_case!(cos, async move {
 });
 
 test_case!(tan, async move {
-    use gluesql_core::prelude::Value::{self, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT TAN(3.141592))",
@@ -192,9 +188,6 @@ test_case!(tan, async move {
 });
 
 test_case!(asin, async move {
-    use gluesql_core::prelude::Value::Null;
-    use gluesql_core::prelude::Value::F64;
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT ASIN(3.1415926))",
@@ -301,9 +294,6 @@ test_case!(acos, async move {
 });
 
 test_case!(atan, async move {
-    use gluesql_core::prelude::Value::Null;
-    use gluesql_core::prelude::Value::F64;
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT ATAN(3.14))",

--- a/test-suite/src/function/pi.rs
+++ b/test-suite/src/function/pi.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(pi, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(pi, async move {
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id FLOAT DEFAULT PI())",

--- a/test-suite/src/function/radians.rs
+++ b/test-suite/src/function/radians.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(radians, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(radians, async move {
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id FLOAT DEFAULT RADIANS(180))",

--- a/test-suite/src/function/repeat.rs
+++ b/test-suite/src/function/repeat.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(repeat, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(repeat, async move {
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT REPEAT("hello", 2))"#,

--- a/test-suite/src/function/reverse.rs
+++ b/test-suite/src/function/reverse.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(reverse, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value},
-    };
+    },
+};
 
+test_case!(reverse, async move {
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT REVERSE("world"))"#,

--- a/test-suite/src/function/round.rs
+++ b/test-suite/src/function/round.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(round, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         executor::EvaluateError,
         prelude::{Payload, Value::*},
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(round, async move {
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id INTEGER DEFAULT ROUND(3.5))",

--- a/test-suite/src/function/sign.rs
+++ b/test-suite/src/function/sign.rs
@@ -1,9 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
+    },
+};
 
 test_case!(sign, async move {
-    use gluesql_core::{
-        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
-    };
     let test_cases = [
         ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
         (

--- a/test-suite/src/function/sqrt_power.rs
+++ b/test-suite/src/function/sqrt_power.rs
@@ -60,8 +60,6 @@ test_case!(sqrt, async move {
 });
 
 test_case!(power, async move {
-    use gluesql_core::prelude::Value::{Null, F64};
-
     let test_cases = [
         (
             "CREATE TABLE SingleItem (id FLOAT DEFAULT POWER(3, 4))",

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -1,14 +1,12 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError,
+        prelude::{Payload, Value::*},
+    },
+};
 
 test_case!(substr, async move {
-    use {
-        crate::*,
-        gluesql_core::{
-            executor::EvaluateError,
-            prelude::{Payload, Value::*},
-        },
-    };
-
     let test_cases = [
         (
             r#"CREATE TABLE Item (name TEXT DEFAULT SUBSTR("abc", 0, 2))"#,

--- a/test-suite/src/function/trim.rs
+++ b/test-suite/src/function/trim.rs
@@ -1,14 +1,12 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError,
+        prelude::{Payload, Value},
+    },
+};
 
 test_case!(trim, async move {
-    use {
-        crate::*,
-        gluesql_core::{
-            executor::EvaluateError,
-            prelude::{Payload, Value},
-        },
-    };
-
     let test_cases = [
         (
             r#"CREATE TABLE Item (

--- a/test-suite/src/function/upper_lower.rs
+++ b/test-suite/src/function/upper_lower.rs
@@ -1,15 +1,13 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        executor::EvaluateError,
+        prelude::{Payload, Value::*},
+        translate::TranslateError,
+    },
+};
 
 test_case!(upper_lower, async move {
-    use {
-        crate::*,
-        gluesql_core::{
-            executor::EvaluateError,
-            prelude::{Payload, Value::*},
-            translate::TranslateError,
-        },
-    };
-
     let test_cases = [
         (
             r#"CREATE TABLE Item (

--- a/test-suite/src/index/and.rs
+++ b/test-suite/src/index/and.rs
@@ -1,4 +1,4 @@
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::ast::IndexOperator::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(and, async move {
     run!(
@@ -31,9 +31,6 @@ CREATE TABLE NullIdx (
         Ok(Payload::CreateIndex),
         "CREATE INDEX idx_date ON NullIdx (date)"
     );
-
-    use gluesql_core::ast::IndexOperator::*;
-    use Value::*;
 
     macro_rules! date {
         ($date: expr) => {

--- a/test-suite/src/index/basic.rs
+++ b/test-suite/src/index/basic.rs
@@ -1,14 +1,15 @@
-use crate::*;
-
-test_case!(basic, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         ast::IndexOperator::*,
         executor::AlterError,
         prelude::{Payload, Value::*},
         store::IndexError,
         translate::TranslateError,
-    };
+    },
+};
 
+test_case!(basic, async move {
     run!(
         r#"
 CREATE TABLE Test (

--- a/test-suite/src/index/expr.rs
+++ b/test-suite/src/index/expr.rs
@@ -1,12 +1,13 @@
-use crate::*;
-
-test_case!(expr, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         ast::IndexOperator::*,
         executor::AlterError,
         prelude::{Payload, Value::*},
-    };
+    },
+};
 
+test_case!(expr, async move {
     run!(
         r#"
 CREATE TABLE Test (

--- a/test-suite/src/index/nested.rs
+++ b/test-suite/src/index/nested.rs
@@ -1,4 +1,10 @@
-use {crate::*, gluesql_core::prelude::Payload};
+use {
+    crate::*,
+    gluesql_core::{
+        ast::IndexOperator::*,
+        prelude::{Payload, Value::*},
+    },
+};
 
 test_case!(nested, async move {
     run!(
@@ -22,8 +28,6 @@ CREATE TABLE User (
             (5, 2, "Builder");
     "#
     );
-
-    use gluesql_core::{ast::IndexOperator::*, prelude::Value::*};
 
     test!(Ok(Payload::CreateIndex), "CREATE INDEX idx_id ON User (id)");
 

--- a/test-suite/src/index/null.rs
+++ b/test-suite/src/index/null.rs
@@ -1,4 +1,8 @@
-use {crate::*, gluesql_core::prelude::*};
+use {
+    crate::*,
+    gluesql_core::{ast::IndexOperator::*, prelude::*},
+    Value::*,
+};
 
 test_case!(null, async move {
     run!(
@@ -35,9 +39,6 @@ CREATE TABLE NullIdx (
         Ok(Payload::CreateIndex),
         "CREATE INDEX idx_flag ON NullIdx (flag)"
     );
-
-    use gluesql_core::ast::IndexOperator::*;
-    use Value::*;
 
     macro_rules! date {
         ($date: expr) => {

--- a/test-suite/src/index/order_by.rs
+++ b/test-suite/src/index/order_by.rs
@@ -1,4 +1,4 @@
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(order_by, async move {
     run!(
@@ -32,8 +32,6 @@ CREATE TABLE Test (
         Ok(Payload::CreateIndex),
         "CREATE INDEX idx_num_desc ON Test (num DESC)"
     );
-
-    use Value::*;
 
     macro_rules! s {
         ($v: literal) => {
@@ -113,8 +111,6 @@ CREATE TABLE Multi (
         Ok(Payload::CreateIndex),
         "CREATE INDEX idx_id_num ON Multi (id + num DESC)"
     );
-
-    use Value::I64;
 
     test_idx!(
         Ok(select!(id | num I64 | I64;

--- a/test-suite/src/index/showindexes.rs
+++ b/test-suite/src/index/showindexes.rs
@@ -1,13 +1,14 @@
-use crate::*;
-
-test_case!(showindexes, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         ast::{BinaryOperator, Expr},
         data::{SchemaIndex, SchemaIndexOrd},
         executor::ExecuteError,
         prelude::Payload,
-    };
+    },
+};
 
+test_case!(showindexes, async move {
     run!(
         r#"
 CREATE TABLE Test (

--- a/test-suite/src/index/value.rs
+++ b/test-suite/src/index/value.rs
@@ -1,4 +1,9 @@
-use {crate::*, gluesql_core::prelude::*};
+use {
+    crate::*,
+    chrono::NaiveTime,
+    gluesql_core::{ast::IndexOperator::*, prelude::*},
+    Value::*,
+};
 
 test_case!(value, async move {
     run!(
@@ -32,10 +37,6 @@ CREATE TABLE IdxValue (
         Ok(Payload::CreateIndex),
         "CREATE INDEX idx_flag ON IdxValue (flag)"
     );
-
-    use chrono::NaiveTime;
-    use gluesql_core::ast::IndexOperator::*;
-    use Value::*;
 
     let t = |h, m| NaiveTime::from_hms(h, m, 0);
 

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -1,4 +1,4 @@
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(join, async move {
     let create_sqls: [&str; 2] = [
@@ -182,8 +182,6 @@ test_case!(blend, async move {
     for insert_sql in insert_sqls {
         run!(insert_sql);
     }
-
-    use Value::{Null, Str, I64};
 
     let sql = "
         SELECT p.id, i.id

--- a/test-suite/src/limit.rs
+++ b/test-suite/src/limit.rs
@@ -1,8 +1,6 @@
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(limit, async move {
-    use Value::I64;
-
     let test_cases = [
         (
             "CREATE TABLE Test (

--- a/test-suite/src/migrate.rs
+++ b/test-suite/src/migrate.rs
@@ -1,10 +1,11 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        data::ValueError, executor::EvaluateError, prelude::Value::*, translate::TranslateError,
+    },
+};
 
 test_case!(migrate, async move {
-    use gluesql_core::{
-        data::ValueError, executor::EvaluateError, prelude::Value::*, translate::TranslateError,
-    };
-
     run!(
         "
         CREATE TABLE Test (

--- a/test-suite/src/order_by.rs
+++ b/test-suite/src/order_by.rs
@@ -1,4 +1,7 @@
-use {crate::*, gluesql_core::translate::TranslateError};
+use {
+    crate::*,
+    gluesql_core::{prelude::Value::*, translate::TranslateError},
+};
 
 test_case!(order_by, async move {
     run!(
@@ -20,8 +23,6 @@ CREATE TABLE Test (
             (4, 7, "Thursday", NULL);
     "#
     );
-
-    use gluesql_core::prelude::Value::*;
 
     test!(
         Ok(select!(

--- a/test-suite/src/showcolumns.rs
+++ b/test-suite/src/showcolumns.rs
@@ -1,9 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{ast::DataType, executor::ExecuteError, executor::Payload},
+};
 
 test_case!(showcolumns, async move {
-    use gluesql_core::ast::DataType;
-    use gluesql_core::{executor::ExecuteError, executor::Payload};
-
     run!(
         "
         CREATE TABLE mytable (

--- a/test-suite/src/synthesize.rs
+++ b/test-suite/src/synthesize.rs
@@ -1,4 +1,4 @@
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(synthesize, async move {
     let create_sql = "
@@ -67,8 +67,6 @@ test_case!(synthesize, async move {
     for insert_sql in insert_sqls {
         run!(insert_sql);
     }
-
-    use Value::I64;
 
     let test_cases = [
         (

--- a/test-suite/src/tester.rs
+++ b/test-suite/src/tester.rs
@@ -247,8 +247,6 @@ macro_rules! test_case {
         where
             T: gluesql_core::store::GStore + gluesql_core::store::GStoreMut,
         {
-            use std::rc::Rc;
-
             let cell = tester.get_cell();
 
             #[allow(unused_macros)]

--- a/test-suite/src/tester.rs
+++ b/test-suite/src/tester.rs
@@ -247,6 +247,8 @@ macro_rules! test_case {
         where
             T: gluesql_core::store::GStore + gluesql_core::store::GStoreMut,
         {
+            use std::rc::Rc;
+
             let cell = tester.get_cell();
 
             #[allow(unused_macros)]

--- a/test-suite/src/transaction/basic.rs
+++ b/test-suite/src/transaction/basic.rs
@@ -1,10 +1,8 @@
 #![cfg(feature = "transaction")]
 
-use {crate::*, gluesql_core::prelude::*};
+use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(basic, async move {
-    use Value::*;
-
     run!(
         "
         CREATE TABLE TxTest (

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -1,11 +1,12 @@
-use crate::*;
-
-test_case!(unary_operator, async move {
-    use gluesql_core::{
+use {
+    crate::*,
+    gluesql_core::{
         data::{LiteralError, ValueError},
         prelude::{Payload, Value::*},
-    };
+    },
+};
 
+test_case!(unary_operator, async move {
     let test_cases = [
         (
             "CREATE TABLE Test (v1 INT, v2 FLOAT, v3 TEXT, v4 INT, v5 INT, v6 INT(8))",

--- a/test-suite/src/update.rs
+++ b/test-suite/src/update.rs
@@ -5,6 +5,7 @@ use {
         prelude::*,
         translate::TranslateError,
     },
+    Value::*,
 };
 
 test_case!(update, async move {
@@ -48,8 +49,6 @@ test_case!(update, async move {
             (4, 7, 4);
         "#
     );
-
-    use Value::*;
 
     let test_cases = [
         (Ok(Payload::Update(4)), "UPDATE TableA SET id = 2"),

--- a/test-suite/src/validate/types.rs
+++ b/test-suite/src/validate/types.rs
@@ -1,15 +1,14 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{
+        ast::DataType,
+        data::{Literal, ValueError},
+        prelude::Value,
+    },
+    std::borrow::Cow,
+};
 
 test_case!(types, async move {
-    use {
-        gluesql_core::{
-            ast::DataType,
-            data::{Literal, ValueError},
-            prelude::Value,
-        },
-        std::borrow::Cow,
-    };
-
     run!("CREATE TABLE TableB (id BOOLEAN);");
     run!("CREATE TABLE TableC (uid INTEGER, null_val INTEGER NULL);");
     run!("INSERT INTO TableB VALUES (FALSE);");

--- a/test-suite/src/validate/unique.rs
+++ b/test-suite/src/validate/unique.rs
@@ -1,8 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{executor::ValidateError, prelude::Value},
+};
 
 test_case!(unique, async move {
-    use gluesql_core::{executor::ValidateError, prelude::Value};
-
     run!(
         r#"
 CREATE TABLE TestA (


### PR DESCRIPTION
## Description
The scattered use crate syntax has been merged into one.

## e.g
```rust
use crate::*;

test_case!(case, async move {
    use gluesql_core::{
        prelude::{Payload, Value::*},
        translate::TranslateError,
    };
});
```
to
```rust
use {
    crate::*,
    gluesql_core::{
        prelude::{Payload, Value::*},
        translate::TranslateError,
    },
};


test_case!(case, async move {
       ...
});
```