### PR TITLE
Upgrade sqlparser-rs to v0.22

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.19", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.22", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.24"
 bigdecimal = { version = "0.3", features = ["serde", "string-only"] }

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -315,12 +315,30 @@ mod tests {
             }
             .to_sql()
         );
+        assert_eq!(
+            r#"id NOT LIKE "%abc""#,
+            Expr::Like {
+                expr: Box::new(Expr::Identifier("id".to_string())),
+                negated: true,
+                pattern: Box::new(Expr::Literal(AstLiteral::QuotedString("%abc".to_owned()))),
+            }
+            .to_sql()
+        );
 
         assert_eq!(
             r#"id ILIKE "%abc_""#,
             Expr::ILike {
                 expr: Box::new(Expr::Identifier("id".to_string())),
                 negated: false,
+                pattern: Box::new(Expr::Literal(AstLiteral::QuotedString("%abc_".to_owned()))),
+            }
+            .to_sql()
+        );
+        assert_eq!(
+            r#"id NOT ILIKE "%abc_""#,
+            Expr::ILike {
+                expr: Box::new(Expr::Identifier("id".to_string())),
+                negated: true,
                 pattern: Box::new(Expr::Literal(AstLiteral::QuotedString("%abc_".to_owned()))),
             }
             .to_sql()

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -31,6 +31,16 @@ pub enum Expr {
         low: Box<Expr>,
         high: Box<Expr>,
     },
+    Like {
+        expr: Box<Expr>,
+        negated: bool,
+        pattern: Box<Expr>,
+    },
+    ILike {
+        expr: Box<Expr>,
+        negated: bool,
+        pattern: Box<Expr>,
+    },
     BinaryOp {
         left: Box<Expr>,
         op: BinaryOperator,
@@ -108,6 +118,32 @@ impl ToSql for Expr {
                 match negated {
                     true => format!("{expr} NOT BETWEEN {low} AND {high}"),
                     false => format!("{expr} BETWEEN {low} AND {high}"),
+                }
+            }
+            Expr::Like {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr = expr.to_sql();
+                let pattern = pattern.to_sql();
+
+                match negated {
+                    true => format!("{expr} NOT LIKE {pattern}"),
+                    false => format!("{expr} LIKE {pattern}"),
+                }
+            }
+            Expr::ILike {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr = expr.to_sql();
+                let pattern = pattern.to_sql();
+
+                match negated {
+                    true => format!("{expr} NOT ILIKE {pattern}"),
+                    false => format!("{expr} ILIKE {pattern}"),
                 }
             }
             Expr::UnaryOp { op, expr } => match op {
@@ -266,6 +302,26 @@ mod tests {
                 negated: true,
                 low: Box::new(Expr::Identifier("low".to_string())),
                 high: Box::new(Expr::Identifier("high".to_string()))
+            }
+            .to_sql()
+        );
+
+        assert_eq!(
+            r#"id LIKE "%abc""#,
+            Expr::Like {
+                expr: Box::new(Expr::Identifier("id".to_string())),
+                negated: false,
+                pattern: Box::new(Expr::Literal(AstLiteral::QuotedString("%abc".to_owned()))),
+            }
+            .to_sql()
+        );
+
+        assert_eq!(
+            r#"id ILIKE "%abc_""#,
+            Expr::ILike {
+                expr: Box::new(Expr::Identifier("id".to_string())),
+                negated: false,
+                pattern: Box::new(Expr::Literal(AstLiteral::QuotedString("%abc_".to_owned()))),
             }
             .to_sql()
         );

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -217,11 +217,15 @@ impl ToSql for Assignment {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "alter-table")]
-    use {crate::ast::AlterTableOperation, bigdecimal::BigDecimal, std::str::FromStr};
+    use crate::ast::AlterTableOperation;
 
-    use crate::ast::{
-        Assignment, AstLiteral, BinaryOperator, ColumnDef, ColumnOption, ColumnOptionDef, DataType,
-        Expr, ObjectName, Query, SetExpr, Statement, ToSql, Values,
+    use {
+        crate::ast::{
+            Assignment, AstLiteral, BinaryOperator, ColumnDef, ColumnOption, ColumnOptionDef,
+            DataType, Expr, ObjectName, Query, SetExpr, Statement, ToSql, Values,
+        },
+        bigdecimal::BigDecimal,
+        std::str::FromStr,
     };
 
     #[test]

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -167,13 +167,12 @@ impl ToSql for Statement {
 
 #[cfg(test)]
 mod tests {
-    use {
-        crate::ast::{
-            AlterTableOperation, AstLiteral, ColumnDef, ColumnOption, ColumnOptionDef, DataType,
-            Expr, ObjectName, Query, SetExpr, Statement, ToSql, Values,
-        },
-        bigdecimal::BigDecimal,
-        std::str::FromStr,
+    #[cfg(feature = "alter-table")]
+    use {crate::ast::AlterTableOperation, bigdecimal::BigDecimal, std::str::FromStr};
+
+    use crate::ast::{
+        AstLiteral, ColumnDef, ColumnOption, ColumnOptionDef, DataType, Expr, ObjectName, Query,
+        SetExpr, Statement, ToSql, Values,
     };
 
     #[test]

--- a/core/src/ast/operator.rs
+++ b/core/src/ast/operator.rs
@@ -39,10 +39,6 @@ pub enum BinaryOperator {
     And,
     Or,
     Xor,
-    Like,
-    ILike,
-    NotLike,
-    NotILike,
 }
 
 impl ToSql for BinaryOperator {
@@ -63,10 +59,6 @@ impl ToSql for BinaryOperator {
             BinaryOperator::And => "AND".to_string(),
             BinaryOperator::Or => "OR".to_string(),
             BinaryOperator::Xor => "XOR".to_string(),
-            BinaryOperator::Like => "LIKE".to_string(),
-            BinaryOperator::ILike => "ILIKE".to_string(),
-            BinaryOperator::NotLike => "NOT LIKE".to_string(),
-            BinaryOperator::NotILike => "NOT ILIKE".to_string(),
         }
     }
 }
@@ -251,42 +243,7 @@ mod tests {
             }
             .to_sql()
         );
-        assert_eq!(
-            "column_0 LIKE pattern",
-            &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("column_0".to_string())),
-                op: BinaryOperator::Like,
-                right: Box::new(Expr::Identifier("pattern".to_string()))
-            }
-            .to_sql()
-        );
-        assert_eq!(
-            "column_0 ILIKE pattern",
-            &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("column_0".to_string())),
-                op: BinaryOperator::ILike,
-                right: Box::new(Expr::Identifier("pattern".to_string()))
-            }
-            .to_sql()
-        );
-        assert_eq!(
-            "column_0 NOT LIKE pattern",
-            &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("column_0".to_string())),
-                op: BinaryOperator::NotLike,
-                right: Box::new(Expr::Identifier("pattern".to_string()))
-            }
-            .to_sql()
-        );
-        assert_eq!(
-            "column_0 NOT ILIKE num",
-            &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("column_0".to_string())),
-                op: BinaryOperator::NotILike,
-                right: Box::new(Expr::Identifier("num".to_string()))
-            }
-            .to_sql()
-        );
+
         assert_eq!(
             "+8",
             Expr::UnaryOp {

--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -68,22 +68,6 @@ impl ExprNode {
     pub fn or<T: Into<Self>>(self, other: T) -> Self {
         self.binary_op(BinaryOperator::Or, other)
     }
-
-    pub fn like<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::Like, other)
-    }
-
-    pub fn ilike<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::ILike, other)
-    }
-
-    pub fn not_like<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::NotLike, other)
-    }
-
-    pub fn not_ilike<T: Into<Self>>(self, other: T) -> Self {
-        self.binary_op(BinaryOperator::NotILike, other)
-    }
 }
 
 #[cfg(test)]
