### PR TITLE
Remove Result from core/ table::get_alias return type

### DIFF
--- a/core/src/data/table.rs
+++ b/core/src/data/table.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        ast::{IndexItem, TableAlias, TableFactor},
-        result::Result,
-    },
+    crate::ast::{IndexItem, TableAlias, TableFactor},
     serde::Serialize,
     std::fmt::Debug,
     thiserror::Error,
@@ -14,26 +11,26 @@ pub enum TableError {
     Unreachable,
 }
 
-pub fn get_alias(table_factor: &TableFactor) -> Result<&String> {
+pub fn get_alias(table_factor: &TableFactor) -> &String {
     match table_factor {
         TableFactor::Table {
             name, alias: None, ..
-        } => Ok(name),
-        TableFactor::Table {
+        }
+        | TableFactor::Table {
             alias: Some(TableAlias { name, .. }),
             ..
         }
         | TableFactor::Derived {
             alias: TableAlias { name, .. },
             ..
-        } => Ok(name),
-        TableFactor::Series {
+        }
+        | TableFactor::Series {
             name, alias: None, ..
-        } => Ok(name),
-        TableFactor::Series {
+        }
+        | TableFactor::Series {
             alias: Some(TableAlias { name, .. }),
             ..
-        } => Ok(name),
+        } => name,
     }
 }
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -199,7 +199,7 @@ pub async fn fetch_relation_columns(
                 let join_columns = fetch_join_columns(joins, storage).await?;
                 let labels = get_labels(
                     projection,
-                    get_alias(relation)?,
+                    get_alias(relation),
                     &columns,
                     Some(&join_columns),
                 )?;
@@ -235,7 +235,7 @@ pub async fn fetch_join_columns<'a>(
         .map(Ok::<_, Error>)
         .and_then(|join| async move {
             let relation = &join.relation;
-            let alias = get_alias(relation)?;
+            let alias = get_alias(relation);
             let columns = fetch_relation_columns(storage, relation).await?;
             Ok((alias, columns))
         })

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -91,7 +91,7 @@ async fn join<'a>(
         join_executor,
     } = ast_join;
 
-    let table_alias = get_alias(relation)?;
+    let table_alias = get_alias(relation);
     let join_executor = JoinExecutor::new(
         storage,
         relation,
@@ -246,7 +246,7 @@ impl<'a> JoinExecutor<'a> {
 
                 async move {
                     let filter_context = Rc::new(FilterContext::new(
-                        get_alias(relation)?,
+                        get_alias(relation),
                         columns,
                         Some(&row),
                         filter_context,

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -222,7 +222,7 @@ pub async fn select_with_labels<'a>(
             .map(move |row| {
                 let row = Some(row?);
                 let columns = Rc::clone(&columns);
-                let alias = get_alias(relation)?;
+                let alias = get_alias(relation);
                 Ok(BlendContext::new(alias, columns, Single(row), None))
             })
     };
@@ -231,7 +231,7 @@ pub async fn select_with_labels<'a>(
     let labels = if with_labels {
         get_labels(
             projection,
-            get_alias(relation)?,
+            get_alias(relation),
             &columns,
             Some(&join_columns),
         )?
@@ -302,7 +302,7 @@ pub async fn select_with_labels<'a>(
 
     let labels = Rc::new(labels);
     let rows = sort
-        .apply(rows, Rc::clone(&labels), get_alias(relation)?)
+        .apply(rows, Rc::clone(&labels), get_alias(relation))
         .await?;
 
     let rows = limit.apply(rows);


### PR DESCRIPTION
core table::get_alias does not return error so remove `Result` from the return type.
`get_alias` now simply returns `&String`.