### PR TITLE
fix: unmatced subquery should return Null (not error)

### DIFF
--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -10,9 +10,6 @@ pub enum EvaluateError {
     #[error(transparent)]
     ChronoFormat(#[from] ChronoFormatError),
 
-    #[error("nested select row not found")]
-    NestedSelectRowNotFound,
-
     #[error("literal add on non-numeric")]
     LiteralAddOnNonNumeric,
 

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -82,7 +82,7 @@ pub async fn evaluate<'a>(
             evaluations
                 .into_iter()
                 .next()
-                .unwrap_or_else(|| Err(EvaluateError::NestedSelectRowNotFound.into()))
+                .unwrap_or_else(|| Ok(Evaluated::from(Value::Null)))
         }
         Expr::BinaryOp { op, left, right } => {
             let left = eval(left).await?;


### PR DESCRIPTION
## Goal
Currently,
```sql
gluesql> SELECT (SELECT N FROM SERIES(3) WHERE N = 4) N;
[error] nested select row not found
```
But it should be
```sql
gluesql> SELECT (SELECT N FROM SERIES(3) WHERE N = 4) N;
```
| N    |
|------|
| NULL |

It affects to scala subquery, In-List subquery.

## Todo
- [x] modify EvaluateError::NestedSelectRowNotFound to Value::Null
- [x] remove EvaluateError::NestedSelectRowNotFound