### PR TITLE
Add setting table_alias support to AST builder table init function

### DIFF
--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -48,7 +48,7 @@ pub use {
     select_item::SelectItemNode,
     select_item_list::SelectItemList,
     show_columns::ShowColumnsNode,
-    table::TableNode,
+    table::{TableAliasNode, TableNode},
     update::UpdateNode,
 };
 

--- a/core/src/ast_builder/select/root.rs
+++ b/core/src/ast_builder/select/root.rs
@@ -1,7 +1,7 @@
 use {
     super::{join::JoinOperatorType, NodeData, Prebuild},
     crate::{
-        ast::{SelectItem, TableFactor},
+        ast::{SelectItem, TableAlias, TableFactor},
         ast_builder::{
             ExprList, ExprNode, FilterNode, GroupByNode, JoinNode, LimitNode, OffsetNode,
             OrderByExprList, OrderByNode, ProjectNode, SelectItemList,
@@ -13,11 +13,15 @@ use {
 #[derive(Clone)]
 pub struct SelectNode {
     table_name: String,
+    table_alias: Option<String>,
 }
 
 impl SelectNode {
-    pub fn new(table_name: String) -> Self {
-        Self { table_name }
+    pub fn new(table_name: String, table_alias: Option<String>) -> Self {
+        Self {
+            table_name,
+            table_alias,
+        }
     }
 
     pub fn filter<T: Into<ExprNode>>(self, expr: T) -> FilterNode {
@@ -75,7 +79,10 @@ impl Prebuild for SelectNode {
     fn prebuild(self) -> Result<NodeData> {
         let relation = TableFactor::Table {
             name: self.table_name,
-            alias: None,
+            alias: self.table_alias.map(|name| TableAlias {
+                name,
+                columns: Vec::new(),
+            }),
             index: None,
         };
 
@@ -102,6 +109,10 @@ mod tests {
         // select node -> build
         let actual = table("App").select().build();
         let expected = "SELECT * FROM App";
+        test(actual, expected);
+
+        let actual = table("Item").alias_as("i").select().build();
+        let expected = "SELECT * FROM Item i";
         test(actual, expected);
     }
 }

--- a/core/src/ast_builder/table.rs
+++ b/core/src/ast_builder/table.rs
@@ -14,8 +14,15 @@ pub struct TableNode {
 }
 
 impl TableNode {
+    pub fn alias_as(self, table_alias: &str) -> TableAliasNode {
+        TableAliasNode {
+            table_node: self,
+            table_alias: table_alias.to_owned(),
+        }
+    }
+
     pub fn select(self) -> SelectNode {
-        SelectNode::new(self.table_name)
+        SelectNode::new(self.table_name, None)
     }
 
     pub fn delete(self) -> DeleteNode {
@@ -63,5 +70,17 @@ impl TableNode {
 
     pub fn insert(self) -> InsertNode {
         InsertNode::new(self.table_name)
+    }
+}
+
+#[derive(Clone)]
+pub struct TableAliasNode {
+    pub table_node: TableNode,
+    pub table_alias: String,
+}
+
+impl TableAliasNode {
+    pub fn select(self) -> SelectNode {
+        SelectNode::new(self.table_node.table_name, Some(self.table_alias))
     }
 }


### PR DESCRIPTION
Add `TableAliasNode` which supports setting table alias for source tables.

```rust
table("Bar").alias_as("b").select()
```
This above is identical to the below SQL query
```sql
SELECT * FROM Bar b;
```
