### PR TITLE
Add /pkg/rust/data/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # GlueSQL project files
 /data/
+/pkg/rust/data/
 /storages/**/data/
 /storages/**/tmp/
 /reports/


### PR DESCRIPTION
Now the main rust package directory is `/pkg/rust/` so it would be expected for users to run `cargo run --example ..` in `/pkg/rust/` directory.
Then, temp `/pkg/rust/data` directory is automatically created but that was not in the `.gitignore`