### PR TITLE
Implement str_position function under enum Value

### DIFF
--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -169,7 +169,7 @@ pub enum ValueError {
     SqrtOnNonNumeric(Value),
 
     #[error("non string value found: from_string is {0:?}, sub_string is {1:?}")]
-    StrPositionOnNonString(Value, Value),
+    UnSupportedArgumentInFunctionPosition(Value, Value),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -168,8 +168,8 @@ pub enum ValueError {
     #[error("non numeric value in sqrt {0:?}")]
     SqrtOnNonNumeric(Value),
 
-    #[error("non string value found: from_string is {0:?}, sub_string is {1:?}")]
-    UnSupportedArgumentInFunctionPosition(Value, Value),
+    #[error("unsupported value by position function: from_str(from_str:?), sub_str(sub_str:?)")]
+    UnSupportedValueByPositionFunction { from_str: Value, sub_str: Value },
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -167,6 +167,9 @@ pub enum ValueError {
 
     #[error("non numeric value in sqrt {0:?}")]
     SqrtOnNonNumeric(Value),
+
+    #[error("non string value found: from_string is {0:?}, sub_string is {1:?}")]
+    StrPositionOnNonString(Value, Value),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -585,10 +585,10 @@ impl Value {
         match (self, other) {
             (Str(from_str), Str(sub_str)) => Ok(I64(str_position(from_str, sub_str) as i64)),
             (Null, _) | (_, Null) => Ok(Null),
-            _ => Err(ValueError::UnSupportedArgumentInFunctionPosition(
-                self.clone(),
-                other.clone(),
-            )
+            _ => Err(ValueError::UnSupportedValueByPositionFunction {
+                from_str: self.clone(),
+                sub_str: other.clone(),
+            }
             .into()),
         }
     }
@@ -1539,7 +1539,11 @@ mod tests {
         assert_eq!(str1.position(&empty_str), Ok(I64(0)));
         assert_eq!(
             str1.position(&I64(1)),
-            Err(ValueError::UnSupportedArgumentInFunctionPosition(str1, I64(1)).into())
+            Err(ValueError::UnSupportedValueByPositionFunction {
+                from_str: str1,
+                sub_str: I64(1)
+            }
+            .into())
         );
     }
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -560,9 +560,9 @@ impl Value {
     ///
     /// Returns the position where the first letter of the substring starts if the string contains a substring.
     ///
-    /// Returns `I64(0)` if the string to be found is not found.
-    /// Returns minimum value `I64(1)` when the string is found.
-    /// Returns Null if NULL parameter found.
+    /// Returns [`Value::I64(0)`] if the string to be found is not found.
+    /// Returns minimum value [`Value::I64(1)`] when the string is found.
+    /// Returns [`Value::Null`] if NULL parameter found.
     ///
     /// # Examples
     ///

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -560,8 +560,8 @@ impl Value {
     /// 1. If both arguments are String
     ///     - Support only [`Value::Str`] variant
     ///     - Returns the position where the first letter of the substring starts if the string contains a substring.
-    ///     - Returns [`Value::I64(0)`] if the string to be found is not found.
-    ///     - Returns minimum value [`Value::I64(1)`] when the string is found.
+    ///     - Returns [`Value::I64`] 0 if the string to be found is not found.
+    ///     - Returns minimum value [`Value::I64`] 1 when the string is found.
     ///     - Returns [`Value::Null`] if NULL parameter found.
     ///
     /// 2. Other arguments
@@ -606,10 +606,10 @@ fn str_position(from_str: &String, sub_str: &String) -> usize {
     if from_str.is_empty() || sub_str.is_empty() {
         return 0;
     }
-    match from_str.find(sub_str).map(|position| position + 1) {
-        Some(pos) => pos,
-        None => 0,
-    }
+    from_str
+        .find(sub_str)
+        .map(|position| position + 1)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -556,13 +556,17 @@ impl Value {
         self.try_into().map(|key: Key| key.to_cmp_be_bytes())
     }
 
-    /// only Value::Str type allowed
-    /// returns positon of substring from string
-    /// if there are substring in string, returns the position where the first letter of the substring begins. The minimum value is 1
-    /// else returns 0 because there is no substring to find within the string
+    /// Support only [`Value::Str`] variant
+    ///
+    /// Returns the position where the first letter of the substring starts if the string contains a substring.
+    ///
+    /// Returns `0` if the string to be found is not found.
+    /// Returns minimum value `1` when the string is found.
+    ///
     /// # Examples
+    ///
     /// ```
-    /// use gluesql_core::data::{ValueError, value::Value::*};
+    /// use gluesql::core::data::{ValueError, value::Value::*};
     ///
     /// let str1 = Str("ramen".to_string());
     /// let str2 = Str("men".to_string());
@@ -582,13 +586,14 @@ impl Value {
         use Value::*;
         match (self, other) {
             (Str(from_str), Str(sub_str)) => {
-                if from_str == &"".to_string() || sub_str == &"".to_string() {
+                if from_str == "" || sub_str == "" {
                     return Ok(0);
                 }
-                match from_str.find(sub_str).map(|position| position + 1) {
-                    Some(pos) => Ok(pos),
-                    None => Ok(0),
-                }
+
+                Ok(from_str
+                    .find(sub_str)
+                    .map(|position| position + 1)
+                    .unwrap_or(0))
             }
             (Null, Str(_)) | (Str(_), Null) => Ok(0),
             _ => Err(ValueError::StrPositionOnNonString(self.clone(), other.clone()).into()),

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -556,6 +556,7 @@ impl Value {
         self.try_into().map(|key: Key| key.to_cmp_be_bytes())
     }
 
+    /// # Description
     /// The operation method differs depending on the argument.
     /// 1. If both arguments are String
     ///     - Support only [`Value::Str`] variant
@@ -569,25 +570,16 @@ impl Value {
     ///
     /// # Examples
     /// ```
-    /// use gluesql_core::{
-    ///     data::ValueError,
-    ///     prelude::Value::*
-    /// };
+    /// use gluesql_core::prelude::Value;
     ///
-    /// let str1 = Str("ramen".to_string());
-    /// let str2 = Str("men".to_string());
-    /// let empty_str = Str("".to_string());
-    /// assert_eq!(str1.position(&str2), Ok(I64(3)));
-    /// assert_eq!(str2.position(&str1), Ok(I64(0)));
-    /// assert!(Null.position(&str2).unwrap().is_null());
-    /// assert!(str1.position(&Null).unwrap().is_null());
-    /// assert_eq!(empty_str.position(&str2), Ok(I64(0)));
-    /// assert_eq!(str1.position(&empty_str), Ok(I64(0)));
-    /// assert_eq!(
-    ///     str1.position(&I64(1)),
-    ///     Err(ValueError::UnSupportedArgumentInFunctionPosition(str1, I64(1)).into())
-    /// );
+    /// let str1 = Value::Str("ramen".to_string());
+    /// let str2 = Value::Str("men".to_string());
+    /// assert_eq!(str1.position(&str2), Ok(Value::I64(3)));
+    /// assert_eq!(str2.position(&str1), Ok(Value::I64(0)));
+    /// assert!(Value::Null.position(&str2).unwrap().is_null());
+    /// assert!(str1.position(&Value::Null).unwrap().is_null());
     /// ```
+
     pub fn position(&self, other: &Value) -> Result<Value> {
         use Value::*;
         match (self, other) {

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -586,7 +586,7 @@ impl Value {
         use Value::*;
         match (self, other) {
             (Str(from_str), Str(sub_str)) => {
-                if from_str == "" || sub_str == "" {
+                if from_str.is_empty() || sub_str.is_empty() {
                     return Ok(0);
                 }
 


### PR DESCRIPTION
## Background
for #855 

### mysql POSITION function return examples
```sql
SELECT POSITION("h" IN "sushi") AS MatchPosition;
```
|MatchPosition|
|----------------|
|4|

```sql
SELECT POSITION("" IN "sushi") AS MatchPosition;
```
|MatchPosition|
|----------------|
|1|

```sql
SELECT POSITION(NULL IN "sushi") AS MatchPosition;
```
|MatchPosition|
|----------------|
|NULL|

```sql
SELECT POSITION(-1 IN "sushi") AS MatchPosition;
```
|MatchPosition|
|----------------|
|0|

```sql
SELECT POSITION(2022-09-25 IN "sushi") AS MatchPosition;
```
|MatchPosition|
|----------------|
|0|

## Description
Added function to support mysql's `POSITION` function.

Since the substring and string to be parsed and received as an argument in the sql statement are value types in glusql, the str_position function has been implemented for the operation.

If `empty_string` found in arguments, I64(0) is returned.
If `substring in string found`, the position of the first occurrence is returned. The minimum value is I64(1).
If `NULL found` in arguments, Null is returned. 
Although mysql returns 0 for other types of arguments, I decided to display an Error for types other than string and null.

## Tasks
- [x] Write implementation
- [x] Add unit, doc Tests
- [x] Add Error