### PR TITLE
[Data] add data type u8

### DIFF
--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -10,6 +10,7 @@ pub enum DataType {
     Int32,
     Int,
     Int128,
+    Uint8,
     Float,
     Text,
     Bytea,

--- a/core/src/data/bigdecimal_ext.rs
+++ b/core/src/data/bigdecimal_ext.rs
@@ -36,10 +36,8 @@ impl BigDecimalExt for BigDecimal {
         }
     }
     fn to_u8(&self) -> Option<u8> {
-        match self.is_integer() {
-            true => bigdecimal::ToPrimitive::to_u8(self),
-            false => None,
-        }
+        self.is_integer()
+            .then(|| bigdecimal::ToPrimitive::to_u8(self))?
     }
     fn to_f64(&self) -> Option<f64> {
         bigdecimal::ToPrimitive::to_f64(self)

--- a/core/src/data/bigdecimal_ext.rs
+++ b/core/src/data/bigdecimal_ext.rs
@@ -6,6 +6,7 @@ pub trait BigDecimalExt {
     fn to_i32(&self) -> Option<i32>;
     fn to_i64(&self) -> Option<i64>;
     fn to_i128(&self) -> Option<i128>;
+    fn to_u8(&self) -> Option<u8>;
     fn to_f64(&self) -> Option<f64>;
 }
 
@@ -31,6 +32,12 @@ impl BigDecimalExt for BigDecimal {
     fn to_i128(&self) -> Option<i128> {
         match self.is_integer() {
             true => bigdecimal::ToPrimitive::to_i128(self),
+            false => None,
+        }
+    }
+    fn to_u8(&self) -> Option<u8> {
+        match self.is_integer() {
+            true => bigdecimal::ToPrimitive::to_u8(self),
             false => None,
         }
     }

--- a/core/src/data/interval/primitive.rs
+++ b/core/src/data/interval/primitive.rs
@@ -58,6 +58,17 @@ impl Mul<i128> for Interval {
     }
 }
 
+impl Mul<u8> for Interval {
+    type Output = Self;
+
+    fn mul(self, rhs: u8) -> Self {
+        match self {
+            Interval::Month(v) => Interval::Month(((v as u8) * rhs) as i32),
+            Interval::Microsecond(v) => Interval::Microsecond(((v as u8) * rhs) as i64),
+        }
+    }
+}
+
 impl Mul<f64> for Interval {
     type Output = Self;
 
@@ -102,6 +113,14 @@ impl Mul<Interval> for i64 {
 }
 
 impl Mul<Interval> for i128 {
+    type Output = Interval;
+
+    fn mul(self, rhs: Interval) -> Interval {
+        rhs * self
+    }
+}
+
+impl Mul<Interval> for u8 {
     type Output = Interval;
 
     fn mul(self, rhs: Interval) -> Interval {
@@ -172,6 +191,17 @@ impl Div<i128> for Interval {
     }
 }
 
+impl Div<u8> for Interval {
+    type Output = Self;
+
+    fn div(self, rhs: u8) -> Self {
+        match self {
+            Interval::Month(v) => Interval::Month(((v as u8) / rhs) as i32),
+            Interval::Microsecond(v) => Interval::Microsecond(((v as u8) / rhs) as i64),
+        }
+    }
+}
+
 impl Div<f64> for Interval {
     type Output = Self;
 
@@ -234,6 +264,17 @@ impl Div<Interval> for i128 {
         match rhs {
             Interval::Month(v) => Interval::Month((self / (v as i128)) as i32),
             Interval::Microsecond(v) => Interval::Microsecond((self / (v as i128)) as i64),
+        }
+    }
+}
+
+impl Div<Interval> for u8 {
+    type Output = Interval;
+
+    fn div(self, rhs: Interval) -> Interval {
+        match rhs {
+            Interval::Month(v) => Interval::Month((self / (v as u8)) as i32),
+            Interval::Microsecond(v) => Interval::Microsecond((self / (v as u8)) as i64),
         }
     }
 }

--- a/core/src/data/interval/primitive.rs
+++ b/core/src/data/interval/primitive.rs
@@ -313,6 +313,9 @@ mod tests {
         assert_eq!(Month(2) * 3_i128, Month(6));
         assert_eq!(2_i128 * Month(3), Month(6));
 
+        assert_eq!(Month(2) * 3_u8, Month(6));
+        assert_eq!(2_u8 * Month(3), Month(6));
+
         assert_eq!(Month(2) * 3.0, Month(6));
         assert_eq!(2.0 * Month(3), Month(6));
 
@@ -330,6 +333,9 @@ mod tests {
 
         assert_eq!(Month(6) / 3_i128, Month(2));
         assert_eq!(6_i128 / Month(2), Month(3));
+
+        assert_eq!(Month(6) / 3_u8, Month(2));
+        assert_eq!(6_u8 / Month(2), Month(3));
 
         assert_eq!(Month(8) / 4.0, Month(2));
         assert_eq!(8.0 / Month(4), Month(2));
@@ -349,6 +355,9 @@ mod tests {
         assert_eq!(Microsecond(2) * 3_i128, Microsecond(6));
         assert_eq!(2_i128 * Microsecond(3), Microsecond(6));
 
+        assert_eq!(Microsecond(2) * 3_u8, Microsecond(6));
+        assert_eq!(2_u8 * Microsecond(3), Microsecond(6));
+
         assert_eq!(Microsecond(6) / 3_i8, Microsecond(2));
         assert_eq!(6_i8 / Microsecond(2), Microsecond(3));
 
@@ -363,5 +372,8 @@ mod tests {
 
         assert_eq!(Microsecond(6) / 3_i128, Microsecond(2));
         assert_eq!(6_i128 / Microsecond(2), Microsecond(3));
+
+        assert_eq!(Microsecond(6) / 3_u8, Microsecond(2));
+        assert_eq!(6_u8 / Microsecond(2), Microsecond(3));
     }
 }

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -29,6 +29,7 @@ pub enum Key {
     I32(i32),
     I64(i64),
     I128(i128),
+    U8(u8),
     Bool(bool),
     Str(String),
     Bytea(Vec<u8>),
@@ -75,6 +76,7 @@ impl TryFrom<Value> for Key {
             I32(v) => Ok(Key::I32(v)),
             I64(v) => Ok(Key::I64(v)),
             I128(v) => Ok(Key::I128(v)),
+            U8(v) => Ok(Key::U8(v)),
             Str(v) => Ok(Key::Str(v)),
             Bytea(v) => Ok(Key::Bytea(v)),
             Date(v) => Ok(Key::Date(v)),
@@ -158,6 +160,11 @@ impl Key {
                     .copied()
                     .collect::<Vec<_>>()
             }
+            Key::U8(v) => [VALUE, 0]
+                .iter()
+                .chain(v.to_be_bytes().iter())
+                .copied()
+                .collect::<Vec<_>>(),
             Key::Str(v) => [VALUE]
                 .iter()
                 .chain(v.as_bytes().iter())

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -49,6 +49,7 @@ impl PartialOrd for Key {
             (Key::I16(l), Key::I16(r)) => Some(l.cmp(r)),
             (Key::I32(l), Key::I32(r)) => Some(l.cmp(r)),
             (Key::I64(l), Key::I64(r)) => Some(l.cmp(r)),
+            (Key::U8(l), Key::U8(r)) => Some(l.cmp(r)),
             (Key::Bool(l), Key::Bool(r)) => Some(l.cmp(r)),
             (Key::Str(l), Key::Str(r)) => Some(l.cmp(r)),
             (Key::Bytea(l), Key::Bytea(r)) => Some(l.cmp(r)),

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -160,7 +160,7 @@ impl Key {
                     .copied()
                     .collect::<Vec<_>>()
             }
-            Key::U8(v) => [VALUE, 0]
+            Key::U8(v) => [VALUE, 1]
                 .iter()
                 .chain(v.to_be_bytes().iter())
                 .copied()
@@ -254,6 +254,7 @@ mod tests {
         assert_eq!(convert("CAST(11 AS INT(16))"), Ok(Key::I16(11)));
         assert_eq!(convert("CAST(11 AS INT(32))"), Ok(Key::I32(11)));
         assert_eq!(convert("2048"), Ok(Key::I64(2048)));
+        assert_eq!(convert("CAST(UNSIGNED INT(32)"), Ok(Key::U8(255)));
         assert_eq!(
             convert(r#""Hello World""#),
             Ok(Key::Str("Hello World".to_owned()))

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -254,7 +254,8 @@ mod tests {
         assert_eq!(convert("CAST(11 AS INT(16))"), Ok(Key::I16(11)));
         assert_eq!(convert("CAST(11 AS INT(32))"), Ok(Key::I32(11)));
         assert_eq!(convert("2048"), Ok(Key::I64(2048)));
-        assert_eq!(convert("CAST(UNSIGNED INT(32)"), Ok(Key::U8(255)));
+        assert_eq!(convert("CAST(11 AS INT(8) UNSIGNED)"), Ok(Key::U8(11)));
+
         assert_eq!(
             convert(r#""Hello World""#),
             Ok(Key::Str("Hello World".to_owned()))
@@ -398,6 +399,15 @@ mod tests {
         assert_eq!(cmp(&n4, &n5), Ordering::Less);
         assert_eq!(cmp(&n6, &n4), Ordering::Greater);
         assert_eq!(cmp(&n4, &null), Ordering::Less);
+
+        let n1 = U8(0).to_cmp_be_bytes();
+        let n2 = U8(3).to_cmp_be_bytes();
+        let n3 = U8(20).to_cmp_be_bytes();
+        let n4 = U8(20).to_cmp_be_bytes();
+        assert_eq!(cmp(&n1, &n2), Ordering::Less);
+        assert_eq!(cmp(&n3, &n2), Ordering::Greater);
+        assert_eq!(cmp(&n1, &n4), Ordering::Less);
+        assert_eq!(cmp(&n3, &n4), Ordering::Equal);
 
         let n1 = Str("a".to_owned()).to_cmp_be_bytes();
         let n2 = Str("ab".to_owned()).to_cmp_be_bytes();

--- a/core/src/data/value/binary_op/decimal.rs
+++ b/core/src/data/value/binary_op/decimal.rs
@@ -17,6 +17,7 @@ impl PartialEq<Value> for Decimal {
             I32(other) => *self == Decimal::from(*other),
             I64(other) => *self == Decimal::from(*other),
             I128(other) => *self == Decimal::from(*other),
+            U8(other) => *self == Decimal::from(*other),
             F64(other) => Decimal::from_f64_retain(*other)
                 .map(|x| *self == x)
                 .unwrap_or(false),
@@ -33,6 +34,7 @@ impl PartialOrd<Value> for Decimal {
             I32(rhs) => self.partial_cmp(&(Decimal::from(rhs))),
             I64(rhs) => self.partial_cmp(&(Decimal::from(rhs))),
             I128(rhs) => self.partial_cmp(&(Decimal::from(rhs))),
+            U8(rhs) => self.partial_cmp(&(Decimal::from(rhs))),
             F64(rhs) => Decimal::from_f64_retain(rhs)
                 .map(|x| self.partial_cmp(&x))
                 .unwrap_or(None),
@@ -88,6 +90,17 @@ impl TryBinaryOperator for Decimal {
                     ValueError::BinaryOperationOverflow {
                         lhs: Decimal(lhs),
                         rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            U8(rhs) => lhs
+                .checked_add(Decimal::from(rhs))
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: Decimal(lhs),
+                        rhs: U8(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
@@ -165,6 +178,17 @@ impl TryBinaryOperator for Decimal {
                     .into()
                 })
                 .map(Decimal),
+            U8(rhs) => lhs
+                .checked_sub(Decimal::from(rhs))
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: Decimal(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             F64(rhs) => Decimal::from_f64_retain(rhs)
                 .map(|x| Ok(Decimal(lhs - x)))
                 .unwrap_or_else(|| Err(ValueError::FloatToDecimalConversionFailure(rhs).into())),
@@ -232,6 +256,17 @@ impl TryBinaryOperator for Decimal {
                     ValueError::BinaryOperationOverflow {
                         lhs: Decimal(lhs),
                         rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(Decimal),
+            U8(rhs) => lhs
+                .checked_mul(Decimal::from(rhs))
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: Decimal(lhs),
+                        rhs: U8(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
@@ -309,6 +344,17 @@ impl TryBinaryOperator for Decimal {
                     .into()
                 })
                 .map(Decimal),
+            U8(rhs) => lhs
+                .checked_div(Decimal::from(rhs))
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: Decimal(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             F64(rhs) => Decimal::from_f64_retain(rhs)
                 .map(|x| Ok(Decimal(lhs / x)))
                 .unwrap_or_else(|| Err(ValueError::FloatToDecimalConversionFailure(rhs).into())),
@@ -378,6 +424,17 @@ impl TryBinaryOperator for Decimal {
                         lhs: Decimal(lhs),
                         operator: NumericBinaryOperator::Modulo,
                         rhs: I128(rhs),
+                    }
+                    .into())
+                }),
+            U8(rhs) => lhs
+                .checked_rem(Decimal::from(rhs))
+                .map(|x| Ok(Decimal(x)))
+                .unwrap_or_else(|| {
+                    Err(ValueError::BinaryOperationOverflow {
+                        lhs: Decimal(lhs),
+                        operator: NumericBinaryOperator::Modulo,
+                        rhs: U8(rhs),
                     }
                     .into())
                 }),
@@ -476,6 +533,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            Decimal::MAX.try_add(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: Decimal(Decimal::MAX),
+                rhs: U8(1),
+                operator: NumericBinaryOperator::Add,
+            }
+            .into())
+        );
 
         assert_eq!(
             Decimal::MIN.try_subtract(&I8(1)),
@@ -509,6 +575,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: Decimal(Decimal::MIN),
                 rhs: I128(1),
+                operator: NumericBinaryOperator::Subtract,
+            }
+            .into())
+        );
+        assert_eq!(
+            Decimal::MIN.try_subtract(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: Decimal(Decimal::MIN),
+                rhs: U8(1),
                 operator: NumericBinaryOperator::Subtract,
             }
             .into())
@@ -556,6 +631,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: Decimal(Decimal::MAX),
                 rhs: I128(2),
+                operator: NumericBinaryOperator::Multiply,
+            }
+            .into())
+        );
+        assert_eq!(
+            Decimal::MAX.try_multiply(&U8(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: Decimal(Decimal::MAX),
+                rhs: U8(2),
                 operator: NumericBinaryOperator::Multiply,
             }
             .into())
@@ -609,6 +693,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            base.try_divide(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: Decimal(base),
+                rhs: U8(0),
+                operator: NumericBinaryOperator::Divide,
+            }
+            .into())
+        );
 
         assert_eq!(
             base.try_divide(&Decimal(Decimal::ZERO)),
@@ -658,6 +751,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            base.try_modulo(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: Decimal(base),
+                rhs: U8(0),
+                operator: NumericBinaryOperator::Modulo,
+            }
+            .into())
+        );
 
         assert_eq!(
             base.try_modulo(&Decimal(Decimal::ZERO)),
@@ -678,6 +780,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -692,6 +795,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
         assert_eq!(
             base.partial_cmp(&Decimal(Decimal::ONE)),
@@ -709,6 +813,7 @@ mod tests {
         assert_eq!(base.try_add(&I32(1)), Ok(Decimal(Decimal::TWO)));
         assert_eq!(base.try_add(&I64(1)), Ok(Decimal(Decimal::TWO)));
         assert_eq!(base.try_add(&I128(1)), Ok(Decimal(Decimal::TWO)));
+        assert_eq!(base.try_add(&U8(1)), Ok(Decimal(Decimal::TWO)));
         assert_eq!(base.try_add(&F64(1.0)), Ok(Decimal(Decimal::TWO)));
         assert_eq!(
             base.try_add(&Decimal(Decimal::ONE)),
@@ -734,6 +839,7 @@ mod tests {
         assert_eq!(base.try_subtract(&I32(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(Decimal(Decimal::ZERO)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_subtract(&F64(1.0)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(
             base.try_subtract(&Decimal(Decimal::ONE)),
@@ -759,6 +865,7 @@ mod tests {
         assert_eq!(base.try_multiply(&I32(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_multiply(&I64(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_multiply(&I128(1)), Ok(Decimal(Decimal::ONE)));
+        assert_eq!(base.try_multiply(&U8(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_multiply(&F64(1.0)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(
             base.try_multiply(&Decimal(Decimal::ONE)),
@@ -784,6 +891,7 @@ mod tests {
         assert_eq!(base.try_divide(&I32(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_divide(&I64(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_divide(&I128(1)), Ok(Decimal(Decimal::ONE)));
+        assert_eq!(base.try_divide(&U8(1)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(base.try_divide(&F64(1.0)), Ok(Decimal(Decimal::ONE)));
         assert_eq!(
             base.try_divide(&Decimal(Decimal::ONE)),
@@ -809,6 +917,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I32(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(Decimal(Decimal::ZERO)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(base.try_modulo(&F64(1.0)), Ok(Decimal(Decimal::ZERO)));
         assert_eq!(
             base.try_modulo(&Decimal(Decimal::ONE)),

--- a/core/src/data/value/binary_op/decimal.rs
+++ b/core/src/data/value/binary_op/decimal.rs
@@ -429,15 +429,15 @@ impl TryBinaryOperator for Decimal {
                 }),
             U8(rhs) => lhs
                 .checked_rem(Decimal::from(rhs))
-                .map(|x| Ok(Decimal(x)))
-                .unwrap_or_else(|| {
-                    Err(ValueError::BinaryOperationOverflow {
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
                         lhs: Decimal(lhs),
-                        operator: NumericBinaryOperator::Modulo,
                         rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
                     }
-                    .into())
-                }),
+                    .into()
+                })
+                .map(Decimal),
             F64(rhs) => match Decimal::from_f64_retain(rhs) {
                 Some(x) => lhs
                     .checked_rem(x)

--- a/core/src/data/value/binary_op/f64.rs
+++ b/core/src/data/value/binary_op/f64.rs
@@ -20,6 +20,7 @@ impl PartialEq<Value> for f64 {
             I32(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I64(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             I128(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
+            U8(rhs) => (lhs - (rhs as f64)).abs() < f64::EPSILON,
             F64(rhs) => (lhs - rhs).abs() < f64::EPSILON,
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| rhs == x)
@@ -37,6 +38,7 @@ impl PartialOrd<Value> for f64 {
             I32(rhs) => self.partial_cmp(&(rhs as f64)),
             I64(rhs) => self.partial_cmp(&(rhs as f64)),
             I128(rhs) => self.partial_cmp(&(rhs as f64)),
+            U8(rhs) => self.partial_cmp(&(rhs as f64)),
             F64(rhs) => self.partial_cmp(&rhs),
             Decimal(rhs) => Decimal::from_f64_retain(*self)
                 .map(|x| x.partial_cmp(&rhs))
@@ -58,6 +60,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs + rhs as f64)),
             I64(rhs) => Ok(F64(lhs + rhs as f64)),
             I128(rhs) => Ok(F64(lhs + rhs as f64)),
+            U8(rhs) => Ok(F64(lhs + rhs as f64)),
             F64(rhs) => Ok(F64(lhs + rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x + rhs)))
@@ -81,6 +84,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs - rhs as f64)),
             I64(rhs) => Ok(F64(lhs - rhs as f64)),
             I128(rhs) => Ok(F64(lhs - rhs as f64)),
+            U8(rhs) => Ok(F64(lhs - rhs as f64)),
             F64(rhs) => Ok(F64(lhs - rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x - rhs)))
@@ -104,6 +108,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs * rhs as f64)),
             I64(rhs) => Ok(F64(lhs * rhs as f64)),
             I128(rhs) => Ok(F64(lhs * rhs as f64)),
+            U8(rhs) => Ok(F64(lhs * rhs as f64)),
             F64(rhs) => Ok(F64(lhs * rhs)),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
@@ -128,6 +133,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs / rhs as f64)),
             I64(rhs) => Ok(F64(lhs / rhs as f64)),
             I128(rhs) => Ok(F64(lhs / rhs as f64)),
+            U8(rhs) => Ok(F64(lhs / rhs as f64)),
             F64(rhs) => Ok(F64(lhs / rhs)),
             Decimal(rhs) => Decimal::from_f64_retain(lhs)
                 .map(|x| Ok(Decimal(x * rhs)))
@@ -151,6 +157,7 @@ impl TryBinaryOperator for f64 {
             I32(rhs) => Ok(F64(lhs % rhs as f64)),
             I64(rhs) => Ok(F64(lhs % rhs as f64)),
             I128(rhs) => Ok(F64(lhs % rhs as f64)),
+            U8(rhs) => Ok(F64(lhs % rhs as f64)),
             F64(rhs) => Ok(F64(lhs % rhs)),
             Decimal(rhs) => match Decimal::from_f64_retain(lhs) {
                 Some(x) => x
@@ -195,6 +202,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::from(1)));
 
@@ -210,6 +218,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
         assert_eq!(
             base.partial_cmp(&Decimal(Decimal::ONE)),
@@ -228,6 +237,7 @@ mod tests {
         assert!(matches!(base.try_add(&I32(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I64(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&I128(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_add(&U8(1)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_add(&Decimal(Decimal::ONE)), Ok(Decimal(x)) if x == Decimal::TWO)
@@ -261,6 +271,7 @@ mod tests {
         assert!(
             matches!(base.try_subtract(&I128(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
+        assert!(matches!(base.try_subtract(&U8(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );
@@ -296,6 +307,7 @@ mod tests {
         assert!(
             matches!(base.try_multiply(&I128(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
+        assert!(matches!(base.try_multiply(&U8(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
@@ -323,6 +335,7 @@ mod tests {
         assert!(matches!(base.try_divide(&I32(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I64(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_divide(&I128(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_divide(&U8(1)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 1.0).abs() < f64::EPSILON )
         );
@@ -350,6 +363,7 @@ mod tests {
         assert!(matches!(base.try_modulo(&I32(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I64(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(matches!(base.try_modulo(&I128(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
+        assert!(matches!(base.try_modulo(&U8(1)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON ));
         assert!(
             matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
         );

--- a/core/src/data/value/binary_op/i128.rs
+++ b/core/src/data/value/binary_op/i128.rs
@@ -18,6 +18,7 @@ impl PartialEq<Value> for i128 {
             I32(other) => self == &(*other as i128),
             I64(other) => self == &(*other as i128),
             I128(other) => self == other,
+            U8(other) => self == &(*other as i128),
             F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
@@ -33,6 +34,7 @@ impl PartialOrd<Value> for i128 {
             I32(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I64(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             I128(other) => PartialOrd::partial_cmp(self, other),
+            U8(other) => PartialOrd::partial_cmp(self, &(*other as i128)),
             F64(other) => PartialOrd::partial_cmp(&(*self as f64), other),
             Decimal(other) => Decimal::from(*self).partial_cmp(other),
             _ => None,
@@ -98,6 +100,17 @@ impl TryBinaryOperator for i128 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I128(lhs),
                         rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I128),
+            U8(rhs) => lhs
+                .checked_add(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: U8(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
@@ -174,6 +187,17 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => lhs
+                .checked_sub(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I128),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) - rhs)),
 
@@ -239,6 +263,17 @@ impl TryBinaryOperator for i128 {
                     ValueError::BinaryOperationOverflow {
                         lhs: I128(lhs),
                         rhs: I128(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I128),
+            U8(rhs) => lhs
+                .checked_mul(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: U8(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
@@ -316,6 +351,17 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => lhs
+                .checked_div(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I128),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) / rhs)),
             Null => Ok(Null),
@@ -386,6 +432,17 @@ impl TryBinaryOperator for i128 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => lhs
+                .checked_rem(rhs as i128)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I128(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I128),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) % rhs)),
             Null => Ok(Null),
@@ -416,6 +473,7 @@ mod tests {
         assert_eq!(I128(1), I64(1));
         assert_eq!(I128(1), I128(1));
         assert_eq!(I128(1), F64(1.0));
+        assert_eq!(I128(1), U8(1));
 
         assert_eq!(-1_i128, I128(-1));
         assert_eq!(0_i128, I128(0));
@@ -471,6 +529,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            i128::MAX.try_add(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: U8(1),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
 
         //try_subtract
         assert_eq!(
@@ -520,12 +587,23 @@ mod tests {
             .into())
         );
 
+        assert_eq!(
+            i128::MIN.try_subtract(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MIN),
+                rhs: U8(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+
         //try multiply
         assert_eq!(i128::MAX.try_multiply(&I8(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I16(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I32(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I64(1)), Ok(I128(i128::MAX)));
         assert_eq!(i128::MAX.try_multiply(&I128(1)), Ok(I128(i128::MAX)));
+        assert_eq!(i128::MAX.try_multiply(&U8(1)), Ok(I128(i128::MAX)));
 
         assert_eq!(
             i128::MAX.try_multiply(&I8(2)),
@@ -568,6 +646,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: I128(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            i128::MAX.try_multiply(&U8(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: U8(2),
                 operator: (NumericBinaryOperator::Multiply)
             }
             .into())
@@ -619,6 +706,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            i128::MAX.try_divide(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
 
         assert_eq!(
             i128::MAX.try_modulo(&I8(0)),
@@ -665,6 +761,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            i128::MAX.try_modulo(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I128(i128::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
     }
 
     #[test]
@@ -676,6 +781,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -691,6 +797,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
@@ -698,6 +805,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
@@ -705,6 +813,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -724,6 +833,7 @@ mod tests {
         assert_eq!(base.try_add(&I32(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I128(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
+        assert_eq!(base.try_add(&U8(1)), Ok(I128(2)));
 
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
@@ -751,6 +861,7 @@ mod tests {
         assert_eq!(base.try_subtract(&I32(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I128(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(I128(0)));
 
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
@@ -818,6 +929,7 @@ mod tests {
         assert_eq!(base.try_divide(&I32(2)), Ok(I128(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I128(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
+        assert_eq!(base.try_divide(&U8(2)), Ok(I128(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I128(-1)));
         assert_eq!(base.try_divide(&I16(-6)), Ok(I128(-1)));
@@ -854,6 +966,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I32(1)), Ok(I128(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I128(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(I128(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I128(1)));
         assert_eq!(base.try_modulo(&I16(2)), Ok(I128(1)));

--- a/core/src/data/value/binary_op/i128.rs
+++ b/core/src/data/value/binary_op/i128.rs
@@ -534,7 +534,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: U8(1),
-                operator: (NumericBinaryOperator::Add)
+                operator: NumericBinaryOperator::Add
             }
             .into())
         );
@@ -592,7 +592,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MIN),
                 rhs: U8(1),
-                operator: (NumericBinaryOperator::Subtract)
+                operator: NumericBinaryOperator::Subtract
             }
             .into())
         );
@@ -655,7 +655,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: U8(2),
-                operator: (NumericBinaryOperator::Multiply)
+                operator: NumericBinaryOperator::Multiply
             }
             .into())
         );
@@ -711,7 +711,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: U8(0),
-                operator: (NumericBinaryOperator::Divide)
+                operator: NumericBinaryOperator::Divide
             }
             .into())
         );
@@ -766,7 +766,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I128(i128::MAX),
                 rhs: U8(0),
-                operator: (NumericBinaryOperator::Modulo)
+                operator: NumericBinaryOperator::Modulo
             }
             .into())
         );

--- a/core/src/data/value/binary_op/i16.rs
+++ b/core/src/data/value/binary_op/i16.rs
@@ -535,7 +535,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I16(i16::MAX),
                 rhs: U8(u8::MAX),
-                operator: (NumericBinaryOperator::Add)
+                operator: NumericBinaryOperator::Add
             }
             .into())
         );
@@ -584,7 +584,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I16(i16::MIN),
                 rhs: U8(1),
-                operator: (NumericBinaryOperator::Subtract)
+                operator: NumericBinaryOperator::Subtract
             }
             .into())
         );
@@ -621,7 +621,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I16(i16::MIN),
                 rhs: U8(u8::MAX),
-                operator: (NumericBinaryOperator::Subtract)
+                operator: NumericBinaryOperator::Subtract
             }
             .into())
         );
@@ -689,7 +689,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I16(i16::MAX),
                 rhs: U8(2),
-                operator: (NumericBinaryOperator::Multiply)
+                operator: NumericBinaryOperator::Multiply
             }
             .into())
         );
@@ -855,7 +855,7 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I16(i16::MAX),
                 rhs: U8(0),
-                operator: (NumericBinaryOperator::Modulo)
+                operator: NumericBinaryOperator::Modulo
             }
             .into())
         );

--- a/core/src/data/value/binary_op/i32.rs
+++ b/core/src/data/value/binary_op/i32.rs
@@ -509,6 +509,16 @@ mod tests {
             Ok(I128((i32::MAX as i128) + 1_i128))
         );
 
+        assert_eq!(
+            i32::MAX.try_add(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MAX),
+                rhs: U8(1),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
         //try_subtract
         assert_eq!(
             i32::MIN.try_subtract(&I8(1)),
@@ -525,12 +535,34 @@ mod tests {
             i32::MIN.try_subtract(&I128(1)),
             Ok(I128(i32::MIN as i128 - 1))
         );
+        assert_eq!(
+            i32::MIN.try_subtract(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MIN),
+                rhs: U8(1),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
 
         //try multiply
         assert_eq!(i32::MAX.try_multiply(&I8(1)), Ok(I32(i32::MAX)));
         assert_eq!(i32::MAX.try_multiply(&I64(1)), Ok(I64(i32::MAX as i64)));
         assert_eq!(i32::MAX.try_multiply(&I128(1)), Ok(I128(i32::MAX as i128)));
-
+        assert_eq!(i32::MAX.try_multiply(&I64(2)), Ok(I64(i32::MAX as i64 * 2)));
+        assert_eq!(
+            i32::MAX.try_multiply(&I128(2)),
+            Ok(I128(i32::MAX as i128 * 2))
+        );
+        assert_eq!(
+            i32::MAX.try_multiply(&U8(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MAX),
+                rhs: U8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
         assert_eq!(
             i32::MAX.try_multiply(&I8(2)),
             Err(ValueError::BinaryOperationOverflow {
@@ -540,11 +572,14 @@ mod tests {
             }
             .into())
         );
-
-        assert_eq!(i32::MAX.try_multiply(&I64(2)), Ok(I64(i32::MAX as i64 * 2)));
         assert_eq!(
-            i32::MAX.try_multiply(&I128(2)),
-            Ok(I128(i32::MAX as i128 * 2))
+            i32::MAX.try_multiply(&U8(2)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MAX),
+                rhs: U8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
         );
 
         //try_divide
@@ -571,6 +606,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I32(i32::MAX),
                 rhs: I128(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            i32::MAX.try_divide(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MAX),
+                rhs: U8(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
@@ -603,6 +647,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            i32::MAX.try_modulo(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I32(i32::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
     }
 
     #[test]
@@ -614,6 +667,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -629,6 +683,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
@@ -636,6 +691,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
@@ -643,6 +699,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -662,6 +719,7 @@ mod tests {
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
+        assert_eq!(base.try_add(&U8(1)), Ok(U8(2)));
 
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
@@ -689,6 +747,7 @@ mod tests {
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(U8(0)));
 
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
@@ -719,6 +778,7 @@ mod tests {
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
+        assert_eq!(base.try_multiply(&U8(2)), Ok(U8(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I32(-3)));
         assert_eq!(base.try_multiply(&I16(-1)), Ok(I32(-3)));
@@ -756,6 +816,7 @@ mod tests {
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
+        assert_eq!(base.try_divide(&U8(2)), Ok(U8(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I32(-1)));
         assert_eq!(base.try_divide(&I16(-6)), Ok(I32(-1)));
@@ -792,12 +853,14 @@ mod tests {
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(U8(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I16(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
+        assert_eq!(base.try_modulo(&U8(2)), Ok(U8(1)));
 
         assert!(matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x).abs() < f64::EPSILON ));
         assert_eq!(

--- a/core/src/data/value/binary_op/i8.rs
+++ b/core/src/data/value/binary_op/i8.rs
@@ -18,6 +18,7 @@ impl PartialEq<Value> for i8 {
             I32(other) => (*self as i32) == *other,
             I64(other) => (*self as i64) == *other,
             I128(other) => (*self as i128) == *other,
+            U8(other) => (*self as i64) == (*other as i64),
             F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
@@ -33,6 +34,7 @@ impl PartialOrd<Value> for i8 {
             I32(other) => (*self as i32).partial_cmp(other),
             I64(other) => (*self as i64).partial_cmp(other),
             I128(other) => (*self as i128).partial_cmp(other),
+            U8(other) => (*self as i64).partial_cmp(&(*other as i64)),
             F64(other) => (*self as f64).partial_cmp(other),
             Decimal(other) => Decimal::from(*self).partial_cmp(other),
             _ => None,
@@ -102,6 +104,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => (lhs as i64)
+                .checked_add(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Add,
+                    }
+                    .into()
+                })
+                .map(I64),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) + rhs)),
             Null => Ok(Null),
@@ -173,6 +186,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => (lhs as i64)
+                .checked_sub(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(I64),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
             Decimal(rhs) => Decimal::from(lhs)
                 .checked_sub(rhs)
@@ -254,6 +278,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => (lhs as i64)
+                .checked_mul(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(I64),
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
             Decimal(rhs) => Decimal::from(lhs)
                 .checked_mul(rhs)
@@ -336,6 +371,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => (lhs as i64)
+                .checked_div(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(I64),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
             Decimal(rhs) => Decimal::from(lhs)
                 .checked_div(rhs)
@@ -417,6 +463,17 @@ impl TryBinaryOperator for i8 {
                     .into()
                 })
                 .map(I128),
+            U8(rhs) => (lhs as i64)
+                .checked_rem(rhs as i64)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: I8(lhs),
+                        rhs: U8(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(I64),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
             Decimal(rhs) => Decimal::from(lhs)
                 .checked_rem(rhs)
@@ -467,6 +524,7 @@ mod tests {
             .into())
         );
 
+        assert_eq!(i8::MAX.try_add(&U8(1)), Ok(I64(i8::MAX as i64 + 1)));
         assert_eq!(i8::MAX.try_add(&I32(1)), Ok(I32(i8::MAX as i32 + 1)));
         assert_eq!(i8::MAX.try_add(&I64(1)), Ok(I64(i8::MAX as i64 + 1)));
         assert_eq!(i8::MAX.try_add(&I128(1)), Ok(I128(i8::MAX as i128 + 1)));
@@ -522,6 +580,8 @@ mod tests {
         );
 
         // these dont overflow since they are not i8 (ie, i32, i64, i128)
+        assert_eq!(i8::MIN.try_subtract(&U8(1)), Ok(I64(i8::MIN as i64 - 1)));
+        assert_eq!(i8::MIN.try_subtract(&I16(1)), Ok(I16(i8::MIN as i16 - 1)));
         assert_eq!(i8::MIN.try_subtract(&I32(1)), Ok(I32(i8::MIN as i32 - 1)));
         assert_eq!(i8::MIN.try_subtract(&I64(1)), Ok(I64(i8::MIN as i64 - 1)));
         assert_eq!(
@@ -566,6 +626,7 @@ mod tests {
             .into())
         );
 
+        assert_eq!(i8::MAX.try_multiply(&U8(1)), Ok(I64(i8::MAX as i64)));
         assert_eq!(i8::MAX.try_multiply(&I8(1)), Ok(I8(i8::MAX)));
         assert_eq!(i8::MAX.try_multiply(&I32(1)), Ok(I32(i8::MAX as i32)));
         assert_eq!(
@@ -631,6 +692,15 @@ mod tests {
 
         //try_divide
         assert_eq!(
+            i8::MAX.try_divide(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
             i8::MAX.try_divide(&I8(0)),
             Err(ValueError::BinaryOperationOverflow {
                 lhs: I8(i8::MAX),
@@ -667,6 +737,15 @@ mod tests {
             .into())
         );
 
+        assert_eq!(
+            i8::MAX.try_modulo(&U8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: I8(i8::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
         assert_eq!(
             i8::MAX.try_modulo(&I8(0)),
             Err(ValueError::BinaryOperationOverflow {
@@ -714,6 +793,7 @@ mod tests {
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -729,6 +809,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
@@ -736,6 +817,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
@@ -743,6 +825,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -762,6 +845,7 @@ mod tests {
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
+        assert_eq!(base.try_add(&U8(1)), Ok(U8(2)));
 
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
@@ -789,6 +873,7 @@ mod tests {
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(U8(0)));
 
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
@@ -820,6 +905,7 @@ mod tests {
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
+        assert_eq!(base.try_multiply(&U8(2)), Ok(U8(6)));
 
         assert_eq!(base.try_multiply(&I8(-1)), Ok(I8(-3)));
         assert_eq!(base.try_multiply(&I16(-1)), Ok(I16(-3)));
@@ -857,6 +943,7 @@ mod tests {
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
+        assert_eq!(base.try_divide(&U8(2)), Ok(U8(3)));
 
         assert_eq!(base.try_divide(&I8(-6)), Ok(I8(-1)));
         assert_eq!(base.try_divide(&I16(-6)), Ok(I16(-1)));
@@ -894,6 +981,7 @@ mod tests {
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(U8(0)));
 
         assert_eq!(base.try_modulo(&I8(2)), Ok(I8(1)));
         assert_eq!(base.try_modulo(&I16(2)), Ok(I16(1)));

--- a/core/src/data/value/binary_op/mod.rs
+++ b/core/src/data/value/binary_op/mod.rs
@@ -7,6 +7,7 @@ mod i16;
 mod i32;
 mod i64;
 mod i8;
+mod u8;
 
 pub trait TryBinaryOperator {
     type Rhs;

--- a/core/src/data/value/binary_op/u8.rs
+++ b/core/src/data/value/binary_op/u8.rs
@@ -271,7 +271,6 @@ impl TryBinaryOperator for u8 {
                     .into()
                 })
                 .map(Decimal),
-            Interval(rhs) => Ok(Interval(lhs * rhs)),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
                 lhs: U8(lhs),
@@ -834,7 +833,6 @@ mod tests {
         assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
-
         assert_ne!(base, Bool(true));
     }
 
@@ -877,7 +875,7 @@ mod tests {
     #[test]
     fn try_add() {
         let base = 1_u8;
-
+        assert!(base.try_add(&Null) != Ok(Null));
         assert_eq!(base.try_add(&I8(1)), Ok(U8(2)));
         assert_eq!(base.try_add(&I16(1)), Ok(I16(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
@@ -905,7 +903,7 @@ mod tests {
     #[test]
     fn try_subtract() {
         let base = 1_u8;
-
+        assert!(base.try_subtract(&Null) != Ok(Null));
         assert_eq!(base.try_subtract(&I8(1)), Ok(U8(0)));
         assert_eq!(base.try_subtract(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
@@ -936,7 +934,7 @@ mod tests {
     #[test]
     fn try_multiply() {
         let base = 3_u8;
-
+        assert!(base.try_multiply(&Null) != Ok(Null));
         // 3 * 2 = 6
         assert_eq!(base.try_multiply(&I8(2)), Ok(U8(6)));
         assert_eq!(base.try_multiply(&I16(2)), Ok(I16(6)));
@@ -974,7 +972,7 @@ mod tests {
     #[test]
     fn try_divide() {
         let base = 6_u8;
-
+        assert!(base.try_divide(&Null) != Ok(Null));
         assert_eq!(base.try_divide(&I8(2)), Ok(U8(3)));
         assert_eq!(base.try_divide(&I16(2)), Ok(I16(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
@@ -1011,7 +1009,7 @@ mod tests {
     #[test]
     fn try_modulo() {
         let base = 9_u8;
-
+        assert!(base.try_modulo(&Null) != Ok(Null));
         assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
         assert_eq!(base.try_modulo(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));

--- a/core/src/data/value/binary_op/u8.rs
+++ b/core/src/data/value/binary_op/u8.rs
@@ -49,17 +49,7 @@ impl TryBinaryOperator for u8 {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => (lhs as i64)
-                .checked_add(rhs as i64)
-                .ok_or_else(|| {
-                    ValueError::BinaryOperationOverflow {
-                        lhs: U8(lhs),
-                        rhs: I8(rhs),
-                        operator: NumericBinaryOperator::Add,
-                    }
-                    .into()
-                })
-                .map(I64),
+            I8(rhs) => Ok(I64(lhs as i64 + rhs as i64)),
             I16(rhs) => (lhs as i16)
                 .checked_add(rhs)
                 .ok_or_else(|| {
@@ -131,17 +121,7 @@ impl TryBinaryOperator for u8 {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => (lhs as i64)
-                .checked_sub(rhs as i64)
-                .ok_or_else(|| {
-                    ValueError::BinaryOperationOverflow {
-                        lhs: U8(lhs),
-                        rhs: I8(rhs),
-                        operator: NumericBinaryOperator::Subtract,
-                    }
-                    .into()
-                })
-                .map(I64),
+            I8(rhs) => Ok(I64(lhs as i64 - rhs as i64)),
             I16(rhs) => (lhs as i16)
                 .checked_sub(rhs)
                 .ok_or_else(|| {
@@ -522,7 +502,7 @@ mod tests {
             }
             .into())
         );
-        assert_eq!(u8::MAX.try_add(&I8(1)), Ok(I16(u8::MAX as i16 + 1)));
+        assert_eq!(u8::MAX.try_add(&I8(1)), Ok(I64(u8::MAX as i64 + 1)));
         assert_eq!(u8::MAX.try_add(&I16(1)), Ok(I16(u8::MAX as i16 + 1)));
         assert_eq!(u8::MAX.try_add(&I32(1)), Ok(I32(u8::MAX as i32 + 1)));
         assert_eq!(u8::MAX.try_add(&I64(1)), Ok(I64(u8::MAX as i64 + 1)));
@@ -784,12 +764,12 @@ mod tests {
     fn eq() {
         let base = 1_u8;
 
-        assert_eq!(base, U8(1));
         assert_eq!(base, I8(1));
         assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
         assert_eq!(base, I64(1));
         assert_eq!(base, I128(1));
+        assert_eq!(base, U8(1));
         assert_eq!(base, F64(1.0));
         assert_eq!(base, Decimal(Decimal::ONE));
 
@@ -800,28 +780,28 @@ mod tests {
     fn partial_cmp() {
         let base = 1_u8;
 
-        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I64(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
+        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
-        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I64(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
-        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I64(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I128(2)), Some(Ordering::Less));
+        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&F64(2.0)), Some(Ordering::Less));
 
         assert_eq!(
@@ -836,12 +816,12 @@ mod tests {
     fn try_add() {
         let base = 1_u8;
 
-        assert_eq!(base.try_add(&U8(1)), Ok(U8(2)));
         assert_eq!(base.try_add(&I8(1)), Ok(U8(2)));
         assert_eq!(base.try_add(&I16(1)), Ok(I16(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
+        assert_eq!(base.try_add(&U8(1)), Ok(U8(2)));
 
         assert!(matches!(base.try_add(&F64(1.0)), Ok(F64(x)) if (x - 2.0).abs() < f64::EPSILON));
         assert_eq!(
@@ -864,12 +844,12 @@ mod tests {
     fn try_subtract() {
         let base = 1_u8;
 
-        assert_eq!(base.try_subtract(&U8(1)), Ok(U8(0)));
         assert_eq!(base.try_subtract(&I8(1)), Ok(U8(0)));
         assert_eq!(base.try_subtract(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(U8(0)));
 
         assert!(
             matches!(base.try_subtract(&F64(1.0)), Ok(F64(x)) if (x - 0.0).abs() < f64::EPSILON )
@@ -896,12 +876,12 @@ mod tests {
         let base = 3_u8;
 
         // 3 * 2 = 6
-        assert_eq!(base.try_multiply(&U8(2)), Ok(U8(6)));
         assert_eq!(base.try_multiply(&I8(2)), Ok(U8(6)));
         assert_eq!(base.try_multiply(&I16(2)), Ok(I16(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
+        assert_eq!(base.try_multiply(&U8(2)), Ok(U8(6)));
 
         assert_eq!(base.try_multiply(&I16(-1)), Ok(I16(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I32(-3)));
@@ -933,12 +913,12 @@ mod tests {
     fn try_divide() {
         let base = 6_u8;
 
-        assert_eq!(base.try_divide(&U8(2)), Ok(U8(3)));
         assert_eq!(base.try_divide(&I8(2)), Ok(U8(3)));
         assert_eq!(base.try_divide(&I16(2)), Ok(I16(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
+        assert_eq!(base.try_divide(&U8(2)), Ok(U8(3)));
 
         assert_eq!(base.try_divide(&I16(-6)), Ok(I16(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I32(-1)));
@@ -970,18 +950,18 @@ mod tests {
     fn try_modulo() {
         let base = 9_u8;
 
-        assert_eq!(base.try_modulo(&U8(1)), Ok(U8(0)));
         assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
         assert_eq!(base.try_modulo(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(U8(0)));
 
-        assert_eq!(base.try_modulo(&U8(2)), Ok(U8(1)));
         assert_eq!(base.try_modulo(&I16(2)), Ok(I16(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
+        assert_eq!(base.try_modulo(&U8(2)), Ok(U8(1)));
 
         assert!(matches!(base.try_modulo(&F64(1.0)), Ok(F64(x)) if (x).abs() < f64::EPSILON ));
         assert_eq!(

--- a/core/src/data/value/binary_op/u8.rs
+++ b/core/src/data/value/binary_op/u8.rs
@@ -203,17 +203,7 @@ impl TryBinaryOperator for u8 {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => (lhs as i64)
-                .checked_mul(rhs as i64)
-                .ok_or_else(|| {
-                    ValueError::BinaryOperationOverflow {
-                        lhs: U8(lhs),
-                        rhs: I8(rhs),
-                        operator: NumericBinaryOperator::Multiply,
-                    }
-                    .into()
-                })
-                .map(I64),
+            I8(rhs) => Ok(I64(lhs as i64 * rhs as i64)),
             I16(rhs) => (lhs as i16)
                 .checked_mul(rhs)
                 .ok_or_else(|| {
@@ -585,6 +575,51 @@ mod tests {
             u8::MIN.try_subtract(&I64(i64::MAX)),
             Ok(I64(i64::MIN as i64 + 1))
         );
+        assert_eq!(
+            u8::MAX.try_subtract(&I16(i16::MIN)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I16(i16::MIN),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_subtract(&I32(i32::MIN)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I32(i32::MIN),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_subtract(&I64(i64::MIN)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I64(i64::MIN),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_subtract(&I128(i128::MIN)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I128(i128::MIN),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_subtract(&Decimal(Decimal::MIN)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: Decimal(Decimal::MIN),
+                operator: (NumericBinaryOperator::Subtract)
+            }
+            .into())
+        );
 
         assert_eq!(u8::MAX.try_multiply(&U8(1)), Ok(U8(u8::MAX)));
         assert_eq!(u8::MAX.try_multiply(&I32(1)), Ok(I32(u8::MAX as i32)));
@@ -647,6 +682,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            2_u8.try_multiply(&Decimal(Decimal::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(2),
+                rhs: Decimal(Decimal::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
 
         //try_divide
         assert_eq!(
@@ -703,6 +747,15 @@ mod tests {
             }
             .into())
         );
+        assert_eq!(
+            u8::MAX.try_divide(&Decimal(Decimal::ZERO)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: Decimal(Decimal::ZERO),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
 
         assert_eq!(
             u8::MAX.try_modulo(&U8(0)),
@@ -754,6 +807,15 @@ mod tests {
             Err(ValueError::BinaryOperationOverflow {
                 lhs: U8(u8::MAX),
                 rhs: I128(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_modulo(&Decimal(Decimal::ZERO)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: Decimal(Decimal::ZERO),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())

--- a/core/src/data/value/binary_op/u8.rs
+++ b/core/src/data/value/binary_op/u8.rs
@@ -10,15 +10,15 @@ use {
     Value::*,
 };
 
-impl PartialEq<Value> for i32 {
+impl PartialEq<Value> for u8 {
     fn eq(&self, other: &Value) -> bool {
         match other {
-            I8(other) => self == &(*other as i32),
-            I16(other) => self == &(*other as i32),
-            I32(other) => self == other,
+            I8(other) => (*self as i16) == (*other as i16),
+            I16(other) => (*self as i16) == *other,
+            I32(other) => (*self as i32) == *other,
             I64(other) => (*self as i64) == *other,
             I128(other) => (*self as i128) == *other,
-            U8(other) => self == &(*other as i32),
+            U8(other) => self == other,
             F64(other) => ((*self as f64) - other).abs() < f64::EPSILON,
             Decimal(other) => Decimal::from(*self) == *other,
             _ => false,
@@ -26,56 +26,56 @@ impl PartialEq<Value> for i32 {
     }
 }
 
-impl PartialOrd<Value> for i32 {
+impl PartialOrd<Value> for u8 {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         match other {
-            I8(other) => PartialOrd::partial_cmp(self, &(*other as i32)),
-            I16(other) => PartialOrd::partial_cmp(self, &(*other as i32)),
-            I32(other) => PartialOrd::partial_cmp(self, other),
-            I64(other) => PartialOrd::partial_cmp(&(*self as i64), other),
-            I128(other) => PartialOrd::partial_cmp(&(*self as i128), other),
-            U8(other) => PartialOrd::partial_cmp(self, &(*other as i32)),
-            F64(other) => PartialOrd::partial_cmp(&(*self as f64), other),
+            I8(other) => (*self as i16).partial_cmp(&(*other as i16)),
+            I16(other) => (*self as i16).partial_cmp(other),
+            I32(other) => (*self as i32).partial_cmp(other),
+            I64(other) => (*self as i64).partial_cmp(other),
+            I128(other) => (*self as i128).partial_cmp(other),
+            U8(other) => self.partial_cmp(other),
+            F64(other) => (*self as f64).partial_cmp(other),
             Decimal(other) => Decimal::from(*self).partial_cmp(other),
             _ => None,
         }
     }
 }
 
-impl TryBinaryOperator for i32 {
+impl TryBinaryOperator for u8 {
     type Rhs = Value;
 
     fn try_add(&self, rhs: &Self::Rhs) -> Result<Value> {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => lhs
-                .checked_add(rhs as i32)
+            I8(rhs) => (lhs as i64)
+                .checked_add(rhs as i64)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I8(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
                 })
-                .map(I32),
-            I16(rhs) => lhs
-                .checked_add(rhs as i32)
+                .map(I64),
+            I16(rhs) => (lhs as i16)
+                .checked_add(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I16(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
                 })
-                .map(I32),
-            I32(rhs) => lhs
+                .map(I16),
+            I32(rhs) => (lhs as i32)
                 .checked_add(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I32(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
@@ -86,7 +86,7 @@ impl TryBinaryOperator for i32 {
                 .checked_add(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I64(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
@@ -97,7 +97,7 @@ impl TryBinaryOperator for i32 {
                 .checked_add(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I128(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
@@ -105,21 +105,21 @@ impl TryBinaryOperator for i32 {
                 })
                 .map(I128),
             U8(rhs) => lhs
-                .checked_add(rhs as i32)
+                .checked_add(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: U8(rhs),
                         operator: NumericBinaryOperator::Add,
                     }
                     .into()
                 })
-                .map(I32),
+                .map(U8),
             F64(rhs) => Ok(F64(lhs as f64 + rhs)),
             Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) + rhs)),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
-                lhs: I32(lhs),
+                lhs: U8(lhs),
                 operator: NumericBinaryOperator::Add,
                 rhs: rhs.clone(),
             }
@@ -131,33 +131,33 @@ impl TryBinaryOperator for i32 {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => lhs
-                .checked_sub(rhs as i32)
+            I8(rhs) => (lhs as i64)
+                .checked_sub(rhs as i64)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I8(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
                     .into()
                 })
-                .map(I32),
-            I16(rhs) => lhs
-                .checked_sub(rhs as i32)
+                .map(I64),
+            I16(rhs) => (lhs as i16)
+                .checked_sub(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I16(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
                     .into()
                 })
-                .map(I32),
-            I32(rhs) => lhs
+                .map(I16),
+            I32(rhs) => (lhs as i32)
                 .checked_sub(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I32(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
@@ -168,7 +168,7 @@ impl TryBinaryOperator for i32 {
                 .checked_sub(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I64(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
@@ -179,7 +179,7 @@ impl TryBinaryOperator for i32 {
                 .checked_sub(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I128(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
@@ -187,58 +187,69 @@ impl TryBinaryOperator for i32 {
                 })
                 .map(I128),
             U8(rhs) => lhs
-                .checked_sub(rhs as i32)
+                .checked_sub(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: U8(rhs),
                         operator: NumericBinaryOperator::Subtract,
                     }
                     .into()
                 })
-                .map(I32),
+                .map(U8),
             F64(rhs) => Ok(F64(lhs as f64 - rhs)),
-            Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) - rhs)),
-
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_sub(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: U8(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Subtract,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
-                lhs: I32(lhs),
+                lhs: U8(lhs),
                 operator: NumericBinaryOperator::Subtract,
                 rhs: rhs.clone(),
             }
             .into()),
         }
     }
+
     fn try_multiply(&self, rhs: &Self::Rhs) -> Result<Value> {
         let lhs = *self;
+
         match *rhs {
-            I8(rhs) => lhs
-                .checked_mul(rhs as i32)
+            I8(rhs) => (lhs as i64)
+                .checked_mul(rhs as i64)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I8(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
                 })
-                .map(I32),
-            I16(rhs) => lhs
-                .checked_mul(rhs as i32)
+                .map(I64),
+            I16(rhs) => (lhs as i16)
+                .checked_mul(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I16(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
                 })
-                .map(I32),
-            I32(rhs) => lhs
+                .map(I16),
+            I32(rhs) => (lhs as i32)
                 .checked_mul(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I32(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
@@ -249,7 +260,7 @@ impl TryBinaryOperator for i32 {
                 .checked_mul(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I64(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
@@ -260,7 +271,7 @@ impl TryBinaryOperator for i32 {
                 .checked_mul(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I128(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
@@ -268,22 +279,32 @@ impl TryBinaryOperator for i32 {
                 })
                 .map(I128),
             U8(rhs) => lhs
-                .checked_mul(rhs as i32)
+                .checked_mul(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: U8(rhs),
                         operator: NumericBinaryOperator::Multiply,
                     }
                     .into()
                 })
-                .map(I32),
+                .map(U8),
             F64(rhs) => Ok(F64(lhs as f64 * rhs)),
-            Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) * rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_mul(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: U8(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Multiply,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             Interval(rhs) => Ok(Interval(lhs * rhs)),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
-                lhs: I32(lhs),
+                lhs: U8(lhs),
                 operator: NumericBinaryOperator::Multiply,
                 rhs: rhs.clone(),
             }
@@ -295,33 +316,33 @@ impl TryBinaryOperator for i32 {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => lhs
-                .checked_div(rhs as i32)
+            I8(rhs) => (lhs as i64)
+                .checked_div(rhs as i64)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I8(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
                     .into()
                 })
-                .map(I32),
-            I16(rhs) => lhs
-                .checked_div(rhs as i32)
+                .map(I64),
+            I16(rhs) => (lhs as i16)
+                .checked_div(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I16(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
                     .into()
                 })
-                .map(I32),
-            I32(rhs) => lhs
+                .map(I16),
+            I32(rhs) => (lhs as i32)
                 .checked_div(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I32(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
@@ -332,7 +353,7 @@ impl TryBinaryOperator for i32 {
                 .checked_div(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I64(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
@@ -343,7 +364,7 @@ impl TryBinaryOperator for i32 {
                 .checked_div(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I128(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
@@ -351,58 +372,69 @@ impl TryBinaryOperator for i32 {
                 })
                 .map(I128),
             U8(rhs) => lhs
-                .checked_div(rhs as i32)
+                .checked_div(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: U8(rhs),
                         operator: NumericBinaryOperator::Divide,
                     }
                     .into()
                 })
-                .map(I32),
+                .map(U8),
             F64(rhs) => Ok(F64(lhs as f64 / rhs)),
-            Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) / rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_div(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: U8(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Divide,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
-                lhs: I32(lhs),
+                lhs: U8(lhs),
                 operator: NumericBinaryOperator::Divide,
                 rhs: rhs.clone(),
             }
             .into()),
         }
     }
+
     fn try_modulo(&self, rhs: &Self::Rhs) -> Result<Value> {
         let lhs = *self;
 
         match *rhs {
-            I8(rhs) => lhs
-                .checked_rem(rhs as i32)
+            I8(rhs) => (lhs as i64)
+                .checked_rem(rhs as i64)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I8(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
                 })
-                .map(I32),
-            I16(rhs) => lhs
-                .checked_rem(rhs as i32)
+                .map(I64),
+            I16(rhs) => (lhs as i16)
+                .checked_rem(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I16(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
                 })
-                .map(I32),
-            I32(rhs) => lhs
+                .map(I16),
+            I32(rhs) => (lhs as i32)
                 .checked_rem(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I32(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
@@ -413,7 +445,7 @@ impl TryBinaryOperator for i32 {
                 .checked_rem(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I64(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
@@ -424,7 +456,7 @@ impl TryBinaryOperator for i32 {
                 .checked_rem(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: I128(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
@@ -432,21 +464,31 @@ impl TryBinaryOperator for i32 {
                 })
                 .map(I128),
             U8(rhs) => lhs
-                .checked_rem(rhs as i32)
+                .checked_rem(rhs)
                 .ok_or_else(|| {
                     ValueError::BinaryOperationOverflow {
-                        lhs: I32(lhs),
+                        lhs: U8(lhs),
                         rhs: U8(rhs),
                         operator: NumericBinaryOperator::Modulo,
                     }
                     .into()
                 })
-                .map(I32),
+                .map(U8),
             F64(rhs) => Ok(F64(lhs as f64 % rhs)),
-            Decimal(rhs) => Ok(Decimal(Decimal::from(lhs) % rhs)),
+            Decimal(rhs) => Decimal::from(lhs)
+                .checked_rem(rhs)
+                .ok_or_else(|| {
+                    ValueError::BinaryOperationOverflow {
+                        lhs: U8(lhs),
+                        rhs: Decimal(rhs),
+                        operator: NumericBinaryOperator::Modulo,
+                    }
+                    .into()
+                })
+                .map(Decimal),
             Null => Ok(Null),
             _ => Err(ValueError::NonNumericMathOperation {
-                lhs: I32(lhs),
+                lhs: U8(lhs),
                 operator: NumericBinaryOperator::Modulo,
                 rhs: rhs.clone(),
             }
@@ -466,110 +508,216 @@ mod tests {
 
     #[test]
     fn test_extremes() {
-        assert_eq!(I32(1), I8(1));
-        assert_eq!(I32(1), I64(1));
-        assert_eq!(I32(1), I128(1));
-        assert_eq!(I32(1), F64(1.0));
-        assert_eq!(I32(1), U8(1));
+        assert_eq!(0u8, U8(0));
+        assert_eq!(1u8, U8(1));
+        assert_eq!(u8::MAX, U8(u8::MAX));
+        assert_eq!(u8::MIN, U8(u8::MIN));
 
-        assert_eq!(-1_i32, I32(-1));
-        assert_eq!(0_i32, I32(0));
-        assert_eq!(1_i32, I32(1));
-        assert_eq!(i32::MIN, I32(i32::MIN));
-        assert_eq!(i32::MAX, I32(i32::MAX));
-
-        //try_add
         assert_eq!(
-            i32::MAX.try_add(&U8(1)),
+            u8::MAX.try_add(&U8(1)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
                 rhs: U8(1),
                 operator: (NumericBinaryOperator::Add)
             }
             .into())
         );
+        assert_eq!(u8::MAX.try_add(&I8(1)), Ok(I16(u8::MAX as i16 + 1)));
+        assert_eq!(u8::MAX.try_add(&I16(1)), Ok(I16(u8::MAX as i16 + 1)));
+        assert_eq!(u8::MAX.try_add(&I32(1)), Ok(I32(u8::MAX as i32 + 1)));
+        assert_eq!(u8::MAX.try_add(&I64(1)), Ok(I64(u8::MAX as i64 + 1)));
+        assert_eq!(u8::MAX.try_add(&I128(1)), Ok(I128(u8::MAX as i128 + 1)));
 
         assert_eq!(
-            i32::MAX.try_add(&I8(1)),
+            u8::MAX.try_add(&I8(i8::MAX)),
+            Ok(I64(u8::MAX as i64 + i8::MAX as i64))
+        );
+
+        assert_eq!(
+            u8::MAX.try_add(&I16(i16::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
-                rhs: I8(1),
+                lhs: U8(u8::MAX),
+                rhs: I16(i16::MAX),
                 operator: (NumericBinaryOperator::Add)
             }
             .into())
         );
 
         assert_eq!(
-            i32::MAX.try_add(&I64(1)),
-            Ok(I64((i32::MAX as i64) + 1_i64))
-        );
-
-        assert_eq!(
-            i32::MAX.try_add(&I128(1)),
-            Ok(I128((i32::MAX as i128) + 1_i128))
-        );
-
-        //try_subtract
-        assert_eq!(
-            i32::MIN.try_subtract(&I8(1)),
+            u8::MAX.try_add(&I32(i32::MAX)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MIN),
-                rhs: I8(1),
+                lhs: U8(u8::MAX),
+                rhs: I32(i32::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            u8::MAX.try_add(&I64(i64::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I64(i64::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            u8::MAX.try_add(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I128(i128::MAX),
+                operator: (NumericBinaryOperator::Add)
+            }
+            .into())
+        );
+
+        assert_eq!(
+            u8::MIN.try_subtract(&U8(1)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MIN),
+                rhs: U8(1),
                 operator: (NumericBinaryOperator::Subtract)
             }
             .into())
         );
 
-        assert_eq!(i32::MIN.try_subtract(&I64(1)), Ok(I64(i32::MIN as i64 - 1)));
         assert_eq!(
-            i32::MIN.try_subtract(&I128(1)),
-            Ok(I128(i32::MIN as i128 - 1))
+            u8::MIN.try_subtract(&I8(i8::MIN)),
+            Ok(I64(u8::MIN as i64 - i8::MIN as i64))
         );
 
-        //try multiply
-        assert_eq!(i32::MAX.try_multiply(&I8(1)), Ok(I32(i32::MAX)));
-        assert_eq!(i32::MAX.try_multiply(&I64(1)), Ok(I64(i32::MAX as i64)));
-        assert_eq!(i32::MAX.try_multiply(&I128(1)), Ok(I128(i32::MAX as i128)));
+        assert_eq!(
+            u8::MIN.try_subtract(&I8(i8::MAX)),
+            Ok(I64(u8::MIN as i64 - i8::MAX as i64))
+        );
 
         assert_eq!(
-            i32::MAX.try_multiply(&I8(2)),
+            u8::MIN.try_subtract(&I16(i16::MAX)),
+            Ok(I16(i16::MIN as i16 + 1))
+        );
+        assert_eq!(
+            u8::MIN.try_subtract(&I32(i32::MAX)),
+            Ok(I32(i32::MIN as i32 + 1))
+        );
+        assert_eq!(
+            u8::MIN.try_subtract(&I64(i64::MAX)),
+            Ok(I64(i64::MIN as i64 + 1))
+        );
+
+        assert_eq!(u8::MAX.try_multiply(&U8(1)), Ok(U8(u8::MAX)));
+        assert_eq!(u8::MAX.try_multiply(&I32(1)), Ok(I32(u8::MAX as i32)));
+
+        assert_eq!(u8::MAX.try_multiply(&U8(1)), Ok(U8(u8::MAX)));
+        assert_eq!(u8::MAX.try_multiply(&I8(1)), Ok(U8(u8::MAX)));
+
+        assert_eq!(u8::MAX.try_multiply(&I16(1)), Ok(I16(u8::MAX as i16)));
+
+        assert_eq!(u8::MAX.try_multiply(&I32(1)), Ok(I32(u8::MAX as i32)));
+        assert_eq!(u8::MAX.try_multiply(&I64(1)), Ok(I64(u8::MAX as i64)));
+        assert_eq!(u8::MAX.try_multiply(&I128(1)), Ok(I128(u8::MAX as i128)));
+
+        assert_eq!(
+            u8::MAX.try_multiply(&U8(2)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
-                rhs: I8(2),
+                lhs: U8(u8::MAX),
+                rhs: U8(2),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2_u8.try_multiply(&I8(i8::MAX)),
+            Ok(I64(2_u8 as i64 * i8::MAX as i64))
+        );
+        assert_eq!(
+            2_u8.try_multiply(&I16(i16::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(2),
+                rhs: I16(i16::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2_u8.try_multiply(&I32(i32::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(2),
+                rhs: I32(i32::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2_u8.try_multiply(&I64(i64::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(2),
+                rhs: I64(i64::MAX),
+                operator: (NumericBinaryOperator::Multiply)
+            }
+            .into())
+        );
+        assert_eq!(
+            2_u8.try_multiply(&I128(i128::MAX)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(2),
+                rhs: I128(i128::MAX),
                 operator: (NumericBinaryOperator::Multiply)
             }
             .into())
         );
 
-        assert_eq!(i32::MAX.try_multiply(&I64(2)), Ok(I64(i32::MAX as i64 * 2)));
-        assert_eq!(
-            i32::MAX.try_multiply(&I128(2)),
-            Ok(I128(i32::MAX as i128 * 2))
-        );
-
         //try_divide
         assert_eq!(
-            i32::MAX.try_divide(&I8(0)),
+            u8::MAX.try_divide(&U8(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_divide(&I8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
                 rhs: I8(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
         );
         assert_eq!(
-            i32::MAX.try_divide(&I64(0)),
+            u8::MAX.try_divide(&I16(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
+                rhs: I16(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_divide(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I32(0),
+                operator: (NumericBinaryOperator::Divide)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_divide(&I64(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
                 rhs: I64(0),
                 operator: (NumericBinaryOperator::Divide)
             }
             .into())
         );
         assert_eq!(
-            i32::MAX.try_divide(&I128(0)),
+            u8::MAX.try_divide(&I128(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
                 rhs: I128(0),
                 operator: (NumericBinaryOperator::Divide)
             }
@@ -577,27 +725,54 @@ mod tests {
         );
 
         assert_eq!(
-            i32::MAX.try_modulo(&I8(0)),
+            u8::MAX.try_modulo(&U8(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
+                rhs: U8(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_modulo(&I8(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
                 rhs: I8(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())
         );
         assert_eq!(
-            i32::MAX.try_modulo(&I64(0)),
+            u8::MAX.try_modulo(&I16(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
+                rhs: I16(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_modulo(&I32(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
+                rhs: I32(0),
+                operator: (NumericBinaryOperator::Modulo)
+            }
+            .into())
+        );
+        assert_eq!(
+            u8::MAX.try_modulo(&I64(0)),
+            Err(ValueError::BinaryOperationOverflow {
+                lhs: U8(u8::MAX),
                 rhs: I64(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
             .into())
         );
         assert_eq!(
-            i32::MAX.try_modulo(&I128(0)),
+            u8::MAX.try_modulo(&I128(0)),
             Err(ValueError::BinaryOperationOverflow {
-                lhs: I32(i32::MAX),
+                lhs: U8(u8::MAX),
                 rhs: I128(0),
                 operator: (NumericBinaryOperator::Modulo)
             }
@@ -607,8 +782,9 @@ mod tests {
 
     #[test]
     fn eq() {
-        let base = 1_i32;
+        let base = 1_u8;
 
+        assert_eq!(base, U8(1));
         assert_eq!(base, I8(1));
         assert_eq!(base, I16(1));
         assert_eq!(base, I32(1));
@@ -622,8 +798,9 @@ mod tests {
 
     #[test]
     fn partial_cmp() {
-        let base = 1_i32;
+        let base = 1_u8;
 
+        assert_eq!(base.partial_cmp(&U8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I8(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I16(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&I32(0)), Some(Ordering::Greater));
@@ -631,6 +808,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I128(0)), Some(Ordering::Greater));
         assert_eq!(base.partial_cmp(&F64(0.0)), Some(Ordering::Greater));
 
+        assert_eq!(base.partial_cmp(&U8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I8(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I16(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&I32(1)), Some(Ordering::Equal));
@@ -638,6 +816,7 @@ mod tests {
         assert_eq!(base.partial_cmp(&I128(1)), Some(Ordering::Equal));
         assert_eq!(base.partial_cmp(&F64(1.0)), Some(Ordering::Equal));
 
+        assert_eq!(base.partial_cmp(&U8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I8(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I16(2)), Some(Ordering::Less));
         assert_eq!(base.partial_cmp(&I32(2)), Some(Ordering::Less));
@@ -655,10 +834,11 @@ mod tests {
 
     #[test]
     fn try_add() {
-        let base = 1_i32;
+        let base = 1_u8;
 
-        assert_eq!(base.try_add(&I8(1)), Ok(I32(2)));
-        assert_eq!(base.try_add(&I16(1)), Ok(I32(2)));
+        assert_eq!(base.try_add(&U8(1)), Ok(U8(2)));
+        assert_eq!(base.try_add(&I8(1)), Ok(U8(2)));
+        assert_eq!(base.try_add(&I16(1)), Ok(I16(2)));
         assert_eq!(base.try_add(&I32(1)), Ok(I32(2)));
         assert_eq!(base.try_add(&I64(1)), Ok(I64(2)));
         assert_eq!(base.try_add(&I128(1)), Ok(I128(2)));
@@ -672,7 +852,7 @@ mod tests {
         assert_eq!(
             base.try_add(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I32(base),
+                lhs: U8(base),
                 operator: NumericBinaryOperator::Add,
                 rhs: Bool(true)
             }
@@ -682,10 +862,11 @@ mod tests {
 
     #[test]
     fn try_subtract() {
-        let base = 1_i32;
+        let base = 1_u8;
 
-        assert_eq!(base.try_subtract(&I8(1)), Ok(I32(0)));
-        assert_eq!(base.try_subtract(&I16(1)), Ok(I32(0)));
+        assert_eq!(base.try_subtract(&U8(1)), Ok(U8(0)));
+        assert_eq!(base.try_subtract(&I8(1)), Ok(U8(0)));
+        assert_eq!(base.try_subtract(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_subtract(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_subtract(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_subtract(&I128(1)), Ok(I128(0)));
@@ -702,7 +883,7 @@ mod tests {
         assert_eq!(
             base.try_subtract(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I32(base),
+                lhs: U8(base),
                 operator: NumericBinaryOperator::Subtract,
                 rhs: Bool(true)
             }
@@ -712,16 +893,17 @@ mod tests {
 
     #[test]
     fn try_multiply() {
-        let base = 3_i32;
+        let base = 3_u8;
 
-        assert_eq!(base.try_multiply(&I8(2)), Ok(I32(6)));
-        assert_eq!(base.try_multiply(&I16(2)), Ok(I32(6)));
+        // 3 * 2 = 6
+        assert_eq!(base.try_multiply(&U8(2)), Ok(U8(6)));
+        assert_eq!(base.try_multiply(&I8(2)), Ok(U8(6)));
+        assert_eq!(base.try_multiply(&I16(2)), Ok(I16(6)));
         assert_eq!(base.try_multiply(&I32(2)), Ok(I32(6)));
         assert_eq!(base.try_multiply(&I64(2)), Ok(I64(6)));
         assert_eq!(base.try_multiply(&I128(2)), Ok(I128(6)));
 
-        assert_eq!(base.try_multiply(&I8(-1)), Ok(I32(-3)));
-        assert_eq!(base.try_multiply(&I16(-1)), Ok(I32(-3)));
+        assert_eq!(base.try_multiply(&I16(-1)), Ok(I16(-3)));
         assert_eq!(base.try_multiply(&I32(-1)), Ok(I32(-3)));
         assert_eq!(base.try_multiply(&I64(-1)), Ok(I64(-3)));
         assert_eq!(base.try_multiply(&I128(-1)), Ok(I128(-3)));
@@ -730,7 +912,7 @@ mod tests {
             matches!(base.try_multiply(&F64(1.0)), Ok(F64(x)) if (x - 3.0).abs() < f64::EPSILON )
         );
 
-        let _result: Decimal = Decimal::from(3_i64);
+        let _result: Decimal = Decimal::from(3);
         assert_eq!(
             base.try_multiply(&Decimal(Decimal::ONE)),
             Ok(Decimal(_result))
@@ -739,7 +921,7 @@ mod tests {
         assert_eq!(
             base.try_multiply(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I32(base),
+                lhs: U8(base),
                 operator: NumericBinaryOperator::Multiply,
                 rhs: Bool(true)
             }
@@ -749,16 +931,16 @@ mod tests {
 
     #[test]
     fn try_divide() {
-        let base = 6_i32;
+        let base = 6_u8;
 
-        assert_eq!(base.try_divide(&I8(2)), Ok(I32(3)));
-        assert_eq!(base.try_divide(&I16(2)), Ok(I32(3)));
+        assert_eq!(base.try_divide(&U8(2)), Ok(U8(3)));
+        assert_eq!(base.try_divide(&I8(2)), Ok(U8(3)));
+        assert_eq!(base.try_divide(&I16(2)), Ok(I16(3)));
         assert_eq!(base.try_divide(&I32(2)), Ok(I32(3)));
         assert_eq!(base.try_divide(&I64(2)), Ok(I64(3)));
         assert_eq!(base.try_divide(&I128(2)), Ok(I128(3)));
 
-        assert_eq!(base.try_divide(&I8(-6)), Ok(I32(-1)));
-        assert_eq!(base.try_divide(&I16(-6)), Ok(I32(-1)));
+        assert_eq!(base.try_divide(&I16(-6)), Ok(I16(-1)));
         assert_eq!(base.try_divide(&I32(-6)), Ok(I32(-1)));
         assert_eq!(base.try_divide(&I64(-6)), Ok(I64(-1)));
         assert_eq!(base.try_divide(&I128(-6)), Ok(I128(-1)));
@@ -767,15 +949,16 @@ mod tests {
             matches!(base.try_divide(&F64(1.0)), Ok(F64(x)) if (x - 6.0).abs() < f64::EPSILON )
         );
 
+        let _decimal_result = Decimal::from(base);
         assert_eq!(
             base.try_divide(&Decimal(Decimal::ONE)),
-            Ok(Decimal(Decimal::from(base)))
+            Ok(Decimal(_decimal_result))
         );
 
         assert_eq!(
             base.try_divide(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I32(base),
+                lhs: U8(base),
                 operator: NumericBinaryOperator::Divide,
                 rhs: Bool(true)
             }
@@ -785,16 +968,17 @@ mod tests {
 
     #[test]
     fn try_modulo() {
-        let base = 9_i32;
+        let base = 9_u8;
 
-        assert_eq!(base.try_modulo(&I8(1)), Ok(I32(0)));
-        assert_eq!(base.try_modulo(&I16(1)), Ok(I32(0)));
+        assert_eq!(base.try_modulo(&U8(1)), Ok(U8(0)));
+        assert_eq!(base.try_modulo(&I8(1)), Ok(I8(0)));
+        assert_eq!(base.try_modulo(&I16(1)), Ok(I16(0)));
         assert_eq!(base.try_modulo(&I32(1)), Ok(I32(0)));
         assert_eq!(base.try_modulo(&I64(1)), Ok(I64(0)));
         assert_eq!(base.try_modulo(&I128(1)), Ok(I128(0)));
 
-        assert_eq!(base.try_modulo(&I8(2)), Ok(I32(1)));
-        assert_eq!(base.try_modulo(&I16(2)), Ok(I32(1)));
+        assert_eq!(base.try_modulo(&U8(2)), Ok(U8(1)));
+        assert_eq!(base.try_modulo(&I16(2)), Ok(I16(1)));
         assert_eq!(base.try_modulo(&I32(2)), Ok(I32(1)));
         assert_eq!(base.try_modulo(&I64(2)), Ok(I64(1)));
         assert_eq!(base.try_modulo(&I128(2)), Ok(I128(1)));
@@ -808,7 +992,7 @@ mod tests {
         assert_eq!(
             base.try_modulo(&Bool(true)),
             Err(ValueError::NonNumericMathOperation {
-                lhs: I32(base),
+                lhs: U8(base),
                 operator: NumericBinaryOperator::Modulo,
                 rhs: Bool(true)
             }

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -701,6 +701,7 @@ mod tests {
         test!(Value::I32(128), Err(ValueError::ImpossibleCast.into()));
         test!(Value::I64(128), Err(ValueError::ImpossibleCast.into()));
         test!(Value::I128(128), Err(ValueError::ImpossibleCast.into()));
+        test!(Value::U8(128), Err(ValueError::ImpossibleCast.into()));
         test!(Value::F64(128.0), Err(ValueError::ImpossibleCast.into()));
     }
 

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -423,7 +423,6 @@ impl TryFrom<&Value> for Decimal {
             Value::I32(value) => Decimal::from_i32(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => Decimal::from_i64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => Decimal::from_i128(*value).ok_or(ValueError::ImpossibleCast)?,
-            Value::U8(value) => Decimal::from_u8(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => Decimal::from_f64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => {
                 Decimal::from_str(value).map_err(|_| ValueError::ImpossibleCast)?
@@ -957,6 +956,11 @@ mod tests {
         test!(Value::F64(122.9), Ok(122));
         test!(Value::Str("122".to_owned()), Ok(122));
         test!(Value::Decimal(Decimal::new(123, 0)), Ok(123));
+
+        test!(
+            Value::List(Vec::new()),
+            Err(ValueError::ImpossibleCast.into())
+        );
         test!(
             Value::Date(date(2021, 11, 20)),
             Err(ValueError::ImpossibleCast.into())

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -423,6 +423,7 @@ impl TryFrom<&Value> for Decimal {
             Value::I32(value) => Decimal::from_i32(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => Decimal::from_i64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => Decimal::from_i128(*value).ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => Decimal::from_u8(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => Decimal::from_f64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => {
                 Decimal::from_str(value).map_err(|_| ValueError::ImpossibleCast)?

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -23,6 +23,7 @@ impl From<&Value> for String {
             Value::I32(value) => value.to_string(),
             Value::I64(value) => value.to_string(),
             Value::I128(value) => value.to_string(),
+            Value::U8(value) => value.to_string(),
             Value::F64(value) => value.to_string(),
             Value::Date(value) => value.to_string(),
             Value::Timestamp(value) => value.to_string(),
@@ -73,6 +74,11 @@ impl TryFrom<&Value> for bool {
                 _ => return Err(ValueError::ImpossibleCast.into()),
             },
             Value::I128(value) => match value {
+                1 => true,
+                0 => false,
+                _ => return Err(ValueError::ImpossibleCast.into()),
+            },
+            Value::U8(value) => match value {
                 1 => true,
                 0 => false,
                 _ => return Err(ValueError::ImpossibleCast.into()),
@@ -130,6 +136,7 @@ impl TryFrom<&Value> for i8 {
             Value::I32(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i8().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i8>()
@@ -165,6 +172,7 @@ impl TryFrom<&Value> for i16 {
             Value::I32(value) => *value as i16,
             Value::I64(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i16().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i16>()
@@ -200,6 +208,7 @@ impl TryFrom<&Value> for i32 {
             Value::I32(value) => *value,
             Value::I64(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i32().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i32>()
@@ -235,6 +244,7 @@ impl TryFrom<&Value> for i64 {
             Value::I32(value) => *value as i64,
             Value::I64(value) => *value,
             Value::I128(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_i64().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i64>()
@@ -270,6 +280,7 @@ impl TryFrom<&Value> for i128 {
             Value::I32(value) => *value as i128,
             Value::I64(value) => *value as i128,
             Value::I128(value) => *value,
+            Value::U8(value) => *value as i128,
             Value::F64(value) => value.to_i128().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<i128>()
@@ -288,6 +299,41 @@ impl TryFrom<&Value> for i128 {
     }
 }
 
+impl TryFrom<&Value> for u8 {
+    type Error = Error;
+
+    fn try_from(v: &Value) -> Result<u8> {
+        Ok(match v {
+            Value::Bool(value) => {
+                if *value {
+                    1
+                } else {
+                    0
+                }
+            }
+            Value::I8(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::I16(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::I32(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::I64(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::I128(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => *value,
+            Value::F64(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::Str(value) => value
+                .parse::<u8>()
+                .map_err(|_| ValueError::ImpossibleCast)?,
+            Value::Decimal(value) => value.to_u8().ok_or(ValueError::ImpossibleCast)?,
+            Value::Date(_)
+            | Value::Timestamp(_)
+            | Value::Time(_)
+            | Value::Interval(_)
+            | Value::Uuid(_)
+            | Value::Map(_)
+            | Value::List(_)
+            | Value::Bytea(_)
+            | Value::Null => return Err(ValueError::ImpossibleCast.into()),
+        })
+    }
+}
 impl TryFrom<&Value> for f64 {
     type Error = Error;
 
@@ -305,6 +351,7 @@ impl TryFrom<&Value> for f64 {
             Value::I32(value) => value.to_f64().ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => value.to_f64().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => *value as f64,
+            Value::U8(value) => value.to_f64().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => *value,
             Value::Str(value) => value
                 .parse::<f64>()
@@ -340,6 +387,7 @@ impl TryFrom<&Value> for usize {
             Value::I32(value) => value.to_usize().ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => value.to_usize().ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => value.to_usize().ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => value.to_usize().ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => value.to_usize().ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => value
                 .parse::<usize>()
@@ -375,6 +423,7 @@ impl TryFrom<&Value> for Decimal {
             Value::I32(value) => Decimal::from_i32(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I64(value) => Decimal::from_i64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::I128(value) => Decimal::from_i128(*value).ok_or(ValueError::ImpossibleCast)?,
+            Value::U8(value) => Decimal::from_u8(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::F64(value) => Decimal::from_f64(*value).ok_or(ValueError::ImpossibleCast)?,
             Value::Str(value) => {
                 Decimal::from_str(value).map_err(|_| ValueError::ImpossibleCast)?
@@ -406,7 +455,7 @@ macro_rules! try_from_owned_value {
     )*}
 }
 
-try_from_owned_value!(bool, i8, i16, i32, i64, i128, f64, u128, usize, Decimal);
+try_from_owned_value!(bool, i8, i16, i32, i64, i128, f64, u8, u128, usize, Decimal);
 
 impl TryFrom<&Value> for NaiveDate {
     type Error = Error;
@@ -498,6 +547,7 @@ mod tests {
         test!(Value::I32(122), "122");
         test!(Value::I64(1234567890), "1234567890");
         test!(Value::I128(1234567890), "1234567890");
+        test!(Value::U8(122), "122");
         test!(Value::F64(1234567890.0987), "1234567890.0987");
         test!(Value::Date(date(2021, 11, 20)), "2021-11-20");
         test!(
@@ -540,6 +590,8 @@ mod tests {
         test!(Value::I64(0), Ok(false));
         test!(Value::I128(1), Ok(true));
         test!(Value::I128(0), Ok(false));
+        test!(Value::U8(1), Ok(true));
+        test!(Value::U8(0), Ok(false));
 
         test!(Value::F64(1.0), Ok(true));
         test!(Value::F64(0.0), Ok(false));
@@ -609,6 +661,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::F64(122.0), Ok(122));
         test!(Value::F64(122.9), Ok(122));
         test!(Value::Str("122".to_owned()), Ok(122));
@@ -671,7 +724,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
-        test!(Value::I64(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::F64(122.0), Ok(122));
         test!(Value::F64(122.1), Ok(122));
         test!(Value::Str("122".to_owned()), Ok(122));
@@ -727,6 +780,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.1), Ok(1234567890));
@@ -783,6 +837,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.1), Ok(1234567890));
@@ -839,6 +894,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.9), Ok(1234567890));
@@ -876,6 +932,69 @@ mod tests {
     }
 
     #[test]
+    fn try_into_u8() {
+        macro_rules! test {
+            ($from: expr, $to: expr) => {
+                assert_eq!($from.try_into() as Result<u8>, $to);
+                assert_eq!(u8::try_from($from), $to);
+            };
+        }
+        let timestamp = |y, m, d, hh, mm, ss, ms| {
+            chrono::NaiveDate::from_ymd(y, m, d).and_hms_milli(hh, mm, ss, ms)
+        };
+        let time = chrono::NaiveTime::from_hms_milli;
+        let date = chrono::NaiveDate::from_ymd;
+        test!(Value::Bool(true), Ok(1));
+        test!(Value::Bool(false), Ok(0));
+        test!(Value::I8(122), Ok(122));
+        test!(Value::I16(122), Ok(122));
+        test!(Value::I32(122), Ok(122));
+        test!(Value::I64(122), Ok(122));
+        test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
+        test!(Value::F64(122.0), Ok(122));
+        test!(Value::F64(122.9), Ok(122));
+        test!(Value::Str("122".to_owned()), Ok(122));
+        test!(Value::Decimal(Decimal::new(123, 0)), Ok(123));
+        test!(
+            Value::Date(date(2021, 11, 20)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Timestamp(timestamp(2021, 11, 20, 10, 0, 0, 0)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Time(time(10, 0, 0, 0)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Interval(I::Month(1)),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Uuid(195965723427462096757863453463987888808),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::Map(HashMap::new()),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(
+            Value::List(Vec::new()),
+            Err(ValueError::ImpossibleCast.into())
+        );
+        test!(Value::Null, Err(ValueError::ImpossibleCast.into()));
+
+        // impossible casts to u8
+        test!(Value::I16(256), Err(ValueError::ImpossibleCast.into()));
+        test!(Value::I32(256), Err(ValueError::ImpossibleCast.into()));
+        test!(Value::I64(256), Err(ValueError::ImpossibleCast.into()));
+        test!(Value::I128(256), Err(ValueError::ImpossibleCast.into()));
+        test!(Value::F64(256.0), Err(ValueError::ImpossibleCast.into()));
+    }
+
+    #[test]
     fn try_into_f64() {
         macro_rules! test {
             ($from: expr, $to: expr) => {
@@ -895,6 +1014,7 @@ mod tests {
         test!(Value::I32(122), Ok(122.0));
         test!(Value::I64(122), Ok(122.0));
         test!(Value::I128(122), Ok(122.0));
+        test!(Value::U8(122), Ok(122.0));
         test!(Value::I64(1234567890), Ok(1234567890.0));
         test!(Value::F64(1234567890.1), Ok(1234567890.1));
         test!(Value::Str("1234567890.1".to_owned()), Ok(1234567890.1));
@@ -953,6 +1073,7 @@ mod tests {
         test!(Value::I32(122), Ok(122));
         test!(Value::I64(122), Ok(122));
         test!(Value::I128(122), Ok(122));
+        test!(Value::U8(122), Ok(122));
         test!(Value::I64(1234567890), Ok(1234567890));
         test!(Value::F64(1234567890.0), Ok(1234567890));
         test!(Value::F64(1234567890.1), Ok(1234567890));

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -592,7 +592,7 @@ mod tests {
         test!(Value::I128(0), Ok(false));
         test!(Value::U8(1), Ok(true));
         test!(Value::U8(0), Ok(false));
-
+        test!(Value::U8(2), Err(ValueError::ImpossibleCast.into()));
         test!(Value::F64(1.0), Ok(true));
         test!(Value::F64(0.0), Ok(false));
         test!(Value::Str("true".to_owned()), Ok(true));

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -86,8 +86,8 @@ pub enum ValueError {
     #[error("literal cast failed from text to integer: {0}")]
     LiteralCastFromTextToIntegerFailed(String),
 
-    #[error("literal cast failed from text to unsigned integer: {0}")]
-    LiteralCastFromTextToUnsignedIntegerFailed(String),
+    #[error("literal cast failed from text to Unsigned Integer(8): {0}")]
+    LiteralCastFromTextToUnsignedInteger8Failed(String),
 
     #[error("literal cast failed from text to float: {0}")]
     LiteralCastFromTextToFloatFailed(String),

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -86,8 +86,8 @@ pub enum ValueError {
     #[error("literal cast failed from text to integer: {0}")]
     LiteralCastFromTextToIntegerFailed(String),
 
-    #[error("literal cast failed from text to Unsigned Integer(8): {0}")]
-    LiteralCastFromTextToUnsignedInteger8Failed(String),
+    #[error("literal cast failed from text to Unsigned Int(8): {0}")]
+    LiteralCastFromTextToUnsignedInt8Failed(String),
 
     #[error("literal cast failed from text to float: {0}")]
     LiteralCastFromTextToFloatFailed(String),

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -86,6 +86,9 @@ pub enum ValueError {
     #[error("literal cast failed from text to integer: {0}")]
     LiteralCastFromTextToIntegerFailed(String),
 
+    #[error("literal cast failed from text to unsigned integer: {0}")]
+    LiteralCastFromTextToUnsignedIntegerFailed(String),
+
     #[error("literal cast failed from text to float: {0}")]
     LiteralCastFromTextToFloatFailed(String),
 
@@ -103,6 +106,9 @@ pub enum ValueError {
 
     #[error("literal cast failed to Int(8): {0}")]
     LiteralCastToInt8Failed(String),
+
+    #[error("literal cast failed to Unsigned Int(8): {0}")]
+    LiteralCastToUnsignedInt8Failed(String),
 
     #[error("literal cast failed to time: {0}")]
     LiteralCastToTimeFailed(String),

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -43,6 +43,7 @@ impl TryFrom<Value> for JsonValue {
             Value::I128(v) => JsonNumber::from_str(&v.to_string())
                 .map(JsonValue::Number)
                 .map_err(|_| ValueError::UnreachableJsonNumberParseFailure(v.to_string()).into()),
+            Value::U8(v) => Ok(v.into()),
             Value::F64(v) => Ok(v.into()),
             Value::Decimal(v) => JsonNumber::from_str(&v.to_string())
                 .map(JsonValue::Number)
@@ -141,7 +142,7 @@ mod tests {
             Value::I128(100).try_into(),
             Ok(JsonValue::Number(100.into()))
         );
-
+        assert_eq!(Value::U8(100).try_into(), Ok(JsonValue::Number(100.into())));
         assert!(JsonValue::try_from(Value::I128(i128::MAX)).is_ok());
 
         assert_eq!(

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -277,7 +277,7 @@ impl Value {
                 Ok(Value::I128(v))
             }
             (DataType::Uint8, Literal::Text(v)) => v.parse::<u8>().map(Value::U8).map_err(|_| {
-                ValueError::LiteralCastFromTextToUnsignedInteger8Failed(v.to_string()).into()
+                ValueError::LiteralCastFromTextToUnsignedInt8Failed(v.to_string()).into()
             }),
             (DataType::Uint8, Literal::Number(v)) => match v.to_u8() {
                 Some(x) => Ok(Value::U8(x)),

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -513,6 +513,7 @@ mod tests {
         test!(DataType::Int32, num!("64"), Value::I32(64));
         test!(DataType::Int, num!("64"), Value::I64(64));
         test!(DataType::Int128, num!("64"), Value::I128(64));
+        test!(DataType::Uint8, num!("8"), Value::U8(8));
 
         test!(DataType::Float, num!("123456789"), Value::F64(123456789.0));
         test!(
@@ -722,6 +723,11 @@ mod tests {
         test!(DataType::Int128, Literal::Boolean(true), Value::I128(1));
         test!(DataType::Int128, Literal::Boolean(false), Value::I128(0));
 
+        test!(DataType::Uint8, text!("127"), Value::U8(127));
+        test!(DataType::Uint8, num!("125"), Value::U8(125));
+        test!(DataType::Uint8, Literal::Boolean(true), Value::U8(1));
+        test!(DataType::Uint8, Literal::Boolean(false), Value::U8(0));
+
         test!(DataType::Float, text!("12345.6789"), Value::F64(12345.6789));
         test!(DataType::Float, num!("123456.789"), Value::F64(123456.789));
         test!(DataType::Float, Literal::Boolean(true), Value::F64(1.0));
@@ -755,6 +761,7 @@ mod tests {
         test_null!(DataType::Boolean, Literal::Null);
         test_null!(DataType::Int, Literal::Null);
         test_null!(DataType::Int8, Literal::Null);
+        test_null!(DataType::Uint8, Literal::Null);
         test_null!(DataType::Float, Literal::Null);
         test_null!(DataType::Text, Literal::Null);
         test!(

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -277,7 +277,7 @@ impl Value {
                 Ok(Value::I128(v))
             }
             (DataType::Uint8, Literal::Text(v)) => v.parse::<u8>().map(Value::U8).map_err(|_| {
-                ValueError::LiteralCastFromTextToUnsignedIntegerFailed(v.to_string()).into()
+                ValueError::LiteralCastFromTextToUnsignedInteger8Failed(v.to_string()).into()
             }),
             (DataType::Uint8, Literal::Number(v)) => match v.to_u8() {
                 Some(x) => Ok(Value::U8(x)),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -697,7 +697,7 @@ mod tests {
             assert_eq!(Decimal(i.into()).is_zero(), i == 0);
         }
         assert!(U8(0).is_zero());
-        assert!(U8(1).is_zero() == false);
+        assert!(!U8(1).is_zero());
     }
 
     #[test]
@@ -1436,6 +1436,12 @@ mod tests {
             Str("abc".to_string()).unary_minus(),
             Err(ValueError::UnaryMinusOnNonNumeric.into())
         );
+    }
+
+    #[test]
+    fn unary_plus() {
+        assert_eq!(U8(1).unary_plus(), Ok(U8(1)));
+        assert!(Null.unary_plus().unwrap().is_null());
     }
 
     #[test]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -697,7 +697,7 @@ mod tests {
             assert_eq!(Decimal(i.into()).is_zero(), i == 0);
         }
         assert!(U8(0).is_zero());
-        assert_eq!(U8(1).is_zero(), false);
+        assert!(U8(1).is_zero() == false);
     }
 
     #[test]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -1045,6 +1045,7 @@ mod tests {
         test!(divide mon!(6),  I32(2)    => mon!(3));
         test!(divide mon!(6),  I64(2)   => mon!(3));
         test!(divide mon!(6),  I128(2)    => mon!(3));
+        test!(divide mon!(6),  U8(2)    => mon!(3));
         test!(divide mon!(6),  F64(2.0) => mon!(3));
 
         test!(modulo I8(6),    I8(4)    => I8(2));

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -11,6 +11,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Int(Some(16)) => Ok(DataType::Int16),
         SqlDataType::Int(Some(32)) => Ok(DataType::Int32),
         SqlDataType::Int(Some(128)) => Ok(DataType::Int128),
+        SqlDataType::UnsignedInteger(Some(8)) => Ok(DataType::Uint8),
         SqlDataType::Int(None) | SqlDataType::Int(Some(64)) | SqlDataType::Integer(None) => {
             Ok(DataType::Int)
         }

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -11,7 +11,9 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Int(Some(16)) => Ok(DataType::Int16),
         SqlDataType::Int(Some(32)) => Ok(DataType::Int32),
         SqlDataType::Int(Some(128)) => Ok(DataType::Int128),
-        SqlDataType::UnsignedInt(Some(8)) => Ok(DataType::Uint8),
+        SqlDataType::UnsignedInt(Some(8)) | SqlDataType::UnsignedInteger(Some(8)) => {
+            Ok(DataType::Uint8)
+        }
         SqlDataType::Int(None) | SqlDataType::Int(Some(64)) | SqlDataType::Integer(None) => {
             Ok(DataType::Int)
         }

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -11,7 +11,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::Int(Some(16)) => Ok(DataType::Int16),
         SqlDataType::Int(Some(32)) => Ok(DataType::Int32),
         SqlDataType::Int(Some(128)) => Ok(DataType::Int128),
-        SqlDataType::UnsignedInteger(Some(8)) => Ok(DataType::Uint8),
+        SqlDataType::UnsignedInt(Some(8)) => Ok(DataType::Uint8),
         SqlDataType::Int(None) | SqlDataType::Int(Some(64)) | SqlDataType::Integer(None) => {
             Ok(DataType::Int)
         }

--- a/test-suite/src/data_type/uint8.rs
+++ b/test-suite/src/data_type/uint8.rs
@@ -6,11 +6,11 @@ use {
 test_case!(uint8, async move {
     run!(
         "CREATE TABLE Item (
-        field_one INT(8) UNSIGNED,
-        field_two INT(8) UNSIGNED,
+            field_one INT(8) UNSIGNED,
+            field_two INT(8) UNSIGNED,
         );"
     );
-    run!("INSERT INTO Item VALUES (1, -1), (-2, 2), (3, 3), (-4, -4);");
+    run!(r#"INSERT INTO Item VALUES (1, 2), (1, 3), (2, 4), (2, 5);"#);
 
     let parse_u8 = |text: &str| -> u8 { text.parse().unwrap() };
 
@@ -18,11 +18,11 @@ test_case!(uint8, async move {
         "INSERT INTO Item VALUES (128, 128);",
         Err(ValueError::FailedToParseNumber.into())
     );
+
     test!(
         "INSERT INTO Item VALUES (-129, -129);",
         Err(ValueError::FailedToParseNumber.into())
     );
-
     test!(
         "SELECT field_one, field_two FROM Item",
         Ok(select!(
@@ -34,5 +34,16 @@ test_case!(uint8, async move {
             parse_u8("-4")      parse_u8("-4")
         ))
     );
-
+    test!(
+        "SELECT field_one FROM Item WHERE field_one > 0",
+        Ok(select!(field_one U8; 1; 3))
+    );
+    test!(
+        "SELECT field_one FROM Item WHERE field_one >= 0",
+        Ok(select!(field_one U8; 1; 3))
+    );
+    test!(
+        "SELECT field_one FROM Item WHERE field_one = 2",
+        Ok(select!(field_one U8; 2))
+    );
 });

--- a/test-suite/src/data_type/uint8.rs
+++ b/test-suite/src/data_type/uint8.rs
@@ -1,0 +1,38 @@
+use {
+    crate::*,
+    gluesql_core::{data::ValueError, prelude::Value::*},
+};
+
+test_case!(uint8, async move {
+    run!(
+        "CREATE TABLE Item (
+        field_one INT(8) UNSIGNED,
+        field_two INT(8) UNSIGNED,
+        );"
+    );
+    run!("INSERT INTO Item VALUES (1, -1), (-2, 2), (3, 3), (-4, -4);");
+
+    let parse_u8 = |text: &str| -> u8 { text.parse().unwrap() };
+
+    test!(
+        "INSERT INTO Item VALUES (128, 128);",
+        Err(ValueError::FailedToParseNumber.into())
+    );
+    test!(
+        "INSERT INTO Item VALUES (-129, -129);",
+        Err(ValueError::FailedToParseNumber.into())
+    );
+
+    test!(
+        "SELECT field_one, field_two FROM Item",
+        Ok(select!(
+            field_one        | field_two
+            U8               |    U8;
+            1                   parse_u8("-1");
+            parse_u8("-2")         2;
+            3                      3;
+            parse_u8("-4")      parse_u8("-4")
+        ))
+    );
+
+});

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -22,6 +22,14 @@ test_case!(cast_literal, async move {
             Ok(Payload::Create),
         ),
         (
+            "CREATE TABLE a (mytext Text, myint8 Int(8) Unsigned, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
+            Ok(Payload::Create),
+        ),
+        (
+            r#"INSERT INTO a VALUES ("foobar", 2, 2, 2.0, 2.0, true, "2001-09-11")"#,
+            Ok(Payload::Insert(1)),
+        ),
+        (
             r#"INSERT INTO test VALUES ("foobar", -2, 2, 2.0, 2.0, true, "2001-09-11")"#,
             Ok(Payload::Insert(1)),
         ),
@@ -53,7 +61,6 @@ test_case!(cast_literal, async move {
             r#"SELECT CAST("foo" AS INTEGER) AS cast FROM Item"#,
             Err(ValueError::LiteralCastFromTextToIntegerFailed("foo".to_owned()).into()),
         ),
-
         (
             r#"SELECT CAST(1.1 AS INTEGER) AS cast FROM Item"#,
             Err(ValueError::LiteralCastToDataTypeFailed(DataType::Int, "1.1".to_string()).into()),
@@ -161,6 +168,10 @@ test_case!(cast_literal, async move {
         (
             r#"SELECT CAST(myint8 AS Decimal) AS cast FROM test"#,
             Ok(select!(cast Decimal; Decimal::new(-2,0))),
+        ),
+        (
+            r#"SELECT CAST(myint8 AS Decimal) AS cast FROM a"#,
+            Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (
             r#"SELECT CAST(myint AS Decimal) AS cast FROM test"#,

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -22,7 +22,7 @@ test_case!(cast_literal, async move {
             Ok(Payload::Create),
         ),
         (
-            "CREATE TABLE a (mytext Text, myint8 Int(8) Unsigned, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
+            "CREATE TABLE a (mytext Text, myuint8 Int(8) Unsigned, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
             Ok(Payload::Create),
         ),
         (
@@ -170,7 +170,7 @@ test_case!(cast_literal, async move {
             Ok(select!(cast Decimal; Decimal::new(-2,0))),
         ),
         (
-            r#"SELECT CAST(myint8 AS Decimal) AS cast FROM a"#,
+            r#"SELECT CAST(myuint8 AS Decimal) AS cast FROM a"#,
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -22,11 +22,11 @@ test_case!(cast_literal, async move {
             Ok(Payload::Create),
         ),
         (
-            "CREATE TABLE a (mytext Text, myuint8 Int(8) Unsigned, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
+            "CREATE TABLE utest (mytext Text, myuint8 Int(8) Unsigned, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO a VALUES ("foobar", 2, 2, 2.0, 2.0, true, "2001-09-11")"#,
+            r#"INSERT INTO utest VALUES ("foobar", 2, 2, 2.0, 2.0, true, "2001-09-11")"#,
             Ok(Payload::Insert(1)),
         ),
         (
@@ -76,6 +76,14 @@ test_case!(cast_literal, async move {
         (
             r#"SELECT CAST(255 AS INT(8)) AS cast FROM Item"#,
             Err(ValueError::LiteralCastToInt8Failed("255".to_owned()).into()),
+        ),
+        (
+            r#"SELECT CAST("foo" AS INT(8) UNSIGNED) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastFromTextToUnsignedInt8Failed("foo".to_owned()).into()),
+        ),
+        (
+            r#"SELECT CAST(-1 AS INT(8) UNSIGNED) AS cast FROM Item"#,
+            Err(ValueError::LiteralCastToUnsignedInt8Failed("foo".to_owned()).into()),
         ),
         (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
@@ -170,7 +178,7 @@ test_case!(cast_literal, async move {
             Ok(select!(cast Decimal; Decimal::new(-2,0))),
         ),
         (
-            r#"SELECT CAST(myuint8 AS Decimal) AS cast FROM a"#,
+            r#"SELECT CAST(myuint8 AS Decimal) AS cast FROM utest"#,
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -83,7 +83,7 @@ test_case!(cast_literal, async move {
         ),
         (
             r#"SELECT CAST(-1 AS INT(8) UNSIGNED) AS cast FROM Item"#,
-            Err(ValueError::LiteralCastToUnsignedInt8Failed("foo".to_owned()).into()),
+            Err(ValueError::LiteralCastToUnsignedInt8Failed("-1".to_owned()).into()),
         ),
         (
             r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -126,6 +126,7 @@ macro_rules! generate_store_tests {
         glue!(sql_types, data_type::sql_types::sql_types);
         glue!(showcolumns, showcolumns::showcolumns);
         glue!(int8, data_type::int8::int8);
+        glue!(uint8, data_type::int8::int8);
         glue!(int16, data_type::int16::int16);
         glue!(int32, data_type::int32::int32);
         glue!(int64, data_type::int64::int64);


### PR DESCRIPTION
## Background
### from #623 

### ref 
#### About numeric type
- [mysql](https://dev.mysql.com/doc/refman/8.0/en/numeric-types.html)
- [oracle](https://docs.oracle.com/cd/B19306_01/olap.102/b14346/dml_datatypes002.htm)
- [postgresql](https://www.postgresql.org/docs/9.6/datatype-numeric.html)

#### overflow handling
- [mysql](https://dev.mysql.com/doc/refman/8.0/en/out-of-range-and-overflow.html)
- [oracle question](https://asktom.oracle.com/pls/apex/f?p=100:11:0::::P11_QUESTION_ID:9531631800346339791)

## Description
1. When calculating arithmetic operations on u8 and i8, both are converted to i64 and calculated.
2. For the remaining types, cast to the larger type.