@@ -146,22 +130,6 @@ mod tests {
 
         let actual = (col("id").gt(num(10))).or(col("id").lt(num(20)));
         let expected = "id > 10 OR id < 20";
-        test_expr(actual, expected);
-
-        let actual = col("name").like(text("a%"));
-        let expected = "name LIKE 'a%'";
-        test_expr(actual, expected);
-
-        let actual = col("name").ilike(text("a%"));
-        let expected = "name ILIKE 'a%'";
-        test_expr(actual, expected);
-
-        let actual = col("name").not_like(text("a%"));
-        let expected = "name NOT LIKE 'a%'";
-        test_expr(actual, expected);
-
-        let actual = col("name").not_ilike(text("a%"));
-        let expected = "name NOT ILIKE 'a%'";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/expr/like.rs
+++ b/core/src/ast_builder/expr/like.rs
@@ -1,0 +1,59 @@
+use super::ExprNode;
+
+impl ExprNode {
+    pub fn like<T: Into<Self>>(self, pattern: T) -> Self {
+        Self::Like {
+            expr: Box::new(self),
+            negated: false,
+            pattern: Box::new(pattern.into()),
+        }
+    }
+
+    pub fn ilike<T: Into<Self>>(self, pattern: T) -> Self {
+        Self::ILike {
+            expr: Box::new(self),
+            negated: false,
+            pattern: Box::new(pattern.into()),
+        }
+    }
+
+    pub fn not_like<T: Into<Self>>(self, pattern: T) -> Self {
+        Self::Like {
+            expr: Box::new(self),
+            negated: true,
+            pattern: Box::new(pattern.into()),
+        }
+    }
+
+    pub fn not_ilike<T: Into<Self>>(self, pattern: T) -> Self {
+        Self::ILike {
+            expr: Box::new(self),
+            negated: true,
+            pattern: Box::new(pattern.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast_builder::{col, test_expr, text};
+
+    #[test]
+    fn like_ilike() {
+        let actual = col("name").like(text("a%"));
+        let expected = "name LIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").ilike(text("a%"));
+        let expected = "name ILIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").not_like(text("a%"));
+        let expected = "name NOT LIKE 'a%'";
+        test_expr(actual, expected);
+
+        let actual = col("name").not_ilike(text("a%"));
+        let expected = "name NOT ILIKE 'a%'";
+        test_expr(actual, expected);
+    }
+}

--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -1,6 +1,7 @@
 mod binary_op;
 mod exists;
 mod is_null;
+mod like;
 mod nested;
 mod unary_op;
 
@@ -46,6 +47,16 @@ pub enum ExprNode {
         negated: bool,
         low: Box<ExprNode>,
         high: Box<ExprNode>,
+    },
+    Like {
+        expr: Box<ExprNode>,
+        negated: bool,
+        pattern: Box<ExprNode>,
+    },
+    ILike {
+        expr: Box<ExprNode>,
+        negated: bool,
+        pattern: Box<ExprNode>,
     },
     BinaryOp {
         left: Box<ExprNode>,
@@ -110,6 +121,34 @@ impl TryFrom<ExprNode> for Expr {
                     negated,
                     low,
                     high,
+                })
+            }
+            ExprNode::Like {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr = Expr::try_from(*expr).map(Box::new)?;
+                let pattern = Expr::try_from(*pattern).map(Box::new)?;
+
+                Ok(Expr::Like {
+                    expr,
+                    negated,
+                    pattern,
+                })
+            }
+            ExprNode::ILike {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr = Expr::try_from(*expr).map(Box::new)?;
+                let pattern = Expr::try_from(*pattern).map(Box::new)?;
+
+                Ok(Expr::ILike {
+                    expr,
+                    negated,
+                    pattern,
                 })
             }
             ExprNode::BinaryOp { left, op, right } => {

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -55,14 +55,6 @@ pub fn binary_op<'a>(
         BinaryOperator::And => cond!(l && r),
         BinaryOperator::Or => cond!(l || r),
         BinaryOperator::Xor => cond!(l ^ r),
-        BinaryOperator::Like => l.like(r, true),
-        BinaryOperator::ILike => l.like(r, false),
-        BinaryOperator::NotLike => {
-            cmp!(l.like(r, true)? == Evaluated::Literal(Literal::Boolean(false)))
-        }
-        BinaryOperator::NotILike => {
-            cmp!(l.like(r, false)? == Evaluated::Literal(Literal::Boolean(false)))
-        }
     }
 }
 

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -8,7 +8,7 @@ use {
     super::{context::FilterContext, select::select},
     crate::{
         ast::{Aggregate, Expr, Function},
-        data::Value,
+        data::{Literal, Value},
         result::Result,
         store::GStore,
     },
@@ -152,6 +152,38 @@ pub async fn evaluate<'a>(
             let high = eval(high).await?;
 
             expr::between(target, *negated, low, high)
+        }
+        Expr::Like {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr).await?;
+            let pattern = eval(pattern).await?;
+            let evaluated = target.like(pattern, true)?;
+
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
+        }
+        Expr::ILike {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr).await?;
+            let pattern = eval(pattern).await?;
+            let evaluated = target.like(pattern, false)?;
+
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
         }
         Expr::Exists { subquery, negated } => select(storage, subquery, context)
             .await?

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -2,7 +2,7 @@ use {
     super::{expr, function, EvaluateError, Evaluated},
     crate::{
         ast::{Expr, Function},
-        data::{Row, Value},
+        data::{Literal, Row, Value},
         result::Result,
     },
     chrono::prelude::Utc,
@@ -100,10 +100,12 @@ pub fn evaluate_stateless<'a>(
             let pattern = eval(pattern)?;
             let evaluated = target.like(pattern, true)?;
 
-            match negated {
-                true => evaluated.unary_minus(),
-                false => Ok(evaluated),
-            }
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
         }
         Expr::ILike {
             expr,
@@ -114,10 +116,12 @@ pub fn evaluate_stateless<'a>(
             let pattern = eval(pattern)?;
             let evaluated = target.like(pattern, false)?;
 
-            match negated {
-                true => evaluated.unary_minus(),
-                false => Ok(evaluated),
-            }
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
         }
         Expr::IsNull(expr) => {
             let v = eval(expr)?.is_null();

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -91,6 +91,34 @@ pub fn evaluate_stateless<'a>(
 
             expr::between(target, *negated, low, high)
         }
