### PR TITLE
Remove deprecated wee_alloc dependency use in gluesql-js/

### DIFF
--- a/gluesql-js/web/Cargo.toml
+++ b/gluesql-js/web/Cargo.toml
@@ -28,13 +28,6 @@ serde_json = "1"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
-
 gluesql-core = { path = "../../core", version = "0.12.0" }
 memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.12.0" }
 

--- a/gluesql-js/web/src/lib.rs
+++ b/gluesql-js/web/src/lib.rs
@@ -13,12 +13,6 @@ use {
     wasm_bindgen_futures::future_to_promise,
 };
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_namespace = console)]


### PR DESCRIPTION
ref. https://github.com/gluesql/gluesql/security/dependabot/1
