### PR TITLE
Remove Option which wraps Row in FilterContext,

### DIFF
--- a/core/src/executor/context/filter_context.rs
+++ b/core/src/executor/context/filter_context.rs
@@ -9,7 +9,7 @@ enum Content<'a> {
     Some {
         table_alias: &'a str,
         columns: Rc<[String]>,
-        row: Option<&'a Row>,
+        row: &'a Row,
     },
     None,
 }
@@ -25,7 +25,7 @@ impl<'a> FilterContext<'a> {
     pub fn new(
         table_alias: &'a str,
         columns: Rc<[String]>,
-        row: Option<&'a Row>,
+        row: &'a Row,
         next: Option<Rc<FilterContext<'a>>>,
     ) -> Self {
         Self {
@@ -51,12 +51,7 @@ impl<'a> FilterContext<'a> {
     }
 
     pub fn get_value(&'a self, target: &str) -> Option<&'a Value> {
-        if let Content::Some {
-            columns,
-            row: Some(row),
-            ..
-        } = &self.content
-        {
+        if let Content::Some { columns, row, .. } = &self.content {
             let value = row.get_value(columns, target);
 
             if value.is_some() {
@@ -80,7 +75,7 @@ impl<'a> FilterContext<'a> {
             Content::Some {
                 table_alias,
                 columns,
-                row: Some(row),
+                row,
             } if table_alias == &target_alias => {
                 let value = row.get_value(columns, target);
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -53,7 +53,7 @@ pub async fn fetch<'a>(
                     Some(expr) => expr,
                 };
 
-                let context = FilterContext::new(table_name, Rc::clone(&columns), Some(&row), None);
+                let context = FilterContext::new(table_name, Rc::clone(&columns), &row, None);
 
                 check_expr(storage, Some(Rc::new(context)), None, expr)
                     .await

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -248,7 +248,7 @@ impl<'a> JoinExecutor<'a> {
                     let filter_context = Rc::new(FilterContext::new(
                         get_alias(relation),
                         columns,
-                        Some(&row),
+                        &row,
                         filter_context,
                     ));
 
@@ -293,8 +293,7 @@ async fn check_where_clause<'a, 'b>(
     where_clause: Option<&'a Expr>,
     row: Cow<'b, Row>,
 ) -> Result<Option<Rc<BlendContext<'a>>>> {
-    let filter_context =
-        FilterContext::new(table_alias, Rc::clone(&columns), Some(&row), filter_context);
+    let filter_context = FilterContext::new(table_alias, Rc::clone(&columns), &row, filter_context);
     let filter_context = Some(Rc::new(filter_context));
 
     match where_clause {

--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -69,7 +69,7 @@ impl<'a> Update<'a> {
 
     async fn find(&self, row: &Row, column_def: &ColumnDef) -> Result<Option<Value>> {
         let all_columns = Rc::from(self.all_columns());
-        let context = FilterContext::new(self.table_name, Rc::clone(&all_columns), Some(row), None);
+        let context = FilterContext::new(self.table_name, Rc::clone(&all_columns), row, None);
         let context = Some(Rc::new(context));
 
         match self


### PR DESCRIPTION
There was no use case of Content::Some { row: None, .. } but Option type was unnecessarily being used. Remove Option from Content::Some { row } in FilterContext