### PR TITLE
Release v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -25,12 +25,12 @@ all-features = true
 # opt-level = "s"
 
 [dependencies]
-gluesql-core = { path = "./core", version = "0.11.0" }
-cli = { package = "gluesql-cli", path = "./cli", version = "0.11.0", optional = true }
-test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.11.0", optional = true }
-memory-storage = { package = "gluesql_memory_storage", path = "./storages/memory-storage", version = "0.11.0", optional = true }
-shared-memory-storage = { package = "gluesql-shared-memory-storage", path = "./storages/shared-memory-storage", version = "0.11.0", optional = true }
-sled-storage = { package = "gluesql_sled_storage", path = "./storages/sled-storage", version = "0.11.0", optional = true }
+gluesql-core = { path = "./core", version = "0.12.0" }
+cli = { package = "gluesql-cli", path = "./cli", version = "0.12.0", optional = true }
+test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.12.0", optional = true }
+memory-storage = { package = "gluesql_memory_storage", path = "./storages/memory-storage", version = "0.12.0", optional = true }
+shared-memory-storage = { package = "gluesql-shared-memory-storage", path = "./storages/shared-memory-storage", version = "0.12.0", optional = true }
+sled-storage = { package = "gluesql_sled_storage", path = "./storages/sled-storage", version = "0.12.0", optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -17,17 +17,18 @@ Developers can choose to use GlueSQL to build their own SQL database, or as an e
 ## Standalone Mode
 
 You can use GlueSQL as an embedded SQL database.  
-GlueSQL provides two reference storage options.
+GlueSQL provides three reference storage options.
 
 - `SledStorage` - Persistent storage engine based on [`sled`](https://github.com/spacejam/sled "sled")
 - `MemoryStorage` - Non-persistent storage engine based on `BTreeMap`
+- `SharedMemoryStorage` - Non-persistent storage engine which works in multi-threaded environment
 
 ### Installation
 
 * `Cargo.toml`
 ```toml
 [dependencies]
-gluesql = "0.11"
+gluesql = "0.12"
 ```
 
 * CLI application
@@ -66,7 +67,7 @@ fn main() {
 
 ```toml
 [dependencies.gluesql]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["alter-table", "index", "transaction", "metadata"]
 ```
@@ -87,14 +88,15 @@ features = ["alter-table", "index", "transaction", "metadata"]
 ```rust
 pub trait Store<T: Debug> {
     async fn fetch_schema(..) -> ..;
+    async fn fetch_data(..) -> ..;
     async fn scan_data(..) -> ..;
 }
 
 pub trait StoreMut<T: Debug> where Self: Sized {
     async fn insert_schema(..) -> ..;
     async fn delete_schema(..) -> ..;
+    async fn append_data(..) -> ..;
     async fn insert_data(..) -> ..;
-    async fn update_data(..) -> ..;
     async fn delete_data(..) -> ..;
 }
 ```
@@ -144,9 +146,11 @@ GlueSQL.js is a SQL database for web browsers and Node.js. It works as an embedd
 GlueSQL currently supports a limited subset of queries. It's being actively developed.
 
 #### Data Types
-- **Numeric** `INT(8)`, `INT(16)`, `INT(32)`, `INT(64)`, `INT(128)`, `INTEGER`, `FLOAT`, `DECIMAL`
-- **Date** `DATE`, `TIMESTAMP`, `TIME` `INTERVAL`
-- `BOOLEAN`, `TEXT`, `UUID`, `MAP`, `LIST`
+| Category | Type                                                                      |
+|----------|---------------------------------------------------------------------------|
+| Numeric  | `INT(8)`, `INT(16)`, `INT(32)`, `INTEGER`, `INT(128)`, `FLOAT`, `DECIMAL` |
+| Date     | `DATE`, `TIME`, `TIMESTAMP`, `INTERVAL`                                   |
+| Others   | `BOOLEAN`, `TEXT`, `UUID`, `MAP`, `LIST`, `BYTEA`                         |
 
 #### Queries
 - `CREATE TABLE`, `DROP TABLE`
@@ -159,11 +163,3 @@ GlueSQL currently supports a limited subset of queries. It's being actively deve
 - Nested select, join, aggregations ...
 
 You can see tests for the currently supported queries in [test-suite/src/\*](https://github.com/gluesql/gluesql/tree/main/test-suite/src).
-
-## Contribution
-
-There are a few simple rules to follow.
-
-- No `mut` keywords in the `core` workspace (except `glue.rs`).
-- Every error must have corresponding integration test cases to generate.  
-  (except for `Unreachable-` and `Conflict-` error types)

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ features = ["alter-table", "index", "transaction", "metadata"]
 - [`Store & StoreMut`](https://github.com/gluesql/gluesql/blob/main/core/src/store/mod.rs)
 
 ```rust
-pub trait Store<T: Debug> {
+pub trait Store {
     async fn fetch_schema(..) -> ..;
     async fn fetch_data(..) -> ..;
     async fn scan_data(..) -> ..;
 }
 
-pub trait StoreMut<T: Debug> where Self: Sized {
+pub trait StoreMut where Self: Sized {
     async fn insert_schema(..) -> ..;
     async fn delete_schema(..) -> ..;
     async fn append_data(..) -> ..;
@@ -113,11 +113,11 @@ pub trait AlterTable where Self: Sized {
     async fn drop_column(..) -> ..;
 }
 
-pub trait Index<T: Debug> {
+pub trait Index {
     async fn scan_indexed_data(..) -> ..;
 }
 
-pub trait IndexMut<T: Debug> where Self: Sized {
+pub trait IndexMut where Self: Sized {
     async fn create_index(..) -> ..;
     async fn drop_index(..) -> ..;
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,9 +9,9 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.11.0", features = ["alter-table", "metadata"] }
-gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.11.0" }
-gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.11.0" }
+gluesql-core = { path = "../core", version = "0.12.0", features = ["alter-table", "metadata"] }
+gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.12.0" }
+gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.12.0" }
 
 clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-utils = { package = "gluesql-utils", path = "../utils", version = "0.11.0" }
+utils = { package = "gluesql-utils", path = "../utils", version = "0.12.0" }
 
 regex = "1"
 async-trait = "0.1"

--- a/gluesql-js/README.md
+++ b/gluesql-js/README.md
@@ -22,7 +22,7 @@ npm install gluesql
 
 #### JavaScript modules
 ```javascript
-import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.11.0/gluesql.js';
+import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.12.0/gluesql.js';
 ```
 
 ## Usage

--- a/gluesql-js/package.json
+++ b/gluesql-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "gluesql.js",
   "main": "gluesql.node.js",

--- a/gluesql-js/web/Cargo.toml
+++ b/gluesql-js/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-js"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -35,8 +35,8 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 wee_alloc = { version = "0.4.5", optional = true }
 
-gluesql-core = { path = "../../core", version = "0.11.0" }
-memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.11.0" }
+gluesql-core = { path = "../../core", version = "0.12.0" }
+memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.12.0" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
@@ -44,5 +44,5 @@ wasm-bindgen-test = "0.3.13"
 [dev-dependencies.test-suite]
 package = "gluesql-test-suite"
 path = "../../test-suite"
-version = "0.11.0"
+version = "0.12.0"
 features = ["alter-table", "metadata"]

--- a/gluesql-js/web/package.json
+++ b/gluesql-js/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "bundler.js",
   "main": "index.js",

--- a/gluesql-js/web/src/payload.rs
+++ b/gluesql-js/web/src/payload.rs
@@ -63,7 +63,7 @@ fn convert_payload(payload: Payload) -> Json {
         Payload::ShowIndexes(indexes) => {
             let indexes = indexes
                 .into_iter()
-                .map(|(index)| {
+                .map(|index| {
                     json!({
                         "name": index.name,
                         "order": index.order.to_string(),

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_memory_storage"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.11.0", features = [
+gluesql-core = { path = "../../core", version = "0.12.0", features = [
 	"alter-table",
 	"index",
 	"transaction",
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 indexmap = { version = "1.8", features = ["serde"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.11.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
 	"alter-table",
 	"index",
 	"transaction",

--- a/storages/shared-memory-storage/Cargo.toml
+++ b/storages/shared-memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-shared-memory-storage"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = [
 	"Jiseok CHOI <jiseok.dev@gmail.com>",
@@ -12,8 +12,8 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-memory-storage = { package = "gluesql_memory_storage", version = "0.11.0", path = "../memory-storage" }
-gluesql-core = { path = "../../core", version = "0.11.0", features = [
+memory-storage = { package = "gluesql_memory_storage", version = "0.12.0", path = "../memory-storage" }
+gluesql-core = { path = "../../core", version = "0.12.0", features = [
 	"alter-table",
 	"index",
 	"transaction",
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.11.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
 	"alter-table",
 	"index",
 	"transaction",

--- a/storages/sled-storage/Cargo.toml
+++ b/storages/sled-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_sled_storage"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,13 +9,13 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.11.0", features = [
+gluesql-core = { path = "../../core", version = "0.12.0", features = [
 	"index",
 	"transaction",
 	"alter-table",
 	"metadata",
 ] }
-utils = { package = "gluesql-utils", path = "../../utils", version = "0.11.0" }
+utils = { package = "gluesql-utils", path = "../../utils", version = "0.12.0" }
 async-trait = "0.1"
 iter-enum = "1"
 serde = { version = "1", features = ["derive"] }
@@ -24,7 +24,7 @@ bincode = "1"
 sled = "0.34"
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.11.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
 	"index",
 	"transaction",
 	"alter-table",

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-test-suite"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.11.0" }
+gluesql-core = { path = "../core", version = "0.12.0" }
 async-trait = "0.1"
 bigdecimal = "0.3"
 uuid = "0.8"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-utils"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"


### PR DESCRIPTION
Bump all workspace versions to v0.11.0
Update README.md & gluesql-js/README.md

- [x] Update README.md
- [x] Update workspace versions
- [x] Write release note
- [ ] Publish to crates.io
- [ ] Publish to npm (gluesql-js)