### PR TITLE
Implement order by ast builder

### DIFF
--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -13,6 +13,7 @@ mod expr_list;
 mod index;
 mod insert;
 mod order_by_expr;
+mod order_by_expr_list;
 mod query;
 mod select;
 mod select_item;
@@ -34,10 +35,11 @@ pub use {
     expr_list::ExprList,
     insert::InsertNode,
     order_by_expr::OrderByExprNode,
+    order_by_expr_list::OrderByExprList,
     query::QueryNode,
     select::{
         GroupByNode, HavingNode, LimitNode, LimitOffsetNode, OffsetLimitNode, OffsetNode,
-        ProjectNode, SelectNode,
+        OrderByNode, ProjectNode, SelectNode,
     },
     select_item::SelectItemNode,
     select_item_list::SelectItemList,

--- a/core/src/ast_builder/order_by_expr.rs
+++ b/core/src/ast_builder/order_by_expr.rs
@@ -1,18 +1,28 @@
-use crate::{
-    ast::OrderByExpr,
-    parse_sql::parse_order_by_expr,
-    result::{Error, Result},
-    translate::translate_order_by_expr,
+use {
+    super::ExprNode,
+    crate::{
+        ast::{Expr, OrderByExpr},
+        parse_sql::parse_order_by_expr,
+        result::{Error, Result},
+        translate::translate_order_by_expr,
+    },
 };
 
 #[derive(Clone)]
 pub enum OrderByExprNode {
     Text(String),
+    Expr(ExprNode),
 }
 
 impl From<&str> for OrderByExprNode {
     fn from(expr: &str) -> Self {
         Self::Text(expr.to_owned())
+    }
+}
+
+impl From<ExprNode> for OrderByExprNode {
+    fn from(expr_node: ExprNode) -> Self {
+        Self::Expr(expr_node)
     }
 }
 
@@ -24,6 +34,11 @@ impl TryFrom<OrderByExprNode> for OrderByExpr {
             OrderByExprNode::Text(expr) => {
                 let expr = parse_order_by_expr(expr).and_then(|op| translate_order_by_expr(&op))?;
                 Ok(expr)
+            }
+            OrderByExprNode::Expr(expr_node) => {
+                let expr = Expr::try_from(expr_node)?;
+
+                Ok(OrderByExpr { expr, asc: None })
             }
         }
     }

--- a/core/src/ast_builder/order_by_expr_list.rs
+++ b/core/src/ast_builder/order_by_expr_list.rs
@@ -1,0 +1,50 @@
+use {
+    super::{ExprNode, OrderByExprNode},
+    crate::{
+        ast::OrderByExpr,
+        parse_sql::parse_order_by_exprs,
+        result::{Error, Result},
+        translate::translate_order_by_expr,
+    },
+};
+
+#[derive(Clone)]
+pub enum OrderByExprList {
+    Text(String),
+    OrderByExprs(Vec<OrderByExprNode>),
+}
+
+impl From<&str> for OrderByExprList {
+    fn from(exprs: &str) -> Self {
+        OrderByExprList::Text(exprs.to_owned())
+    }
+}
+
+impl From<Vec<&str>> for OrderByExprList {
+    fn from(exprs: Vec<&str>) -> Self {
+        OrderByExprList::OrderByExprs(exprs.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<ExprNode> for OrderByExprList {
+    fn from(expr_node: ExprNode) -> Self {
+        OrderByExprList::OrderByExprs(vec![expr_node.into()])
+    }
+}
+
+impl TryFrom<OrderByExprList> for Vec<OrderByExpr> {
+    type Error = Error;
+
+    fn try_from(order_by_exprs: OrderByExprList) -> Result<Self> {
+        match order_by_exprs {
+            OrderByExprList::Text(exprs) => parse_order_by_exprs(exprs)?
+                .iter()
+                .map(translate_order_by_expr)
+                .collect::<Result<Vec<_>>>(),
+            OrderByExprList::OrderByExprs(exprs) => exprs
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>>>(),
+        }
+    }
+}

--- a/core/src/ast_builder/select/group_by.rs
+++ b/core/src/ast_builder/select/group_by.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         ast::Statement,
         ast_builder::{
-            ExprList, ExprNode, HavingNode, LimitNode, OffsetNode, ProjectNode, SelectItemList,
-            SelectNode,
+            ExprList, ExprNode, HavingNode, LimitNode, OffsetNode, OrderByExprList, OrderByNode,
+            ProjectNode, SelectItemList, SelectNode,
         },
         result::Result,
     },
@@ -57,6 +57,10 @@ impl GroupByNode {
 
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
         ProjectNode::new(self, select_items)
+    }
+
+    pub fn order_by<T: Into<OrderByExprList>>(self, expr_list: T) -> OrderByNode {
+        OrderByNode::new(self, expr_list)
     }
 
     pub fn build(self) -> Result<Statement> {

--- a/core/src/ast_builder/select/having.rs
+++ b/core/src/ast_builder/select/having.rs
@@ -2,7 +2,10 @@ use {
     super::{NodeData, Prebuild},
     crate::{
         ast::Statement,
-        ast_builder::{ExprNode, GroupByNode, LimitNode, OffsetNode, ProjectNode, SelectItemList},
+        ast_builder::{
+            ExprNode, GroupByNode, LimitNode, OffsetNode, OrderByExprList, OrderByNode,
+            ProjectNode, SelectItemList,
+        },
         result::Result,
     },
 };
@@ -50,6 +53,10 @@ impl HavingNode {
 
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
         ProjectNode::new(self, select_items)
+    }
+
+    pub fn order_by<T: Into<OrderByExprList>>(self, expr_list: T) -> OrderByNode {
+        OrderByNode::new(self, expr_list)
     }
 
     pub fn build(self) -> Result<Statement> {

--- a/core/src/ast_builder/select/limit.rs
+++ b/core/src/ast_builder/select/limit.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         ast::Statement,
         ast_builder::{
-            ExprNode, GroupByNode, HavingNode, LimitOffsetNode, ProjectNode, SelectItemList,
-            SelectNode,
+            ExprNode, GroupByNode, HavingNode, LimitOffsetNode, OrderByNode, ProjectNode,
+            SelectItemList, SelectNode,
         },
         result::Result,
     },
@@ -15,6 +15,7 @@ pub enum PrevNode {
     Select(SelectNode),
     GroupBy(GroupByNode),
     Having(HavingNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -23,6 +24,7 @@ impl Prebuild for PrevNode {
             Self::Select(node) => node.prebuild(),
             Self::GroupBy(node) => node.prebuild(),
             Self::Having(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -42,6 +44,12 @@ impl From<GroupByNode> for PrevNode {
 impl From<HavingNode> for PrevNode {
     fn from(node: HavingNode) -> Self {
         PrevNode::Having(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/mod.rs
+++ b/core/src/ast_builder/select/mod.rs
@@ -4,12 +4,14 @@ mod limit;
 mod limit_offset;
 mod offset;
 mod offset_limit;
+mod order_by;
 mod project;
 mod root;
 
 pub use {
     group_by::GroupByNode, having::HavingNode, limit::LimitNode, limit_offset::LimitOffsetNode,
-    offset::OffsetNode, offset_limit::OffsetLimitNode, project::ProjectNode, root::SelectNode,
+    offset::OffsetNode, offset_limit::OffsetLimitNode, order_by::OrderByNode, project::ProjectNode,
+    root::SelectNode,
 };
 
 use crate::{

--- a/core/src/ast_builder/select/offset.rs
+++ b/core/src/ast_builder/select/offset.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         ast::Statement,
         ast_builder::{
-            ExprNode, GroupByNode, HavingNode, OffsetLimitNode, ProjectNode, SelectItemList,
-            SelectNode,
+            ExprNode, GroupByNode, HavingNode, OffsetLimitNode, OrderByNode, ProjectNode,
+            SelectItemList, SelectNode,
         },
         result::Result,
     },
@@ -15,6 +15,7 @@ pub enum PrevNode {
     Select(SelectNode),
     GroupBy(GroupByNode),
     Having(HavingNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -23,6 +24,7 @@ impl Prebuild for PrevNode {
             Self::Select(node) => node.prebuild(),
             Self::GroupBy(node) => node.prebuild(),
             Self::Having(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -42,6 +44,12 @@ impl From<GroupByNode> for PrevNode {
 impl From<HavingNode> for PrevNode {
     fn from(node: HavingNode) -> Self {
         PrevNode::Having(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -118,7 +118,7 @@ mod tests {
 
         let actual = table("Bar")
             .select()
-            .order_by(vec!["name asc", "id desc", "country"])
+            .order_by("name asc, id desc, country")
             .offset(10)
             .build();
         let expected = "

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -2,7 +2,9 @@ use {
     super::{NodeData, Prebuild},
     crate::{
         ast::Statement,
-        ast_builder::{ExprNode, GroupByNode, HavingNode, LimitNode, OrderByExprList, SelectNode},
+        ast_builder::{
+            ExprNode, GroupByNode, HavingNode, LimitNode, OffsetNode, OrderByExprList, SelectNode,
+        },
         result::Result,
     },
 };
@@ -56,6 +58,10 @@ impl OrderByNode {
         }
     }
 
+    pub fn offset<T: Into<ExprNode>>(self, expr: T) -> OffsetNode {
+        OffsetNode::new(self, expr)
+    }
+
     pub fn limit<T: Into<ExprNode>>(self, expr: T) -> LimitNode {
         LimitNode::new(self, expr)
     }
@@ -102,6 +108,18 @@ mod tests {
             ORDER BY name
             LIMIT 3
             OFFSET 2
+        ";
+        test(actual, expected);
+
+        let actual = table("Bar")
+            .select()
+            .order_by(vec!["name asc", "id desc", "country"])
+            .offset(10)
+            .build();
+        let expected = "
+            SELECT * FROM Bar 
+            ORDER BY name asc, id desc, country 
+            OFFSET 10
         ";
         test(actual, expected);
     }

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -3,7 +3,8 @@ use {
     crate::{
         ast::Statement,
         ast_builder::{
-            ExprNode, GroupByNode, HavingNode, LimitNode, OffsetNode, OrderByExprList, SelectNode,
+            ExprNode, GroupByNode, HavingNode, LimitNode, OffsetNode, OrderByExprList, ProjectNode,
+            SelectItemList, SelectNode,
         },
         result::Result,
     },
@@ -66,6 +67,10 @@ impl OrderByNode {
         LimitNode::new(self, expr)
     }
 
+    pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
+        ProjectNode::new(self, select_items)
+    }
+
     pub fn build(self) -> Result<Statement> {
         self.prebuild().map(NodeData::build_stmt)
     }
@@ -120,6 +125,17 @@ mod tests {
             SELECT * FROM Bar 
             ORDER BY name asc, id desc, country 
             OFFSET 10
+        ";
+        test(actual, expected);
+
+        let actual = table("Bar")
+            .select()
+            .order_by(vec!["id desc"])
+            .project("name, id")
+            .build();
+        let expected = "
+            SELECT name, id FROM Bar 
+            ORDER BY id DESC
         ";
         test(actual, expected);
     }

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -1,0 +1,86 @@
+use {
+    super::{NodeData, Prebuild},
+    crate::{
+        ast::Statement,
+        ast_builder::{GroupByNode, HavingNode, OrderByExprList, SelectNode},
+        result::Result,
+    },
+};
+
+#[derive(Clone)]
+pub enum PrevNode {
+    Select(SelectNode),
+    Having(HavingNode),
+    GroupBy(GroupByNode),
+}
+
+impl Prebuild for PrevNode {
+    fn prebuild(self) -> Result<NodeData> {
+        match self {
+            Self::Select(node) => node.prebuild(),
+            Self::Having(node) => node.prebuild(),
+            Self::GroupBy(node) => node.prebuild(),
+        }
+    }
+}
+
+impl From<SelectNode> for PrevNode {
+    fn from(node: SelectNode) -> Self {
+        PrevNode::Select(node)
+    }
+}
+
+impl From<HavingNode> for PrevNode {
+    fn from(node: HavingNode) -> Self {
+        PrevNode::Having(node)
+    }
+}
+
+impl From<GroupByNode> for PrevNode {
+    fn from(node: GroupByNode) -> Self {
+        PrevNode::GroupBy(node)
+    }
+}
+
+#[derive(Clone)]
+pub struct OrderByNode {
+    prev_node: PrevNode,
+    expr_list: OrderByExprList,
+}
+
+impl OrderByNode {
+    pub fn new<N: Into<PrevNode>, T: Into<OrderByExprList>>(prev_node: N, expr_list: T) -> Self {
+        Self {
+            prev_node: prev_node.into(),
+            expr_list: expr_list.into(),
+        }
+    }
+
+    pub fn build(self) -> Result<Statement> {
+        self.prebuild().map(NodeData::build_stmt)
+    }
+}
+
+impl Prebuild for OrderByNode {
+    fn prebuild(self) -> Result<NodeData> {
+        let mut select_data = self.prev_node.prebuild()?;
+        select_data.order_by = self.expr_list.try_into()?;
+
+        Ok(select_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast_builder::{table, test};
+
+    #[test]
+    fn order_by() {
+        let actual = table("Foo").select().order_by(vec!["name desc"]).build();
+        let expected = "
+            SELECT * FROM Foo
+            ORDER BY name DESC
+        ";
+        test(actual, expected);
+    }
+}

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -130,11 +130,13 @@ mod tests {
 
         let actual = table("Bar")
             .select()
+            .group_by("name")
             .order_by(vec!["id desc"])
             .project("name, id")
             .build();
         let expected = "
             SELECT name, id FROM Bar 
+            GROUP BY name
             ORDER BY id DESC
         ";
         test(actual, expected);

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -4,7 +4,7 @@ use {
         ast::Statement,
         ast_builder::{
             GroupByNode, HavingNode, LimitNode, LimitOffsetNode, OffsetLimitNode, OffsetNode,
-            SelectItemList, SelectNode,
+            OrderByNode, SelectItemList, SelectNode,
         },
         result::Result,
     },
@@ -19,6 +19,7 @@ pub enum PrevNode {
     LimitOffset(LimitOffsetNode),
     Offset(OffsetNode),
     OffsetLimit(OffsetLimitNode),
+    OrderBy(OrderByNode),
 }
 
 impl Prebuild for PrevNode {
@@ -31,6 +32,7 @@ impl Prebuild for PrevNode {
             Self::LimitOffset(node) => node.prebuild(),
             Self::Offset(node) => node.prebuild(),
             Self::OffsetLimit(node) => node.prebuild(),
+            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -74,6 +76,12 @@ impl From<OffsetNode> for PrevNode {
 impl From<OffsetLimitNode> for PrevNode {
     fn from(node: OffsetLimitNode) -> Self {
         PrevNode::OffsetLimit(node)
+    }
+}
+
+impl From<OrderByNode> for PrevNode {
+    fn from(node: OrderByNode) -> Self {
+        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -3,7 +3,8 @@ use {
     crate::{
         ast::{Expr, ObjectName, SelectItem, Statement, TableFactor, TableWithJoins},
         ast_builder::{
-            ExprList, ExprNode, GroupByNode, LimitNode, OffsetNode, ProjectNode, SelectItemList,
+            ExprList, ExprNode, GroupByNode, LimitNode, OffsetNode, OrderByExprList, OrderByNode,
+            ProjectNode, SelectItemList,
         },
         result::Result,
     },
@@ -47,6 +48,10 @@ impl SelectNode {
 
     pub fn project<T: Into<SelectItemList>>(self, select_items: T) -> ProjectNode {
         ProjectNode::new(self, select_items)
+    }
+
+    pub fn order_by<T: Into<OrderByExprList>>(self, order_by_exprs: T) -> OrderByNode {
+        OrderByNode::new(self, order_by_exprs)
     }
 
     pub fn build(self) -> Result<Statement> {

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -3,7 +3,7 @@ use {
     sqlparser::{
         ast::{
             Assignment as SqlAssignment, ColumnDef as SqlColumnDef, DataType as SqlDataType,
-            Expr as SqlExpr, Ident as SqlIdent, OrderByExpr, Query as SqlQuery,
+            Expr as SqlExpr, Ident as SqlIdent, OrderByExpr as SqlOrderByExpr, Query as SqlQuery,
             SelectItem as SqlSelectItem, Statement as SqlStatement,
         },
         dialect::GenericDialect,
@@ -78,13 +78,25 @@ pub fn parse_interval<Sql: AsRef<str>>(sql_interval: Sql) -> Result<SqlExpr> {
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 
-pub fn parse_order_by_expr<Sql: AsRef<str>>(sql_order_by_expr: Sql) -> Result<OrderByExpr> {
+pub fn parse_order_by_expr<Sql: AsRef<str>>(sql_order_by_expr: Sql) -> Result<SqlOrderByExpr> {
     let tokens = Tokenizer::new(&DIALECT, sql_order_by_expr.as_ref())
         .tokenize()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
     Parser::new(tokens, &DIALECT)
         .parse_order_by_expr()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))
+}
+
+pub fn parse_order_by_exprs<Sql: AsRef<str>>(
+    sql_orderby_exprs: Sql,
+) -> Result<Vec<SqlOrderByExpr>> {
+    let tokens = Tokenizer::new(&DIALECT, sql_orderby_exprs.as_ref())
+        .tokenize()
+        .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
+
+    Parser::new(tokens, &DIALECT)
+        .parse_comma_separated(Parser::parse_order_by_expr)
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 


### PR DESCRIPTION
## Description
Implementation of [#696](https://github.com/gluesql/gluesql/issues/696)
scope: This pr only covers `Support order_by vector str`.

## Review Required:
- [ ] **FSM structure**
  - As woojin mentioned in #707, fsm structure seems to be as:
  - {Select, Having, GroupBy} -> {OrderBy} -> {Offset, Limit, Project}

reference: https://www.postgresql.org/docs/current/queries-order.html

## Remaining Works:  
from issue #696 
- [ ] Support In Sub query Expression
- [ ] Support null first