### PR TITLE
Move [profile.release] config from pkg/rust/Cargo.toml to root /Cargo…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ default-members = [
 	"test-suite",
 	"utils",
 ]
+
+# ref. https://github.com/rustwasm/wasm-pack/issues/1111
+# enable this only for gluesql-js build
+# [profile.release]
+# opt-level = "s"

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -20,11 +20,6 @@ keywords = [
 [package.metadata.docs.rs]
 all-features = true
 
-# ref. https://github.com/rustwasm/wasm-pack/issues/1111
-# enable this only for gluesql-js build
-# [profile.release]
-# opt-level = "s"
-
 [dependencies]
 gluesql-core = { path = "../../core", version = "0.13.0" }
 cli = { package = "gluesql-cli", path = "../../cli", version = "0.13.0", optional = true }


### PR DESCRIPTION
….toml

`[profile.release]` config is a global property so it is required to be located in the root Cargo.toml