### PR TITLE
Expose Row to Payload::Select and add Row to core::prelude

### DIFF
--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -299,7 +299,7 @@ mod tests {
     fn print_payload() {
         use gluesql_core::{
             ast::{BinaryOperator, DataType, Expr},
-            prelude::{Payload, PayloadVariable, Value},
+            prelude::{Payload, PayloadVariable, Row, Value},
         };
 
         let mut print = Print::new(Vec::new(), None, Default::default());
@@ -362,8 +362,8 @@ mod tests {
                 rows: [101, 202, 301, 505, 1001]
                     .into_iter()
                     .map(Value::I64)
-                    .map(|v| vec![v])
-                    .collect::<Vec<Vec<Value>>>(),
+                    .map(|v| vec![v].into())
+                    .collect::<Vec<Row>>(),
             },
             "
 | id   |
@@ -385,27 +385,32 @@ mod tests {
                         Value::I64(1),
                         Value::Str("foo".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(2),
                         Value::Str("bar".to_owned()),
                         Value::Bool(false)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(3),
                         Value::Str("bas".to_owned()),
                         Value::Bool(false)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(4),
                         Value::Str("lim".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(5),
                         Value::Str("kim".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                 ],
             },
             "
@@ -503,13 +508,15 @@ mod tests {
                         Value::I64(1),
                         Value::Str("foo".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(2),
                         Value::Str("bar".to_owned()),
                         Value::Bool(false)
-                    ],
-                ],
+                    ]
+                    .into(),
+                ]
             },
             "
 id|title|valid
@@ -532,12 +539,14 @@ id|title|valid
                         Value::I64(1),
                         Value::Str("foo".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(2),
                         Value::Str("bar".to_owned()),
                         Value::Bool(false)
-                    ],
+                    ]
+                    .into(),
                 ],
             },
             "
@@ -560,12 +569,14 @@ id,title,valid
                         Value::I64(1),
                         Value::Str("foo".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(2),
                         Value::Str("bar".to_owned()),
                         Value::Bool(false)
-                    ],
+                    ]
+                    .into(),
                 ],
             },
             "
@@ -587,12 +598,14 @@ id,title,valid
                         Value::I64(1),
                         Value::Str("foo".to_owned()),
                         Value::Bool(true)
-                    ],
+                    ]
+                    .into(),
                     vec![
                         Value::I64(2),
                         Value::Str("bar".to_owned()),
                         Value::Bool(false)
-                    ],
+                    ]
+                    .into(),
                 ],
             },
             "

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -6,7 +6,7 @@ use {
         result::Result,
     },
     serde::{Deserialize, Serialize},
-    std::fmt::Debug,
+    std::{fmt::Debug, slice::Iter, vec::IntoIter},
     thiserror::Error,
 };
 
@@ -120,5 +120,51 @@ impl Row {
         }
 
         Ok(())
