### PR TITLE
refactor: remove redundant TableFactor::Series.name

### DIFF
--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -67,8 +67,7 @@ pub enum TableFactor {
         alias: TableAlias,
     },
     Series {
-        name: String,
-        alias: Option<TableAlias>,
+        alias: TableAlias,
         size: Expr,
     },
 }

--- a/core/src/data/table.rs
+++ b/core/src/data/table.rs
@@ -25,10 +25,7 @@ pub fn get_alias(table_factor: &TableFactor) -> &String {
             ..
         }
         | TableFactor::Series {
-            name, alias: None, ..
-        }
-        | TableFactor::Series {
-            alias: Some(TableAlias { name, .. }),
+            alias: TableAlias { name, .. },
             ..
         } => name,
     }

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -138,11 +138,13 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
 
 fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFactor) -> bool {
     let alias = match table_factor {
-        TableFactor::Table { name, alias, .. } | TableFactor::Series { name, alias, .. } => alias
+        TableFactor::Table { name, alias, .. } => alias
             .as_ref()
             .map(|TableAlias { name, .. }| name.clone())
             .unwrap_or_else(|| name.clone()),
-        TableFactor::Derived { alias, .. } => alias.to_owned().name,
+        TableFactor::Derived { alias, .. } | TableFactor::Series { alias, .. } => {
+            alias.to_owned().name
+        }
     };
 
     context

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -163,12 +163,12 @@ pub trait Planner<'a> {
         table_factor: &TableFactor,
     ) -> Option<Rc<Context<'a>>> {
         let (name, alias) = match table_factor {
-            TableFactor::Table { name, alias, .. } | TableFactor::Series { name, alias, .. } => {
+            TableFactor::Table { name, alias, .. } => {
                 let alias = alias.as_ref().map(|TableAlias { name, .. }| name.clone());
 
                 (name, alias)
             }
-            TableFactor::Derived { .. } => return next,
+            TableFactor::Derived { .. } | TableFactor::Series { .. } => return next,
         };
 
         let column_defs = match self.get_schema(name) {

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -80,8 +80,10 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
         Some(sql_table_with_joins) => translate_table_with_joins(sql_table_with_joins)?,
         None => TableWithJoins {
             relation: TableFactor::Series {
-                name: "Series".to_owned(),
-                alias: None,
+                alias: TableAlias {
+                    name: "Seires".to_owned(),
+                    columns: Vec::new(),
+                },
                 size: Expr::Literal(AstLiteral::Number(1.into())),
             },
             joins: vec![],
@@ -172,9 +174,16 @@ fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFact
         SqlTableFactor::Table {
             name, alias, args, ..
         } if translate_object_name(name)?.to_uppercase() == "SERIES" && args.is_some() => {
+            let name = match alias {
+                Some(SqlTableAlias { name, .. }) => name.value.to_owned(),
+                None => translate_object_name(name)?,
+            };
+
             Ok(TableFactor::Series {
-                name: translate_object_name(name)?,
-                alias: translate_table_alias(alias),
+                alias: TableAlias {
+                    name,
+                    columns: Vec::new(),
+                },
                 size: translate_table_args(args)?,
             })
         }


### PR DESCRIPTION
## Goal
The `TableFactor` which does not fetch data from storage with `specific table_name` does not need to own `name`.

Instead, Let's use alias and remove Tablefactor::Series.name. 
(If there is no alias, consider name as a alias)