### PR TITLE
Remove unneccesary syntax in enum Evaluated

### DIFF
--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -87,7 +87,7 @@ impl<'a> Update<'a> {
                     Evaluated::Literal(v) => Value::try_from_literal(data_type, &v)?,
                     Evaluated::Value(v) => {
                         v.validate_type(data_type)?;
-                        v.into_owned()
+                        v
                     }
                 };
 


### PR DESCRIPTION
## Description
```rust
pub enum Evaluated<'a> {
    Literal(Literal<'a>),
    Value(Cow<'a, Value>),
}
```

to

```rust
pub enum Evaluated<'a> {
    Literal(Literal<'a>),
    Value(Value),
}
```
enum `Evaluated` does not need to use Cow for enum `Value`

