### PR TITLE
Implement ValidationContext(schema_map + alias) to enhance validation of ambiguous columns

### DIFF
--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -23,7 +23,6 @@ pub use {
 
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
-
     let schema_context = update_schema_context(&schema_map, &statement);
 
     // let statement = validate(&schema_map, statement)?;

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -12,10 +12,7 @@ mod validate;
 #[cfg(test)]
 mod mock;
 
-use {
-    self::validate::contextualize_stmt,
-    crate::{ast::Statement, result::Result, store::Store},
-};
+use crate::{ast::Statement, result::Result, store::Store};
 
 pub use {
     self::validate::validate, error::*, index::plan as plan_index, join::plan as plan_join,
@@ -24,8 +21,7 @@ pub use {
 
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
-    let validation_context = contextualize_stmt(&schema_map, &statement);
-    validate(validation_context, &statement)?;
+    validate(&schema_map, &statement)?;
     let statement = plan_primary_key(&schema_map, statement);
     let statement = plan_index(&schema_map, statement)?;
     let statement = plan_join(&schema_map, statement);

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -12,9 +12,10 @@ mod validate;
 #[cfg(test)]
 mod mock;
 
-use crate::{ast::Statement, result::Result, store::Store};
-
-use self::validate::update_schema_context;
+use {
+    self::validate::update_schema_context,
+    crate::{ast::Statement, result::Result, store::Store},
+};
 
 pub use {
     self::validate::validate, error::*, index::plan as plan_index, join::plan as plan_join,

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -24,10 +24,7 @@ pub use {
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
     let schema_context = update_schema_context(&schema_map, &statement);
-
-    // let statement = validate(&schema_map, statement)?;
     validate(schema_context, &statement)?;
-
     let statement = plan_primary_key(&schema_map, statement);
     let statement = plan_index(&schema_map, statement)?;
     let statement = plan_join(&schema_map, statement);

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -13,7 +13,7 @@ mod validate;
 mod mock;
 
 use {
-    self::validate::update_validation_context,
+    self::validate::contextualize_stmt,
     crate::{ast::Statement, result::Result, store::Store},
 };
 
@@ -24,7 +24,7 @@ pub use {
 
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
-    let validation_context = update_validation_context(&schema_map, &statement);
+    let validation_context = contextualize_stmt(&schema_map, &statement);
     validate(validation_context, &statement)?;
     let statement = plan_primary_key(&schema_map, statement);
     let statement = plan_index(&schema_map, statement)?;

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -13,7 +13,7 @@ mod validate;
 mod mock;
 
 use {
-    self::validate::update_schema_context,
+    self::validate::update_validation_context,
     crate::{ast::Statement, result::Result, store::Store},
 };
 
@@ -24,8 +24,8 @@ pub use {
 
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
-    let schema_context = update_schema_context(&schema_map, &statement);
-    validate(schema_context, &statement)?;
+    let validation_context = update_validation_context(&schema_map, &statement);
+    validate(validation_context, &statement)?;
     let statement = plan_primary_key(&schema_map, statement);
     let statement = plan_index(&schema_map, statement)?;
     let statement = plan_join(&schema_map, statement);

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -14,6 +14,8 @@ mod mock;
 
 use crate::{ast::Statement, result::Result, store::Store};
 
+use self::validate::update_schema_context;
+
 pub use {
     self::validate::validate, error::*, index::plan as plan_index, join::plan as plan_join,
     primary_key::plan as plan_primary_key, schema::fetch_schema_map,
@@ -22,7 +24,10 @@ pub use {
 pub async fn plan(storage: &dyn Store, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
 
-    let statement = validate(&schema_map, statement)?;
+    let schema_context = update_schema_context(&schema_map, &statement);
+
+    // let statement = validate(&schema_map, statement)?;
+    validate(schema_context, &statement)?;
 
     let statement = plan_primary_key(&schema_map, statement);
     let statement = plan_index(&schema_map, statement)?;

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -166,13 +166,15 @@ async fn scan_table_factor(
     match table_factor {
         TableFactor::Table { name, alias, .. } => {
             let schema = storage.fetch_schema(name).await?;
-            let alias = match alias {
-                Some(TableAlias { name, .. }) => name,
-                None => name,
-            };
-            let schema_list: HashMap<String, Schema> = schema.map_or_else(HashMap::new, |schema| {
-                HashMap::from([(alias.to_owned(), schema)])
-            });
+            let alias = alias
+                .as_ref()
+                .map_or_else(|| name.clone(), |TableAlias { name, .. }| name.to_string());
+            // let alias = match alias {
+            //     Some(TableAlias { name, .. }) => name,
+            //     None => name,
+            // };
+            let schema_list: HashMap<String, Schema> =
+                schema.map_or_else(HashMap::new, |schema| HashMap::from([(alias, schema)]));
 
             Ok(schema_list)
         }

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -166,11 +166,16 @@ async fn scan_join(storage: &dyn Store, join: &Join) -> Result<Vec<Schema>> {
 }
 
 #[async_recursion(?Send)]
-async fn scan_table_factor(storage: &dyn Store, table_factor: &TableFactor) -> Result<Vec<Schema>> {
+async fn scan_table_factor(
+    storage: &dyn Store,
+    table_factor: &TableFactor,
+) -> Result<HashMap<String, Schema>> {
     match table_factor {
-        TableFactor::Table { name, .. } => {
+        TableFactor::Table { name, alias, .. } => {
             let schema = storage.fetch_schema(name).await?;
-            let schema_list = schema.map(|schema| vec![schema]).unwrap_or_else(Vec::new);
+            let schema_list = schema.map_or_else(|| HashMap::new, |schema| (alias, schema));
+            // .map(|schema| (alias, schema))
+            // .unwrap_or_else(HashMap::new);
 
             Ok(schema_list)
         }

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -1,5 +1,3 @@
-use crate::ast::TableAlias;
-
 use {
     super::expr::PlanExpr,
     crate::{
@@ -164,7 +162,7 @@ async fn scan_table_factor(
     table_factor: &TableFactor,
 ) -> Result<HashMap<String, Schema>> {
     match table_factor {
-        TableFactor::Table { name, alias, .. } => {
+        TableFactor::Table { name, .. } => {
             let schema = storage.fetch_schema(name).await?;
             let schema_list: HashMap<String, Schema> = schema.map_or_else(HashMap::new, |schema| {
                 HashMap::from([(name.to_owned(), schema)])

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -166,15 +166,9 @@ async fn scan_table_factor(
     match table_factor {
         TableFactor::Table { name, alias, .. } => {
             let schema = storage.fetch_schema(name).await?;
-            let alias = alias
-                .as_ref()
-                .map_or_else(|| name.clone(), |TableAlias { name, .. }| name.to_string());
-            // let alias = match alias {
-            //     Some(TableAlias { name, .. }) => name,
-            //     None => name,
-            // };
-            let schema_list: HashMap<String, Schema> =
-                schema.map_or_else(HashMap::new, |schema| HashMap::from([(alias, schema)]));
+            let schema_list: HashMap<String, Schema> = schema.map_or_else(HashMap::new, |schema| {
+                HashMap::from([(name.to_owned(), schema)])
+            });
 
             Ok(schema_list)
         }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -96,11 +96,7 @@ impl<'a> ValidationContext<'a> {
                     .column_defs
                     .as_ref()
                     .map(|column_defs| {
-                        if column_defs.iter().any(|column| &column.name == column_name) {
-                            1
-                        } else {
-                            0
-                        }
+                        i32::from(column_defs.iter().any(|column| &column.name == column_name))
                     })
                     .unwrap_or(0);
 

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -96,11 +96,11 @@ impl<'a> ValidationContext<'a> {
                     .column_defs
                     .as_ref()
                     .map(|column_defs| {
-                        column_defs
-                            .iter()
-                            .any(|column| &column.name == column_name)
-                            .then_some(1)
-                            .unwrap_or(0)
+                        if column_defs.iter().any(|column| &column.name == column_name) {
+                            1
+                        } else {
+                            0
+                        }
                     })
                     .unwrap_or(0);
 
@@ -147,7 +147,7 @@ pub fn contextualize_stmt<'a>(
                 let schema = schema_map.get(name);
                 schema.map(|schema| Rc::from(ValidationContext::new(name, None, schema, None)))
             })
-            .fold(None, |acc, cur| ValidationContext::concat(acc, cur)),
+            .fold(None, ValidationContext::concat),
         _ => None,
     }
 }
@@ -176,7 +176,7 @@ fn contextualize_query<'a>(
             let by_joins = joins
                 .iter()
                 .map(|Join { relation, .. }| contextualize_table_factor(schema_map, relation))
-                .fold(None, |acc, cur| ValidationContext::concat(acc, cur));
+                .fold(None, ValidationContext::concat);
 
             ValidationContext::concat(by_table, by_joins)
         }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -73,7 +73,7 @@ impl<'a> Context<'a> {
                     (true, true) => {
                         Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()).into())
                     }
-                    _ => Ok(current | next),
+                    _ => Ok(current || next),
                 }
             }
             Context::Bridge { left, right } => {
@@ -84,7 +84,7 @@ impl<'a> Context<'a> {
                     (true, true) => {
                         Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()).into())
                     }
-                    _ => Ok(left | right),
+                    _ => Ok(left || right),
                 }
             }
         }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -95,6 +95,7 @@ fn update_schema_context_by_query<'a>(
     let Query { body, .. } = query;
     match body {
         SetExpr::Select(select) => {
+            // todo!()
             let TableWithJoins { relation, joins } = &select.from;
 
             let by_table = match relation {

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -63,7 +63,6 @@ pub enum ValidationContext<'a> {
     },
 }
 
-#[derive(Debug)]
 enum SchemaCount {
     Zero,
     One,

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -11,11 +11,9 @@ use {
     std::{collections::HashMap, ops::Add, rc::Rc},
 };
 
+type SchemaMap = HashMap<String, Schema>;
 /// Validate user select column should not be ambiguous
-pub fn validate(
-    validation_context: Option<Rc<ValidationContext>>,
-    statement: &Statement,
-) -> Result<()> {
+pub fn validate(schema_map: &SchemaMap, statement: &Statement) -> Result<()> {
     if let Statement::Query(query) = &statement {
         if let SetExpr::Select(select) = &query.body {
             if !select.from.joins.is_empty() {
@@ -28,6 +26,7 @@ pub fn validate(
                             ..
                         } = select_item
                         {
+                            let validation_context = contextualize_stmt(schema_map, statement);
                             let tables_with_given_col = validation_context
                                 .as_ref()
                                 .map(|context| context.count(ident))
@@ -139,7 +138,6 @@ impl<'a> ValidationContext<'a> {
     }
 }
 
-type SchemaMap = HashMap<String, Schema>;
 pub fn contextualize_stmt<'a>(
     schema_map: &'a SchemaMap,
     statement: &'a Statement,

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -1,3 +1,7 @@
+use std::rc::Rc;
+
+use crate::ast::{Join, Query, TableAlias, TableFactor, TableWithJoins};
+
 use {
     super::PlanError,
     crate::{
@@ -9,7 +13,11 @@ use {
 };
 
 /// Validate user select column should not be ambiguous
-pub fn validate(schema_map: &HashMap<String, Schema>, statement: Statement) -> Result<Statement> {
+// pub fn validate(schema_map: &HashMap<String, Schema>, statement: Statement) -> Result<Statement> {
+pub fn validate(
+    schema_map: HashMap<(&String, &Option<TableAlias>), &Schema>,
+    statement: &Statement,
+) -> Result<()> {
     if let Statement::Query(query) = &statement {
         if let SetExpr::Select(select) = &query.body {
             if !select.from.joins.is_empty() {
@@ -46,5 +54,76 @@ pub fn validate(schema_map: &HashMap<String, Schema>, statement: Statement) -> R
         }
     }
 
-    Ok(statement)
+    Ok(())
+}
+
+// enum SchemaContext {
+//     Data {
+//         schema: Schema,
+//         alias: String,
+//         next: Option<Rc<SchemaContext>>,
+//     },
+//     Bridge {
+//         left: Option<Rc<SchemaContext>>,
+//         right: Option<Rc<SchemaContext>>,
+//     },
+// }
+
+// struct SchemaContext {
+//
+// }
+
+pub fn update_schema_context<'a>(
+    schema_map: &'a HashMap<String, Schema>,
+    statement: &'a Statement,
+) -> HashMap<(&'a String, &'a Option<TableAlias>), &'a Schema> {
+    match statement {
+        Statement::Query(Query { ref body, .. }) => match body {
+            SetExpr::Select(select) => {
+                let TableWithJoins { relation, joins } = &select.from;
+
+                let by_table = match relation {
+                    TableFactor::Table { name, alias, index } => {
+                        let schema = schema_map.get(name);
+                        schema
+                            .map(|schema| HashMap::from([((name, alias), schema)]))
+                            .unwrap_or(HashMap::new())
+                    }
+                    TableFactor::Derived { subquery, alias } => todo!(),
+                    TableFactor::Series { alias, size } => todo!(),
+                    TableFactor::Dictionary { dict, alias } => todo!(),
+                };
+
+                let by_join = joins
+                    .into_iter()
+                    .map(
+                        |Join {
+                             relation,
+                             join_operator,
+                             join_executor,
+                         }| {
+                            match relation {
+                                TableFactor::Table { name, alias, index } => {
+                                    let schema = schema_map.get(name);
+                                    schema
+                                        .map(|schema| HashMap::from([((name, alias), schema)]))
+                                        .unwrap_or(HashMap::new())
+                                }
+                                TableFactor::Derived { subquery, alias } => todo!(),
+                                TableFactor::Series { alias, size } => todo!(),
+                                TableFactor::Dictionary { dict, alias } => todo!(),
+                            }
+                        },
+                    )
+                    .flatten()
+                    .chain(by_table)
+                    .collect();
+
+                by_join
+                // todo!()
+            }
+            SetExpr::Values(_) => todo!(),
+        },
+        _ => todo!(),
+    }
 }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -86,7 +86,7 @@ impl Add for SchemaCount {
 
 impl<'a> ValidationContext<'a> {
     fn new(
-        table_name: &'a String,
+        table_name: &'a str,
         alias: Option<&'a TableAlias>,
         schema: &'a Schema,
         next: Option<Rc<ValidationContext<'a>>>,

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -52,7 +52,7 @@ pub fn validate(
 
 pub enum ValidationContext<'a> {
     Data {
-        table_name: &'a String,
+        table_name: &'a str,
         alias: Option<&'a TableAlias>,
         schema: &'a Schema,
         next: Option<Rc<ValidationContext<'a>>>,
@@ -89,14 +89,14 @@ impl<'a> ValidationContext<'a> {
         }
     }
 
-    fn count(&self, column_name: &String) -> i32 {
+    fn count(&self, column_name: &str) -> i32 {
         match self {
             ValidationContext::Data { schema, next, .. } => {
                 let current = schema
                     .column_defs
                     .as_ref()
                     .map(|column_defs| {
-                        i32::from(column_defs.iter().any(|column| &column.name == column_name))
+                        i32::from(column_defs.iter().any(|column| column.name == column_name))
                     })
                     .unwrap_or(0);
 

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -11,17 +11,19 @@ use {
 type SchemaMap = HashMap<String, Schema>;
 /// Validate user select column should not be ambiguous
 pub fn validate(schema_map: &SchemaMap, statement: &Statement) -> Result<()> {
-    if let Statement::Query(Query { body, .. }) = &statement {
-        if let SetExpr::Select(select) = body {
-            for select_item in &select.projection {
-                if let SelectItem::Expr {
-                    expr: Expr::Identifier(ident),
-                    ..
-                } = select_item
-                {
-                    if let Some(context) = contextualize_stmt(schema_map, statement) {
-                        context.validate_duplicated(ident)?;
-                    }
+    if let Statement::Query(Query {
+        body: SetExpr::Select(select),
+        ..
+    }) = &statement
+    {
+        for select_item in &select.projection {
+            if let SelectItem::Expr {
+                expr: Expr::Identifier(ident),
+                ..
+            } = select_item
+            {
+                if let Some(context) = contextualize_stmt(schema_map, statement) {
+                    context.validate_duplicated(ident)?;
                 }
             }
         }
@@ -71,7 +73,7 @@ impl<'a> Context<'a> {
                     (true, true) => {
                         Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()).into())
                     }
-                    _ => Ok(current || next),
+                    _ => Ok(current | next),
                 }
             }
             Context::Bridge { left, right } => {
@@ -82,7 +84,7 @@ impl<'a> Context<'a> {
                     (true, true) => {
                         Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()).into())
                     }
-                    _ => Ok(left || right),
+                    _ => Ok(left | right),
                 }
             }
         }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -118,11 +118,11 @@ impl<'a> ValidationContext<'a> {
                     .column_defs
                     .as_ref()
                     .map(|column_defs| {
-                        column_defs
-                            .iter()
-                            .any(|column| column.name == column_name)
-                            .then_some(SchemaCount::One)
-                            .unwrap_or(SchemaCount::Zero)
+                        if column_defs.iter().any(|column| column.name == column_name) {
+                            SchemaCount::One
+                        } else {
+                            SchemaCount::Zero
+                        }
                     })
                     .unwrap_or(SchemaCount::Zero);
 

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -51,9 +51,6 @@ CREATE TABLE TestA (
 
     run!("UPDATE Test SET id = 2");
 
-    run!("CREATE TABLE Validate(no int)");
-    run!("INSERT INTO Validate VALUES(1)");
-
     let test_cases = [
         ("SELECT id FROM Test", Ok(select!(id; I64; 2; 2; 2; 2))),
         (
@@ -63,10 +60,6 @@ CREATE TABLE TestA (
         (
             "SELECT id FROM FOO.Test",
             Err(TranslateError::CompoundObjectNotSupported("FOO.Test".to_owned()).into()),
-        ),
-        (
-            "SELECT no FROM Validate a join Validate b on a.no = b.no",
-            Ok(select!(no; I64; 2)),
         ),
     ];
 

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -51,6 +51,9 @@ CREATE TABLE TestA (
 
     run!("UPDATE Test SET id = 2");
 
+    run!("CREATE TABLE Validate(no int)");
+    run!("INSERT INTO Validate VALUES(1)");
+
     let test_cases = [
         ("SELECT id FROM Test", Ok(select!(id; I64; 2; 2; 2; 2))),
         (
@@ -60,6 +63,10 @@ CREATE TABLE TestA (
         (
             "SELECT id FROM FOO.Test",
             Err(TranslateError::CompoundObjectNotSupported("FOO.Test".to_owned()).into()),
+        ),
+        (
+            "SELECT no FROM Validate a join Validate b on a.no = b.no",
+            Ok(select!(no; I64; 2)),
         ),
     ];
 

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -252,10 +252,10 @@ test_case!(project, async move {
     test!(sql, Ok(expected));
 
     // To test `PlanError` while using `JOIN`
-    run!("CREATE TABLE users (id INTEGER, name TEXT);");
-    run!("INSERT INTO users (id, name) VALUES (1, 'Harry');");
-    run!("CREATE TABLE testers (id INTEGER, nickname TEXT);");
-    run!("INSERT INTO testers (id, nickname) VALUES (1, 'Ron');");
+    run!("CREATE TABLE Users (id INTEGER, name TEXT);");
+    run!("INSERT INTO Users (id, name) VALUES (1, 'Harry');");
+    run!("CREATE TABLE Testers (id INTEGER, nickname TEXT);");
+    run!("INSERT INTO Testers (id, nickname) VALUES (1, 'Ron');");
 
     let error_cases = [
         (

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -267,7 +267,12 @@ test_case!(project, async move {
             TranslateError::UnsupportedJoinOperator("CrossJoin".to_owned()).into(),
         ),
         (
-            "SELECT id FROM users JOIN testers ON users.id = testers.id;",
+            "SELECT id FROM Users JOIN Testers ON Users.id = Testers.id;",
+            PlanError::ColumnReferenceAmbiguous("id".to_owned()).into(),
+        ),
+        (
+            // Ambiguous column should return error even with identical table join
+            "SELECT id FROM Users A JOIN Users B on A.id = B.id",
             PlanError::ColumnReferenceAmbiguous("id".to_owned()).into(),
         ),
         (


### PR DESCRIPTION
To resolve #868 

## Todo
- [x] test: add a case Ambiguous column should return error even with identical table join
- [x] feat: implement `ValidationContext` and `contextualize_stmt` to stack `alias` to `schema_map`
- [x] feat: implement `ValidationContext.count()` to count the number of schemas having identical column name