### PR TITLE
Improvement `validate_unique` function when only `PrimaryKey` exists

### DIFF
--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -243,12 +243,11 @@ pub async fn execute<T: GStore + GStoreMut>(
                 let rows = match primary_key {
                     Some(i) => rows
                         .into_iter()
-                        .filter_map(|row| match row.0.get(i) {
-                            Some(value) => Key::try_from(value)
-                                .map(|key| (key, row))
-                                .map(Some)
-                                .transpose(),
-                            None => None,
+                        .filter_map(|row| {
+                            row.0
+                                .get(i)
+                                .map(Key::try_from)
+                                .map(|result| result.map(|key| (key, row)))
                         })
                         .collect::<Result<Vec<_>>>()
                         .map(RowsData::Insert)?,

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        ast::{ColumnDef, ColumnOption},
+        ast::{ColumnDef, ColumnOption, ColumnOptionDef},
         data::{Key, Row, Value},
         result::Result,
         store::Store,
@@ -17,12 +17,17 @@ pub enum ValidateError {
     #[error("conflict! storage row has no column on index {0}")]
     ConflictOnStorageColumnIndex(usize),
 
-    #[error("duplicate entry '{0:?}' for unique column '{1}'")]
+    #[error("duplicate entry '{}' for unique column '{1}'", String::from(.0))]
     DuplicateEntryOnUniqueField(Value, String),
+
+    #[error("duplicate entry '{0:?}' for primary_key field")]
+    DuplicateEntryOnPrimaryKeyField(Key),
 }
 
 pub enum ColumnValidation {
+    /// `INSERT`
     All(Rc<[ColumnDef]>),
+    /// `UPDATE`
     SpecifiedColumns(Rc<[ColumnDef]>, Vec<String>),
 }
 
@@ -74,39 +79,93 @@ impl UniqueConstraint {
 }
 
 pub async fn validate_unique(
-    storage: &impl Store,
+    storage: &dyn Store,
     table_name: &str,
     column_validation: ColumnValidation,
     row_iter: impl Iterator<Item = &Row> + Clone,
 ) -> Result<()> {
-    let columns = match column_validation {
-        ColumnValidation::All(column_defs) => fetch_all_unique_columns(&column_defs),
-        ColumnValidation::SpecifiedColumns(column_defs, specified_columns) => {
-            fetch_specified_unique_columns(&column_defs, &specified_columns)
-        }
-    };
-
-    let unique_constraints: Vec<_> = create_unique_constraints(columns, row_iter)?.into();
-    if unique_constraints.is_empty() {
-        return Ok(());
+    enum Columns {
+        /// key index
+        PrimaryKeyOnly(usize),
+        /// `[(key_index, table_name)]`
+        All(Vec<(usize, String)>),
     }
 
-    let unique_constraints = Rc::new(unique_constraints);
-    storage.scan_data(table_name).await?.try_for_each(|result| {
-        let (_, row) = result?;
-        Rc::clone(&unique_constraints)
-            .iter()
-            .try_for_each(|constraint| {
-                let col_idx = constraint.column_index;
-                let val = row
-                    .get_value(col_idx)
-                    .ok_or(ValidateError::ConflictOnStorageColumnIndex(col_idx))?;
+    let columns = match &column_validation {
+        ColumnValidation::All(column_defs) => {
+            let primary_key_index = column_defs
+                .iter()
+                .enumerate()
+                .find(|(_, column_def)| {
+                    column_def
+                        .options
+                        .iter()
+                        .any(|ColumnOptionDef { option, .. }| {
+                            matches!(option, ColumnOption::Unique { is_primary: true })
+                        })
+                })
+                .map(|(i, _)| i);
+            let other_unique_column_def_count = column_defs
+                .iter()
+                .filter(|column_def| {
+                    column_def
+                        .options
+                        .iter()
+                        .any(|ColumnOptionDef { option, .. }| {
+                            matches!(option, ColumnOption::Unique { is_primary: false })
+                        })
+                })
+                .count();
 
-                constraint.check(val)?;
+            match (primary_key_index, other_unique_column_def_count) {
+                (Some(primary_key_index), 0) => Columns::PrimaryKeyOnly(primary_key_index),
+                _ => Columns::All(fetch_all_unique_columns(column_defs)),
+            }
+        }
+        ColumnValidation::SpecifiedColumns(column_defs, specified_columns) => Columns::All(
+            fetch_specified_unique_columns(column_defs, specified_columns),
+        ),
+    };
 
-                Ok(())
+    match columns {
+        Columns::PrimaryKeyOnly(primary_key_index) => {
+            for primary_key in row_iter.filter_map(|row| match row.0.get(primary_key_index) {
+                Some(value) => Key::try_from(value).map(Some).transpose(),
+                None => None,
+            }) {
+                let key = primary_key?;
+
+                if storage.fetch_data(table_name, &key).await?.is_some() {
+                    return Err(ValidateError::DuplicateEntryOnPrimaryKeyField(key).into());
+                }
+            }
+
+            Ok(())
+        }
+        Columns::All(columns) => {
+            let unique_constraints: Vec<_> = create_unique_constraints(columns, row_iter)?.into();
+            if unique_constraints.is_empty() {
+                return Ok(());
+            }
+
+            let unique_constraints = Rc::new(unique_constraints);
+            storage.scan_data(table_name).await?.try_for_each(|result| {
+                let (_, row) = result?;
+                Rc::clone(&unique_constraints)
+                    .iter()
+                    .try_for_each(|constraint| {
+                        let col_idx = constraint.column_index;
+                        let val = row
+                            .get_value(col_idx)
+                            .ok_or(ValidateError::ConflictOnStorageColumnIndex(col_idx))?;
+
+                        constraint.check(val)?;
+
+                        Ok(())
+                    })
             })
-    })
+        }
+    }
 }
 
 fn create_unique_constraints<'a>(
@@ -124,6 +183,7 @@ fn create_unique_constraints<'a>(
                     let val = row
                         .get_value(col_idx)
                         .ok_or(ValidateError::ConflictOnStorageColumnIndex(col_idx))?;
+
                     constraint.add(val)
                 })?;
             Ok(constraints.push(new_constraint))
@@ -135,15 +195,11 @@ fn fetch_all_unique_columns(column_defs: &[ColumnDef]) -> Vec<(usize, String)> {
         .iter()
         .enumerate()
         .filter_map(|(i, table_col)| {
-            if table_col
+            table_col
                 .options
                 .iter()
                 .any(|opt_def| matches!(opt_def.option, ColumnOption::Unique { .. }))
-            {
-                Some((i, table_col.name.to_owned()))
-            } else {
-                None
-            }
+                .then_some((i, table_col.name.to_owned()))
         })
         .collect()
 }
@@ -156,20 +212,16 @@ fn fetch_specified_unique_columns(
         .iter()
         .enumerate()
         .filter_map(|(i, table_col)| {
-            if table_col
+            table_col
                 .options
                 .iter()
-                .any(|opt_def| match opt_def.option {
+                .any(|ColumnOptionDef { option, .. }| match option {
                     ColumnOption::Unique { .. } => specified_columns
                         .iter()
                         .any(|specified_col| specified_col == &table_col.name),
                     _ => false,
                 })
-            {
-                Some((i, table_col.name.to_owned()))
-            } else {
-                None
-            }
+                .then_some((i, table_col.name.to_owned()))
         })
         .collect()
 }

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -129,10 +129,9 @@ pub async fn validate_unique(
 
     match columns {
         Columns::PrimaryKeyOnly(primary_key_index) => {
-            for primary_key in row_iter.filter_map(|row| match row.0.get(primary_key_index) {
-                Some(value) => Key::try_from(value).map(Some).transpose(),
-                None => None,
-            }) {
+            for primary_key in
+                row_iter.filter_map(|row| row.0.get(primary_key_index).map(Key::try_from))
+            {
                 let key = primary_key?;
 
                 if storage.fetch_data(table_name, &key).await?.is_some() {

--- a/test-suite/src/primary_key.rs
+++ b/test-suite/src/primary_key.rs
@@ -3,7 +3,7 @@ use {
     gluesql_core::{
         data::{Value::*, ValueError},
         executor::{UpdateError, ValidateError},
-        prelude::Payload,
+        prelude::{Key, Payload},
     },
 };
 
@@ -111,7 +111,7 @@ test_case!(primary_key, async move {
     // PRIMARY KEY includes UNIQUE constraint
     test!(
         "INSERT INTO Allegro VALUES (1, 'another hello');",
-        Err(ValidateError::DuplicateEntryOnUniqueField(I64(1), "id".to_owned()).into())
+        Err(ValidateError::DuplicateEntryOnPrimaryKeyField(Key::I64(1)).into())
     );
 
     // PRIMARY KEY includes NOT NULL constraint


### PR DESCRIPTION
The existing `validate_unique` function creates a unique constraint by looping through all rows even when only `PrimaryKey` exists.

Use `Store::fetch_data` to improve speed in the above situation.