### PR TITLE
Check for `Value::Null` in `Aggregate` except `*`,

### DIFF
--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -49,7 +49,7 @@ impl AggrValue {
             },
             Aggregate::Count(CountArgExpr::Expr(_)) => AggrValue::Count {
                 wildcard: false,
-                count: 1,
+                count: if value.is_null() { 0 } else { 1 },
             },
             Aggregate::Sum(_) => AggrValue::Sum(value),
             Aggregate::Min(_) => AggrValue::Min(value),

--- a/test-suite/src/aggregate/count.rs
+++ b/test-suite/src/aggregate/count.rs
@@ -5,7 +5,7 @@ test_case!(count, async move {
         "
         CREATE TABLE Item (
             id INTEGER,
-            quantity INTEGER,
+            quantity INTEGER NULL,
             age INTEGER NULL,
             total INTEGER,
         );
@@ -14,7 +14,7 @@ test_case!(count, async move {
     run!(
         "
         INSERT INTO Item (id, quantity, age, total) VALUES
-            (1, 10,   11, 1),
+            (1, NULL,   11, 1),
             (2,  0,   90, 2),
             (3,  9, NULL, 3),
             (4,  3,    3, 1),
@@ -23,15 +23,29 @@ test_case!(count, async move {
     );
 
     let test_cases = [
-        ("SELECT COUNT(*) FROM Item", select!("COUNT(*)"; I64; 5)),
-        ("SELECT count(*) FROM Item", select!("count(*)"; I64; 5)),
         (
-            "SELECT COUNT(*), COUNT(*) FROM Item",
-            select!("COUNT(*)" | "COUNT(*)"; I64 | I64; 5 5),
+            "SELECT COUNT(*) FROM Item;",
+            select!(
+                "COUNT(*)";
+                I64;
+                5
+            ),
         ),
         (
-            "SELECT COUNT(age), COUNT(quantity) FROM Item",
-            select!("COUNT(age)" | "COUNT(quantity)"; I64 | I64; 3 5),
+            "SELECT COUNT(age), COUNT(quantity) FROM Item;",
+            select!(
+                "COUNT(age)" | "COUNT(quantity)";
+                I64          |               I64;
+                3                              4
+            ),
+        ),
+        (
+            "SELECT COUNT(NULL);",
+            select!(
+                "COUNT(NULL)";
+                I64;
+                0
+            ),
         ),
     ];
 

--- a/test-suite/src/aggregate/group_by.rs
+++ b/test-suite/src/aggregate/group_by.rs
@@ -26,7 +26,15 @@ test_case!(group_by, async move {
     let test_cases = [
         (
             "SELECT id, COUNT(*) FROM Item GROUP BY id",
-            select!(id | "COUNT(*)"; I64 | I64; 1 1; 2 1; 3 2; 4 1; 5 1),
+            select!(
+                id  | "COUNT(*)";
+                I64 | I64;
+                1       1;
+                2       1;
+                3       2;
+                4       1;
+                5       1
+            ),
         ),
         (
             "SELECT id FROM Item GROUP BY id",


### PR DESCRIPTION
fixed #944 

- if `Value::Null`, init count is `0`, otherwise `1`


