### PR TITLE
Update test-suite Tester trait to use Glue struct

### DIFF
--- a/gluesql-js/web/tests/memory_storage.rs
+++ b/gluesql-js/web/tests/memory_storage.rs
@@ -1,28 +1,25 @@
 #![cfg(target_arch = "wasm32")]
 
 use {
-    memory_storage::MemoryStorage,
-    std::{cell::RefCell, rc::Rc},
-    test_suite::*,
-    wasm_bindgen_test::*,
+    gluesql_core::prelude::Glue, memory_storage::MemoryStorage, test_suite::*, wasm_bindgen_test::*,
 };
 
 wasm_bindgen_test_configure!(run_in_browser);
 
 struct MemoryTester {
-    storage: Rc<RefCell<Option<MemoryStorage>>>,
+    glue: Glue<MemoryStorage>,
 }
 
 impl Tester<MemoryStorage> for MemoryTester {
     fn new(_: &str) -> Self {
-        let storage = Some(MemoryStorage::default());
-        let storage = Rc::new(RefCell::new(storage));
+        let storage = MemoryStorage::default();
+        let glue = Glue::new(storage);
 
-        MemoryTester { storage }
+        MemoryTester { glue }
     }
 
-    fn get_cell(&mut self) -> Rc<RefCell<Option<MemoryStorage>>> {
-        Rc::clone(&self.storage)
+    fn get_glue(&mut self) -> &mut Glue<MemoryStorage> {
+        &mut self.glue
     }
 }
 

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -1,23 +1,19 @@
-use {
-    gluesql_memory_storage::MemoryStorage,
-    std::{cell::RefCell, rc::Rc},
-    test_suite::*,
-};
+use {gluesql_core::prelude::Glue, gluesql_memory_storage::MemoryStorage, test_suite::*};
 
 struct MemoryTester {
-    storage: Rc<RefCell<Option<MemoryStorage>>>,
+    glue: Glue<MemoryStorage>,
 }
 
 impl Tester<MemoryStorage> for MemoryTester {
     fn new(_: &str) -> Self {
-        let storage = Some(MemoryStorage::default());
-        let storage = Rc::new(RefCell::new(storage));
+        let storage = MemoryStorage::default();
+        let glue = Glue::new(storage);
 
-        MemoryTester { storage }
+        MemoryTester { glue }
     }
 
-    fn get_cell(&mut self) -> Rc<RefCell<Option<MemoryStorage>>> {
-        Rc::clone(&self.storage)
+    fn get_glue(&mut self) -> &mut Glue<MemoryStorage> {
+        &mut self.glue
     }
 }
 

--- a/storages/shared-memory-storage/tests/shared_memory_storage.rs
+++ b/storages/shared-memory-storage/tests/shared_memory_storage.rs
@@ -1,23 +1,21 @@
 use {
-    gluesql_shared_memory_storage::SharedMemoryStorage,
-    std::{cell::RefCell, rc::Rc},
-    test_suite::*,
+    gluesql_core::prelude::Glue, gluesql_shared_memory_storage::SharedMemoryStorage, test_suite::*,
 };
 
 struct SharedMemoryTester {
-    storage: Rc<RefCell<Option<SharedMemoryStorage>>>,
+    glue: Glue<SharedMemoryStorage>,
 }
 
 impl Tester<SharedMemoryStorage> for SharedMemoryTester {
     fn new(_: &str) -> Self {
-        let storage = Some(SharedMemoryStorage::new());
-        let storage = Rc::new(RefCell::new(storage));
+        let storage = SharedMemoryStorage::new();
+        let glue = Glue::new(storage);
 
-        SharedMemoryTester { storage }
+        SharedMemoryTester { glue }
     }
 
-    fn get_cell(&mut self) -> Rc<RefCell<Option<SharedMemoryStorage>>> {
-        Rc::clone(&self.storage)
+    fn get_glue(&mut self) -> &mut Glue<SharedMemoryStorage> {
+        &mut self.glue
     }
 }
 

--- a/storages/sled-storage/tests/sled_storage.rs
+++ b/storages/sled-storage/tests/sled_storage.rs
@@ -1,11 +1,7 @@
-use {
-    gluesql_sled_storage::SledStorage,
-    std::{cell::RefCell, rc::Rc},
-    test_suite::*,
-};
+use {gluesql_core::prelude::Glue, gluesql_sled_storage::SledStorage, test_suite::*};
 
 struct SledTester {
-    storage: Rc<RefCell<Option<SledStorage>>>,
+    glue: Glue<SledStorage>,
 }
 
 impl Tester<SledStorage> for SledTester {
@@ -24,17 +20,14 @@ impl Tester<SledStorage> for SledTester {
             .temporary(true)
             .mode(sled::Mode::HighThroughput);
 
-        let storage = SledStorage::try_from(config)
-            .map(Some)
-            .map(RefCell::new)
-            .map(Rc::new)
-            .expect("SledStorage::new");
+        let storage = SledStorage::try_from(config).expect("SledStorage::new");
+        let glue = Glue::new(storage);
 
-        SledTester { storage }
+        SledTester { glue }
     }
 
-    fn get_cell(&mut self) -> Rc<RefCell<Option<SledStorage>>> {
-        Rc::clone(&self.storage)
+    fn get_glue(&mut self) -> &mut Glue<SledStorage> {
+        &mut self.glue
     }
 }
 

--- a/test-suite/src/tester/mod.rs
+++ b/test-suite/src/tester/mod.rs
@@ -226,7 +226,7 @@ macro_rules! test_case {
         where
             T: gluesql_core::store::GStore + gluesql_core::store::GStoreMut,
         {
-            let mut glue = tester.get_glue();
+            let glue = tester.get_glue();
 
             #[allow(unused_macros)]
             macro_rules! schema {
@@ -251,14 +251,14 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! run {
                 ($sql: expr) => {
-                    $crate::run($sql, &mut glue, None).await.unwrap()
+                    $crate::run($sql, glue, None).await.unwrap()
                 };
             }
 
             #[allow(unused_macros)]
             macro_rules! count {
                 ($count: expr, $sql: expr) => {
-                    match $crate::run($sql, &mut glue, None).await.unwrap() {
+                    match $crate::run($sql, glue, None).await.unwrap() {
                         gluesql_core::prelude::Payload::Select { rows, .. } => {
                             assert_eq!($count, rows.len())
                         }
@@ -272,7 +272,7 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! type_match {
                 ($expected: expr, $sql: expr) => {
-                    let found = run($sql, &mut glue, None).await;
+                    let found = run($sql, glue, None).await;
 
                     $crate::type_match($expected, found);
                 };
@@ -281,19 +281,19 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! test {
                 (name: $test_name: literal, sql: $sql: expr, expected: $expected: expr) => {
-                    let found = run($sql, &mut glue, None).await;
+                    let found = run($sql, glue, None).await;
 
                     $crate::test(found, $expected);
                 };
 
                 (sql: $sql: expr, expected: $expected: expr) => {
-                    let found = run($sql, &mut glue, None).await;
+                    let found = run($sql, glue, None).await;
 
                     $crate::test(found, $expected);
                 };
 
                 ($sql: expr, $expected: expr) => {
-                    let found = run($sql, &mut glue, None).await;
+                    let found = run($sql, glue, None).await;
 
                     $crate::test(found, $expected);
                 };
@@ -302,7 +302,7 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! test_idx {
                 ($expected: expr, $indexes: expr, $sql: expr) => {
-                    let found = run($sql, &mut glue, Some($indexes)).await;
+                    let found = run($sql, glue, Some($indexes)).await;
 
                     $crate::test($expected, found);
                 };

--- a/test-suite/src/tester/mod.rs
+++ b/test-suite/src/tester/mod.rs
@@ -8,7 +8,6 @@ use {
         store::{GStore, GStoreMut},
         translate::translate_expr,
     },
-    std::{cell::RefCell, rc::Rc},
 };
 
 pub mod macros;
@@ -90,43 +89,19 @@ pub fn test(found: Result<Payload>, expected: Result<Payload>) {
 
 pub async fn run<T: GStore + GStoreMut>(
     sql: &str,
-    cell: Rc<RefCell<Option<T>>>,
+    glue: &mut Glue<T>,
     indexes: Option<Vec<IndexItem>>,
 ) -> Result<Payload> {
-    let storage = cell.replace(None).unwrap();
-
-    macro_rules! try_run {
-        ($expr: expr) => {
-            match $expr {
-                Ok(v) => v,
-                Err(e) => {
-                    cell.replace(Some(storage));
-
-                    return Err(e);
-                }
-            }
-        };
-    }
+    let storage = glue.storage.as_ref().unwrap();
 
     println!("[SQL] {}", sql);
-    let parsed = try_run!(parse(sql));
-    let statement = try_run!(translate(&parsed[0]));
-    let statement = try_run!(plan(&storage, statement).await);
+    let parsed = parse(sql)?;
+    let statement = translate(&parsed[0])?;
+    let statement = plan(storage, statement).await?;
 
     test_indexes(&statement, indexes);
 
-    match execute(storage, &statement).await {
-        Ok((storage, payload)) => {
-            cell.replace(Some(storage));
-
-            Ok(payload)
-        }
-        Err((storage, error)) => {
-            cell.replace(Some(storage));
-
-            Err(error)
-        }
-    }
+    glue.execute_stmt_async(&statement).await
 }
 
 pub fn test_indexes(statement: &Statement, indexes: Option<Vec<IndexItem>>) {
@@ -241,7 +216,7 @@ pub fn type_match(expected: &[DataType], found: Result<Payload>) {
 pub trait Tester<T: GStore + GStoreMut> {
     fn new(namespace: &str) -> Self;
 
-    fn get_cell(&mut self) -> Rc<RefCell<Option<T>>>;
+    fn get_glue(&mut self) -> &mut Glue<T>;
 }
 
 #[macro_export]
@@ -251,16 +226,14 @@ macro_rules! test_case {
         where
             T: gluesql_core::store::GStore + gluesql_core::store::GStoreMut,
         {
-            use std::rc::Rc;
-
-            let cell = tester.get_cell();
+            let mut glue = tester.get_glue();
 
             #[allow(unused_macros)]
             macro_rules! schema {
                 ($table_name: literal) => {
-                    cell.borrow()
+                    glue.storage
                         .as_ref()
-                        .expect("cell is empty")
+                        .expect("storage is empty")
                         .fetch_schema($table_name)
                         .await
                         .expect("error fetching schema")
@@ -278,14 +251,14 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! run {
                 ($sql: expr) => {
-                    $crate::run($sql, Rc::clone(&cell), None).await.unwrap()
+                    $crate::run($sql, &mut glue, None).await.unwrap()
                 };
             }
 
             #[allow(unused_macros)]
             macro_rules! count {
                 ($count: expr, $sql: expr) => {
-                    match $crate::run($sql, Rc::clone(&cell), None).await.unwrap() {
+                    match $crate::run($sql, &mut glue, None).await.unwrap() {
                         gluesql_core::prelude::Payload::Select { rows, .. } => {
                             assert_eq!($count, rows.len())
                         }
@@ -299,7 +272,7 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! type_match {
                 ($expected: expr, $sql: expr) => {
-                    let found = run($sql, Rc::clone(&cell), None).await;
+                    let found = run($sql, &mut glue, None).await;
 
                     $crate::type_match($expected, found);
                 };
@@ -308,19 +281,19 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! test {
                 (name: $test_name: literal, sql: $sql: expr, expected: $expected: expr) => {
-                    let found = run($sql, Rc::clone(&cell), None).await;
+                    let found = run($sql, &mut glue, None).await;
 
                     $crate::test(found, $expected);
                 };
 
                 (sql: $sql: expr, expected: $expected: expr) => {
-                    let found = run($sql, Rc::clone(&cell), None).await;
+                    let found = run($sql, &mut glue, None).await;
 
                     $crate::test(found, $expected);
                 };
 
                 ($sql: expr, $expected: expr) => {
-                    let found = run($sql, Rc::clone(&cell), None).await;
+                    let found = run($sql, &mut glue, None).await;
 
                     $crate::test(found, $expected);
                 };
@@ -329,7 +302,7 @@ macro_rules! test_case {
             #[allow(unused_macros)]
             macro_rules! test_idx {
                 ($expected: expr, $indexes: expr, $sql: expr) => {
-                    let found = $crate::run($sql, Rc::clone(&cell), Some($indexes)).await;
+                    let found = run($sql, &mut glue, Some($indexes)).await;
 
                     $crate::test($expected, found);
                 };


### PR DESCRIPTION
before:
https://github.com/gluesql/gluesql/blob/316fbdb6878bc5051b9cf2c0efa46eeea3e2b20a/test-suite/src/tester/mod.rs#L240-L245

now:
```rust
#[async_trait]
pub trait Tester<T: GStore + GStoreMut> {
    fn new(namespace: &str) -> Self;

    fn get_glue(&mut self) -> &mut Glue<T>;
}
```