### PR TITLE
Update core/ chrono dependency version to 0.4.22, specify patch version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ async-recursion = "1"
 cfg-if = "1"
 futures-enum = "0.1.17"
 futures = "0.3"
-chrono = { version = "0.4", features = ["serde", "wasmbind"] }
+chrono = { version = "0.4.22", features = ["serde", "wasmbind"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
 im-rc = "15"
 iter-enum = "1"


### PR DESCRIPTION
Currently core compile fails with chrono v0.4.19.
So, update the chrono dep version and specify the patch number.