### PR TITLE
Add cli/ print and command modules to code coverage tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,10 @@ jobs:
             --branch \
             --ignore-not-existing \
             --ignore "/*" \
-            --ignore "cli/src/*" \
+            --ignore "cli/src/cli.rs" \
+            --ignore "cli/src/helper.rs" \
+            --ignore "cli/src/lib.rs" \
+            --ignore "cli/src/main.rs" \
             --excl-line "#\\[derive\\(" \
             -o ./coverage/lcov.info
       - name: Coveralls

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,10 +43,7 @@ jobs:
             --branch \
             --ignore-not-existing \
             --ignore "/*" \
-            --ignore "cli/src/cli.rs" \
-            --ignore "cli/src/helper.rs" \
-            --ignore "cli/src/lib.rs" \
-            --ignore "cli/src/main.rs" \
+            --ignore "cli/src/{cli,helper,lib,main}.rs" \
             --excl-line "#\\[derive\\(" \
             -o ./coverage/lcov.info
       - name: Coveralls


### PR DESCRIPTION
In `cli` workspace, rusty_line dependent modules are not able to be tested.
Except for those, there is no issue for us to run coverage tests.
e.g. `print` and `command` modules