+    }
+
+    pub fn iter(&self) -> Iter<'_, Value> {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl IntoIterator for Row {
+    type Item = Value;
+    type IntoIter = IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl From<Row> for Vec<Value> {
+    fn from(row: Row) -> Self {
+        row.0
+    }
+}
+
+impl From<Vec<Value>> for Row {
+    fn from(values: Vec<Value>) -> Self {
+        Row(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::Row, crate::data::Value};
+
+    #[test]
+    fn len() {
+        let row: Row = vec![Value::Bool(true), Value::I64(100)].into();
+
+        assert_eq!(row.len(), 2);
+        assert!(!row.is_empty());
     }
 }

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -12,7 +12,7 @@ use {
             SelectItem, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins, Values,
             Variable,
         },
-        data::{Key, Row, Schema, Value},
+        data::{Key, Row, Schema},
         executor::limit::Limit,
         result::{MutResult, Result},
         store::{GStore, GStoreMut},
@@ -42,7 +42,7 @@ pub enum Payload {
     Insert(usize),
     Select {
         labels: Vec<String>,
-        rows: Vec<Vec<Value>>,
+        rows: Vec<Row>,
     },
     Delete(usize),
     Update(usize),
@@ -334,10 +334,7 @@ pub async fn execute<T: GStore + GStoreMut>(
         Statement::Query(query) => {
             let (labels, rows) = try_block!(storage, {
                 let (labels, rows) = select_with_labels(&storage, query, None, true).await?;
-                let rows = rows
-                    .map_ok(|Row(values)| values)
-                    .try_collect::<Vec<_>>()
-                    .await?;
+                let rows = rows.try_collect::<Vec<_>>().await?;
                 Ok((labels, rows))
             });
             Ok((storage, Payload::Select { labels, rows }))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod translate;
 pub mod prelude {
     pub use crate::{
         ast::DataType,
-        data::{Key, Value},
+        data::{Key, Row, Value},
         executor::{execute, Payload, PayloadVariable},
         glue::Glue,
         parse_sql::parse,

--- a/pkg/rust/examples/hello_world.rs
+++ b/pkg/rust/examples/hello_world.rs
@@ -54,7 +54,7 @@ mod hello_world {
         };
 
         let first_row = &rows[0];
-        let first_value = &first_row[0];
+        let first_value = first_row.iter().next().unwrap();
 
         /*
             Row values are wrapped into a value enum, on the basis of the result type

--- a/pkg/rust/examples/sled_multi_threaded.rs
+++ b/pkg/rust/examples/sled_multi_threaded.rs
@@ -57,7 +57,7 @@ mod sled_multi_threaded {
         };
 
         let first_row = &rows[0];
-        let first_value = &first_row[0];
+        let first_value = first_row.iter().next().unwrap();
         let to_greet = match first_value {
             Value::Str(to_greet) => to_greet,
             value => panic!("Unexpected type: {:?}", value),

--- a/pkg/rust/tests/glue.rs
+++ b/pkg/rust/tests/glue.rs
@@ -39,12 +39,14 @@ fn basic<T: GStore + GStoreMut>(mut glue: Glue<T>) {
                     Value::I64(1),
                     Value::Str(String::from("test1")),
                     Value::Bool(true)
-                ],
+                ]
+                .into(),
                 vec![
                     Value::I64(2),
                     Value::Str(String::from("test2")),
                     Value::Bool(false)
                 ]
+                .into()
             ]
         }])
     );

--- a/storages/shared-memory-storage/tests/concurrent_access.rs
+++ b/storages/shared-memory-storage/tests/concurrent_access.rs
@@ -38,7 +38,7 @@ async fn concurrent_access() {
     let actual = glue.execute("SELECT * FROM Thread").unwrap();
     let expected = vec![Payload::Select {
         labels: vec!["id".to_owned()],
-        rows: vec![vec![Value::I64(1)], vec![Value::I64(2)]],
+        rows: vec![vec![Value::I64(1)].into(), vec![Value::I64(2)].into()],
     }];
     assert_eq!(actual, expected);
 }

--- a/test-suite/src/tester/macros.rs
+++ b/test-suite/src/tester/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! row {
     ( $( $p:path )* ; $( $v:expr )* ) => (
-        vec![$( $p($v) ),*]
+        gluesql_core::data::Row(vec![$( $p($v) ),*])
     )
 }
 
@@ -101,12 +101,12 @@ macro_rules! select_with_null {
     ( $( $c: tt )|* ; $( $v: expr )* ) => (
         gluesql_core::executor::Payload::Select {
             labels: vec![$( stringify_label!($c).to_owned()),+],
-            rows: vec![vec![$( $v ),*]],
+            rows: vec![gluesql_core::data::Row(vec![$( $v ),*])],
         }
     );
     ( $( $c: tt )|* ; $( $v: expr )* ; $( $( $v2: expr )* );*) => ({
         let mut rows = vec![
-            vec![$( $v ),*]
+            gluesql_core::data::Row(vec![$( $v ),*])
         ];
 
         gluesql_core::executor::Payload::Select {
@@ -119,12 +119,12 @@ macro_rules! select_with_null {
 #[macro_export]
 macro_rules! concat_with_null {
     ( $rows: ident ; $( $v: expr )* ) => ({
-        $rows.push(vec![$( $v ),*]);
+        $rows.push(gluesql_core::data::Row(vec![$( $v ),*]));
 
         $rows
     });
     ( $rows: ident ; $( $v: expr )* ; $( $( $v2: expr )* );* ) => ({
-        $rows.push(vec![$( $v ),*]);
+        $rows.push(gluesql_core::data::Row(vec![$( $v ),*]));
 
         concat_with_null!($rows ; $( $( $v2 )* );* )
     });


### PR DESCRIPTION
prev
```rust
Payload::Select {
  labels: Vec<String>,
  rows: Vec<Vec<Value>>,
}
```

now
```rust
Payload::Select {
  labels: Vec<String>,
  rows: Vec<Row>,
}
```

Expose `Row` struct to user-side, add `Row` to `core::prelude`.
`Row` was being used only for internal core development because it was just a thin wrapper of `Vec<Value>`.
However, we can expect to provide some useful helper functions to users using `Row` and more importantly, `Row` will have more than a single variant of `Vec<Value>` when we add schemaless feature to our core.
