### PR TITLE
Auto Implement `GStore`, `GStoreMut` traits

### DIFF
--- a/core/src/plan/mock.rs
+++ b/core/src/plan/mock.rs
@@ -14,7 +14,7 @@ use {
         executor::execute,
         parse_sql::parse,
         result::{Error, MutResult, Result},
-        store::{GStore, GStoreMut, RowIter, Store, StoreMut},
+        store::{RowIter, Store, StoreMut},
         translate::translate,
     },
     async_trait::async_trait,
@@ -124,9 +124,6 @@ impl Transaction for MockStorage {}
 
 #[cfg(feature = "metadata")]
 impl Metadata for MockStorage {}
-
-impl GStore for MockStorage {}
-impl GStoreMut for MockStorage {}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -32,32 +32,44 @@ cfg_if! {
 cfg_if! {
     if #[cfg(all(feature = "metadata", feature = "index"))] {
         pub trait GStore: Store + Metadata + Index {}
+        impl<S: Store + Metadata + Index> GStore for S {}
     } else if #[cfg(feature = "metadata")] {
         pub trait GStore: Store + Metadata {}
+        impl<S: Store + Metadata> GStore for S {}
     } else if #[cfg(feature = "index")] {
         pub trait GStore: Store + Index {}
+        impl<S: Store + Index> GStore for S {}
     } else {
         pub trait GStore: Store {}
+        impl<S: Store> GStore for S {}
     }
 }
 
 cfg_if! {
     if #[cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))] {
         pub trait GStoreMut: StoreMut + IndexMut + AlterTable + Transaction {}
+        impl<S: StoreMut + IndexMut + AlterTable+ Transaction> GStoreMut for S {}
     } else if #[cfg(all(feature = "alter-table", feature = "index"))] {
         pub trait GStoreMut: StoreMut + IndexMut + AlterTable {}
+        impl<S: StoreMut + IndexMut + AlterTable> GStoreMut for S {}
     } else if #[cfg(all(feature = "alter-table", feature = "transaction"))] {
         pub trait GStoreMut: StoreMut + Transaction + AlterTable {}
+        impl<S: StoreMut + Transaction + AlterTable> GStoreMut for S {}
     } else if #[cfg(all(feature = "index", feature = "transaction"))] {
         pub trait GStoreMut: StoreMut + IndexMut + Transaction {}
+        impl<S: StoreMut + IndexMut + Transaction> GStoreMut for S {}
     } else if #[cfg(feature = "alter-table")] {
         pub trait GStoreMut: StoreMut + AlterTable {}
+        impl<S: StoreMut+ AlterTable> GStoreMut for S {}
     } else if #[cfg(feature = "index")] {
         pub trait GStoreMut: StoreMut + IndexMut {}
+        impl<S: StoreMut + IndexMut> GStoreMut for S {}
     } else if #[cfg(feature = "transaction")] {
         pub trait GStoreMut: StoreMut + Transaction {}
+        impl<S: StoreMut + Transaction> GStoreMut for S {}
     } else {
         pub trait GStoreMut: StoreMut {}
+        impl<S: StoreMut> GStoreMut for S {}
     }
 }
 

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -57,7 +57,7 @@ cfg_if! {
     } else if #[cfg(feature = "transaction")] {
         pub trait GStoreMut: StoreMut + Transaction {}
     } else {
-        pub trait GStoreMut: Store + StoreMut {}
+        pub trait GStoreMut: StoreMut {}
     }
 }
 

--- a/storages/memory-storage/src/lib.rs
+++ b/storages/memory-storage/src/lib.rs
@@ -8,7 +8,7 @@ use {
     gluesql_core::{
         data::{Key, Row, Schema},
         result::{MutResult, Result},
-        store::{GStore, GStoreMut, RowIter, Store, StoreMut},
+        store::{RowIter, Store, StoreMut},
     },
     indexmap::IndexMap,
     serde::{Deserialize, Serialize},
@@ -139,6 +139,3 @@ impl StoreMut for MemoryStorage {
         Ok((storage, ()))
     }
 }
-
-impl GStore for MemoryStorage {}
-impl GStoreMut for MemoryStorage {}

--- a/storages/shared-memory-storage/src/lib.rs
+++ b/storages/shared-memory-storage/src/lib.rs
@@ -8,7 +8,7 @@ use {
     gluesql_core::{
         data::{Key, Row, Schema},
         result::{MutResult, Result},
-        store::{GStore, GStoreMut, RowIter, Store, StoreMut},
+        store::{RowIter, Store, StoreMut},
     },
     memory_storage::MemoryStorage,
     std::sync::Arc,
@@ -113,6 +113,3 @@ impl StoreMut for SharedMemoryStorage {
         Ok((self, ()))
     }
 }
-
-impl GStore for SharedMemoryStorage {}
-impl GStoreMut for SharedMemoryStorage {}

--- a/storages/sled-storage/src/lib.rs
+++ b/storages/sled-storage/src/lib.rs
@@ -21,7 +21,6 @@ use {
     gluesql_core::{
         data::Schema,
         result::{Error, Result},
-        store::{GStore, GStoreMut},
     },
     sled::{
         transaction::{
@@ -152,6 +151,3 @@ fn fetch_schema(
 
     Ok((key, schema_snapshot))
 }
-
-impl GStore for SledStorage {}
-impl GStoreMut for SledStorage {}


### PR DESCRIPTION
## Before

```rust
// implement Store, StoreMut, Optional traits ...

// must be written explicitly
impl GStore for Storage {}
impl GStoreMut for Storage {}

let storage = Storage::new();
let mut glue = Glue::new(storage);
```

## After

```rust
// implement Store, StoreMut, Optional traits ...

let storage = Storage::new();
// It works even if omitted because it is automatically implemented as Generic
let mut glue = Glue::new(storage);
```