### PR TITLE
refactor: Replace `ObjectName` with `String`

### DIFF
--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -1,5 +1,5 @@
 use {
-    super::{DataType, Expr, ObjectName},
+    super::{DataType, Expr},
     crate::ast::ToSql,
     serde::{Deserialize, Serialize},
 };
@@ -19,7 +19,7 @@ pub enum AlterTableOperation {
         new_column_name: String,
     },
     /// `RENAME TO <table_name>`
-    RenameTable { table_name: ObjectName },
+    RenameTable { table_name: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -65,7 +65,7 @@ impl ToSql for AlterTableOperation {
                 new_column_name,
             } => format!("RENAME COLUMN {old_column_name} TO {new_column_name}"),
             AlterTableOperation::RenameTable { table_name } => {
-                format!("RENAME TO {}", table_name.to_sql())
+                format!("RENAME TO {table_name}")
             }
         }
     }

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -202,8 +202,8 @@ mod tests {
     use {
         crate::ast::{
             Aggregate, AstLiteral, BinaryOperator, CountArgExpr, DataType, DateTimeField, Expr,
-            Function, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins,
-            ToSql, UnaryOperator,
+            Function, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins, ToSql,
+            UnaryOperator,
         },
         bigdecimal::BigDecimal,
         regex::Regex,
@@ -380,7 +380,7 @@ mod tests {
                         projection: vec![SelectItem::Wildcard],
                         from: TableWithJoins {
                             relation: TableFactor::Table {
-                                name: ObjectName(vec!["Foo".to_owned()]),
+                                name: "Foo".to_owned(),
                                 alias: None,
                                 index: None,
                             },
@@ -407,7 +407,7 @@ mod tests {
                         projection: vec![SelectItem::Wildcard],
                         from: TableWithJoins {
                             relation: TableFactor::Table {
-                                name: ObjectName(vec!["Foo".to_owned()]),
+                                name: "Foo".to_owned(),
                                 alias: None,
                                 index: None,
                             },

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -16,9 +16,6 @@ pub use query::*;
 
 use serde::{Deserialize, Serialize};
 
-// #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-// pub struct ObjectName(pub Vec<String>);
-
 pub trait ToSql {
     fn to_sql(&self) -> String;
 }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -16,8 +16,8 @@ pub use query::*;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ObjectName(pub Vec<String>);
+// #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+// pub struct ObjectName(pub Vec<String>);
 
 pub trait ToSql {
     fn to_sql(&self) -> String;
@@ -26,14 +26,14 @@ pub trait ToSql {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Statement {
     ShowColumns {
-        table_name: ObjectName,
+        table_name: String,
     },
     /// SELECT, VALUES
     Query(Query),
     /// INSERT
     Insert {
         /// TABLE
-        table_name: ObjectName,
+        table_name: String,
         /// COLUMNS
         columns: Vec<String>,
         /// A SQL query that specifies what to insert
@@ -42,7 +42,7 @@ pub enum Statement {
     /// UPDATE
     Update {
         /// TABLE
-        table_name: ObjectName,
+        table_name: String,
         /// Column assignments
         assignments: Vec<Assignment>,
         /// WHERE
@@ -51,7 +51,7 @@ pub enum Statement {
     /// DELETE
     Delete {
         /// FROM
-        table_name: ObjectName,
+        table_name: String,
         /// WHERE
         selection: Option<Expr>,
     },
@@ -59,7 +59,7 @@ pub enum Statement {
     CreateTable {
         if_not_exists: bool,
         /// Table name
-        name: ObjectName,
+        name: String,
         /// Optional schema
         columns: Vec<ColumnDef>,
         source: Option<Box<Query>>,
@@ -68,7 +68,7 @@ pub enum Statement {
     #[cfg(feature = "alter-table")]
     AlterTable {
         /// Table name
-        name: ObjectName,
+        name: String,
         operation: AlterTableOperation,
     },
     /// DROP TABLE
@@ -76,20 +76,20 @@ pub enum Statement {
         /// An optional `IF EXISTS` clause. (Non-standard.)
         if_exists: bool,
         /// One or more objects to drop. (ANSI SQL requires exactly one.)
-        names: Vec<ObjectName>,
+        names: Vec<String>,
     },
     /// CREATE INDEX
     #[cfg(feature = "index")]
     CreateIndex {
-        name: ObjectName,
-        table_name: ObjectName,
+        name: String,
+        table_name: String,
         column: OrderByExpr,
     },
     /// DROP INDEX
     #[cfg(feature = "index")]
     DropIndex {
-        name: ObjectName,
-        table_name: ObjectName,
+        name: String,
+        table_name: String,
     },
     /// START TRANSACTION, BEGIN
     #[cfg(feature = "transaction")]
@@ -104,7 +104,7 @@ pub enum Statement {
     #[cfg(feature = "metadata")]
     ShowVariable(Variable),
     #[cfg(feature = "index")]
-    ShowIndexes(ObjectName),
+    ShowIndexes(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -120,19 +120,19 @@ pub enum Variable {
     Version,
 }
 
-impl ToSql for ObjectName {
-    fn to_sql(&self) -> String {
-        match self {
-            ObjectName(names) => names.join("."),
-        }
-    }
-}
+// impl ToSql for ObjectName {
+//     fn to_sql(&self) -> String {
+//         match self {
+//             ObjectName(names) => names.join("."),
+//         }
+//     }
+// }
 
 impl ToSql for Statement {
     fn to_sql(&self) -> String {
         match self {
             Statement::ShowColumns { table_name } => {
-                format!("SHOW COLUMNS FROM {}", table_name.to_sql())
+                format!("SHOW COLUMNS FROM {table_name}")
             }
             Statement::Insert {
                 table_name,
@@ -140,10 +140,7 @@ impl ToSql for Statement {
                 source: _,
             } => {
                 let columns = columns.join(", ");
-                format!(
-                    "INSERT INTO {} ({columns}) (..query..)",
-                    table_name.to_sql()
-                )
+                format!("INSERT INTO {table_name} ({columns}) (..query..)",)
             }
             Statement::Update {
                 table_name,
@@ -158,24 +155,19 @@ impl ToSql for Statement {
                 match selection {
                     Some(expr) => {
                         format!(
-                            "UPDATE {} SET {assignments} WHERE {}",
-                            table_name.to_sql(),
+                            "UPDATE {table_name} SET {assignments} WHERE {}",
                             expr.to_sql()
                         )
                     }
-                    None => format!("UPDATE {} SET {assignments}", table_name.to_sql()),
+                    None => format!("UPDATE {table_name} SET {assignments}"),
                 }
             }
             Statement::Delete {
                 table_name,
                 selection,
             } => match selection {
-                Some(expr) => format!(
-                    "DELETE FROM {} WHERE {}",
-                    table_name.to_sql(),
-                    expr.to_sql()
-                ),
-                None => format!("DELETE FROM {}", table_name.to_sql()),
+                Some(expr) => format!("DELETE FROM {table_name} WHERE {}", expr.to_sql()),
+                None => format!("DELETE FROM {table_name}"),
             },
             Statement::CreateTable {
                 if_not_exists,
@@ -184,11 +176,8 @@ impl ToSql for Statement {
                 source,
             } => match source {
                 Some(_query) => match if_not_exists {
-                    true => format!(
-                        "CREATE TABLE IF NOT EXISTS {} AS (..query..)",
-                        name.to_sql()
-                    ),
-                    false => format!("CREATE TABLE {} AS (..query..)", name.to_sql()),
+                    true => format!("CREATE TABLE IF NOT EXISTS {name} AS (..query..)",),
+                    false => format!("CREATE TABLE {name} AS (..query..)"),
                 },
                 None => {
                     let columns = columns
@@ -197,21 +186,17 @@ impl ToSql for Statement {
                         .collect::<Vec<_>>()
                         .join(", ");
                     match if_not_exists {
-                        true => format!("CREATE TABLE IF NOT EXISTS {} ({columns})", name.to_sql()),
-                        false => format!("CREATE TABLE {} ({columns})", name.to_sql()),
+                        true => format!("CREATE TABLE IF NOT EXISTS {name} ({columns})"),
+                        false => format!("CREATE TABLE {name} ({columns})"),
                     }
                 }
             },
             #[cfg(feature = "alter-table")]
             Statement::AlterTable { name, operation } => {
-                format!("ALTER TABLE {} {}", name.to_sql(), operation.to_sql())
+                format!("ALTER TABLE {name} {}", operation.to_sql())
             }
             Statement::DropTable { if_exists, names } => {
-                let names = names
-                    .iter()
-                    .map(ToSql::to_sql)
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let names = names.join(", ");
                 match if_exists {
                     true => format!("DROP TABLE IF EXISTS {}", names),
                     false => format!("DROP TABLE {}", names),
@@ -223,16 +208,11 @@ impl ToSql for Statement {
                 table_name,
                 column,
             } => {
-                format!(
-                    "CREATE INDEX {} ON {} {}",
-                    name.to_sql(),
-                    table_name.to_sql(),
-                    column.to_sql()
-                )
+                format!("CREATE INDEX {name} ON {table_name} {}", column.to_sql())
             }
             #[cfg(feature = "index")]
             Statement::DropIndex { name, table_name } => {
-                format!("DROP INDEX {}.{}", table_name.to_sql(), name.to_sql())
+                format!("DROP INDEX {table_name}.{name}")
             }
             #[cfg(feature = "transaction")]
             Statement::StartTransaction => "START TRANSACTION".to_string(),
@@ -247,7 +227,7 @@ impl ToSql for Statement {
             },
             #[cfg(feature = "index")]
             Statement::ShowIndexes(object_name) => {
-                format!("SHOW INDEXES FROM {}", object_name.to_sql())
+                format!("SHOW INDEXES FROM {object_name}")
             }
             _ => "(..statement..)".to_string(),
         }
@@ -274,33 +254,33 @@ mod tests {
     use {
         crate::ast::{
             Assignment, AstLiteral, BinaryOperator, ColumnDef, ColumnOption, ColumnOptionDef,
-            DataType, Expr, ObjectName, Query, SetExpr, Statement, ToSql, Values,
+            DataType, Expr, Query, SetExpr, Statement, ToSql, Values,
         },
         bigdecimal::BigDecimal,
         std::str::FromStr,
     };
 
-    #[test]
-    fn to_sql_object_name() {
-        assert_eq!("Foo", ObjectName(vec!["Foo".to_string()]).to_sql());
+    // #[test]
+    // fn to_sql_object_name() {
+    //     assert_eq!("Foo", ObjectName(vec!["Foo".to_string()]).to_sql());
 
-        assert_eq!(
-            "Foo.bar.bax",
-            ObjectName(vec![
-                "Foo".to_string(),
-                "bar".to_string(),
-                "bax".to_string()
-            ])
-            .to_sql()
-        );
-    }
+    //     assert_eq!(
+    //         "Foo.bar.bax",
+    //         ObjectName(vec![
+    //             "Foo".to_string(),
+    //             "bar".to_string(),
+    //             "bax".to_string()
+    //         ])
+    //         .to_sql()
+    //     );
+    // }
 
     #[test]
     fn to_sql_show_columns() {
         assert_eq!(
             "SHOW COLUMNS FROM Bar",
             Statement::ShowColumns {
-                table_name: ObjectName(vec!["Bar".to_string()])
+                table_name: "Bar".into()
             }
             .to_sql()
         )
@@ -311,7 +291,7 @@ mod tests {
         assert_eq!(
             "INSERT INTO Test (id, num, name) (..query..)",
             Statement::Insert {
-                table_name: ObjectName(vec!["Test".to_string()]),
+                table_name: "Test".into(),
                 columns: vec!["id".to_string(), "num".to_string(), "name".to_string()],
                 source: Query {
                     body: SetExpr::Values(Values(vec![vec![
@@ -333,7 +313,7 @@ mod tests {
         assert_eq!(
             r#"UPDATE Foo SET id = 4, color = "blue""#,
             Statement::Update {
-                table_name: ObjectName(vec!["Foo".to_string()]),
+                table_name: "Foo".into(),
                 assignments: vec![
                     Assignment {
                         id: "id".to_string(),
@@ -354,7 +334,7 @@ mod tests {
         assert_eq!(
             r#"UPDATE Foo SET name = "first" WHERE a > b"#,
             Statement::Update {
-                table_name: ObjectName(vec!["Foo".to_string()]),
+                table_name: "Foo".into(),
                 assignments: vec![Assignment {
                     id: "name".to_string(),
                     value: Expr::Literal(AstLiteral::QuotedString("first".to_string()))
@@ -374,7 +354,7 @@ mod tests {
         assert_eq!(
             "DELETE FROM Foo",
             Statement::Delete {
-                table_name: ObjectName(vec!["Foo".to_string()]),
+                table_name: "Foo".into(),
                 selection: None
             }
             .to_sql()
@@ -383,7 +363,7 @@ mod tests {
         assert_eq!(
             r#"DELETE FROM Foo WHERE item = "glue""#,
             Statement::Delete {
-                table_name: ObjectName(vec!["Foo".to_string()]),
+                table_name: "Foo".into(),
                 selection: Some(Expr::BinaryOp {
                     left: Box::new(Expr::Identifier("item".to_string())),
                     op: BinaryOperator::Eq,
@@ -400,7 +380,7 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS Foo ()",
             Statement::CreateTable {
                 if_not_exists: true,
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 columns: vec![],
                 source: None
             }
@@ -411,7 +391,7 @@ mod tests {
             "CREATE TABLE Foo (id INT, num INT NULL, name TEXT)",
             Statement::CreateTable {
                 if_not_exists: false,
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 columns: vec![
                     ColumnDef {
                         name: "id".to_string(),
@@ -444,7 +424,7 @@ mod tests {
             "CREATE TABLE Foo AS (..query..)",
             Statement::CreateTable {
                 if_not_exists: false,
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 columns: vec![],
                 source: Some(Box::new(Query {
                     body: SetExpr::Values(Values(vec![vec![Expr::Literal(AstLiteral::Boolean(
@@ -462,7 +442,7 @@ mod tests {
             "CREATE TABLE IF NOT EXISTS Foo AS (..query..)",
             Statement::CreateTable {
                 if_not_exists: true,
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 columns: vec![],
                 source: Some(Box::new(Query {
                     body: SetExpr::Values(Values(vec![vec![Expr::Literal(AstLiteral::Boolean(
@@ -483,7 +463,7 @@ mod tests {
         assert_eq!(
             "ALTER TABLE Foo ADD COLUMN amount INT DEFAULT 10",
             Statement::AlterTable {
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 operation: AlterTableOperation::AddColumn {
                     column_def: ColumnDef {
                         name: "amount".to_string(),
@@ -503,7 +483,7 @@ mod tests {
         assert_eq!(
             "ALTER TABLE Foo DROP COLUMN something",
             Statement::AlterTable {
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 operation: AlterTableOperation::DropColumn {
                     column_name: "something".to_string(),
                     if_exists: false
@@ -515,7 +495,7 @@ mod tests {
         assert_eq!(
             "ALTER TABLE Foo DROP COLUMN IF EXISTS something",
             Statement::AlterTable {
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".into(),
                 operation: AlterTableOperation::DropColumn {
                     column_name: "something".to_string(),
                     if_exists: true
@@ -527,7 +507,7 @@ mod tests {
         assert_eq!(
             "ALTER TABLE Bar RENAME COLUMN id TO new_id",
             Statement::AlterTable {
-                name: ObjectName(vec!["Bar".to_string()]),
+                name: "Bar".into(),
                 operation: AlterTableOperation::RenameColumn {
                     old_column_name: "id".to_string(),
                     new_column_name: "new_id".to_string()
@@ -539,9 +519,9 @@ mod tests {
         assert_eq!(
             "ALTER TABLE Foo RENAME TO Bar",
             Statement::AlterTable {
-                name: ObjectName(vec!["Foo".to_string()]),
+                name: "Foo".to_owned(),
                 operation: AlterTableOperation::RenameTable {
-                    table_name: ObjectName(vec!["Bar".to_string()])
+                    table_name: "Bar".to_owned(),
                 }
             }
             .to_sql()
@@ -554,7 +534,7 @@ mod tests {
             "DROP TABLE Test",
             Statement::DropTable {
                 if_exists: false,
-                names: vec![ObjectName(vec!["Test".to_string()])]
+                names: vec!["Test".into()]
             }
             .to_sql()
         );
@@ -563,7 +543,7 @@ mod tests {
             "DROP TABLE IF EXISTS Test",
             Statement::DropTable {
                 if_exists: true,
-                names: vec![ObjectName(vec!["Test".to_string()])]
+                names: vec!["Test".into()]
             }
             .to_sql()
         );
@@ -572,10 +552,7 @@ mod tests {
             "DROP TABLE Foo, Bar",
             Statement::DropTable {
                 if_exists: false,
-                names: vec![
-                    ObjectName(vec!["Foo".to_string()]),
-                    ObjectName(vec!["Bar".to_string()])
-                ]
+                names: vec!["Foo".into(), "Bar".into(),]
             }
             .to_sql()
         );
@@ -587,8 +564,8 @@ mod tests {
         assert_eq!(
             "CREATE INDEX idx_name ON Test LastName",
             Statement::CreateIndex {
-                name: ObjectName(vec!["idx_name".to_string()]),
-                table_name: ObjectName(vec!["Test".to_string()]),
+                name: "idx_name".into(),
+                table_name: "Test".into(),
                 column: OrderByExpr {
                     expr: Expr::Identifier("LastName".to_string()),
                     asc: None
@@ -604,8 +581,8 @@ mod tests {
         assert_eq!(
             "DROP INDEX Test.idx_id",
             Statement::DropIndex {
-                name: ObjectName(vec!["idx_id".to_string()]),
-                table_name: ObjectName(vec!["Test".to_string()])
+                name: "idx_id".into(),
+                table_name: "Test".into(),
             }
             .to_sql()
         )
@@ -637,7 +614,7 @@ mod tests {
     fn to_sql_show_indexes() {
         assert_eq!(
             "SHOW INDEXES FROM Test",
-            Statement::ShowIndexes(ObjectName(vec!["Test".to_string()])).to_sql()
+            Statement::ShowIndexes("Test".into()).to_sql()
         );
     }
 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -117,14 +117,6 @@ pub enum Variable {
     Version,
 }
 
-// impl ToSql for ObjectName {
-//     fn to_sql(&self) -> String {
-//         match self {
-//             ObjectName(names) => names.join("."),
-//         }
-//     }
-// }
-
 impl ToSql for Statement {
     fn to_sql(&self) -> String {
         match self {

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Expr, IndexOperator, ObjectName},
+    super::{Expr, IndexOperator},
     crate::ast::ToSql,
     serde::{Deserialize, Serialize},
 };
@@ -33,7 +33,7 @@ pub enum SelectItem {
     /// An expression
     Expr { expr: Expr, label: String },
     /// `alias.*` or even `schema.table.*`
-    QualifiedWildcard(ObjectName),
+    QualifiedWildcard(String),
     /// An unqualified `*`
     Wildcard,
 }
@@ -57,7 +57,7 @@ pub enum IndexItem {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TableFactor {
     Table {
-        name: ObjectName,
+        name: String,
         alias: Option<TableAlias>,
         /// Query planner result
         index: Option<IndexItem>,
@@ -67,7 +67,7 @@ pub enum TableFactor {
         alias: TableAlias,
     },
     Series {
-        name: ObjectName,
+        name: String,
         alias: Option<TableAlias>,
         size: Expr,
     },

--- a/core/src/ast_builder/alter_table.rs
+++ b/core/src/ast_builder/alter_table.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "alter-table")]
 use crate::{
-    ast::{AlterTableOperation, ObjectName, Statement},
+    ast::{AlterTableOperation, Statement},
     ast_builder::ColumnDefNode,
     result::Result,
 };
@@ -60,7 +60,7 @@ pub struct AddColumnNode {
 
 impl AddColumnNode {
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_node.table_name]);
+        let table_name = self.table_node.table_name;
         let operation = AlterTableOperation::AddColumn {
             column_def: self.column_def.try_into()?,
         };
@@ -79,7 +79,7 @@ pub struct DropColumnNode {
 
 impl DropColumnNode {
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_node.table_name]);
+        let table_name = self.table_node.table_name;
         let operation = AlterTableOperation::DropColumn {
             column_name: self.column_name,
             if_exists: self.if_exists,
@@ -99,7 +99,7 @@ pub struct RenameColumnNode {
 
 impl RenameColumnNode {
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_node.table_name]);
+        let table_name = self.table_node.table_name;
         let operation = AlterTableOperation::RenameColumn {
             old_column_name: self.old_column_name,
             new_column_name: self.new_column_name,
@@ -118,9 +118,9 @@ pub struct RenameTableNode {
 
 impl RenameTableNode {
     pub fn build(self) -> Result<Statement> {
-        let old_table_name = ObjectName(vec![self.table_node.table_name]);
+        let old_table_name = self.table_node.table_name;
         let operation = AlterTableOperation::RenameTable {
-            table_name: ObjectName(vec![self.new_table_name]),
+            table_name: self.new_table_name,
         };
         Ok(Statement::AlterTable {
             name: old_table_name,

--- a/core/src/ast_builder/create_table.rs
+++ b/core/src/ast_builder/create_table.rs
@@ -1,8 +1,4 @@
-use crate::{
-    ast::{ObjectName, Statement},
-    ast_builder::ColumnDefNode,
-    result::Result,
-};
+use crate::{ast::Statement, ast_builder::ColumnDefNode, result::Result};
 
 #[derive(Clone)]
 pub struct CreateTableNode {
@@ -21,7 +17,7 @@ impl CreateTableNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
+        let table_name = self.table_name;
         let columns = self
             .columns
             .into_iter()

--- a/core/src/ast_builder/delete.rs
+++ b/core/src/ast_builder/delete.rs
@@ -1,7 +1,7 @@
 use {
     super::ExprNode,
     crate::{
-        ast::{Expr, ObjectName, Statement},
+        ast::{Expr, Statement},
         result::Result,
     },
 };
@@ -27,7 +27,7 @@ impl DeleteNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
+        let table_name = self.table_name;
         let selection = self.filter_expr.map(Expr::try_from).transpose()?;
 
         Ok(Statement::Delete {

--- a/core/src/ast_builder/drop_table.rs
+++ b/core/src/ast_builder/drop_table.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ast::{ObjectName, Statement},
-    result::Result,
-};
+use crate::{ast::Statement, result::Result};
 
 #[derive(Clone)]
 pub struct DropTableNode {
@@ -18,7 +15,7 @@ impl DropTableNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let names = vec![ObjectName(vec![self.table_name])];
+        let names = vec![self.table_name];
         let if_exists = self.if_exists;
 
         Ok(Statement::DropTable { names, if_exists })

--- a/core/src/ast_builder/index.rs
+++ b/core/src/ast_builder/index.rs
@@ -1,9 +1,6 @@
 #![cfg(feature = "index")]
 
-use crate::{
-    ast::{ObjectName, Statement},
-    result::Result,
-};
+use crate::{ast::Statement, result::Result};
 
 use super::OrderByExprNode;
 
@@ -24,8 +21,8 @@ impl CreateIndexNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
-        let name = ObjectName(vec![self.name]);
+        let table_name = self.table_name;
+        let name = self.name;
         let column = self.column.try_into()?;
 
         Ok(Statement::CreateIndex {
@@ -48,8 +45,8 @@ impl DropIndexNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
-        let name = ObjectName(vec![self.name]);
+        let table_name = self.table_name;
+        let name = self.name;
 
         Ok(Statement::DropIndex { name, table_name })
     }

--- a/core/src/ast_builder/insert.rs
+++ b/core/src/ast_builder/insert.rs
@@ -1,7 +1,7 @@
 pub use {
     super::{ColumnList, ExprList, QueryNode, SelectNode},
     crate::{
-        ast::{Expr, ObjectName, Statement},
+        ast::{Expr, Statement},
         result::Result,
     },
 };
@@ -50,7 +50,7 @@ pub struct InsertSourceNode {
 
 impl InsertSourceNode {
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.insert_node.table_name]);
+        let table_name = self.insert_node.table_name;
         let columns = self.insert_node.columns;
         let columns = columns.map_or_else(|| Ok(vec![]), |v| v.try_into())?;
         let source = self.source.try_into()?;

--- a/core/src/ast_builder/select/join.rs
+++ b/core/src/ast_builder/select/join.rs
@@ -2,8 +2,7 @@ use {
     super::{NodeData, Prebuild},
     crate::{
         ast::{
-            Join, JoinConstraint, JoinExecutor, JoinOperator, ObjectName, Statement, TableAlias,
-            TableFactor,
+            Join, JoinConstraint, JoinExecutor, JoinOperator, Statement, TableAlias, TableFactor,
         },
         ast_builder::{
             ExprList, ExprNode, FilterNode, GroupByNode, JoinConstraintNode, LimitNode, OffsetNode,
@@ -64,7 +63,7 @@ pub struct JoinNode {
 impl JoinNode {
     pub fn new<N: Into<PrevNode>>(
         prev_node: N,
-        table_name: String,
+        name: String,
         alias: Option<String>,
         join_operator_type: JoinOperatorType,
     ) -> Self {
@@ -73,7 +72,7 @@ impl JoinNode {
             join_operator_type,
             relation: match alias {
                 Some(alias) => TableFactor::Table {
-                    name: ObjectName(vec![table_name]),
+                    name,
                     alias: Some(TableAlias {
                         name: alias,
                         columns: vec![],
@@ -81,7 +80,7 @@ impl JoinNode {
                     index: None,
                 },
                 None => TableFactor::Table {
-                    name: ObjectName(vec![table_name]),
+                    name,
                     alias: None,
                     index: None,
                 },

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -1,7 +1,7 @@
 use {
     super::{join::JoinOperatorType, NodeData, Prebuild},
     crate::{
-        ast::{ObjectName, SelectItem, Statement, TableFactor},
+        ast::{SelectItem, Statement, TableFactor},
         ast_builder::{
             ExprList, ExprNode, FilterNode, GroupByNode, JoinNode, LimitNode, OffsetNode,
             OrderByExprList, OrderByNode, ProjectNode, SelectItemList,
@@ -78,7 +78,7 @@ impl SelectNode {
 impl Prebuild for SelectNode {
     fn prebuild(self) -> Result<NodeData> {
         let relation = TableFactor::Table {
-            name: ObjectName(vec![self.table_name]),
+            name: self.table_name,
             alias: None,
             index: None,
         };

--- a/core/src/ast_builder/show_columns.rs
+++ b/core/src/ast_builder/show_columns.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ast::{ObjectName, Statement},
-    result::Result,
-};
+use crate::{ast::Statement, result::Result};
 
 #[derive(Clone)]
 pub struct ShowColumnsNode {
@@ -13,7 +10,7 @@ impl ShowColumnsNode {
         Self { table_name }
     }
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
+        let table_name = self.table_name;
         Ok(Statement::ShowColumns { table_name })
     }
 }

--- a/core/src/ast_builder/update.rs
+++ b/core/src/ast_builder/update.rs
@@ -1,7 +1,7 @@
 use {
     super::{AssignmentNode, ExprNode},
     crate::{
-        ast::{Assignment, Expr, ObjectName, Statement},
+        ast::{Assignment, Expr, Statement},
         result::Result,
     },
 };
@@ -34,7 +34,7 @@ impl UpdateNode {
     }
 
     pub fn build(self) -> Result<Statement> {
-        let table_name = ObjectName(vec![self.table_name]);
+        let table_name = self.table_name;
         let selection = self.selection.map(Expr::try_from).transpose()?;
         let assignments = self
             .assignments

--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -17,6 +17,6 @@ pub use {
     row::{Row, RowError},
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
     string_ext::{StringExt, StringExtError},
-    table::{get_alias, get_index, get_name, TableError},
+    table::{get_alias, get_index, TableError},
     value::{NumericBinaryOperator, Value, ValueError},
 };

--- a/core/src/data/table.rs
+++ b/core/src/data/table.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        ast::{IndexItem, ObjectName, TableAlias, TableFactor},
+        ast::{IndexItem, TableAlias, TableFactor},
         result::Result,
     },
     serde::Serialize,
@@ -14,16 +14,16 @@ pub enum TableError {
     Unreachable,
 }
 
-pub fn get_name(table_name: &ObjectName) -> Result<&String> {
-    let ObjectName(idents) = table_name;
-    idents.last().ok_or_else(|| TableError::Unreachable.into())
-}
+// pub fn get_name(table_name: &String) -> Result<&String> {
+//     let ObjectName(idents) = table_name;
+//     idents.last().ok_or_else(|| TableError::Unreachable.into())
+// }
 
 pub fn get_alias(table_factor: &TableFactor) -> Result<&String> {
     match table_factor {
         TableFactor::Table {
             name, alias: None, ..
-        } => get_name(name),
+        } => Ok(name),
         TableFactor::Table {
             alias: Some(TableAlias { name, .. }),
             ..
@@ -34,7 +34,7 @@ pub fn get_alias(table_factor: &TableFactor) -> Result<&String> {
         } => Ok(name),
         TableFactor::Series {
             name, alias: None, ..
-        } => get_name(name),
+        } => Ok(name),
         TableFactor::Series {
             alias: Some(TableAlias { name, .. }),
             ..

--- a/core/src/data/table.rs
+++ b/core/src/data/table.rs
@@ -14,11 +14,6 @@ pub enum TableError {
     Unreachable,
 }
 
-// pub fn get_name(table_name: &String) -> Result<&String> {
-//     let ObjectName(idents) = table_name;
-//     idents.last().ok_or_else(|| TableError::Unreachable.into())
-// }
-
 pub fn get_alias(table_factor: &TableFactor) -> Result<&String> {
     match table_factor {
         TableFactor::Table {

--- a/core/src/executor/alter/alter_table.rs
+++ b/core/src/executor/alter/alter_table.rs
@@ -21,7 +21,7 @@ use {
 
 pub async fn alter_table<T: GStore + GStoreMut>(
     storage: T,
-    table_name: &String,
+    table_name: &str,
     operation: &AlterTableOperation,
 ) -> MutResult<T, ()> {
     match operation {

--- a/core/src/executor/alter/alter_table.rs
+++ b/core/src/executor/alter/alter_table.rs
@@ -3,8 +3,7 @@
 use {
     super::validate,
     crate::{
-        ast::{AlterTableOperation, ObjectName},
-        data::get_name,
+        ast::AlterTableOperation,
         result::{MutResult, TrySelf},
         store::{GStore, GStoreMut},
     },
@@ -22,19 +21,13 @@ use {
 
 pub async fn alter_table<T: GStore + GStoreMut>(
     storage: T,
-    name: &ObjectName,
+    table_name: &String,
     operation: &AlterTableOperation,
 ) -> MutResult<T, ()> {
-    let (storage, table_name) = get_name(name).try_self(storage)?;
-
     match operation {
         AlterTableOperation::RenameTable {
             table_name: new_table_name,
-        } => {
-            let (storage, new_table_name) = get_name(new_table_name).try_self(storage)?;
-
-            storage.rename_schema(table_name, new_table_name).await
-        }
+        } => storage.rename_schema(table_name, new_table_name).await,
         AlterTableOperation::RenameColumn {
             old_column_name,
             new_column_name,

--- a/core/src/executor/alter/index.rs
+++ b/core/src/executor/alter/index.rs
@@ -12,8 +12,8 @@ use {
 
 pub async fn create_index<T: GStore + GStoreMut>(
     storage: T,
-    table_name: &String,
-    index_name: &String,
+    table_name: &str,
+    index_name: &str,
     column: &OrderByExpr,
 ) -> MutResult<T, ()> {
     let names = (|| async {

--- a/core/src/executor/alter/mod.rs
+++ b/core/src/executor/alter/mod.rs
@@ -10,5 +10,5 @@ use validate::validate;
 pub use alter_table::alter_table;
 pub use error::AlterError;
 #[cfg(feature = "index")]
-pub use index::{create_index, drop_index};
+pub use index::create_index;
 pub use table::{create_table, drop_table};

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -17,7 +17,7 @@ use {
 
 pub async fn create_table<T: GStore + GStoreMut>(
     storage: T,
-    target_table_name: &String,
+    target_table_name: &str,
     column_defs: &[ColumnDef],
     if_not_exists: bool,
     source: &Option<Box<Query>>,

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -1,11 +1,8 @@
 use {
     super::{validate, AlterError},
     crate::{
-        ast::{
-            ColumnDef, ColumnOption, ColumnOptionDef, ObjectName, Query, SetExpr, TableFactor,
-            Values,
-        },
-        data::{get_name, Schema, TableError},
+        ast::{ColumnDef, ColumnOption, ColumnOptionDef, Query, SetExpr, TableFactor, Values},
+        data::{Schema, TableError},
         executor::{evaluate_stateless, select::select},
         prelude::{DataType, Value},
         result::{Error, IntoControlFlow, MutResult, Result, TrySelf},
@@ -20,26 +17,22 @@ use {
 
 pub async fn create_table<T: GStore + GStoreMut>(
     storage: T,
-    name: &ObjectName,
+    target_table_name: &String,
     column_defs: &[ColumnDef],
     if_not_exists: bool,
     source: &Option<Box<Query>>,
 ) -> MutResult<T, ()> {
-    let (storage, target_table_name) = get_name(name).try_self(storage)?;
     let schema = (|| async {
         let target_columns_defs = match source.as_ref().map(AsRef::as_ref) {
             Some(Query { body, .. }) => match body {
                 SetExpr::Select(select_query) => match &select_query.from.relation {
-                    TableFactor::Table {
-                        name: source_name, ..
-                    } => {
-                        let table_name = get_name(source_name)?;
-                        let schema = storage.fetch_schema(table_name).await?;
+                    TableFactor::Table { name, .. } => {
+                        let schema = storage.fetch_schema(name).await?;
                         let Schema {
                             column_defs: source_column_defs,
                             ..
                         } = schema.ok_or_else(|| -> Error {
-                            AlterError::CtasSourceTableNotFound(table_name.to_owned()).into()
+                            AlterError::CtasSourceTableNotFound(name.to_owned()).into()
                         })?;
 
                         source_column_defs
@@ -155,13 +148,12 @@ pub async fn create_table<T: GStore + GStoreMut>(
 
 pub async fn drop_table<T: GStore + GStoreMut>(
     storage: T,
-    table_names: &[ObjectName],
+    table_names: &[String],
     if_exists: bool,
 ) -> MutResult<T, ()> {
     stream::iter(table_names.iter().map(Ok))
         .try_fold((storage, ()), |(storage, _), table_name| async move {
             let schema = (|| async {
-                let table_name = get_name(table_name)?;
                 let schema = storage.fetch_schema(table_name).await?;
 
                 if !if_exists {

--- a/core/src/executor/select/blend.rs
+++ b/core/src/executor/select/blend.rs
@@ -2,7 +2,7 @@ use {
     super::SelectError,
     crate::{
         ast::{Aggregate, SelectItem},
-        data::{get_name, Row, Value},
+        data::{Row, Value},
         executor::{
             context::{BlendContext, FilterContext},
             evaluate::evaluate,
@@ -55,9 +55,7 @@ impl<'a> Blend<'a> {
                 async move {
                     match item {
                         SelectItem::Wildcard => Ok(context.get_all_values()),
-                        SelectItem::QualifiedWildcard(alias) => {
-                            let table_alias = get_name(alias)?;
-
+                        SelectItem::QualifiedWildcard(table_alias) => {
                             match context.get_alias_values(table_alias) {
                                 Some(values) => Ok(values),
                                 None => Err(SelectError::BlendTableAliasNotFound(

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -17,7 +17,7 @@ use {
     },
     crate::{
         ast::{Expr, OrderByExpr, Query, Select, SelectItem, SetExpr, TableWithJoins, Values},
-        data::{get_alias, get_name, Row, RowError},
+        data::{get_alias, Row, RowError},
         prelude::{DataType, Value},
         result::{Error, Result},
         store::GStore,
@@ -82,9 +82,7 @@ pub fn get_labels<'a>(
                 let labels = labels.map(Ok);
                 Labeled::Wildcard(Wildcard::WithoutJoin(labels))
             }
-            SelectItem::QualifiedWildcard(target) => {
-                let target_table_alias = try_into!(get_name(target));
-
+            SelectItem::QualifiedWildcard(target_table_alias) => {
                 if table_alias == target_table_alias {
                     return Labeled::QualifiedWildcard(to_labels(columns).map(Ok));
                 }

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -1,11 +1,8 @@
 use {
     super::{context::Context, expr::PlanExpr},
-    crate::{
-        ast::{
-            Expr, Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr,
-            TableAlias, TableFactor, TableWithJoins, Values,
-        },
-        data::get_name,
+    crate::ast::{
+        Expr, Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr, TableAlias,
+        TableFactor, TableWithJoins, Values,
     },
     std::{convert::identity, rc::Rc},
 };
@@ -141,17 +138,10 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
 
 fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFactor) -> bool {
     let alias = match table_factor {
-        TableFactor::Table { name, alias, .. } | TableFactor::Series { name, alias, .. } => {
-            let name = match get_name(name) {
-                Ok(name) => name,
-                Err(_) => return false,
-            };
-
-            alias
-                .as_ref()
-                .map(|TableAlias { name, .. }| name.clone())
-                .unwrap_or_else(|| name.clone())
-        }
+        TableFactor::Table { name, alias, .. } | TableFactor::Series { name, alias, .. } => alias
+            .as_ref()
+            .map(|TableAlias { name, .. }| name.clone())
+            .unwrap_or_else(|| name.clone()),
         TableFactor::Derived { alias, .. } => alias.to_owned().name,
     };
 

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -4,7 +4,7 @@ use {
             AstLiteral, BinaryOperator, Expr, IndexItem, IndexOperator, OrderByExpr, Query, Select,
             SetExpr, Statement, TableFactor, TableWithJoins,
         },
-        data::{get_name, Schema, SchemaIndex, SchemaIndexOrd, TableError},
+        data::{Schema, SchemaIndex, SchemaIndexOrd, TableError},
         result::{Error, Result},
     },
     std::collections::HashMap,
@@ -70,7 +70,7 @@ fn plan_query(schema_map: &HashMap<String, Schema>, query: Query) -> Result<Quer
 
     let TableWithJoins { relation, .. } = &select.from;
     let table_name = match relation {
-        TableFactor::Table { name, .. } => get_name(name)?,
+        TableFactor::Table { name, .. } => name,
         TableFactor::Derived { .. } => {
             return Ok(Query {
                 body: SetExpr::Select(select),
@@ -79,7 +79,7 @@ fn plan_query(schema_map: &HashMap<String, Schema>, query: Query) -> Result<Quer
                 offset,
             });
         }
-        TableFactor::Series { name, .. } => get_name(name)?,
+        TableFactor::Series { name, .. } => name,
     };
 
     let indexes = match schema_map.get(table_name) {

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -399,8 +399,8 @@ mod tests {
         crate::{
             ast::{
                 BinaryOperator, DataType, DateTimeField, Expr, Join, JoinConstraint, JoinExecutor,
-                JoinOperator, ObjectName, Query, Select, SelectItem, SetExpr, Statement,
-                TableAlias, TableFactor, TableWithJoins, UnaryOperator,
+                JoinOperator, Query, Select, SelectItem, SetExpr, Statement, TableAlias,
+                TableFactor, TableWithJoins, UnaryOperator,
             },
             parse_sql::{parse, parse_expr},
             plan::{
@@ -446,7 +446,7 @@ mod tests {
 
     fn table_factor(name: &str, alias: Option<&str>) -> TableFactor {
         TableFactor::Table {
-            name: ObjectName(vec![name.to_owned()]),
+            name: name.to_string(),
             alias: alias.map(|alias| TableAlias {
                 name: alias.to_owned(),
                 columns: Vec::new(),
@@ -495,7 +495,7 @@ mod tests {
         let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan_join(&storage, sql);
         let expected = Statement::Delete {
-            table_name: ObjectName(vec!["Player".to_owned()]),
+            table_name: "Player".into(),
             selection: Some(expr("id = 1")),
         };
         assert_eq!(actual, expected, "plan not covered:\n{sql}");

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -446,7 +446,7 @@ mod tests {
 
     fn table_factor(name: &str, alias: Option<&str>) -> TableFactor {
         TableFactor::Table {
-            name: name.to_string(),
+            name: name.to_owned(),
             alias: alias.map(|alias| TableAlias {
                 name: alias.to_owned(),
                 columns: Vec::new(),
@@ -495,7 +495,7 @@ mod tests {
         let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan_join(&storage, sql);
         let expected = Statement::Delete {
-            table_name: "Player".into(),
+            table_name: "Player".to_owned(),
             selection: Some(expr("id = 1")),
         };
         assert_eq!(actual, expected, "plan not covered:\n{sql}");

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -171,7 +171,7 @@ pub trait Planner<'a> {
             TableFactor::Derived { .. } => return next,
         };
 
-        let column_defs = match self.get_schema(&name) {
+        let column_defs = match self.get_schema(name) {
             Some(Schema { column_defs, .. }) => column_defs,
             None => return next,
         };
@@ -193,7 +193,7 @@ pub trait Planner<'a> {
             });
 
         let context = Context::new(
-            alias.unwrap_or(name.to_owned()),
+            alias.unwrap_or_else(|| name.to_owned()),
             columns,
             primary_key,
             next,

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -2,7 +2,7 @@ use {
     super::context::Context,
     crate::{
         ast::{ColumnDef, ColumnOption, ColumnOptionDef, Expr, Query, TableAlias, TableFactor},
-        data::{get_name, Schema},
+        data::Schema,
     },
     std::rc::Rc,
 };
@@ -164,10 +164,6 @@ pub trait Planner<'a> {
     ) -> Option<Rc<Context<'a>>> {
         let (name, alias) = match table_factor {
             TableFactor::Table { name, alias, .. } | TableFactor::Series { name, alias, .. } => {
-                let name = match get_name(name) {
-                    Ok(name) => name.clone(),
-                    Err(_) => return next,
-                };
                 let alias = alias.as_ref().map(|TableAlias { name, .. }| name.clone());
 
                 (name, alias)
@@ -196,7 +192,13 @@ pub trait Planner<'a> {
                     .then(|| name.as_str())
             });
 
-        let context = Context::new(alias.unwrap_or(name), columns, primary_key, next, None);
+        let context = Context::new(
+            alias.unwrap_or(name.to_owned()),
+            columns,
+            primary_key,
+            next,
+            None,
+        );
         Some(Rc::new(context))
     }
 }

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -220,8 +220,8 @@ mod tests {
         crate::{
             ast::{
                 AstLiteral, BinaryOperator, Expr, IndexItem, Join, JoinConstraint, JoinExecutor,
-                JoinOperator, ObjectName, Query, Select, SelectItem, SetExpr, Statement,
-                TableFactor, TableWithJoins, Values,
+                JoinOperator, Query, Select, SelectItem, SetExpr, Statement, TableFactor,
+                TableWithJoins, Values,
             },
             parse_sql::{parse, parse_expr},
             plan::{
@@ -271,7 +271,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -289,7 +289,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -307,7 +307,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -331,7 +331,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -364,7 +364,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -396,13 +396,13 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["Badge".to_owned()]),
+                        name: "Badge".into(),
                         alias: None,
                         index: None,
                     },
@@ -422,13 +422,13 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: None,
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["Badge".to_owned()]),
+                        name: "Badge".into(),
                         alias: None,
                         index: None,
                     },
@@ -454,7 +454,7 @@ mod tests {
                     projection: vec![SelectItem::Wildcard],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["Player".to_owned()]),
+                            name: "Player".into(),
                             alias: None,
                             index: Some(IndexItem::PrimaryKey(expr("1"))),
                         },
@@ -473,7 +473,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["Player".to_owned()]),
+                        name: "Player".into(),
                         alias: None,
                         index: None,
                     },
@@ -511,7 +511,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["Player".to_owned()]),
+                            name: "Player".into(),
                             alias: None,
                             index: None,
                         },
@@ -530,7 +530,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["Player".to_owned()]),
+                        name: "Player".into(),
                         alias: None,
                         index: None,
                     },
@@ -562,7 +562,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: ObjectName(vec!["Player".to_owned()]),
+                            name: "Player".into(),
                             alias: None,
                             index: None,
                         },
@@ -581,7 +581,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: ObjectName(vec!["Player".to_owned()]),
+                        name: "Player".into(),
                         alias: None,
                         index: None,
                     },
@@ -601,7 +601,7 @@ mod tests {
         let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan(&storage, sql);
         let expected = Statement::Delete {
-            table_name: ObjectName(vec!["Player".to_owned()]),
+            table_name: "Player".into(),
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("id".to_owned())),
                 op: BinaryOperator::Eq,
@@ -629,7 +629,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: ObjectName(vec!["Player".to_owned()]),
+                    name: "Player".into(),
                     alias: None,
                     index: None,
                 },

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -271,7 +271,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -289,7 +289,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -307,7 +307,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -331,7 +331,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -364,7 +364,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
@@ -396,13 +396,13 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: Some(IndexItem::PrimaryKey(expr("1"))),
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
-                        name: "Badge".into(),
+                        name: "Badge".to_owned(),
                         alias: None,
                         index: None,
                     },
@@ -422,13 +422,13 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: None,
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
-                        name: "Badge".into(),
+                        name: "Badge".to_owned(),
                         alias: None,
                         index: None,
                     },
@@ -454,7 +454,7 @@ mod tests {
                     projection: vec![SelectItem::Wildcard],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: "Player".into(),
+                            name: "Player".to_owned(),
                             alias: None,
                             index: Some(IndexItem::PrimaryKey(expr("1"))),
                         },
@@ -473,7 +473,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: "Player".into(),
+                        name: "Player".to_owned(),
                         alias: None,
                         index: None,
                     },
@@ -511,7 +511,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: "Player".into(),
+                            name: "Player".to_owned(),
                             alias: None,
                             index: None,
                         },
@@ -530,7 +530,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: "Player".into(),
+                        name: "Player".to_owned(),
                         alias: None,
                         index: None,
                     },
@@ -562,7 +562,7 @@ mod tests {
                     }],
                     from: TableWithJoins {
                         relation: TableFactor::Table {
-                            name: "Player".into(),
+                            name: "Player".to_owned(),
                             alias: None,
                             index: None,
                         },
@@ -581,7 +581,7 @@ mod tests {
                 projection: vec![SelectItem::Wildcard],
                 from: TableWithJoins {
                     relation: TableFactor::Table {
-                        name: "Player".into(),
+                        name: "Player".to_owned(),
                         alias: None,
                         index: None,
                     },
@@ -601,7 +601,7 @@ mod tests {
         let sql = "DELETE FROM Player WHERE id = 1;";
         let actual = plan(&storage, sql);
         let expected = Statement::Delete {
-            table_name: "Player".into(),
+            table_name: "Player".to_owned(),
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("id".to_owned())),
                 op: BinaryOperator::Eq,
@@ -629,7 +629,7 @@ mod tests {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
                 relation: TableFactor::Table {
-                    name: "Player".into(),
+                    name: "Player".to_owned(),
                     alias: None,
                     index: None,
                 },

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -49,8 +49,6 @@ pub async fn fetch_schema_map(
             stream::iter(names)
                 .map(Ok)
                 .try_filter_map(|table_name| async move {
-                    // let table_name = get_name(table_name)?;
-
                     Ok(storage
                         .fetch_schema(table_name)
                         .await?

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -5,7 +5,7 @@ use {
             Expr, Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr,
             Statement, TableFactor, TableWithJoins,
         },
-        data::{get_name, Schema},
+        data::Schema,
         result::Result,
         store::Store,
     },
@@ -31,7 +31,6 @@ pub async fn fetch_schema_map(
         Statement::Insert {
             table_name, source, ..
         } => {
-            let table_name = get_name(table_name)?;
             let table_schema = storage
                 .fetch_schema(table_name)
                 .await?
@@ -50,7 +49,7 @@ pub async fn fetch_schema_map(
             stream::iter(names)
                 .map(Ok)
                 .try_filter_map(|table_name| async move {
-                    let table_name = get_name(table_name)?;
+                    // let table_name = get_name(table_name)?;
 
                     Ok(storage
                         .fetch_schema(table_name)
@@ -172,8 +171,7 @@ async fn scan_join(storage: &dyn Store, join: &Join) -> Result<Vec<Schema>> {
 async fn scan_table_factor(storage: &dyn Store, table_factor: &TableFactor) -> Result<Vec<Schema>> {
     match table_factor {
         TableFactor::Table { name, .. } => {
-            let table_name = get_name(name)?;
-            let schema = storage.fetch_schema(table_name).await?;
+            let schema = storage.fetch_schema(name).await?;
             let schema_list = schema.map(|schema| vec![schema]).unwrap_or_else(Vec::new);
 
             Ok(schema_list)

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -41,7 +41,7 @@ pub fn translate_alter_table_operation(
         }),
         SqlAlterTableOperation::RenameTable { table_name } => {
             Ok(AlterTableOperation::RenameTable {
-                table_name: translate_object_name(table_name),
+                table_name: translate_object_name(table_name)?,
             })
         }
         _ => Err(TranslateError::UnsupportedAlterTableOperation(

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -116,4 +116,10 @@ pub enum TranslateError {
 
     #[error("Series should have size")]
     LackOfArgs,
+
+    #[error("unreachable empty object")]
+    UnreachableEmptyObject,
+
+    #[error("unimplemented - compound object is supported: {0}")]
+    CompoundObjectNotSupported(String),
 }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -4,7 +4,7 @@ use {
         TranslateError,
     },
     crate::{
-        ast::{Aggregate, CountArgExpr, Expr, Function, ObjectName},
+        ast::{Aggregate, CountArgExpr, Expr, Function},
         result::Result,
     },
     sqlparser::ast::{
@@ -144,11 +144,7 @@ pub fn translate_function_arg_exprs(
 
 pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let SqlFunction { name, args, .. } = sql_function;
-    let name = {
-        let ObjectName(names) = translate_object_name(name);
-
-        names[0].to_uppercase()
-    };
+    let name = translate_object_name(name).to_uppercase();
 
     let function_arg_exprs = args
         .iter()
@@ -166,8 +162,8 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         let count_arg = match function_arg_exprs[0] {
             SqlFunctionArgExpr::Expr(expr) => CountArgExpr::Expr(translate_expr(expr)?),
             SqlFunctionArgExpr::QualifiedWildcard(idents) => {
-                let ObjectName(idents) = translate_object_name(idents);
-                let idents = format!("{}.*", idents.join("."));
+                let table_name = translate_object_name(idents);
+                let idents = format!("{}.*", table_name);
 
                 return Err(TranslateError::QualifiedWildcardInCountNotSupported(idents).into());
             }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -144,7 +144,7 @@ pub fn translate_function_arg_exprs(
 
 pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let SqlFunction { name, args, .. } = sql_function;
-    let name = translate_object_name(name).to_uppercase();
+    let name = translate_object_name(name)?.to_uppercase();
 
     let function_arg_exprs = args
         .iter()
@@ -162,7 +162,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         let count_arg = match function_arg_exprs[0] {
             SqlFunctionArgExpr::Expr(expr) => CountArgExpr::Expr(translate_expr(expr)?),
             SqlFunctionArgExpr::QualifiedWildcard(idents) => {
-                let table_name = translate_object_name(idents);
+                let table_name = translate_object_name(idents)?;
                 let idents = format!("{}.*", table_name);
 
                 return Err(TranslateError::QualifiedWildcardInCountNotSupported(idents).into());

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -24,7 +24,7 @@ use crate::ast::Variable;
 
 use {
     crate::{
-        ast::{Assignment, ObjectName, Statement},
+        ast::{Assignment, Statement},
         result::Result,
     },
     sqlparser::ast::{
@@ -135,8 +135,8 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
                 return Err(TranslateError::InvalidParamsInDropIndex.into());
             }
 
-            let table_name = ObjectName(vec![object_name[0].value.to_owned()]);
-            let name = ObjectName(vec![object_name[1].value.to_owned()]);
+            let table_name = object_name[0].value.to_owned();
+            let name = object_name[1].value.to_owned();
 
             Ok(Statement::DropIndex { name, table_name })
         }
@@ -161,11 +161,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             #[cfg(feature = "index")]
             (3, Some(keyword)) => match keyword.value.to_uppercase().as_str() {
                 "INDEXES" => match variable.get(2) {
-                    Some(tablename) => {
-                        Ok(Statement::ShowIndexes(ObjectName(Vec::from([tablename
-                            .value
-                            .to_string()]))))
-                    }
+                    Some(tablename) => Ok(Statement::ShowIndexes(tablename.value.to_owned())),
                     _ => Err(TranslateError::UnsupportedShowVariableStatement(
                         sql_statement.to_string(),
                     )
@@ -206,7 +202,7 @@ pub fn translate_assignment(sql_assignment: &SqlAssignment) -> Result<Assignment
     })
 }
 
-fn translate_table_with_join(table: &TableWithJoins) -> Result<ObjectName> {
+fn translate_table_with_join(table: &TableWithJoins) -> Result<String> {
     if !table.joins.is_empty() {
         return Err(TranslateError::JoinOnUpdateNotSupported.into());
     }
@@ -216,8 +212,9 @@ fn translate_table_with_join(table: &TableWithJoins) -> Result<ObjectName> {
     }
 }
 
-fn translate_object_name(sql_object_name: &SqlObjectName) -> ObjectName {
-    ObjectName(translate_idents(&sql_object_name.0))
+fn translate_object_name(sql_object_name: &SqlObjectName) -> String {
+    // translate_idents(&sql_object_name.0)
+    sql_object_name.0[0].value.to_owned()
 }
 
 pub fn translate_idents(idents: &[SqlIdent]) -> Vec<String> {

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -216,9 +216,9 @@ fn translate_table_with_join(table: &TableWithJoins) -> Result<String> {
 }
 
 fn translate_object_name(sql_object_name: &SqlObjectName) -> Result<String> {
-    let sql_object_name = sql_object_name.0.to_owned();
+    let sql_object_name = &sql_object_name.0;
     if sql_object_name.len() > 1 {
-        let compound_object_name = translate_idents(&sql_object_name).join(".");
+        let compound_object_name = translate_idents(sql_object_name).join(".");
         return Err(TranslateError::CompoundObjectNotSupported(compound_object_name).into());
     }
 

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -42,7 +42,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             source,
             ..
         } => Ok(Statement::Insert {
-            table_name: translate_object_name(table_name),
+            table_name: translate_object_name(table_name)?,
             columns: translate_idents(columns),
             source: translate_query(source)?,
         }),
@@ -66,7 +66,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             selection,
             ..
         } => Ok(Statement::Delete {
-            table_name: translate_object_name(table_name),
+            table_name: translate_object_name(table_name)?,
             selection: selection.as_ref().map(translate_expr).transpose()?,
         }),
         SqlStatement::CreateTable {
@@ -77,7 +77,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             ..
         } => Ok(Statement::CreateTable {
             if_not_exists: *if_not_exists,
-            name: translate_object_name(name),
+            name: translate_object_name(name)?,
             columns: columns
                 .iter()
                 .map(translate_column_def)
@@ -91,7 +91,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
         SqlStatement::AlterTable {
             name, operation, ..
         } => Ok(Statement::AlterTable {
-            name: translate_object_name(name),
+            name: translate_object_name(name)?,
             operation: translate_alter_table_operation(operation)?,
         }),
         SqlStatement::Drop {
@@ -101,7 +101,10 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             ..
         } => Ok(Statement::DropTable {
             if_exists: *if_exists,
-            names: names.iter().map(translate_object_name).collect(),
+            names: names
+                .iter()
+                .map(translate_object_name)
+                .collect::<Result<Vec<_>>>()?,
         }),
         #[cfg(feature = "index")]
         SqlStatement::CreateIndex {
@@ -115,8 +118,8 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             }
 
             Ok(Statement::CreateIndex {
-                name: translate_object_name(name),
-                table_name: translate_object_name(table_name),
+                name: translate_object_name(name)?,
+                table_name: translate_object_name(table_name)?,
                 column: translate_order_by_expr(&columns[0])?,
             })
         }
@@ -177,7 +180,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             ),
         },
         SqlStatement::ShowColumns { table_name, .. } => Ok(Statement::ShowColumns {
-            table_name: translate_object_name(table_name),
+            table_name: translate_object_name(table_name)?,
         }),
         _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
     }
@@ -207,13 +210,22 @@ fn translate_table_with_join(table: &TableWithJoins) -> Result<String> {
         return Err(TranslateError::JoinOnUpdateNotSupported.into());
     }
     match &table.relation {
-        TableFactor::Table { name, .. } => Ok(translate_object_name(name)),
+        TableFactor::Table { name, .. } => translate_object_name(name),
         t => Err(TranslateError::UnsupportedTableFactor(t.to_string()).into()),
     }
 }
 
-fn translate_object_name(sql_object_name: &SqlObjectName) -> String {
-    sql_object_name.0[0].value.to_owned()
+fn translate_object_name(sql_object_name: &SqlObjectName) -> Result<String> {
+    let sql_object_name = sql_object_name.0.to_owned();
+    if sql_object_name.len() > 1 {
+        let compound_object_name = translate_idents(&sql_object_name).join(".");
+        return Err(TranslateError::CompoundObjectNotSupported(compound_object_name).into());
+    }
+
+    sql_object_name
+        .get(0)
+        .map(|v| v.value.to_owned())
+        .ok_or_else(|| TranslateError::UnreachableEmptyObject.into())
 }
 
 pub fn translate_idents(idents: &[SqlIdent]) -> Vec<String> {

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -213,7 +213,6 @@ fn translate_table_with_join(table: &TableWithJoins) -> Result<String> {
 }
 
 fn translate_object_name(sql_object_name: &SqlObjectName) -> String {
-    // translate_idents(&sql_object_name.0)
     sql_object_name.0[0].value.to_owned()
 }
 

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -123,7 +123,7 @@ pub fn translate_select_item(sql_select_item: &SqlSelectItem) -> Result<SelectIt
             })
         }
         SqlSelectItem::QualifiedWildcard(object_name) => Ok(SelectItem::QualifiedWildcard(
-            translate_object_name(object_name),
+            translate_object_name(object_name)?,
         )),
         SqlSelectItem::Wildcard => Ok(SelectItem::Wildcard),
     }
@@ -171,16 +171,16 @@ fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFact
     match sql_table_factor {
         SqlTableFactor::Table {
             name, alias, args, ..
-        } if translate_object_name(name).to_uppercase() == "SERIES" && args.is_some() => {
+        } if translate_object_name(name)?.to_uppercase() == "SERIES" && args.is_some() => {
             Ok(TableFactor::Series {
-                name: translate_object_name(name),
+                name: translate_object_name(name)?,
                 alias: translate_table_alias(alias),
                 size: translate_table_args(args)?,
             })
         }
         SqlTableFactor::Table { name, alias, .. } => {
             Ok(TableFactor::Table {
-                name: translate_object_name(name),
+                name: translate_object_name(name)?,
                 alias: translate_table_alias(alias),
                 index: None, // query execution plan
             })

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -80,7 +80,7 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
         Some(sql_table_with_joins) => translate_table_with_joins(sql_table_with_joins)?,
         None => TableWithJoins {
             relation: TableFactor::Series {
-                name: "Series".into(),
+                name: "Series".to_owned(),
                 alias: None,
                 size: Expr::Literal(AstLiteral::Number(1.into())),
             },

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -5,10 +5,9 @@ use {
     },
     crate::{
         ast::{
-            AstLiteral, Expr, Join, JoinConstraint, JoinExecutor, JoinOperator, ObjectName, Query,
-            Select, SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, Values,
+            AstLiteral, Expr, Join, JoinConstraint, JoinExecutor, JoinOperator, Query, Select,
+            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, Values,
         },
-        data::get_name,
         result::Result,
     },
     sqlparser::ast::{
@@ -81,7 +80,7 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
         Some(sql_table_with_joins) => translate_table_with_joins(sql_table_with_joins)?,
         None => TableWithJoins {
             relation: TableFactor::Series {
-                name: ObjectName(vec!["Series".into()]),
+                name: "Series".into(),
                 alias: None,
                 size: Expr::Literal(AstLiteral::Number(1.into())),
             },
@@ -172,9 +171,7 @@ fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFact
     match sql_table_factor {
         SqlTableFactor::Table {
             name, alias, args, ..
-        } if get_name(&translate_object_name(name))?.to_uppercase() == "SERIES"
-            && args.is_some() =>
-        {
+        } if translate_object_name(name).to_uppercase() == "SERIES" && args.is_some() => {
             Ok(TableFactor::Series {
                 name: translate_object_name(name),
                 alias: translate_table_alias(alias),

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -59,7 +59,7 @@ CREATE TABLE TestA (
         ),
         (
             "SELECT id FROM FOO.Test",
-            Err(TranslateError::CompoundObjectNotSupported("FOO.Test".into()).into()),
+            Err(TranslateError::CompoundObjectNotSupported("FOO.Test".to_owned()).into()),
         ),
     ];
 

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -1,4 +1,7 @@
-use {crate::*, gluesql_core::prelude::Value::*};
+use {
+    crate::*,
+    gluesql_core::{prelude::Value::*, translate::TranslateError},
+};
 
 test_case!(basic, async move {
     run!(
@@ -53,6 +56,10 @@ CREATE TABLE TestA (
         (
             "SELECT id, num FROM Test",
             Ok(select!(id | num; I64 | I64; 2 2; 2 9; 2 4; 2 7)),
+        ),
+        (
+            "SELECT id FROM FOO.Test",
+            Err(TranslateError::CompoundObjectNotSupported("FOO.Test".into()).into()),
         ),
     ];
 


### PR DESCRIPTION
## Goal
Currently table_name, alias and index_name are using `ObjectName(Vec<String>)` but redundant.
Let's replace all `ObjectName` with `String`

## Todo
- [x] replace all `ObjectName` with `String`
- [x] Throw Error if the number of `ObjectName` is more than 2

## In Future
To support multiple schemas or databases in future, it would be inevitable to replace with better struct.