+        Expr::Like {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr)?;
+            let pattern = eval(pattern)?;
+            let evaluated = target.like(pattern, true)?;
+
+            match negated {
+                true => evaluated.unary_minus(),
+                false => Ok(evaluated),
+            }
+        }
+        Expr::ILike {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr)?;
+            let pattern = eval(pattern)?;
+            let evaluated = target.like(pattern, false)?;
+
+            match negated {
+                true => evaluated.unary_minus(),
+                false => Ok(evaluated),
+            }
+        }
         Expr::IsNull(expr) => {
             let v = eval(expr)?.is_null();
 

--- a/core/src/plan/expr/mod.rs
+++ b/core/src/plan/expr/mod.rs
@@ -38,6 +38,9 @@ impl<'a> From<&'a Expr> for PlanExpr<'a> {
                 None => PlanExpr::None,
             },
             Expr::BinaryOp { left, right, .. } => PlanExpr::TwoExprs(left, right),
+            Expr::Like { expr, pattern, .. } | Expr::ILike { expr, pattern, .. } => {
+                PlanExpr::TwoExprs(expr, pattern)
+            }
             Expr::Between {
                 expr, low, high, ..
             } => PlanExpr::ThreeExprs(expr, low, high),
@@ -165,6 +168,18 @@ mod tests {
         let left = expr("100");
         let right = expr("rate");
         let expected = PlanExpr::TwoExprs(&left, &right);
+        test!(actual, expected);
+
+        let actual = expr("name LIKE '_foo%'");
+        let target = expr("name");
+        let pattern = expr(r#""_foo%""#);
+        let expected = PlanExpr::TwoExprs(&target, &pattern);
+        test!(actual, expected);
+
+        let actual = expr("name ILIKE '_foo%'");
+        let target = expr("name");
+        let pattern = expr(r#""_foo%""#);
+        let expected = PlanExpr::TwoExprs(&target, &pattern);
         test!(actual, expected);
 
         // PlanExpr::ThreeExprs

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -467,23 +467,23 @@ mod tests {
     #[test]
     fn basic() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER,
                 name TEXT
             );
-            CREATE TABLE UserItem (
+            CREATE TABLE PlayerItem (
                 user_id INTEGER,
                 item_id INTEGER,
                 amount INTEGER
             );
         ");
 
-        let sql = "SELECT * FROM User;";
+        let sql = "SELECT * FROM Player;";
         let actual = plan_join(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
-                relation: table_factor("User", None),
+                relation: table_factor("Player", None),
                 joins: Vec::new(),
             },
             selection: None,
@@ -492,27 +492,27 @@ mod tests {
         });
         assert_eq!(actual, expected, "basic select:\n{sql}");
 
-        let sql = "DELETE FROM User WHERE id = 1;";
+        let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan_join(&storage, sql);
         let expected = Statement::Delete {
-            table_name: ObjectName(vec!["User".to_owned()]),
+            table_name: ObjectName(vec!["Player".to_owned()]),
             selection: Some(expr("id = 1")),
         };
         assert_eq!(actual, expected, "plan not covered:\n{sql}");
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON UserItem.user_id != User.id
+            FROM Player
+            JOIN PlayerItem ON PlayerItem.user_id != Player.id
         ";
         let actual = plan_join(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
-                relation: table_factor("User", None),
+                relation: table_factor("Player", None),
                 joins: vec![Join {
-                    relation: table_factor("UserItem", None),
-                    join_operator: inner(Some("UserItem.user_id != User.id")),
+                    relation: table_factor("PlayerItem", None),
+                    join_operator: inner(Some("PlayerItem.user_id != Player.id")),
                     join_executor: JoinExecutor::NestedLoop,
                 }],
             },
@@ -524,17 +524,17 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            LEFT JOIN UserItem ON UserItem.amount > 2
+            FROM Player
+            LEFT JOIN PlayerItem ON PlayerItem.amount > 2
         ";
         let actual = plan_join(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
-                relation: table_factor("User", None),
+                relation: table_factor("Player", None),
                 joins: vec![Join {
-                    relation: table_factor("UserItem", None),
-                    join_operator: left_outer(Some("UserItem.amount > 2")),
+                    relation: table_factor("PlayerItem", None),
+                    join_operator: left_outer(Some("PlayerItem.amount > 2")),
                     join_executor: JoinExecutor::NestedLoop,
                 }],
             },
@@ -546,15 +546,15 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
+            FROM Player
             JOIN Empty u2
-            LEFT JOIN User u3;
+            LEFT JOIN Player u3;
         ";
         let actual = plan_join(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
-                relation: table_factor("User", None),
+                relation: table_factor("Player", None),
                 joins: vec![
                     Join {
                         relation: table_factor("Empty", Some("u2")),
@@ -562,7 +562,7 @@ mod tests {
                         join_executor: JoinExecutor::NestedLoop,
                     },
                     Join {
-                        relation: table_factor("User", Some("u3")),
+                        relation: table_factor("Player", Some("u3")),
                         join_operator: left_outer(None),
                         join_executor: JoinExecutor::NestedLoop,
                     },
@@ -576,23 +576,23 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON UserItem.user_id = User.id
+            FROM Player
+            JOIN PlayerItem ON PlayerItem.user_id = Player.id
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
                 where_clause: None,
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
+                        relation: table_factor("PlayerItem", None),
                         join_operator: inner(None),
                         join_executor,
                     }],
@@ -606,8 +606,8 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON UserItem.user_id = User.id
+            FROM Player
+            JOIN PlayerItem ON PlayerItem.user_id = Player.id
         ";
         let actual = plan_join(&storage, sql);
         let actual = {
@@ -617,17 +617,17 @@ mod tests {
         };
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
                 where_clause: None,
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
+                        relation: table_factor("PlayerItem", None),
                         join_operator: inner(None),
                         join_executor,
                     }],
@@ -643,18 +643,18 @@ mod tests {
         );
 
         let sql = "
-            SELECT * FROM User
-            JOIN UserItem ON (SELECT * FROM User u2)
+            SELECT * FROM Player
+            JOIN PlayerItem ON (SELECT * FROM Player u2)
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
-                        join_operator: inner(Some("(SELECT * FROM User u2)")),
+                        relation: table_factor("PlayerItem", None),
+                        join_operator: inner(Some("(SELECT * FROM Player u2)")),
                         join_executor: JoinExecutor::NestedLoop,
                     }],
                 },
