### PR TITLE
[Data] remove data type int64

### DIFF
--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -14,9 +14,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
         SqlDataType::UnsignedInt(Some(8)) | SqlDataType::UnsignedInteger(Some(8)) => {
             Ok(DataType::Uint8)
         }
-        SqlDataType::Int(None) | SqlDataType::Int(Some(64)) | SqlDataType::Integer(None) => {
-            Ok(DataType::Int)
-        }
+        SqlDataType::Int(None) | SqlDataType::Integer(None) => Ok(DataType::Int),
         SqlDataType::Float(_) => Ok(DataType::Float),
         SqlDataType::Text => Ok(DataType::Text),
         SqlDataType::Bytea => Ok(DataType::Bytea),
@@ -32,6 +30,7 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
             match name.as_deref() {
                 Some("MAP") => Ok(DataType::Map),
                 Some("LIST") => Ok(DataType::List),
+                Some("INT64") => Ok(DataType::Int),
                 _ => Err(TranslateError::UnsupportedDataType(sql_data_type.to_string()).into()),
             }
         }

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -30,7 +30,6 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
                 Some("INT8") => Ok(DataType::Int8),
                 Some("INT16") => Ok(DataType::Int16),
                 Some("INT32") => Ok(DataType::Int32),
-                Some("INT64") => Ok(DataType::Int),
 
                 _ => Err(TranslateError::UnsupportedDataType(sql_data_type.to_string()).into()),
             }

--- a/test-suite/src/data_type/int64.rs
+++ b/test-suite/src/data_type/int64.rs
@@ -14,25 +14,8 @@ test_case!(int64, async move {
     );"
     );
     run!("INSERT INTO Item VALUES (1, -1), (-2, 2), (3, 3), (-4, -4);");
-    run!(
-        "CREATE TABLE Menu (
-        sushi INT64,
-        curry INT64,
-    );"
-    );
-    run!("INSERT INTO Menu VALUES (1, -1), (-2, 2)");
 
     let parse_i64 = |text: &str| -> i64 { text.parse().unwrap() };
-
-    test!(
-        "SELECT sushi, curry FROM Menu",
-        Ok(select!(
-            sushi            | curry
-            I64              | I64;
-            1                  parse_i64("-1");
-            parse_i64("-2")    2
-        ))
-    );
 
     test!(
         &format!(

--- a/test-suite/src/data_type/int64.rs
+++ b/test-suite/src/data_type/int64.rs
@@ -14,8 +14,25 @@ test_case!(int64, async move {
     );"
     );
     run!("INSERT INTO Item VALUES (1, -1), (-2, 2), (3, 3), (-4, -4);");
+    run!(
+        "CREATE TABLE Menu (
+        sushi INT64,
+        curry INT64,
+    );"
+    );
+    run!("INSERT INTO Menu VALUES (1, -1), (-2, 2)");
 
     let parse_i64 = |text: &str| -> i64 { text.parse().unwrap() };
+
+    test!(
+        "SELECT sushi, curry FROM Menu",
+        Ok(select!(
+            sushi            | curry
+            I64              | I64;
+            1                  parse_i64("-1");
+            parse_i64("-2")    2
+        ))
+    );
 
     test!(
         &format!(


### PR DESCRIPTION
## Background
ref #845 

## Description
https://github.com/gluesql/gluesql/blob/main/core/src/translate/data_type.rs#L14
Since 64 bit signed integers are already supported as INT and INTEGER, in this case, there is no need for an additional name.
