### PR TITLE
Simplify root doc comment code example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,29 +9,29 @@
 //! ## Examples
 //!
 //! ```
-//! #[cfg(feature = "sled-storage")]
-//! fn main() {
-//!     use gluesql::prelude::*;
+//! # #[cfg(feature = "sled-storage")]
+//! # fn main() {
+//! use gluesql::prelude::*;
 //!
-//!     let storage = SledStorage::new("data/doc-db").unwrap();
-//!     let mut glue = Glue::new(storage);
+//! let storage = SledStorage::new("data/doc-db").unwrap();
+//! let mut glue = Glue::new(storage);
 //!     
-//!     let sqls = vec![
-//!         "DROP TABLE IF EXISTS Glue;",
-//!         "CREATE TABLE Glue (id INTEGER);",
-//!         "INSERT INTO Glue VALUES (100);",
-//!         "INSERT INTO Glue VALUES (200);",
-//!         "SELECT * FROM Glue WHERE id > 100;",
-//!     ];
+//! let sqls = vec![
+//!     "DROP TABLE IF EXISTS Glue;",
+//!     "CREATE TABLE Glue (id INTEGER);",
+//!     "INSERT INTO Glue VALUES (100);",
+//!     "INSERT INTO Glue VALUES (200);",
+//!     "SELECT * FROM Glue WHERE id > 100;",
+//! ];
 //!
-//!     for sql in sqls {
-//!         let output = glue.execute(sql).unwrap();
-//!         println!("{:?}", output)
-//!     }
+//! for sql in sqls {
+//!     let output = glue.execute(sql).unwrap();
+//!     println!("{:?}", output)
 //! }
+//! # }
 //!
-//! #[cfg(not(feature = "sled-storage"))]
-//! fn main() {}
+//! # #[cfg(not(feature = "sled-storage"))]
+//! # fn main() {}
 //! ```
 //!
 //! ## Custom Storage


### PR DESCRIPTION
Hide unnecessary info to users - fn main, cfg info, ...

ref. https://docs.rs/gluesql/latest/gluesql/
prev.
<img width="452" alt="image" src="https://user-images.githubusercontent.com/2025065/189513695-2230f0d9-869f-41f9-b80f-1638c8e26051.png">

now.
<img width="416" alt="image" src="https://user-images.githubusercontent.com/2025065/189513698-423e0202-b823-4cae-8332-10a700f919a7.png">