@@ -669,7 +669,7 @@ mod tests {
     #[test]
     fn hash_join() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER,
                 name TEXT
             );
@@ -677,7 +677,7 @@ mod tests {
                 id INTEGER,
                 name TEXT
             );
-            CREATE TABLE UserItem (
+            CREATE TABLE PlayerItem (
                 user_id INTEGER,
                 item_id INTEGER,
                 amount INTEGER
@@ -686,26 +686,26 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            LEFT JOIN UserItem ON
-                UserItem.amount > 10 AND
-                UserItem.user_id = User.id
+            FROM Player
+            LEFT JOIN PlayerItem ON
+                PlayerItem.amount > 10 AND
+                PlayerItem.user_id = Player.id
             WHERE True;
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
-                where_clause: Some(expr("UserItem.amount > 10")),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
+                where_clause: Some(expr("PlayerItem.amount > 10")),
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
+                        relation: table_factor("PlayerItem", None),
                         join_operator: left_outer(None),
                         join_executor,
                     }],
@@ -719,27 +719,29 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON
-                (UserItem.user_id = User.id) AND
-                User.name = 'abcd' AND
-                User.name != 'barcode'
+            FROM Player
+            JOIN PlayerItem ON
+                (PlayerItem.user_id = Player.id) AND
+                Player.name = 'abcd' AND
+                Player.name != 'barcode'
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
                 where_clause: None,
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
-                        join_operator: inner(Some("User.name = 'abcd' AND User.name != 'barcode'")),
+                        relation: table_factor("PlayerItem", None),
+                        join_operator: inner(Some(
+                            "Player.name = 'abcd' AND Player.name != 'barcode'",
+                        )),
                         join_executor,
                     }],
                 },
@@ -755,27 +757,29 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            LEFT JOIN UserItem ON
-                UserItem.amount > 10 AND
-                UserItem.amount * 3 <= 2 AND
-                UserItem.user_id = User.id
+            FROM Player
+            LEFT JOIN PlayerItem ON
+                PlayerItem.amount > 10 AND
+                PlayerItem.amount * 3 <= 2 AND
+                PlayerItem.user_id = Player.id
             WHERE True;
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
-                where_clause: Some(expr("UserItem.amount > 10 AND UserItem.amount * 3 <= 2")),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
+                where_clause: Some(expr(
+                    "PlayerItem.amount > 10 AND PlayerItem.amount * 3 <= 2",
+                )),
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
+                        relation: table_factor("PlayerItem", None),
                         join_operator: left_outer(None),
                         join_executor,
                     }],
@@ -789,26 +793,26 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON
-                User.id = UserItem.user_id AND
-                UserItem.amount > 10
+            FROM Player
+            JOIN PlayerItem ON
+                Player.id = PlayerItem.user_id AND
+                PlayerItem.amount > 10
             WHERE True;
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
-                where_clause: Some(expr("UserItem.amount > 10")),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
+                where_clause: Some(expr("PlayerItem.amount > 10")),
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
+                        relation: table_factor("PlayerItem", None),
                         join_operator: inner(None),
                         join_executor,
                     }],
@@ -822,12 +826,12 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User u1
-            LEFT OUTER JOIN User u2
+            FROM Player u1
+            LEFT OUTER JOIN Player u2
             WHERE u2.id = (
                 SELECT u3.id
-                FROM User u3
-                JOIN User u4 ON
+                FROM Player u3
+                JOIN Player u4 ON
                     u4.id = u3.id AND
                     u4.id = u1.id
             );
