### PR TITLE
Update Cargo.toml, README.md & package.json versions to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GlueSQL provides three reference storage options.
 
 ```toml
 [dependencies]
-gluesql = "0.12"
+gluesql = "0.13"
 ```
 
 - CLI application
@@ -69,7 +69,7 @@ fn main() {
 
 ```toml
 [dependencies.gluesql]
-version = "0.12"
+version = "0.13"
 default-features = false
 features = ["alter-table", "index", "transaction"]
 ```

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,9 +9,9 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.12.0", features = ["alter-table"] }
-gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.12.0" }
-gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.12.0" }
+gluesql-core = { path = "../core", version = "0.13.0", features = ["alter-table"] }
+gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.13.0" }
+gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.13.0" }
 
 clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-utils = { package = "gluesql-utils", path = "../utils", version = "0.12.0" }
+utils = { package = "gluesql-utils", path = "../utils", version = "0.13.0" }
 
 regex = "1"
 async-trait = "0.1"

--- a/pkg/javascript/README.md
+++ b/pkg/javascript/README.md
@@ -22,7 +22,7 @@ npm install gluesql
 
 #### JavaScript modules
 ```javascript
-import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.12.0/gluesql.js';
+import { gluesql } from 'https://cdn.jsdelivr.net/npm/gluesql@0.13.0/gluesql.js';
 ```
 
 ## Usage

--- a/pkg/javascript/package.json
+++ b/pkg/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "gluesql.js",
   "main": "gluesql.node.js",

--- a/pkg/javascript/web/Cargo.toml
+++ b/pkg/javascript/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-js"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -28,8 +28,8 @@ serde_json = "1"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-gluesql-core = { path = "../../../core", version = "0.12.0" }
-memory-storage = { package = "gluesql_memory_storage", path = "../../../storages/memory-storage", version = "0.12.0" }
+gluesql-core = { path = "../../../core", version = "0.13.0" }
+memory-storage = { package = "gluesql_memory_storage", path = "../../../storages/memory-storage", version = "0.13.0" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
@@ -37,5 +37,5 @@ wasm-bindgen-test = "0.3.13"
 [dev-dependencies.test-suite]
 package = "gluesql-test-suite"
 path = "../../../test-suite"
-version = "0.12.0"
+version = "0.13.0"
 features = ["alter-table"]

--- a/pkg/javascript/web/package.json
+++ b/pkg/javascript/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "bundler.js",
   "main": "index.js",

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 default-run = "gluesql"
@@ -26,12 +26,12 @@ all-features = true
 # opt-level = "s"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.12.0" }
-cli = { package = "gluesql-cli", path = "../../cli", version = "0.12.0", optional = true }
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", optional = true }
-memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.12.0", optional = true }
-shared-memory-storage = { package = "gluesql-shared-memory-storage", path = "../../storages/shared-memory-storage", version = "0.12.0", optional = true }
-sled-storage = { package = "gluesql_sled_storage", path = "../../storages/sled-storage", version = "0.12.0", optional = true }
+gluesql-core = { path = "../../core", version = "0.13.0" }
+cli = { package = "gluesql-cli", path = "../../cli", version = "0.13.0", optional = true }
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", optional = true }
+memory-storage = { package = "gluesql_memory_storage", path = "../../storages/memory-storage", version = "0.13.0", optional = true }
+shared-memory-storage = { package = "gluesql-shared-memory-storage", path = "../../storages/shared-memory-storage", version = "0.13.0", optional = true }
+sled-storage = { package = "gluesql_sled_storage", path = "../../storages/sled-storage", version = "0.13.0", optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_memory_storage"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.12.0", features = [
+gluesql-core = { path = "../../core", version = "0.13.0", features = [
 	"alter-table",
 	"index",
 	"transaction",
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 indexmap = { version = "1.8", features = ["serde"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
 	"alter-table",
 	"index",
 	"transaction",

--- a/storages/shared-memory-storage/Cargo.toml
+++ b/storages/shared-memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-shared-memory-storage"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = [
 	"Jiseok CHOI <jiseok.dev@gmail.com>",
@@ -12,8 +12,8 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-memory-storage = { package = "gluesql_memory_storage", version = "0.12.0", path = "../memory-storage" }
-gluesql-core = { path = "../../core", version = "0.12.0", features = [
+memory-storage = { package = "gluesql_memory_storage", version = "0.13.0", path = "../memory-storage" }
+gluesql-core = { path = "../../core", version = "0.13.0", features = [
 	"alter-table",
 	"index",
 	"transaction",
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
 	"alter-table",
 	"index",
 	"transaction",

--- a/storages/sled-storage/Cargo.toml
+++ b/storages/sled-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql_sled_storage"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,12 +9,12 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.12.0", features = [
+gluesql-core = { path = "../../core", version = "0.13.0", features = [
 	"index",
 	"transaction",
 	"alter-table",
 ] }
-utils = { package = "gluesql-utils", path = "../../utils", version = "0.12.0" }
+utils = { package = "gluesql-utils", path = "../../utils", version = "0.13.0" }
 async-trait = "0.1"
 iter-enum = "1"
 serde = { version = "1", features = ["derive"] }
@@ -23,7 +23,7 @@ bincode = "1"
 sled = "0.34"
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.12.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
 	"index",
 	"transaction",
 	"alter-table",

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-test-suite"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
@@ -9,7 +9,7 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.12.0" }
+gluesql-core = { path = "../core", version = "0.13.0" }
 async-trait = "0.1"
 bigdecimal = "0.3"
 chrono = "0.4"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluesql-utils"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"


### PR DESCRIPTION
Bump all workspace versions to v0.13.0
Update README.md & gluesql-js/README.md

- [x] Update README.md
- [x] Update workspace versions
- [x] Write release note
- [ ] Publish to crates.io
- [ ] Publish to npm (gluesql-js)

ref. https://github.com/gluesql/gluesql/releases/tag/untagged-dfc1995fc55dc400a8ac