### PR TITLE
Update test-suite select macros to support raw string literals for labels

### DIFF
--- a/test-suite/src/blend.rs
+++ b/test-suite/src/blend.rs
@@ -55,7 +55,7 @@ test_case!(blend, async move {
     }
 
     let test_cases = [
-        ("SELECT 1 FROM BlendUser", select!(1; I64; 1; 1; 1)),
+        ("SELECT 1 FROM BlendUser", select!("1"; I64; 1; 1; 1)),
         (
             "SELECT id, name FROM BlendUser",
             select!(

--- a/test-suite/src/series.rs
+++ b/test-suite/src/series.rs
@@ -95,9 +95,9 @@ test_case!(series, async move {
             // SELECT without Table
             "SELECT 1, 'a', true, 1 + 2, 'a' || 'b'",
             Ok(select!(
-                1   | "'a'"      | true | "1 + 2" | "'a' || 'b'"
-                I64 | Str        | Bool | I64     | Str;
-                1     "a".into()   true   3         "ab".into()
+                "1"   | "'a'"      | "true" | "1 + 2" | "'a' || 'b'"
+                I64   | Str        | Bool   | I64     | Str;
+                1       "a".into()   true     3         "ab".into()
             )),
         ),
         (
@@ -122,7 +122,7 @@ test_case!(series, async move {
             // SELECT without Table in Drived
             "SELECT * FROM (SELECT 1) AS Drived",
             Ok(select!(
-                1
+                "1"
                 I64;
                 1
             )),

--- a/test-suite/src/series.rs
+++ b/test-suite/src/series.rs
@@ -95,18 +95,18 @@ test_case!(series, async move {
             // SELECT without Table
             "SELECT 1, 'a', true, 1 + 2, 'a' || 'b'",
             Ok(select!(
-                1   | 'a'       | true | "1 + 2" | "'a' || 'b'"
-                I64 | Str       | Bool | I64     | Str;
-                1     "a".into()  true   3         "ab".into()
+                1   | "'a'"      | true | "1 + 2" | "'a' || 'b'"
+                I64 | Str        | Bool | I64     | Str;
+                1     "a".into()   true   3         "ab".into()
             )),
         ),
         (
             // SELECT without Table in Scalar subquery
-            "SELECT (SELECT 1)",
+            r#"SELECT (SELECT "Hello")"#,
             Ok(select!(
-                (SELECT 1)
-                I64;
-                1
+                r#"(SELECT "Hello")"#
+                Str;
+                "Hello".to_owned()
             )),
         ),
         (

--- a/test-suite/src/tester/macros.rs
+++ b/test-suite/src/tester/macros.rs
@@ -12,7 +12,7 @@ macro_rules! idx {
     };
     ($name: path, $op: path, $sql_expr: literal) => {
         vec![gluesql_core::ast::IndexItem::NonClustered {
-            name: stringify!($name).to_owned(),
+            name: stringify_label!($name).to_owned(),
             asc: None,
             cmp_expr: Some((
                 $op,
@@ -25,21 +25,21 @@ macro_rules! idx {
     };
     ($name: path) => {
         vec![gluesql_core::ast::IndexItem::NonClustered {
-            name: stringify!($name).to_owned(),
+            name: stringify_label!($name).to_owned(),
             asc: None,
             cmp_expr: None,
         }]
     };
     ($name: path, ASC) => {
         vec![gluesql_core::ast::IndexItem::NonClustered {
-            name: stringify!($name).to_owned(),
+            name: stringify_label!($name).to_owned(),
             asc: Some(true),
             cmp_expr: None,
         }]
     };
     ($name: path, DESC) => {
         vec![gluesql_core::ast::IndexItem::NonClustered {
-            name: stringify!($name).to_owned(),
+            name: stringify_label!($name).to_owned(),
             asc: Some(false),
             cmp_expr: None,
         }]
@@ -54,19 +54,19 @@ macro_rules! select {
         ];
 
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: vec![$( stringify_label!($c).to_string()),+],
             rows: concat_with!(rows ; $( $t )+ ; $( $( $v2 )+ );+)
         }
     });
     ( $( $c: tt )|+ $( ; )? $( $t: path )|+ ; $( $v: expr )+ ) => (
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: vec![$( stringify_label!($c).to_string()),+],
             rows: vec![row!($( $t )+ ; $( $v )+ )],
         }
     );
     ( $( $c: tt )|+ $( ; )?) => (
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: vec![$( stringify_label!($c).to_string()),+],
             rows: vec![],
         }
     );
@@ -87,10 +87,20 @@ macro_rules! concat_with {
 }
 
 #[macro_export]
+macro_rules! stringify_label {
+    ($label: literal) => {
+        $label
+    };
+    ($label: tt) => {
+        stringify!($label)
+    };
+}
+
+#[macro_export]
 macro_rules! select_with_null {
     ( $( $c: tt )|* ; $( $v: expr )* ) => (
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: vec![$( stringify_label!($c).to_owned().replace("\"", "")),+],
             rows: vec![vec![$( $v ),*]],
         }
     );
@@ -100,7 +110,7 @@ macro_rules! select_with_null {
         ];
 
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify!($c).to_owned().replace("\"", "")),+],
+            labels: vec![$( stringify_label!($c).to_owned().replace("\"", "")),+],
             rows: concat_with_null!(rows ; $( $( $v2 )* );*),
         }
     });

--- a/test-suite/src/tester/macros.rs
+++ b/test-suite/src/tester/macros.rs
@@ -54,19 +54,19 @@ macro_rules! select {
         ];
 
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify_label!($c).to_string()),+],
+            labels: vec![$( stringify_label!($c).to_owned()),+],
             rows: concat_with!(rows ; $( $t )+ ; $( $( $v2 )+ );+)
         }
     });
     ( $( $c: tt )|+ $( ; )? $( $t: path )|+ ; $( $v: expr )+ ) => (
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify_label!($c).to_string()),+],
+            labels: vec![$( stringify_label!($c).to_owned()),+],
             rows: vec![row!($( $t )+ ; $( $v )+ )],
         }
     );
     ( $( $c: tt )|+ $( ; )?) => (
         gluesql_core::executor::Payload::Select {
-            labels: vec![$( stringify_label!($c).to_string()),+],
+            labels: vec![$( stringify_label!($c).to_owned()),+],
             rows: vec![],
         }
     );


### PR DESCRIPTION
```rust
r#"SELECT (SELECT "Hello")"#,

Ok(select!(
    r#"(SELECT "Hello")"#
    Str;
    "Hello".to_owned()
)),
```

Now raw string literals are supported for labels in `select!` and `select_with_null!` macros.

cc. @ding-young 