### PR TITLE
Upgrade sqlparser-rs to v0.24, migrate Interval from Literal to Expr

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.22", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.24", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.24"
 bigdecimal = { version = "0.3", features = ["serde", "string-only"] }

--- a/core/src/data/interval/mod.rs
+++ b/core/src/data/interval/mod.rs
@@ -177,8 +177,8 @@ impl Interval {
 
     pub fn try_from_literal(
         value: &str,
-        leading_field: Option<&DateTimeField>,
-        last_field: Option<&DateTimeField>,
+        leading_field: Option<DateTimeField>,
+        last_field: Option<DateTimeField>,
     ) -> Result<Self> {
         use DateTimeField::*;
 
@@ -436,15 +436,15 @@ mod tests {
         macro_rules! test {
             ($value: expr, $datetime: ident => $expected_value: expr, $duration: ident) => {
                 let interval =
-                    Interval::try_from_literal($value, Some(&DateTimeField::$datetime), None);
+                    Interval::try_from_literal($value, Some(DateTimeField::$datetime), None);
 
                 assert_eq!(interval, Ok(Interval::$duration($expected_value)));
             };
             ($value: expr, $from: ident to $to: ident => $expected_value: expr, $duration: ident) => {
                 let interval = Interval::try_from_literal(
                     $value,
-                    Some(&DateTimeField::$from),
-                    Some(&DateTimeField::$to),
+                    Some(DateTimeField::$from),
+                    Some(DateTimeField::$to),
                 );
 
                 assert_eq!(interval, Ok(Interval::$duration($expected_value)));

--- a/core/src/data/interval/string.rs
+++ b/core/src/data/interval/string.rs
@@ -1,7 +1,9 @@
 use {
     super::{Interval, IntervalError, DAY, HOUR, MINUTE, SECOND},
     crate::{
-        ast::{AstLiteral, Expr},
+        ast::Expr,
+        data::Value,
+        executor::evaluate_stateless,
         parse_sql::parse_interval,
         result::{Error, Result},
         translate::translate_expr,
@@ -15,11 +17,17 @@ impl TryFrom<&str> for Interval {
         let parsed = parse_interval(s)?;
 
         match translate_expr(&parsed)? {
-            Expr::Literal(AstLiteral::Interval {
-                value,
+            Expr::Interval {
+                expr,
                 leading_field,
                 last_field,
-            }) => Interval::try_from_literal(&value, leading_field.as_ref(), last_field.as_ref()),
+            } => {
+                let value = evaluate_stateless(None, &expr)
+                    .and_then(Value::try_from)
+                    .map(String::from)?;
+
+                Interval::try_from_literal(&value, leading_field, last_field)
+            }
             _ => Err(IntervalError::Unreachable.into()),
         }
     }

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -530,7 +530,7 @@ impl Value {
             _ => {
                 return Err(ValueError::ExtractFormatNotMatched {
                     value: self.clone(),
-                    field: date_type.clone(),
+                    field: *date_type,
                 }
                 .into())
             }

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -1,7 +1,7 @@
 use {
     super::error::EvaluateError,
     crate::{
-        ast::{DataType, DateTimeField},
+        ast::DataType,
         data::{Key, Literal, Value},
         result::{Error, Result},
     },
@@ -210,14 +210,6 @@ impl<'a> Evaluated<'a> {
         };
 
         Ok(evaluated)
-    }
-
-    pub fn extract(&self, date_type: &DateTimeField) -> Result<Evaluated<'a>> {
-        match self {
-            Evaluated::Literal(l) => l.extract(date_type),
-            Evaluated::Value(v) => v.extract(date_type),
-        }
-        .map(Evaluated::from)
     }
 
     pub fn is_null(&self) -> bool {

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -2,7 +2,7 @@ use {
     super::{expr, function, EvaluateError, Evaluated},
     crate::{
         ast::{Expr, Function},
-        data::{Literal, Row, Value},
+        data::{Interval, Literal, Row, Value},
         result::Result,
     },
     chrono::prelude::Utc,
@@ -138,6 +138,18 @@ pub fn evaluate_stateless<'a>(
             let indexes = indexes.iter().map(eval).collect::<Result<Vec<_>>>()?;
             expr::array_index(obj, indexes)
         }
+        Expr::Interval {
+            expr,
+            leading_field,
+            last_field,
+        } => {
+            let value = eval(expr).and_then(Value::try_from).map(String::from)?;
+
+            Interval::try_from_literal(&value, *leading_field, *last_field)
+                .map(Value::Interval)
+                .map(Evaluated::from)
+        }
+
         Expr::Function(func) => evaluate_function(context, func),
         _ => Err(EvaluateError::UnsupportedStatelessExpr(expr.clone()).into()),
     }

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -74,7 +74,7 @@ pub fn parse_interval<Sql: AsRef<str>>(sql_interval: Sql) -> Result<SqlExpr> {
         .map_err(|e| Error::Parser(format!("{:#?}", e)))?;
 
     Parser::new(tokens, &DIALECT)
-        .parse_literal_interval()
+        .parse_interval()
         .map_err(|e| Error::Parser(format!("{:#?}", e)))
 }
 

--- a/core/src/plan/expr/mod.rs
+++ b/core/src/plan/expr/mod.rs
@@ -32,7 +32,8 @@ impl<'a> From<&'a Expr> for PlanExpr<'a> {
             | Expr::Cast { expr, .. }
             | Expr::Extract { expr, .. }
             | Expr::IsNull(expr)
-            | Expr::IsNotNull(expr) => PlanExpr::Expr(expr),
+            | Expr::IsNotNull(expr)
+            | Expr::Interval { expr, .. } => PlanExpr::Expr(expr),
             Expr::Aggregate(aggregate) => match aggregate.as_expr() {
                 Some(expr) => PlanExpr::Expr(expr),
                 None => PlanExpr::None,

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -161,6 +161,15 @@ pub trait Planner<'a> {
                 let obj = Box::new(self.subquery_expr(outer_context, *obj));
                 Expr::ArrayIndex { obj, indexes }
             }
+            Expr::Interval {
+                expr,
+                leading_field,
+                last_field,
+            } => Expr::Interval {
+                expr: Box::new(self.subquery_expr(outer_context, *expr)),
+                leading_field,
+                last_field,
+            },
             Expr::Function(_) | Expr::Aggregate(_) => expr,
         }
     }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -78,9 +78,6 @@ pub enum TranslateError {
     #[error("unsupported ast literal: {0}")]
     UnsupportedAstLiteral(String),
 
-    #[error("unsupported interval value: {0}")]
-    UnsupportedIntervalValue(String),
-
     #[error("unreachable unary operator: {0}")]
     UnreachableUnaryOperator(String),
 

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -143,6 +143,22 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             indexes: indexes.iter().map(translate_expr).collect::<Result<_>>()?,
         }),
         SqlExpr::Position { expr, r#in } => translate_positon(expr, r#in),
+        SqlExpr::Interval {
+            value,
+            leading_field,
+            last_field,
+            ..
+        } => Ok(Expr::Interval {
+            expr: translate_expr(value).map(Box::new)?,
+            leading_field: leading_field
+                .as_ref()
+                .map(translate_datetime_field)
+                .transpose()?,
+            last_field: last_field
+                .as_ref()
+                .map(translate_datetime_field)
+                .transpose()?,
+        }),
         _ => Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into()),
     }
 }

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -57,8 +57,8 @@ test_case!(create_table, async move {
             Err(TranslateError::UnsupportedDataType("SOMEWHAT".to_owned()).into()),
         ),
         (
-            "CREATE TABLE Gluery (id BLOB);",
-            Err(TranslateError::UnsupportedDataType("BLOB".to_owned()).into()),
+            "CREATE TABLE Gluery (id GLOBE);",
+            Err(TranslateError::UnsupportedDataType("GLOBE".to_owned()).into()),
         ),
         (
             "CREATE TABLE Gluery (id INTEGER CHECK (true));",

--- a/test-suite/src/arithmetic/error.rs
+++ b/test-suite/src/arithmetic/error.rs
@@ -98,11 +98,11 @@ test_case!(error, async move {
         ),
         (
             "SELECT * FROM Arith WHERE id = INTERVAL '2' HOUR / 0",
-            LiteralError::DivisorShouldNotBeZero.into(),
+            ValueError::DivisorShouldNotBeZero.into(),
         ),
         (
             "SELECT * FROM Arith WHERE id = INTERVAL '2' HOUR / 0.0",
-            LiteralError::DivisorShouldNotBeZero.into(),
+            ValueError::DivisorShouldNotBeZero.into(),
         ),
         (
             "SELECT * FROM Arith WHERE id = 2 % 0",

--- a/test-suite/src/data_type/interval.rs
+++ b/test-suite/src/data_type/interval.rs
@@ -3,7 +3,6 @@ use {
     gluesql_core::{
         data::{Interval as I, IntervalError},
         prelude::Value::*,
-        translate::TranslateError,
     },
 };
 
@@ -63,7 +62,7 @@ INSERT INTO IntervalLog VALUES
             id,
             interval1 / 3 AS i1,
             interval2 - INTERVAL 3600 SECOND AS i2,
-            INTERVAL 30 SECOND + INTERVAL 10 SECOND * 3 AS i3
+            INTERVAL 20 + 10 SECOND + INTERVAL 10 SECOND * 3 AS i3
         FROM IntervalLog WHERE id = 2;"#,
         Ok(select!(
             id  | i1         | i2           | i3
@@ -125,10 +124,5 @@ INSERT INTO IntervalLog VALUES
     test!(
         r#"SELECT INTERVAL "111" DAY TO Second FROM IntervalLog;"#,
         Err(IntervalError::FailedToParseDayToSecond("111".to_owned()).into())
-    );
-
-    test!(
-        "SELECT INTERVAL a + b DAY TO MINUTE;",
-        Err(TranslateError::UnsupportedIntervalValue("a + b".to_owned()).into())
     );
 });

--- a/test-suite/src/function/extract.rs
+++ b/test-suite/src/function/extract.rs
@@ -7,7 +7,7 @@ use {
                 Value::{self, *},
                 ValueError,
             },
-            IntervalError, LiteralError,
+            IntervalError,
         },
         prelude::Payload,
         translate::TranslateError,
@@ -88,7 +88,11 @@ test_case!(extract, async move {
         ),
         (
             r#"SELECT EXTRACT(HOUR FROM 100) FROM Item"#,
-            Err(LiteralError::CannotExtract.into()),
+            Err(ValueError::ExtractFormatNotMatched {
+                value: Value::I64(100),
+                field: DateTimeField::Hour,
+            }
+            .into()),
         ),
         (
             r#"SELECT EXTRACT(microseconds FROM "2011-01-1") FROM Item;"#,


### PR DESCRIPTION
Main change is that we now no longer have `AstLiteral::Interval` and that is replaced by `Expr::Interval`.

cc. @ding-young 