@@ -841,9 +845,9 @@ mod tests {
                         label: "id".to_owned(),
                     }],
                     from: TableWithJoins {
-                        relation: table_factor("User", Some("u3")),
+                        relation: table_factor("Player", Some("u3")),
                         joins: vec![Join {
-                            relation: table_factor("User", Some("u4")),
+                            relation: table_factor("Player", Some("u4")),
                             join_operator: inner(None),
                             join_executor: JoinExecutor::Hash {
                                 key_expr: expr("u4.id"),
@@ -864,9 +868,9 @@ mod tests {
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", Some("u1")),
+                    relation: table_factor("Player", Some("u1")),
                     joins: vec![Join {
-                        relation: table_factor("User", Some("u2")),
+                        relation: table_factor("Player", Some("u2")),
                         join_operator: left_outer(None),
                         join_executor: JoinExecutor::NestedLoop,
                     }],
@@ -883,12 +887,12 @@ mod tests {
         assert_eq!(actual, expected, "hash join in subquery:\n{sql}");
 
         let sql = "
-            SELECT * FROM User u1
+            SELECT * FROM Player u1
             WHERE u1.id = (
-                SELECT * FROM User u2
+                SELECT * FROM Player u2
                 WHERE u2.id = (
-                    SELECT * FROM User u3
-                    JOIN User u4 ON
+                    SELECT * FROM Player u3
+                    JOIN Player u4 ON
                         u4.id = u3.id + u1.id
                 )
             );
@@ -905,9 +909,9 @@ mod tests {
                 body: SetExpr::Select(Box::new(Select {
                     projection: vec![SelectItem::Wildcard],
                     from: TableWithJoins {
-                        relation: table_factor("User", Some("u3")),
+                        relation: table_factor("Player", Some("u3")),
                         joins: vec![Join {
-                            relation: table_factor("User", Some("u4")),
+                            relation: table_factor("Player", Some("u4")),
                             join_operator: inner(None),
                             join_executor,
                         }],
@@ -925,7 +929,7 @@ mod tests {
                 body: SetExpr::Select(Box::new(Select {
                     projection: vec![SelectItem::Wildcard],
                     from: TableWithJoins {
-                        relation: table_factor("User", Some("u2")),
+                        relation: table_factor("Player", Some("u2")),
                         joins: Vec::new(),
                     },
                     selection: Some(Expr::BinaryOp {
@@ -944,7 +948,7 @@ mod tests {
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", Some("u1")),
+                    relation: table_factor("Player", Some("u1")),
                     joins: Vec::new(),
                 },
                 selection: Some(Expr::BinaryOp {
@@ -960,31 +964,31 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON
-                User.id = UserItem.user_id AND
-                User.id > 10 AND
-                UserItem.item_id IS NOT NULL AND
-                UserItem.amount > 10
+            FROM Player
+            JOIN PlayerItem ON
+                Player.id = PlayerItem.user_id AND
+                Player.id > 10 AND
+                PlayerItem.item_id IS NOT NULL AND
+                PlayerItem.amount > 10
             WHERE True;
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
                 where_clause: Some(expr(
-                    "UserItem.item_id IS NOT NULL AND UserItem.amount > 10",
+                    "PlayerItem.item_id IS NOT NULL AND PlayerItem.amount > 10",
                 )),
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
-                        join_operator: inner(Some("User.id > 10")),
+                        relation: table_factor("PlayerItem", None),
+                        join_operator: inner(Some("Player.id > 10")),
                         join_executor,
                     }],
                 },
@@ -1000,31 +1004,31 @@ mod tests {
 
         let sql = "
             SELECT *
-            FROM User
-            JOIN UserItem ON
-                User.id > User.id + UserItem.user_id AND
-                User.id = UserItem.user_id AND
-                UserItem.item_id IS NOT NULL AND
-                UserItem.amount > 10
+            FROM Player
+            JOIN PlayerItem ON
+                Player.id > Player.id + PlayerItem.user_id AND
+                Player.id = PlayerItem.user_id AND
+                PlayerItem.item_id IS NOT NULL AND
+                PlayerItem.amount > 10
             WHERE True;
         ";
         let actual = plan_join(&storage, sql);
         let expected = {
             let join_executor = JoinExecutor::Hash {
-                key_expr: expr("UserItem.user_id"),
-                value_expr: expr("User.id"),
+                key_expr: expr("PlayerItem.user_id"),
+                value_expr: expr("Player.id"),
                 where_clause: Some(expr(
-                    "UserItem.item_id IS NOT NULL AND UserItem.amount > 10",
+                    "PlayerItem.item_id IS NOT NULL AND PlayerItem.amount > 10",
                 )),
             };
 
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: vec![Join {
-                        relation: table_factor("UserItem", None),
-                        join_operator: inner(Some("User.id > User.id + UserItem.user_id")),
+                        relation: table_factor("PlayerItem", None),
+                        join_operator: inner(Some("Player.id > Player.id + PlayerItem.user_id")),
                         join_executor,
                     }],
                 },
@@ -1042,7 +1046,7 @@ mod tests {
     #[test]
     fn hash_join_in_subquery() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER,
                 name TEXT
             );
@@ -1055,7 +1059,7 @@ mod tests {
 
         let subquery_sql = "
             SELECT u.id
-            FROM User u
+            FROM Player u
             JOIN Flag f ON f.user_id = u.id
         ";
         let subquery = || {
@@ -1072,7 +1076,7 @@ mod tests {
                         label: "id".to_owned(),
                     }],
                     from: TableWithJoins {
-                        relation: table_factor("User", Some("u")),
+                        relation: table_factor("Player", Some("u")),
                         joins: vec![Join {
                             relation: table_factor("Flag", Some("f")),
                             join_operator: inner(None),
@@ -1094,7 +1098,7 @@ mod tests {
             select(Select {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
-                    relation: table_factor("User", None),
+                    relation: table_factor("Player", None),
                     joins: Vec::new(),
                 },
                 selection: Some(selection),
@@ -1103,7 +1107,7 @@ mod tests {
             })
         };
 
-        let sql = format!("SELECT * FROM User WHERE id = ({subquery_sql})");
+        let sql = format!("SELECT * FROM Player WHERE id = ({subquery_sql})");
         let actual = plan_join(&storage, &sql);
         let expected = gen_expected(Expr::BinaryOp {
             left: Box::new(expr("id")),
@@ -1112,7 +1116,7 @@ mod tests {
         });
         assert_eq!(actual, expected, "binary operator:\n{sql}");
 
-        let sql = format!("SELECT * FROM User WHERE -({subquery_sql}) IN ({subquery_sql})");
+        let sql = format!("SELECT * FROM Player WHERE -({subquery_sql}) IN ({subquery_sql})");
         let actual = plan_join(&storage, &sql);
         let expected = gen_expected(Expr::InSubquery {
             expr: Box::new(Expr::UnaryOp {
@@ -1126,7 +1130,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE -({subquery_sql}) IN ({subquery_sql})
         "
         );
@@ -1143,7 +1147,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE
                 CAST(({subquery_sql}) AS INTEGER) IN (1, 2, 3)
         "
@@ -1161,7 +1165,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE 
                 ({subquery_sql}) IS NULL
                 OR
@@ -1176,7 +1180,7 @@ mod tests {
         });
         assert_eq!(actual, expected, "is null and is not null:\n{sql}");
 
-        let sql = format!("SELECT * FROM User WHERE EXISTS({subquery_sql})");
+        let sql = format!("SELECT * FROM Player WHERE EXISTS({subquery_sql})");
         let actual = plan_join(&storage, &sql);
         let expected = gen_expected(Expr::Exists {
             subquery: subquery(),
@@ -1186,7 +1190,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE ({subquery_sql}) BETWEEN ({subquery_sql}) AND 100;
         "
         );
@@ -1201,7 +1205,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE EXTRACT(HOUR FROM (({subquery_sql}))) IS NULL
         "
         );
@@ -1214,7 +1218,7 @@ mod tests {
 
         let sql = format!(
             "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE
                 CASE ({subquery_sql})
                     WHEN 10 THEN True

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -77,6 +77,38 @@ pub trait Planner<'a> {
                     high,
                 }
             }
+            Expr::Like {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr =
+                    Box::new(self.subquery_expr(outer_context.as_ref().map(Rc::clone), *expr));
+                let pattern =
+                    Box::new(self.subquery_expr(outer_context.as_ref().map(Rc::clone), *pattern));
+
+                Expr::Like {
+                    expr,
+                    negated,
+                    pattern,
+                }
+            }
+            Expr::ILike {
+                expr,
+                negated,
+                pattern,
+            } => {
+                let expr =
+                    Box::new(self.subquery_expr(outer_context.as_ref().map(Rc::clone), *expr));
+                let pattern =
+                    Box::new(self.subquery_expr(outer_context.as_ref().map(Rc::clone), *pattern));
+
+                Expr::ILike {
+                    expr,
+                    negated,
+                    pattern,
+                }
+            }
             Expr::BinaryOp { left, op, right } => Expr::BinaryOp {
                 left: Box::new(self.subquery_expr(outer_context.as_ref().map(Rc::clone), *left)),
                 op,

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -259,19 +259,19 @@ mod tests {
     #[test]
     fn where_expr() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER PRIMARY KEY,
                 name TEXT
             );
         ");
 
-        let sql = "SELECT * FROM User WHERE id = 1;";
+        let sql = "SELECT * FROM Player WHERE id = 1;";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -283,13 +283,13 @@ mod tests {
         });
         assert_eq!(actual, expected, "primary key in lhs:\n{sql}");
 
-        let sql = "SELECT * FROM User WHERE 1 = id;";
+        let sql = "SELECT * FROM Player WHERE 1 = id;";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -301,13 +301,13 @@ mod tests {
         });
         assert_eq!(actual, expected, "primary key in rhs:\n{sql}");
 
-        let sql = "SELECT * FROM User WHERE id = 1 AND True;";
+        let sql = "SELECT * FROM Player WHERE id = 1 AND True;";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -320,7 +320,7 @@ mod tests {
         assert_eq!(actual, expected, "AND binary op:\n{sql}");
 
         let sql = "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE
                 name IS NOT NULL
                 AND id = 1
@@ -331,7 +331,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(actual, expected, "AND binary op 2:\n{sql}");
 
         let sql = "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE
                 name IS NOT NULL
                 AND True
@@ -354,7 +354,7 @@ mod tests {
         assert_eq!(actual, expected, "AND binary op 3:\n{sql}");
 
         let sql = "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE
                 name IS NOT NULL
                 AND (True AND id = 1);
@@ -364,7 +364,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn join_and_nested() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER PRIMARY KEY,
                 name TEXT,
             );
@@ -390,13 +390,13 @@ mod tests {
             );
         ");
 
-        let sql = "SELECT * FROM User JOIN Badge WHERE User.id = 1";
+        let sql = "SELECT * FROM Player JOIN Badge WHERE Player.id = 1";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -416,13 +416,13 @@ mod tests {
         });
         assert_eq!(actual, expected, "basic inner join:\n{sql}");
 
-        let sql = "SELECT * FROM User JOIN Badge WHERE User.id = Badge.user_id";
+        let sql = "SELECT * FROM Player JOIN Badge WHERE Player.id = Badge.user_id";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: None,
                 },
@@ -436,16 +436,16 @@ mod tests {
                     join_executor: JoinExecutor::NestedLoop,
                 }],
             },
-            selection: Some(expr("User.id = Badge.user_id")),
+            selection: Some(expr("Player.id = Badge.user_id")),
             group_by: Vec::new(),
             having: None,
         });
         assert_eq!(actual, expected, "join but no primary key:\n{sql}");
 
         let sql = "
-            SELECT * FROM User
+            SELECT * FROM Player
             WHERE name IN (
-                SELECT * FROM User WHERE id = 1
+                SELECT * FROM Player WHERE id = 1
             )";
         let actual = plan(&storage, sql);
         let expected = {
@@ -454,7 +454,7 @@ mod tests {
                     projection: vec![SelectItem::Wildcard],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["User".to_owned()]),
+                            name: ObjectName(vec!["Player".to_owned()]),
                             alias: None,
                             index: Some(IndexItem::PrimaryKey(expr("1"))),
                         },
@@ -473,7 +473,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["User".to_owned()]),
+                        name: ObjectName(vec!["Player".to_owned()]),
                         alias: None,
                         index: None,
                     },
@@ -494,13 +494,13 @@ mod tests {
     #[test]
     fn not_found() {
         let storage = run("
-            CREATE TABLE User (
+            CREATE TABLE Player (
                 id INTEGER PRIMARY KEY,
                 name TEXT
             );
         ");
 
-        let sql = "SELECT * FROM User WHERE name = (SELECT name FROM User LIMIT 1);";
+        let sql = "SELECT * FROM Player WHERE name = (SELECT name FROM Player LIMIT 1);";
         let actual = plan(&storage, sql);
         let expected = {
             let subquery = Query {
@@ -511,7 +511,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["User".to_owned()]),
+                            name: ObjectName(vec!["Player".to_owned()]),
                             alias: None,
                             index: None,
                         },
@@ -530,7 +530,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["User".to_owned()]),
+                        name: ObjectName(vec!["Player".to_owned()]),
                         alias: None,
                         index: None,
                     },
@@ -548,8 +548,8 @@ mod tests {
         assert_eq!(actual, expected, "name is not primary key:\n{sql}");
 
         let sql = "
-            SELECT * FROM User WHERE id IN (
-                SELECT id FROM User WHERE id = id
+            SELECT * FROM Player WHERE id IN (
+                SELECT id FROM Player WHERE id = id
             );
         ";
         let actual = plan(&storage, sql);
@@ -562,7 +562,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["User".to_owned()]),
+                            name: ObjectName(vec!["Player".to_owned()]),
                             alias: None,
                             index: None,
                         },
@@ -581,7 +581,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["User".to_owned()]),
+                        name: ObjectName(vec!["Player".to_owned()]),
                         alias: None,
                         index: None,
                     },
@@ -598,10 +598,10 @@ mod tests {
         };
         assert_eq!(actual, expected, "ambiguous nested contexts:\n{sql}");
 
-        let sql = "DELETE FROM User WHERE id = 1;";
+        let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan(&storage, sql);
         let expected = Statement::Delete {
-            table_name: ObjectName(vec!["User".to_owned()]),
+            table_name: ObjectName(vec!["Player".to_owned()]),
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("id".to_owned())),
                 op: BinaryOperator::Eq,
@@ -623,13 +623,13 @@ mod tests {
         });
         assert_eq!(actual, expected, "values:\n{sql}");
 
-        let sql = "SELECT * FROM User WHERE (name);";
+        let sql = "SELECT * FROM Player WHERE (name);";
         let actual = plan(&storage, sql);
         let expected = select(Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["User".to_owned()]),
+                    name: ObjectName(vec!["Player".to_owned()]),
                     alias: None,
                     index: None,
                 },

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -59,6 +59,26 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             low: translate_expr(low).map(Box::new)?,
             high: translate_expr(high).map(Box::new)?,
         }),
+        SqlExpr::Like {
+            expr,
+            negated,
+            pattern,
+            escape_char: None,
+        } => Ok(Expr::Like {
+            expr: translate_expr(expr).map(Box::new)?,
+            negated: *negated,
+            pattern: translate_expr(pattern).map(Box::new)?,
+        }),
+        SqlExpr::ILike {
+            expr,
+            negated,
+            pattern,
+            escape_char: None,
+        } => Ok(Expr::ILike {
+            expr: translate_expr(expr).map(Box::new)?,
+            negated: *negated,
+            pattern: translate_expr(pattern).map(Box::new)?,
+        }),
         SqlExpr::BinaryOp { left, op, right } => Ok(Expr::BinaryOp {
             left: translate_expr(left).map(Box::new)?,
             op: translate_binary_operator(op)?,
@@ -83,7 +103,11 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             value: value.to_owned(),
         }),
         SqlExpr::Function(function) => translate_function(function),
-        SqlExpr::Trim { expr, trim_where } => translate_trim(expr, trim_where),
+        SqlExpr::Trim {
+            expr,
+            trim_where,
+            trim_what,
+        } => translate_trim(expr, trim_where, trim_what),
         SqlExpr::Exists { subquery, negated } => Ok(Expr::Exists {
             subquery: translate_query(subquery).map(Box::new)?,
             negated: *negated,

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -147,9 +147,14 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
         #[cfg(feature = "transaction")]
         SqlStatement::Rollback { .. } => Ok(Statement::Rollback),
         #[cfg(feature = "metadata")]
+        SqlStatement::ShowTables {
+            filter: None,
+            db_name: None,
+            ..
+        } => Ok(Statement::ShowVariable(Variable::Tables)),
+        #[cfg(feature = "metadata")]
         SqlStatement::ShowVariable { variable } => match (variable.len(), variable.get(0)) {
             (1, Some(keyword)) => match keyword.value.to_uppercase().as_str() {
-                "TABLES" => Ok(Statement::ShowVariable(Variable::Tables)),
                 "VERSION" => Ok(Statement::ShowVariable(Variable::Version)),
                 v => Err(TranslateError::UnsupportedShowVariableKeyword(v.to_string()).into()),
             },

--- a/core/src/translate/operator.rs
+++ b/core/src/translate/operator.rs
@@ -36,10 +36,6 @@ pub fn translate_binary_operator(
         SqlBinaryOperator::And => Ok(BinaryOperator::And),
         SqlBinaryOperator::Or => Ok(BinaryOperator::Or),
         SqlBinaryOperator::Xor => Ok(BinaryOperator::Xor),
-        SqlBinaryOperator::Like => Ok(BinaryOperator::Like),
-        SqlBinaryOperator::ILike => Ok(BinaryOperator::ILike),
-        SqlBinaryOperator::NotLike => Ok(BinaryOperator::NotLike),
-        SqlBinaryOperator::NotILike => Ok(BinaryOperator::NotILike),
         _ => Err(TranslateError::UnsupportedBinaryOperator(sql_binary_operator.to_string()).into()),
     }
 }

--- a/test-suite/src/filter.rs
+++ b/test-suite/src/filter.rs
@@ -1,9 +1,4 @@
-use {
-    crate::*,
-    bigdecimal::BigDecimal,
-    gluesql_core::data::*,
-    std::{borrow::Cow, str::FromStr},
-};
+use {crate::*, gluesql_core::data::*};
 
 test_case!(filter, async move {
     let create_sqls = [
@@ -81,19 +76,6 @@ test_case!(filter, async move {
         (3, "SELECT id FROM Hunter WHERE +2 > +1.0"),
         (2, "SELECT name FROM Boss WHERE id <= +2"),
         (2, "SELECT name FROM Boss WHERE +id <= 2"),
-        (2, "SELECT name FROM Boss WHERE name LIKE '_a%'"),
-        (2, "SELECT name FROM Boss WHERE name LIKE '%r%'"),
-        (2, "SELECT name FROM Boss WHERE name LIKE '%a'"),
-        (5, "SELECT name FROM Boss WHERE name LIKE '%%'"),
-        (0, "SELECT name FROM Boss WHERE name LIKE 'g%'"),
-        (2, "SELECT name FROM Boss WHERE name ILIKE '_A%'"),
-        (2, "SELECT name FROM Boss WHERE name ILIKE 'g%'"),
-        (5, "SELECT name FROM Boss WHERE name ILIKE '%%'"),
-        (1, "SELECT name FROM Boss WHERE name NOT LIKE '%a%'"),
-        (1, "SELECT name FROM Boss WHERE name NOT ILIKE '%A%'"),
-        (5, "SELECT name FROM Boss WHERE 'ABC' LIKE '_B_'"),
-        (5, "SELECT name FROM Boss WHERE 'abc' ILIKE '_B_'"),
-        (5, "SELECT name FROM Boss WHERE 'ABC' ILIKE '_B_'"),
     ];
 
     for (num, sql) in select_sqls {
@@ -127,25 +109,6 @@ test_case!(filter, async move {
         (
             "SELECT id FROM Hunter WHERE -name < 1.0",
             ValueError::UnaryMinusOnNonNumeric.into(),
-        ),
-        (
-            "SELECT name FROM Boss WHERE 'ABC' LIKE 10",
-            LiteralError::LikeOnNonString(
-                format!("{:?}", Literal::Text(Cow::Owned("ABC".to_string()))),
-                format!(
-                    "{:?}",
-                    Literal::Number(Cow::Owned(BigDecimal::from_str("10").unwrap()))
-                ),
-            )
-            .into(),
-        ),
-        (
-            "SELECT name FROM Boss WHERE name = 'Amelia' AND name LIKE 10",
-            ValueError::LikeOnNonString(Value::Str("Amelia".to_string()), Value::I64(10)).into(),
-        ),
-        (
-            "SELECT name FROM Boss WHERE name = 'Amelia' AND name ILIKE 10",
-            ValueError::ILikeOnNonString(Value::Str("Amelia".to_string()), Value::I64(10)).into(),
         ),
     ];
 

--- a/test-suite/src/function/trim.rs
+++ b/test-suite/src/function/trim.rs
@@ -117,6 +117,18 @@ test_case!(trim, async move {
                 "xxxyzblankxyz  ".to_owned()
             )),
         ),
+        (
+            "SELECT
+                TRIM(BOTH '  hello  ') AS both,
+                TRIM(LEADING '  hello  ') AS leading,
+                TRIM(TRAILING '  hello  ') AS trailing
+            ",
+            Ok(select!(
+                both               | leading              | trailing
+                Value::Str         | Value::Str           | Value::Str;
+                "hello".to_owned()   "hello  ".to_owned()   "  hello".to_owned()
+            )),
+        ),
     ];
 
     for (sql, expected) in test_cases {

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -12,6 +12,7 @@ pub mod function;
 pub mod index;
 pub mod inline_view;
 pub mod join;
+pub mod like_ilike;
 pub mod limit;
 pub mod metadata;
 pub mod migrate;
@@ -76,6 +77,7 @@ macro_rules! generate_store_tests {
         glue!(drop_table, alter::drop_table);
         glue!(default, default::default);
         glue!(limit, limit::limit);
+        glue!(like_ilike, like_ilike::like_ilike);
         glue!(filter, filter::filter);
         glue!(inline_view, inline_view::inline_view);
         glue!(values, values::values);

--- a/test-suite/src/like_ilike.rs
+++ b/test-suite/src/like_ilike.rs
@@ -1,0 +1,97 @@
+use {
+    crate::*,
+    bigdecimal::BigDecimal,
+    gluesql_core::{
+        data::{Literal, LiteralError, ValueError},
+        prelude::Value::{self, Bool},
+    },
+    std::{borrow::Cow, str::FromStr},
+};
+
+test_case!(like_ilike, async move {
+    test! {
+        name: "basic usage - LIKE and ILIKE",
+        sql: "
+            VALUES
+                ('abc' LIKE '%c'),
+                ('abc' NOT LIKE '_c'),
+                ('abc' LIKE '_b_'),
+                ('HELLO' ILIKE '%el%'),
+                ('HELLO' NOT ILIKE '_ELLE');
+        ",
+        expected: Ok(select!(column1 Bool; true; true; true; true; true))
+    };
+
+    run!(
+        "
+        CREATE TABLE Item (
+            id INTEGER,
+            name TEXT
+        );
+    "
+    );
+    run!(
+        r#"
+        INSERT INTO Item (id, name) VALUES
+            (1,    "Amelia"),
+            (2,      "Doll"),
+            (3, "Gascoigne"),
+            (4,   "Gehrman"),
+            (5,     "Maria");
+    "#
+    );
+
+    let test_cases = [
+        (2, "SELECT name FROM Item WHERE name LIKE '_a%'"),
+        (2, "SELECT name FROM Item WHERE name LIKE '%r%'"),
+        (2, "SELECT name FROM Item WHERE name LIKE '%a'"),
+        (5, "SELECT name FROM Item WHERE name LIKE '%%'"),
+        (0, "SELECT name FROM Item WHERE name LIKE 'g%'"),
+        (2, "SELECT name FROM Item WHERE name ILIKE '_A%'"),
+        (2, "SELECT name FROM Item WHERE name ILIKE 'g%'"),
+        (5, "SELECT name FROM Item WHERE name ILIKE '%%'"),
+        (1, "SELECT name FROM Item WHERE name NOT LIKE '%a%'"),
+        (1, "SELECT name FROM Item WHERE name NOT ILIKE '%A%'"),
+        (5, "SELECT name FROM Item WHERE 'ABC' LIKE '_B_'"),
+        (5, "SELECT name FROM Item WHERE 'abc' ILIKE '_B_'"),
+        (5, "SELECT name FROM Item WHERE 'ABC' ILIKE '_B_'"),
+    ];
+
+    for (num, sql) in test_cases {
+        count!(num, sql);
+    }
+
+    let error_sqls = [
+        (
+            "SELECT name FROM Item WHERE 'ABC' LIKE 10",
+            LiteralError::LikeOnNonString(
+                format!("{:?}", Literal::Text(Cow::Owned("ABC".to_string()))),
+                format!(
+                    "{:?}",
+                    Literal::Number(Cow::Owned(BigDecimal::from_str("10").unwrap()))
+                ),
+            )
+            .into(),
+        ),
+        (
+            "SELECT name FROM Item WHERE True LIKE '_B_'",
+            LiteralError::LikeOnNonString(
+                format!("{:?}", Literal::Boolean(true)),
+                format!("{:?}", Literal::Text(Cow::Owned("_B_".to_owned()))),
+            )
+            .into(),
+        ),
+        (
+            "SELECT name FROM Item WHERE name = 'Amelia' AND name LIKE 10",
+            ValueError::LikeOnNonString(Value::Str("Amelia".to_string()), Value::I64(10)).into(),
+        ),
+        (
+            "SELECT name FROM Item WHERE name = 'Amelia' AND name ILIKE 10",
+            ValueError::ILikeOnNonString(Value::Str("Amelia".to_string()), Value::I64(10)).into(),
+        ),
+    ];
+
+    for (sql, error) in error_sqls {
+        test!(sql, Err(error));
+    }
+});

--- a/test-suite/src/nested_select.rs
+++ b/test-suite/src/nested_select.rs
@@ -3,7 +3,7 @@ use {crate::*, gluesql_core::executor::EvaluateError};
 test_case!(nested_select, async move {
     let create_sqls: [&str; 2] = [
         "
-        CREATE TABLE User (
+        CREATE TABLE Player (
             id INTEGER,
             name TEXT
         );
@@ -23,7 +23,7 @@ test_case!(nested_select, async move {
 
     let insert_sqls = [
         "
-        INSERT INTO User (id, name) VALUES
+        INSERT INTO Player (id, name) VALUES
             (1, \"Taehoon\"),
             (2,    \"Mike\"),
             (3,   \"Jorno\"),
@@ -59,26 +59,26 @@ test_case!(nested_select, async move {
         (9, "SELECT * FROM Request WHERE quantity NOT IN (5, 1);"),
         (
             4,
-            "SELECT * FROM Request WHERE user_id IN (SELECT id FROM User WHERE id = 3);",
+            "SELECT * FROM Request WHERE user_id IN (SELECT id FROM Player WHERE id = 3);",
         ),
         (
             4,
-            "SELECT * FROM User WHERE id IN (SELECT user_id FROM Request);",
+            "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request);",
         ),
         (
             4,
-            "SELECT * FROM User WHERE id IN (SELECT user_id FROM Request WHERE user_id = User.id);",
+            "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request WHERE user_id = Player.id);",
         ),
-        (4, "SELECT * FROM User WHERE id IN (SELECT user_id FROM Request WHERE user_id IN (User.id));"),
-        (2, "SELECT * FROM User WHERE id IN (SELECT user_id FROM Request WHERE quantity IN (6, 7, 8, 9));"),
-        (9, "SELECT * FROM Request WHERE user_id IN (SELECT id FROM User WHERE name IN (\"Taehoon\", \"Hwan\"));"),
+        (4, "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request WHERE user_id IN (Player.id));"),
+        (2, "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request WHERE quantity IN (6, 7, 8, 9));"),
+        (9, "SELECT * FROM Request WHERE user_id IN (SELECT id FROM Player WHERE name IN (\"Taehoon\", \"Hwan\"));"),
     ];
     for (num, sql) in select_sqls {
         count!(num, sql);
     }
 
     let error_cases = [(
-        "SELECT * FROM User WHERE id = (SELECT id FROM User WHERE id = 9);",
+        "SELECT * FROM Player WHERE id = (SELECT id FROM Player WHERE id = 9);",
         EvaluateError::NestedSelectRowNotFound.into(),
     )];
 


### PR DESCRIPTION
Upgrade sqlparser-rs from v0.19 to v0.22
Migrate translate_trim, add new supported test case.
Move Like, ILike from ast::BinaryOperator to ast::Expr.
Now "User" is a reserved keyword, so rename test cases which used "User" to use "Player".