### PR TITLE
Replace crate::`comfy-table` with `tabled` 

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,5 @@ gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.12.
 clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"
 rustyline-derive = "0.6"
-comfy-table = "5"
 tabled ="0.8"
 thiserror = "1.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,4 +17,5 @@ clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"
 rustyline-derive = "0.6"
 comfy-table = "5"
+tabled ="0.8"
 thiserror = "1.0"

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -10,6 +10,7 @@ use {
         io::{Result, Write},
         path::Path,
     },
+    tabled::{builder::Builder, Table as Table2, Tabled},
 };
 
 pub struct Print<W: Write> {
@@ -65,13 +66,13 @@ impl<W: Write> Print<W> {
                 self.write(table)?;
             }
             Payload::Select { labels, rows } => {
-                let mut table = get_table(labels);
+                let mut table = get_table2(labels);
                 for values in rows {
                     let values: Vec<String> = values.iter().map(Into::into).collect();
 
-                    table.add_row(values);
+                    table.add_record(values);
                 }
-                self.write(table)?;
+                self.write(table.build())?;
             }
             _ => {}
         };
@@ -124,6 +125,13 @@ fn get_table<T: Into<Row>>(header: T) -> Table {
         .load_preset(UTF8_BORDERS_ONLY)
         .apply_modifier(UTF8_ROUND_CORNERS)
         .set_header(header);
+
+    table
+}
+
+fn get_table2(header: &Vec<String>) -> Builder {
+    let mut table = Builder::default();
+    table.set_columns(header);
 
     table
 }

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -38,7 +38,7 @@ impl<W: Write> Print<W> {
             Payload::Update(n) => affected(*n, "updated")?,
             Payload::ShowVariable(PayloadVariable::Version(v)) => self.write(format!("v{v}"))?,
             Payload::ShowVariable(PayloadVariable::Tables(names)) => {
-                let mut table = get_table(&["tables"]);
+                let mut table = get_table(["tables"]);
                 for name in names {
                     table.add_record([name]);
                 }
@@ -46,7 +46,7 @@ impl<W: Write> Print<W> {
                 self.write(table)?;
             }
             Payload::ShowColumns(columns) => {
-                let mut table = get_table(&["Field", "Type"]);
+                let mut table = get_table(["Field", "Type"]);
                 for (field, field_type) in columns {
                     table.add_record([field, &field_type.to_string()]);
                 }
@@ -54,7 +54,7 @@ impl<W: Write> Print<W> {
                 self.write(table)?;
             }
             Payload::ShowIndexes(indexes) => {
-                let mut table = get_table(&["Index Name", "Order", "Description"]);
+                let mut table = get_table(["Index Name", "Order", "Description"]);
                 for index in indexes {
                     table.add_record([
                         index.name.to_string(),
@@ -66,7 +66,7 @@ impl<W: Write> Print<W> {
                 self.write(table)?;
             }
             Payload::Select { labels, rows } => {
-                let labels = &labels.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
+                let labels = labels.iter().map(AsRef::as_ref);
                 let mut table = get_table(labels);
                 for values in rows {
                     let values: Vec<String> = values.iter().map(Into::into).collect();
@@ -101,7 +101,7 @@ impl<W: Write> Print<W> {
             [".spool FILE|off", "spool to file or off"],
         ];
 
-        let mut table = get_table(&HEADER);
+        let mut table = get_table(HEADER);
         for row in CONTENT {
             table.add_record(row);
         }
@@ -122,7 +122,7 @@ impl<W: Write> Print<W> {
     }
 }
 
-fn get_table(header: &[&str]) -> Builder {
+fn get_table<'a, T: IntoIterator<Item = &'a str>>(header: T) -> Builder {
     let mut table = Builder::default();
     table.set_columns(header);
 

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -9,7 +9,7 @@ use {
         io::{Result, Write},
         path::Path,
     },
-    tabled::{builder::Builder, Style},
+    tabled::{builder::Builder, Style, Table},
 };
 
 pub struct Print<W: Write> {
@@ -42,7 +42,7 @@ impl<W: Write> Print<W> {
                 for name in names {
                     table.add_record([name]);
                 }
-                let table = table.build().with(Style::markdown());
+                let table = build_table(table);
                 self.write(table)?;
             }
             Payload::ShowColumns(columns) => {
@@ -50,7 +50,7 @@ impl<W: Write> Print<W> {
                 for (field, field_type) in columns {
                     table.add_record([field, &field_type.to_string()]);
                 }
-                let table = table.build().with(Style::markdown());
+                let table = build_table(table);
                 self.write(table)?;
             }
             Payload::ShowIndexes(indexes) => {
@@ -62,7 +62,7 @@ impl<W: Write> Print<W> {
                         index.expr.to_sql(),
                     ]);
                 }
-                let table = table.build().with(Style::markdown());
+                let table = build_table(table);
                 self.write(table)?;
             }
             Payload::Select { labels, rows } => {
@@ -73,7 +73,7 @@ impl<W: Write> Print<W> {
 
                     table.add_record(values);
                 }
-                let table = table.build().with(Style::markdown());
+                let table = build_table(table);
                 self.write(table)?;
             }
             _ => {}
@@ -105,7 +105,7 @@ impl<W: Write> Print<W> {
         for row in CONTENT {
             table.add_record(row);
         }
-        let table = table.build().with(Style::markdown());
+        let table = build_table(table);
 
         writeln!(self.output, "{}\n", table)
     }
@@ -127,6 +127,10 @@ fn get_table(header: &[&str]) -> Builder {
     table.set_columns(header);
 
     table
+}
+
+fn build_table(builder: Builder) -> Table {
+    builder.build().with(Style::markdown())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a prerequisite PR for #820 
To support CLI option, we decided to replace crate `comfy-table` with `tabled`

## Goal
- Apply new `tabled` to cli
- Set html as default print style like below
```sql
gluesql> SELECT * FROM (VALUES (1, 'a', true), (2, 'b', false)) AS Sub;
```
(pasted from gluesql directly)
| column1 | column2 | column3 |
|---------|---------|---------|
| 1       | a       | TRUE    |
| 2       | b       | FALSE   |
## Todo
- [x] apply crate::tabled
- [x] set html as default print style
- [x] remove crate::comfy-table 
- [x] generalize build(with_style) 
- [x] features QA
  - every features works fine!
```
"command"        ,"description"                       
".help"          ,"show help"                                                                               
".quit"          ,"quit program"                   
".tables"        ,"show table names"                                                                        
".columns TABLE" ,"show columns from TABLE"          
".version"       ,"show version"                                                                            
".execute FILE"  ,"execute SQL from a file"                                                                 
".spool FILE|off","spool to file or off" 
```