### PR TITLE
Support CLI options

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -123,7 +123,7 @@ where
                     self.print.spool_off();
                 }
                 Command::Set(option) => self.print.set_option(option),
-                Command::Show(name) => self.print.show_option(name)?,
+                Command::Show(option) => self.print.show_option(option)?,
             }
         }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -32,7 +32,7 @@ where
 {
     pub fn new(storage: T, output: W) -> Self {
         let glue = Glue::new(storage);
-        let print = Print::new(output, None);
+        let print = Print::new(output, None, Default::default());
 
         Self { glue, print }
     }
@@ -81,6 +81,14 @@ where
                     println!("\n  type .help to list all available commands.\n");
                     continue;
                 }
+                Err(CommandError::LackOfOption) => {
+                    println!("[error] should specify option.\n");
+                    continue;
+                }
+                Err(CommandError::LackOfValue) => {
+                    println!("[error] should specify value.\n");
+                    continue;
+                }
             };
 
             match command {
@@ -109,6 +117,7 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
+                Command::Set(name, value) => self.print.set_option(name, value),
             }
         }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -118,6 +118,7 @@ where
                     self.print.spool_off();
                 }
                 Command::Set(name, value) => self.print.set_option(name, value),
+                Command::Show(name) => self.print.show_option(name),
             }
         }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -86,8 +86,8 @@ where
                     println!("[error] should specify option.\n");
                     continue;
                 }
-                Err(CommandError::LackOfValue) => {
-                    println!("[error] should specify value.\n");
+                Err(CommandError::LackOfValue(usage)) => {
+                    println!("[error] should specify value.\n{usage}\n");
                     continue;
                 }
                 Err(CommandError::WrongOption(e)) => {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -26,7 +26,7 @@ where
     print: Print<W>,
 }
 
-impl<'a, T, W> Cli<T, W>
+impl<T, W> Cli<T, W>
 where
     T: GStore + GStoreMut,
     W: Write,
@@ -122,12 +122,11 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
-                Command::Set(name, value) => match self.print.set_option(name, value) {
-                    Err(e) => {
+                Command::Set(name, value) => {
+                    if let Err(e) = self.print.set_option(name, value) {
                         println!("[error] {}\n", e);
                     }
-                    _ => {}
-                },
+                }
                 Command::Show(name) => self.print.show_option(name)?,
             }
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -91,7 +91,7 @@ where
                     continue;
                 }
                 Err(CommandError::WrongOption(e)) => {
-                    println!("[error] cannot support option: {e}");
+                    println!("[error] cannot support option: {e}\n");
                     continue;
                 }
             };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -67,7 +67,7 @@ where
 
             rl.add_history_entry(&line);
 
-            let command = match Command::parse(&line) {
+            let command = match Command::parse(&line, &self.print.option) {
                 Ok(command) => command,
                 Err(CommandError::LackOfTable) => {
                     println!("[error] should specify table. eg: .columns TableName\n");
@@ -122,11 +122,7 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
-                Command::Set { key, value } => {
-                    if let Err(e) = self.print.set_option(key, value) {
-                        println!("[error] {}\n", e);
-                    }
-                }
+                Command::Set(option) => self.print.set_option(option),
                 Command::Show(name) => self.print.show_option(name)?,
             }
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -122,8 +122,8 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
-                Command::Set(name, value) => {
-                    if let Err(e) = self.print.set_option(name, value) {
+                Command::Set { key, value } => {
+                    if let Err(e) = self.print.set_option(key, value) {
                         println!("[error] {}\n", e);
                     }
                 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -26,7 +26,7 @@ where
     print: Print<W>,
 }
 
-impl<T, W> Cli<T, W>
+impl<'a, T, W> Cli<T, W>
 where
     T: GStore + GStoreMut,
     W: Write,
@@ -122,7 +122,12 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
-                Command::Set(name, value) => self.print.set_option(name, value)?,
+                Command::Set(name, value) => match self.print.set_option(name, value) {
+                    Err(e) => {
+                        println!("[error] {}\n", e);
+                    }
+                    _ => {}
+                },
                 Command::Show(name) => self.print.show_option(name)?,
             }
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -10,6 +10,7 @@ use {
     },
     rustyline::{error::ReadlineError, Editor},
     std::{
+        error::Error,
         fs::File,
         io::{Read, Result, Write},
         path::Path,
@@ -37,7 +38,7 @@ where
         Self { glue, print }
     }
 
-    pub fn run(&mut self) -> Result<()> {
+    pub fn run(&mut self) -> std::result::Result<(), Box<dyn Error>> {
         macro_rules! println {
             ($($p:tt),*) => ( writeln!(&mut self.print.output, $($p),*)?; )
         }
@@ -89,6 +90,10 @@ where
                     println!("[error] should specify value.\n");
                     continue;
                 }
+                Err(CommandError::WrongOption(e)) => {
+                    println!("cannot support option: {e}");
+                    continue;
+                }
             };
 
             match command {
@@ -117,8 +122,8 @@ where
                 Command::SpoolOff => {
                     self.print.spool_off();
                 }
-                Command::Set(name, value) => self.print.set_option(name, value),
-                Command::Show(name) => self.print.show_option(name),
+                Command::Set(name, value) => self.print.set_option(name, value)?,
+                Command::Show(name) => self.print.show_option(name)?,
             }
         }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -91,7 +91,7 @@ where
                     continue;
                 }
                 Err(CommandError::WrongOption(e)) => {
-                    println!("cannot support option: {e}");
+                    println!("[error] cannot support option: {e}");
                     continue;
                 }
             };

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -8,7 +8,7 @@ pub enum Command {
     ExecuteFromFile(String),
     SpoolOn(String),
     SpoolOff,
-    Set(String, String),
+    Set { key: String, value: String },
     Show(String),
 }
 
@@ -52,7 +52,10 @@ impl Command {
                     None => Err(CommandError::LackOfFile),
                 },
                 ".set" => match (params.get(1), params.get(2)) {
-                    (Some(name), Some(value)) => Ok(Self::Set(name.to_string(), value.to_string())),
+                    (Some(key), Some(value)) => Ok(Self::Set {
+                        key: key.to_string(),
+                        value: value.to_string(),
+                    }),
                     (Some(_), None) => Err(CommandError::LackOfValue),
                     (None, Some(_)) => Err(CommandError::LackOfOption),
                     (None, None) => Err(CommandError::LackOfOption),

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -148,5 +148,17 @@ mod tests {
         );
         assert_eq!(Ok(Command::SpoolOff), parse(".spool off"));
         assert_eq!(Err(CommandError::LackOfFile), parse(".spool"));
+        assert_eq!(
+            Err(CommandError::WrongOption("run .set tabular OFF".into())),
+            parse(".set colsep ,")
+        );
+        assert_eq!(
+            Err(CommandError::WrongOption("run .set tabular OFF".into())),
+            parse(".set colwrap '")
+        );
+        assert_eq!(
+            Err(CommandError::WrongOption("run .set tabular OFF".into())),
+            parse(".set heading off")
+        );
     }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -9,6 +9,7 @@ pub enum Command {
     SpoolOn(String),
     SpoolOff,
     Set(String, String),
+    Show(String),
 }
 
 #[derive(ThisError, Debug, PartialEq)]
@@ -54,6 +55,11 @@ impl Command {
                     (None, Some(_)) => Err(CommandError::LackOfOption),
                     (None, None) => Err(CommandError::LackOfOption),
                 },
+                ".show" => match params.get(1) {
+                    Some(name) => Ok(Self::Show(name.to_string())),
+                    None => Err(CommandError::LackOfOption),
+                },
+
                 _ => Err(CommandError::NotSupported),
             }
         } else {

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -22,6 +22,8 @@ pub enum CommandError {
     LackOfValue,
     #[error("should specify option")]
     LackOfOption,
+    #[error("cannot support option: {0}")]
+    WrongOption(String),
     #[error("command not supported")]
     NotSupported,
 }
@@ -56,7 +58,7 @@ impl Command {
                     (None, None) => Err(CommandError::LackOfOption),
                 },
                 ".show" => match params.get(1) {
-                    Some(name) => Ok(Self::Show(name.to_string())),
+                    Some(option) => Ok(Self::Show(option.to_string())),
                     None => Err(CommandError::LackOfOption),
                 },
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Display};
+
 use crate::print::bool_from;
 
 use {
@@ -15,7 +17,7 @@ pub enum Command {
     SpoolOn(String),
     SpoolOff,
     Set(SetOption),
-    Show(String),
+    Show(ShowOption),
 }
 
 #[derive(ThisError, Debug, PartialEq)]
@@ -44,7 +46,7 @@ pub enum SetOption {
 
 impl SetOption {
     fn parse(key: &str, value: String, option: &PrintOption) -> Result<Self, CommandError> {
-        let key = match (key.to_lowercase().as_str(), &option.tabular) {
+        let set_option = match (key.to_lowercase().as_str(), &option.tabular) {
             ("tabular", _) => Self::Tabular(bool_from(value)?),
             ("colsep", Tabular::Off { .. }) => Self::Colsep(value),
             ("colwrap", Tabular::Off { .. }) => Self::Colwrap(value),
@@ -56,10 +58,45 @@ impl SetOption {
             _ => return Err(CommandError::WrongOption(key.into())),
         };
 
-        Ok(key)
+        Ok(set_option)
     }
 }
 
+#[derive(Eq, Debug, PartialEq)]
+pub enum ShowOption {
+    Tabular,
+    Colsep,
+    Colwrap,
+    Heading,
+    All,
+}
+
+impl Display for ShowOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ShowOption::Tabular => write!(f, "sadf"),
+            ShowOption::Colsep => todo!(),
+            ShowOption::Colwrap => todo!(),
+            ShowOption::Heading => todo!(),
+            ShowOption::All => todo!(),
+        }
+        // write!(f, "({}, {})", self.x, self.y)
+    }
+}
+impl ShowOption {
+    fn parse(key: &str) -> Result<Self, CommandError> {
+        let show_option = match key.to_lowercase().as_str() {
+            "tabular" => Self::Tabular,
+            "colsep" => Self::Colsep,
+            "colwrap" => Self::Colwrap,
+            "heading" => Self::Heading,
+            "all" => Self::All,
+            _ => return Err(CommandError::WrongOption(key.into())),
+        };
+
+        Ok(show_option)
+    }
+}
 impl Command {
     pub fn parse(line: &str, option: &PrintOption) -> Result<Self, CommandError> {
         let line = line.trim_start().trim_end_matches(|c| c == ' ' || c == ';');
@@ -92,7 +129,7 @@ impl Command {
                     (None, None) => Err(CommandError::LackOfOption),
                 },
                 ".show" => match params.get(1) {
-                    Some(option) => Ok(Self::Show(option.to_string())),
+                    Some(key) => Ok(Self::Show(ShowOption::parse(key)?)),
                     None => Err(CommandError::LackOfOption),
                 },
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -1,7 +1,3 @@
-use std::fmt::{self, Display};
-
-use crate::print::bool_from;
-
 use {crate::print::PrintOption, std::fmt::Debug, thiserror::Error as ThisError};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -42,6 +38,14 @@ pub enum SetOption {
 
 impl SetOption {
     fn parse(key: &str, value: String, option: &PrintOption) -> Result<Self, CommandError> {
+        fn bool_from(value: String) -> Result<bool, CommandError> {
+            match value.to_uppercase().as_str() {
+                "ON" => Ok(true),
+                "OFF" => Ok(false),
+                _ => Err(CommandError::WrongOption(value)),
+            }
+        }
+
         let set_option = match (key.to_lowercase().as_str(), &option.tabular) {
             ("tabular", _) => Self::Tabular(bool_from(value)?),
             ("colsep", false) => Self::Colsep(value),
@@ -65,18 +69,6 @@ pub enum ShowOption {
     All,
 }
 
-impl Display for ShowOption {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ShowOption::Tabular => write!(f, "sadf"),
-            ShowOption::Colsep => todo!(),
-            ShowOption::Colwrap => todo!(),
-            ShowOption::Heading => todo!(),
-            ShowOption::All => todo!(),
-        }
-        // write!(f, "({}, {})", self.x, self.y)
-    }
-}
 impl ShowOption {
     fn parse(key: &str) -> Result<Self, CommandError> {
         let show_option = match key.to_lowercase().as_str() {
@@ -91,6 +83,7 @@ impl ShowOption {
         Ok(show_option)
     }
 }
+
 impl Command {
     pub fn parse(line: &str, option: &PrintOption) -> Result<Self, CommandError> {
         let line = line.trim_start().trim_end_matches(|c| c == ' ' || c == ';');
@@ -143,13 +136,6 @@ mod tests {
     fn parse_command() {
         use super::Command;
         let option = PrintOption::default();
-        // {
-        //     tabular: true,
-        //     colsep:
-        //     colwrap: todo!(),
-        //     heading: todo!(),
-        // };
-        // pk
         let parse = |command| Command::parse(command, &option);
 
         assert_eq!(parse(".help"), Ok(Command::Help));

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -119,46 +119,46 @@ mod tests {
         };
         let parse = |command| Command::parse(command, &option);
 
-        assert_eq!(Ok(Command::Help), parse(".help"));
-        assert_eq!(Ok(Command::Help), parse("   .help;"));
-        assert_eq!(Ok(Command::Quit), parse(".quit"));
-        assert_eq!(Ok(Command::Quit), parse(".quit;"));
-        assert_eq!(Ok(Command::Quit), parse(" .quit; "));
+        assert_eq!(parse(".help"), Ok(Command::Help));
+        assert_eq!(parse("   .help;"), Ok(Command::Help));
+        assert_eq!(parse(".quit"), Ok(Command::Quit));
+        assert_eq!(parse(".quit;"), Ok(Command::Quit));
+        assert_eq!(parse(" .quit; "), Ok(Command::Quit));
         assert_eq!(
+            parse(".tables"),
             Ok(Command::Execute("SHOW TABLES".to_owned())),
-            parse(".tables")
         );
         assert_eq!(
+            parse(".columns Foo"),
             Ok(Command::Execute("SHOW COLUMNS FROM Foo".to_owned())),
-            parse(".columns Foo")
         );
-        assert_eq!(Err(CommandError::LackOfTable), parse(".columns"));
+        assert_eq!(parse(".columns"), Err(CommandError::LackOfTable));
         assert_eq!(
-            Ok(Command::Execute("SHOW VERSION".to_owned())),
-            parse(".version")
+            parse(".version"),
+            Ok(Command::Execute("SHOW VERSION".to_owned()))
         );
-        assert_eq!(Err(CommandError::NotSupported), parse(".foo"));
+        assert_eq!(parse(".foo"), Err(CommandError::NotSupported));
         assert_eq!(
+            parse("SELECT * FROM Foo;"),
             Ok(Command::Execute("SELECT * FROM Foo".to_owned())),
-            parse("SELECT * FROM Foo;")
         );
         assert_eq!(
-            Ok(Command::SpoolOn("query.log".into())),
-            parse(".spool query.log")
+            parse(".spool query.log"),
+            Ok(Command::SpoolOn("query.log".into()))
         );
-        assert_eq!(Ok(Command::SpoolOff), parse(".spool off"));
-        assert_eq!(Err(CommandError::LackOfFile), parse(".spool"));
+        assert_eq!(parse(".spool off"), Ok(Command::SpoolOff));
+        assert_eq!(parse(".spool"), Err(CommandError::LackOfFile));
         assert_eq!(
-            Err(CommandError::WrongOption("run .set tabular OFF".into())),
-            parse(".set colsep ,")
-        );
-        assert_eq!(
-            Err(CommandError::WrongOption("run .set tabular OFF".into())),
-            parse(".set colwrap '")
+            parse(".set colsep ,"),
+            Err(CommandError::WrongOption("run .set tabular OFF".into()))
         );
         assert_eq!(
-            Err(CommandError::WrongOption("run .set tabular OFF".into())),
-            parse(".set heading off")
+            parse(".set colwrap '"),
+            Err(CommandError::WrongOption("run .set tabular OFF".into()))
+        );
+        assert_eq!(
+            parse(".set heading off"),
+            Err(CommandError::WrongOption("run .set tabular OFF".into()))
         );
     }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -74,7 +74,7 @@ impl SetOption {
                 _ => return Err(CommandError::WrongOption(key.into())),
             };
 
-            return Err(CommandError::LackOfValue(payload.into()));
+            Err(CommandError::LackOfValue(payload.into()))
         }
     }
 }
@@ -127,7 +127,7 @@ impl Command {
                     None => Err(CommandError::LackOfFile),
                 },
                 ".set" => match (params.get(1), params.get(2)) {
-                    (Some(key), value) => Ok(Self::Set(SetOption::parse(key, value, &option)?)),
+                    (Some(key), value) => Ok(Self::Set(SetOption::parse(key, value, option)?)),
                     (None, Some(_)) => Err(CommandError::LackOfOption),
                     (None, None) => Err(CommandError::LackOfOption),
                 },

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -2,11 +2,7 @@ use std::fmt::{self, Display};
 
 use crate::print::bool_from;
 
-use {
-    crate::print::{PrintOption, Tabular},
-    std::fmt::Debug,
-    thiserror::Error as ThisError,
-};
+use {crate::print::PrintOption, std::fmt::Debug, thiserror::Error as ThisError};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
@@ -48,12 +44,10 @@ impl SetOption {
     fn parse(key: &str, value: String, option: &PrintOption) -> Result<Self, CommandError> {
         let set_option = match (key.to_lowercase().as_str(), &option.tabular) {
             ("tabular", _) => Self::Tabular(bool_from(value)?),
-            ("colsep", Tabular::Off { .. }) => Self::Colsep(value),
-            ("colwrap", Tabular::Off { .. }) => Self::Colwrap(value),
-            ("heading", Tabular::Off { .. }) => Self::Heading(bool_from(value)?),
-            (_, Tabular::On) => {
-                return Err(CommandError::WrongOption("run .set tabular OFF".into()))
-            }
+            ("colsep", false) => Self::Colsep(value),
+            ("colwrap", false) => Self::Colwrap(value),
+            ("heading", false) => Self::Heading(bool_from(value)?),
+            (_, true) => return Err(CommandError::WrongOption("run .set tabular OFF".into())),
 
             _ => return Err(CommandError::WrongOption(key.into())),
         };
@@ -143,17 +137,19 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        command::CommandError,
-        print::{PrintOption, Tabular},
-    };
+    use crate::{command::CommandError, print::PrintOption};
 
     #[test]
     fn parse_command() {
         use super::Command;
-        let option = PrintOption {
-            tabular: Tabular::On,
-        };
+        let option = PrintOption::default();
+        // {
+        //     tabular: true,
+        //     colsep:
+        //     colwrap: todo!(),
+        //     heading: todo!(),
+        // };
+        // pk
         let parse = |command| Command::parse(command, &option);
 
         assert_eq!(parse(".help"), Ok(Command::Help));

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -8,6 +8,7 @@ pub enum Command {
     ExecuteFromFile(String),
     SpoolOn(String),
     SpoolOff,
+    Set(String, String),
 }
 
 #[derive(ThisError, Debug, PartialEq)]
@@ -16,6 +17,10 @@ pub enum CommandError {
     LackOfTable,
     #[error("should specify file path")]
     LackOfFile,
+    #[error("should specify value for option")]
+    LackOfValue,
+    #[error("should specify option")]
+    LackOfOption,
     #[error("command not supported")]
     NotSupported,
 }
@@ -42,6 +47,12 @@ impl Command {
                     Some(&"off") => Ok(Self::SpoolOff),
                     Some(path) => Ok(Self::SpoolOn(path.to_string())),
                     None => Err(CommandError::LackOfFile),
+                },
+                ".set" => match (params.get(1), params.get(2)) {
+                    (Some(name), Some(value)) => Ok(Self::Set(name.to_string(), value.to_string())),
+                    (Some(_), None) => Err(CommandError::LackOfValue),
+                    (None, Some(_)) => Err(CommandError::LackOfOption),
+                    (None, None) => Err(CommandError::LackOfOption),
                 },
                 _ => Err(CommandError::NotSupported),
             }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,18 +1,14 @@
-use crate::command::{SetOption, ShowOption};
-
 use {
-    crate::command::CommandError,
+    crate::command::{SetOption, ShowOption},
     gluesql_core::{
         ast::ToSql,
         prelude::{Payload, PayloadVariable},
     },
     std::{
-        error::Error,
         fmt::Display,
         fs::File,
         io::{Result as IOResult, Write},
         path::Path,
-        result::Result,
     },
     tabled::{builder::Builder, Style, Table},
 };
@@ -24,7 +20,6 @@ pub struct Print<W: Write> {
 }
 
 pub struct PrintOption {
-    // pub tabular: Tabular,
     pub tabular: bool,
     colsep: String,
     colwrap: String,
@@ -48,103 +43,18 @@ impl PrintOption {
         self.heading = heading;
     }
 
-    // fn fmt_tabular(&self) -> String {
-    //     format!("tabular {}", Self::string_from(&self.tabular))
-    // }
-
-    // fn fmt_colsep(&self) -> String {
-    //     format!("colsep \"{}\"", self.colsep)
-    // }
-
-    // fn fmt_colwrap(&self) -> String {
-    //     format!("colwrap \"{}\"", self.colwrap)
-    // }
-
-    // fn fmt_heading(&self) -> String {
-    //     format!("heading {}", Self::string_from(&self.heading))
-    // }
-
-    fn string_from(value: &bool) -> String {
-        match value {
-            true => "ON".into(),
-            false => "OFF".into(),
-        }
-    }
-}
-
-pub enum Tabular {
-    On,
-    Off { option: TabularOffOption },
-}
-
-pub struct TabularOffOption {
-    colsep: String,
-    colwrap: String,
-    heading: bool,
-}
-
-impl TabularOffOption {
-    fn colsep(&mut self, colsep: String) {
-        self.colsep = colsep;
-    }
-
-    fn colwrap(&mut self, colwrap: String) {
-        self.colwrap = colwrap;
-    }
-
-    fn heading(&mut self, heading: bool) {
-        self.heading = heading;
-    }
-}
-
-impl Tabular {
-    fn get_option(&self) -> (&str, &str, bool) {
-        match self {
-            Tabular::On => ("|", "", true),
-            Tabular::Off {
-                option:
-                    TabularOffOption {
-                        colsep,
-                        colwrap,
-                        heading,
-                    },
-            } => (colsep, colwrap, *heading),
-        }
-    }
-
-    fn get_string(&self) -> &str {
-        match self {
-            Tabular::On => "ON",
-            Tabular::Off { .. } => "OFF",
-        }
-    }
-
-    // fn update_option(&mut self, key: SetOption, value: String) {
-    //     match self {
-    //         Tabular::On => todo!(),
-    //         Tabular::Off { option } => {
-    //             match key {
-    //                 SetOption::Colsep(value) => option.colsep(value),
-    //                 SetOption::Colwrap(value) => option.colwrap(value),
-    //                 SetOption::Heading(value) => option.heading(value),
-    //                 SetOption::Tabular(_) => todo!(),
-    //                 // "colsep" => option.colsep(value),
-    //                 // "colwrap" => option.colwrap(value),
-    //                 // "heading" => option.heading(bool_from(value)?),
-    //                 // _ => return Err(CommandError::WrongOption(key)),
-    //             };
-    //         }
-    //     }
-    // }
-}
-
-impl PrintOption {
     fn format(&self, option: ShowOption) -> String {
+        fn string_from(value: &bool) -> String {
+            match value {
+                true => "ON".into(),
+                false => "OFF".into(),
+            }
+        }
         match option {
-            ShowOption::Tabular => format!("tabular {}", Self::string_from(&self.tabular)),
+            ShowOption::Tabular => format!("tabular {}", string_from(&self.tabular)),
             ShowOption::Colsep => format!("colsep \"{}\"", self.colsep),
             ShowOption::Colwrap => format!("colwrap \"{}\"", self.colwrap),
-            ShowOption::Heading => format!("heading {}", Self::string_from(&self.heading)),
+            ShowOption::Heading => format!("heading {}", string_from(&self.heading)),
             ShowOption::All => format!(
                 "{}\n{}\n{}\n{}",
                 self.format(ShowOption::Tabular),
@@ -153,20 +63,6 @@ impl PrintOption {
                 self.format(ShowOption::Heading),
             ),
         }
-    }
-
-    fn set_tabular(&mut self, value: bool) {
-        // let tabular = match value {
-        //     true => Tabular::On,
-        //     false => Tabular::Off {
-        //         option: TabularOffOption {
-        //             colsep: "|".into(),
-        //             colwrap: "".into(),
-        //             heading: true,
-        //         },
-        //     },
-        // };
-        // self.tabular = tabular;
     }
 }
 
@@ -346,14 +242,6 @@ impl<'a, W: Write> Print<W> {
 
     fn build_table(&self, builder: Builder) -> Table {
         builder.build().with(Style::markdown())
-    }
-}
-
-pub fn bool_from(value: String) -> Result<bool, CommandError> {
-    match value.to_uppercase().as_str() {
-        "ON" => Ok(true),
-        "OFF" => Ok(false),
-        _ => Err(CommandError::WrongOption(value)),
     }
 }
 
@@ -587,20 +475,6 @@ mod tests {
 | hash   | MAP       |
 | mylist | LIST      |"
         );
-
-        // To set colsep or colwrap, should run ".set tabular off" first
-        // assert_eq!(
-        //     print.set_option(SetOption::Colsep(",".into())),
-        //     Err(CommandError::WrongOption("run .set tabular OFF".into()))
-        // );
-        // assert_eq!(
-        //     print.set_option("colwrap".into(), "'".into()),
-        //     Err(CommandError::WrongOption("run .set tabular OFF".into()))
-        // );
-        // assert_eq!(
-        //     print.set_option("heading".into(), "OFF".into()),
-        //     Err(CommandError::WrongOption("run .set tabular OFF".into()))
-        // );
 
         // ".set tabular OFF" should print SELECTED payload without tabular option
         print.set_option(SetOption::Tabular(false));

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -33,6 +33,7 @@ impl PrintOption {
                 self.tabular = tabular;
                 self.colsep("|".into());
                 self.colwrap("".into());
+                self.heading(true);
             }
             false => self.tabular = tabular,
         }
@@ -595,7 +596,9 @@ id,title,valid
 
         // ".set tabular ON" should recover default option: colsep("|"), colwrap("")
         print.set_option(SetOption::Tabular(true));
+        assert_eq!(print.option.format(ShowOption::Tabular), "tabular ON");
         assert_eq!(print.option.format(ShowOption::Colsep), r#"colsep "|""#);
         assert_eq!(print.option.format(ShowOption::Colwrap), r#"colwrap """#);
+        assert_eq!(print.option.format(ShowOption::Heading), "heading ON");
     }
 }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -195,7 +195,7 @@ impl<'a, W: Write> Print<W> {
 
     pub fn help(&mut self) -> IOResult<()> {
         const HEADER: [&str; 2] = ["command", "description"];
-        const CONTENT: [[&str; 2]; 7] = [
+        const CONTENT: [[&str; 2]; 9] = [
             [".help", "show help"],
             [".quit", "quit program"],
             [".tables", "show table names"],
@@ -203,6 +203,8 @@ impl<'a, W: Write> Print<W> {
             [".version", "show version"],
             [".execute FILE", "execute SQL from a file"],
             [".spool FILE|off", "spool to file or off"],
+            [".show OPTION", "show print option eg).show all"],
+            [".set OPTION", "set print option eg).set tabular off"],
         ];
 
         let mut table = self.get_table(HEADER);
@@ -273,15 +275,17 @@ mod tests {
             String::from_utf8(print.output).unwrap()
         };
         let expected = "
-| command         | description             |
-|-----------------|-------------------------|
-| .help           | show help               |
-| .quit           | quit program            |
-| .tables         | show table names        |
-| .columns TABLE  | show columns from TABLE |
-| .version        | show version            |
-| .execute FILE   | execute SQL from a file |
-| .spool FILE|off | spool to file or off    |";
+| command         | description                          |
+|-----------------|--------------------------------------|
+| .help           | show help                            |
+| .quit           | quit program                         |
+| .tables         | show table names                     |
+| .columns TABLE  | show columns from TABLE              |
+| .version        | show version                         |
+| .execute FILE   | execute SQL from a file              |
+| .spool FILE|off | spool to file or off                 |
+| .show OPTION    | show print option eg).show all       |
+| .set OPTION     | set print option eg).set tabular off |";
 
         assert_eq!(
             actual.as_str().trim_matches('\n'),

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -310,7 +310,6 @@ impl<'a, W: Write> Print<W> {
 
 #[cfg(test)]
 mod tests {
-
     use super::Print;
     use gluesql_core::{data::SchemaIndex, data::SchemaIndexOrd};
 
@@ -534,5 +533,83 @@ mod tests {
                 ("mylist".to_string(), DataType::List),
             ],)
         );
+
+        print.set_option("tabular".into(), "off".into()).unwrap();
+        test!(
+            "
+id|title|valid
+1 |foo  |TRUE 
+2 |bar  |FALSE",
+            &Payload::Select {
+                labels: ["id", "title", "valid"]
+                    .into_iter()
+                    .map(ToOwned::to_owned)
+                    .collect(),
+                rows: vec![
+                    vec![
+                        Value::I64(1),
+                        Value::Str("foo".to_owned()),
+                        Value::Bool(true)
+                    ],
+                    vec![
+                        Value::I64(2),
+                        Value::Str("bar".to_owned()),
+                        Value::Bool(false)
+                    ],
+                ],
+            }
+        );
+
+        print.set_option("colsep".into(), ",".into()).unwrap();
+        test!(
+            "
+id,title,valid
+1,foo,TRUE 
+2,bar,FALSE",
+            &Payload::Select {
+                labels: ["id", "title", "valid"]
+                    .into_iter()
+                    .map(ToOwned::to_owned)
+                    .collect(),
+                rows: vec![
+                    vec![
+                        Value::I64(1),
+                        Value::Str("foo".to_owned()),
+                        Value::Bool(true)
+                    ],
+                    vec![
+                        Value::I64(2),
+                        Value::Str("bar".to_owned()),
+                        Value::Bool(false)
+                    ],
+                ],
+            }
+        );
+
+        //         print.set_option("colwrap".into(), "'".into()).unwrap();
+        //         test!(
+        //             "
+        // 'id','title','valid'
+        // '1','foo','TRUE'
+        // '2','bar','FALSE'",
+        //             &Payload::Select {
+        //                 labels: ["id", "title", "valid"]
+        //                     .into_iter()
+        //                     .map(ToOwned::to_owned)
+        //                     .collect(),
+        //                 rows: vec![
+        //                     vec![
+        //                         Value::I64(1),
+        //                         Value::Str("foo".to_owned()),
+        //                         Value::Bool(true)
+        //                     ],
+        //                     vec![
+        //                         Value::I64(2),
+        //                         Value::Str("bar".to_owned()),
+        //                         Value::Bool(false)
+        //                     ],
+        //                 ],
+        //             }
+        //         );
     }
 }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -225,6 +225,17 @@ impl<'a, W: Write> Print<W> {
         self.spool_file = None;
     }
 
+    fn get_table<T: IntoIterator<Item = &'a str>>(&self, headers: T) -> Builder {
+        let mut table = Builder::default();
+        table.set_columns(headers);
+
+        table
+    }
+
+    fn build_table(&self, builder: Builder) -> Table {
+        builder.build().with(Style::markdown())
+    }
+
     pub fn set_option(&mut self, option: SetOption) {
         match option {
             SetOption::Tabular(value) => self.option.tabular(value),
@@ -239,17 +250,6 @@ impl<'a, W: Write> Print<W> {
         self.write(payload)?;
 
         Ok(())
-    }
-
-    fn get_table<T: IntoIterator<Item = &'a str>>(&self, headers: T) -> Builder {
-        let mut table = Builder::default();
-        table.set_columns(headers);
-
-        table
-    }
-
-    fn build_table(&self, builder: Builder) -> Table {
-        builder.build().with(Style::markdown())
     }
 }
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -318,8 +318,9 @@ impl<'a, W: Write> Print<W> {
 
     fn get_table<T: IntoIterator<Item = &'a str>>(&self, headers: T) -> Builder {
         let mut table = Builder::default();
+        table.set_columns(headers);
 
-        table.set_columns(headers).clone()
+        table
     }
 
     fn build_table(&self, builder: Builder) -> Table {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -15,11 +15,34 @@ use {
 pub struct Print<W: Write> {
     pub output: W,
     spool_file: Option<File>,
+    option: PrintOption,
+}
+
+pub struct PrintOption {
+    colsep: String,
+    colwrap: String,
+    tabular: String,
+    heading: String,
+}
+
+impl Default for PrintOption {
+    fn default() -> Self {
+        Self {
+            colsep: " ".to_string(),
+            colwrap: "".to_string(),
+            tabular: "on".to_string(),
+            heading: "on".to_string(),
+        }
+    }
 }
 
 impl<W: Write> Print<W> {
-    pub fn new(output: W, spool_file: Option<File>) -> Self {
-        Print { output, spool_file }
+    pub fn new(output: W, spool_file: Option<File>, option: PrintOption) -> Self {
+        Print {
+            output,
+            spool_file,
+            option,
+        }
     }
 
     pub fn payloads(&mut self, payloads: &[Payload]) -> Result<()> {
@@ -120,6 +143,26 @@ impl<W: Write> Print<W> {
     pub fn spool_off(&mut self) {
         self.spool_file = None;
     }
+
+    pub fn get_option(self, name: String) -> String {
+        match name.as_str() {
+            "colsep" => self.option.colsep,
+            "colwrap" => self.option.colwrap,
+            "tabular" => self.option.tabular,
+            "heading" => self.option.heading,
+            _ => todo!(),
+        }
+    }
+
+    pub fn set_option(&mut self, name: String, value: String) {
+        match name.as_str() {
+            "colsep" => self.option.colsep = value,
+            "colwrap" => self.option.colwrap = value,
+            "tabular" => self.option.tabular = value,
+            "heading" => self.option.heading = value,
+            _ => todo!(),
+        }
+    }
 }
 
 fn get_table<'a, T: IntoIterator<Item = &'a str>>(header: T) -> Builder {
@@ -141,7 +184,7 @@ mod tests {
 
     #[test]
     fn print_help() {
-        let mut print = Print::new(Vec::new(), None);
+        let mut print = Print::new(Vec::new(), None, Default::default());
 
         let expected = "
 | command         | description             |
@@ -172,7 +215,7 @@ mod tests {
             prelude::{Payload, PayloadVariable, Value},
         };
 
-        let mut print = Print::new(Vec::new(), None);
+        let mut print = Print::new(Vec::new(), None, Default::default());
 
         macro_rules! test {
             ($expected: literal, $payload: expr) => {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -317,27 +317,8 @@ impl<'a, W: Write> Print<W> {
     }
 
     fn build_table(&self, builder: Builder) -> Table {
-        let builder = builder.build().with(Style::markdown());
-
-        builder
-        // match self.option.tabular.clone() {
-        //     Tabular::On => builder,
-        //     Tabular::Off { colsep, colwrap } => {
-        //         let colsep = Style::empty().vertical(colsep);
-        //         let padding_zero = Modify::new(Segment::all()).with(Padding::new(0, 0, 0, 0));
-        //         let wrapped_data = Modify::new(Segment::all())
-        //             .with(Format::new(|data| format!("{colwrap}{data}{colwrap}")));
-
-        //         builder.with(padding_zero).with(colsep).with(wrapped_data)
-        //     }
-        // }
+        builder.build().with(Style::markdown())
     }
-
-    // fn get_table2<T: IntoIterator<Item = &'a str>>(&self, headers: T, names: &[String]) -> Table {
-    //     let table = names.table().with(Disable::Row(..1)).with(Header(names));
-
-    //     table
-    // }
 }
 
 #[cfg(test)]

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -28,7 +28,14 @@ pub struct PrintOption {
 
 impl PrintOption {
     fn tabular(&mut self, tabular: bool) {
-        self.tabular = tabular;
+        match tabular {
+            true => {
+                self.tabular = tabular;
+                self.colsep("|".into());
+                self.colwrap("".into());
+            }
+            false => self.tabular = tabular,
+        }
     }
 
     fn colsep(&mut self, colsep: String) {
@@ -71,8 +78,8 @@ impl Default for PrintOption {
         Self {
             tabular: true,
             colsep: "|".into(),
-            colwrap: "'".into(),
-            heading: false,
+            colwrap: "".into(),
+            heading: true,
         }
     }
 }
@@ -589,7 +596,6 @@ id,title,valid
         // ".set tabular ON" should recover default option: colsep("|"), colwrap("")
         print.set_option(SetOption::Tabular(true));
         assert_eq!(print.option.format(ShowOption::Colsep), r#"colsep "|""#);
-
         assert_eq!(print.option.format(ShowOption::Colwrap), r#"colwrap """#);
     }
 }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,4 +1,4 @@
-use crate::command::SetOption;
+use crate::command::{SetOption, ShowOption};
 
 use {
     crate::command::CommandError,
@@ -294,9 +294,32 @@ impl<'a, W: Write> Print<W> {
         };
     }
 
-    pub fn show_option(&mut self, name: String) -> Result<(), Box<dyn Error>> {
-        let payload = self.option.to_show(name);
-        self.write(payload?)?;
+    pub fn show_option(&mut self, option: ShowOption) -> IOResult<()> {
+        todo!();
+        // let payload = self.option.to_show(name);
+        // let payload = match option {
+        //     ShowOption::Tabular => todo!(),
+        //     ShowOption::Colsep => todo!(),
+        //     ShowOption::Colwrap => todo!(),
+        //     ShowOption::Heading => todo!(),
+        //     ShowOption::All => todo!(),
+        // };
+        // let payload = match name.to_lowercase().as_str() {
+        //     "colsep" => format!("colsep \"{}\"", self.tabular.get_option().0),
+        //     "colwrap" => format!("colwrap \"{}\"", self.tabular.get_option().1),
+        //     "tabular" => format!("tabular {}", &self.tabular.get_string()),
+        //     "heading" => format!("heading {}", string_from(&self.tabular.get_option().2)),
+        //     "all" => format!(
+        //         "{}\n{}\n{}\n{}",
+        //         self.to_show("colsep".into())?,
+        //         self.to_show("colwrap".into())?,
+        //         self.to_show("tabular".into())?,
+        //         self.to_show("heading".into())?
+        //     ),
+        //     option => return Err(CommandError::WrongOption(option.into())),
+        // };
+
+        // self.write(payload)?;
 
         Ok(())
     }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -68,7 +68,7 @@ impl Tabular {
     }
 }
 
-impl<'a> PrintOption {
+impl PrintOption {
     fn to_show(&self, name: String) -> Result<String, CommandError> {
         let payload = match name.to_lowercase().as_str() {
             "colsep" => format!("colsep \"{}\"", self.tabular.get_option().0),
@@ -82,7 +82,7 @@ impl<'a> PrintOption {
                 self.to_show("tabular".into())?,
                 self.to_show("heading".into())?
             ),
-            option => return Err(CommandError::WrongOption(option.into()).into()),
+            option => return Err(CommandError::WrongOption(option.into())),
         };
 
         Ok(payload)
@@ -111,7 +111,7 @@ fn string_from(value: &bool) -> &str {
     }
 }
 
-impl<'a> Default for PrintOption {
+impl Default for PrintOption {
     fn default() -> Self {
         Self {
             tabular: Tabular::On,
@@ -145,11 +145,6 @@ impl<'a, W: Write> Print<W> {
             Payload::Update(n) => affected(*n, "updated")?,
             Payload::ShowVariable(PayloadVariable::Version(v)) => self.write(format!("v{v}"))?,
             Payload::ShowVariable(PayloadVariable::Tables(names)) => {
-                // // let table = names.table().with(Disable::Row(..1)).with(Header("tables"));
-                // let headers = ["tables"];
-                // let table = self.get_table(headers);
-
-                // self.write(table)?;
                 let mut table = self.get_table(["tables"]);
                 for name in names {
                     table.add_record([name]);
@@ -158,11 +153,6 @@ impl<'a, W: Write> Print<W> {
                 self.write(table)?;
             }
             Payload::ShowColumns(columns) => {
-                // let data = columns
-                //     .iter()
-                //     .map(|(field, field_type)| [field, &field_type.to_string()])
-                //     .collect::<Vec<_>>();
-
                 let mut table = self.get_table(vec!["Field", "Type"]);
                 for (field, field_type) in columns {
                     table.add_record([field, &field_type.to_string()]);
@@ -199,7 +189,7 @@ impl<'a, W: Write> Print<W> {
                         .iter()
                         .map(|v| format!("{colwrap}{v}{colwrap}"))
                         .collect::<Vec<_>>()
-                        .join(&colsep.to_string());
+                        .join(colsep);
                     writeln!(self.output, "{}", labels)?;
 
                     for row in rows {
@@ -208,7 +198,7 @@ impl<'a, W: Write> Print<W> {
                             .map(Into::into)
                             .map(|v: String| format!("{colwrap}{v}{colwrap}"))
                             .collect::<Vec<_>>()
-                            .join(&colsep.to_string());
+                            .join(colsep);
                         writeln!(self.output, "{}", row)?
                     }
                 }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -257,11 +257,9 @@ impl<'a, W: Write> Print<W> {
 
 #[cfg(test)]
 mod tests {
-    use crate::command::ShowOption;
-
     use {
         super::Print,
-        crate::command::SetOption,
+        crate::command::{SetOption, ShowOption},
         gluesql_core::{data::SchemaIndex, data::SchemaIndexOrd},
     };
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -1,4 +1,4 @@
-use tabled::{object::Segment, Format, Modify, ModifyList, Padding};
+use tabled::{object::Segment, Format, Modify, Padding};
 
 use {
     crate::command::CommandError,
@@ -284,9 +284,11 @@ impl<'a, W: Write> Print<W> {
 
     fn get_table<T: IntoIterator<Item = &'a str>>(&self, header: T) -> Builder {
         let mut table = Builder::default();
-        table.set_columns(header);
 
-        table
+        match self.option.heading {
+            true => table.set_columns(header).clone(),
+            false => table,
+        }
     }
 
     fn build_table(&self, builder: Builder) -> Table {

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -27,7 +27,7 @@ pub struct PrintOption {
 }
 
 impl PrintOption {
-    fn tabular(&mut self, tabular: bool) {
+    pub fn tabular(&mut self, tabular: bool) {
         match tabular {
             true => {
                 self.tabular = tabular;

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -320,11 +320,6 @@ impl<'a, W: Write> Print<W> {
         let mut table = Builder::default();
 
         table.set_columns(headers).clone()
-
-        // match self.option.heading {
-        //     true => table.set_columns(headers).clone(),
-        //     false => table,
-        // }
     }
 
     fn build_table(&self, builder: Builder) -> Table {


### PR DESCRIPTION
## Goal
Support CLI options like
```
gluesql> .set tabular OFF
gluesql> .set colsep ,
gluesql> .set colwrap '
gluesql> .set heading OFF
gluesql> VALUES (1, 'a', true), (2, 'b', false)
```
```
'1','a','true'
'2','b','false'
```
## Todo
- [x] add .set command
- [x] add .show command
- [x] add PrintOptions
- [x] print with option states
