### PR TITLE
Update AST builder ExprNode & ExprList to accept borrowed values

### DIFF
--- a/core/src/ast_builder/expr_list.rs
+++ b/core/src/ast_builder/expr_list.rs
@@ -6,29 +6,48 @@ use {
         result::{Error, Result},
         translate::translate_expr,
     },
+    std::borrow::Cow,
 };
 
 #[derive(Clone)]
 pub enum ExprList<'a> {
-    Text(String),
-    Exprs(Vec<ExprNode<'a>>),
+    Text(Cow<'a, str>),
+    Exprs(Cow<'a, [ExprNode<'a>]>),
 }
 
-impl<'a> From<&str> for ExprList<'a> {
-    fn from(exprs: &str) -> Self {
-        ExprList::Text(exprs.to_owned())
+impl<'a> From<&'a str> for ExprList<'a> {
+    fn from(exprs: &'a str) -> Self {
+        ExprList::Text(Cow::Borrowed(exprs))
     }
 }
 
-impl<'a> From<Vec<ExprNode<'a>>> for ExprList<'a> {
-    fn from(exprs: Vec<ExprNode<'a>>) -> Self {
-        ExprList::Exprs(exprs)
+impl<'a> From<String> for ExprList<'a> {
+    fn from(exprs: String) -> Self {
+        ExprList::Text(Cow::from(exprs))
     }
 }
 
-impl<'a> From<Vec<&str>> for ExprList<'a> {
-    fn from(exprs: Vec<&str>) -> Self {
-        ExprList::Exprs(exprs.into_iter().map(Into::into).collect())
+impl<'a, T: Into<ExprNode<'a>>> From<Vec<T>> for ExprList<'a> {
+    fn from(exprs: Vec<T>) -> Self {
+        ExprList::Exprs(Cow::Owned(exprs.into_iter().map(Into::into).collect()))
+    }
+}
+
+impl<'a, T: Into<ExprNode<'a>> + Copy> From<&'a Vec<T>> for ExprList<'a> {
+    fn from(exprs: &'a Vec<T>) -> Self {
+        exprs.as_slice().into()
+    }
+}
+
+impl<'a, T: Into<ExprNode<'a>> + Copy> From<&'a [T]> for ExprList<'a> {
+    fn from(exprs: &'a [T]) -> Self {
+        ExprList::Exprs(Cow::Owned(exprs.iter().map(|&v| v.into()).collect()))
+    }
+}
+
+impl<'a> From<&'a [ExprNode<'a>]> for ExprList<'a> {
+    fn from(exprs: &'a [ExprNode<'a>]) -> Self {
+        ExprList::Exprs(Cow::Borrowed(exprs))
     }
 }
 
@@ -41,10 +60,74 @@ impl<'a> TryFrom<ExprList<'a>> for Vec<Expr> {
                 .iter()
                 .map(translate_expr)
                 .collect::<Result<Vec<_>>>(),
-            ExprList::Exprs(nodes) => nodes
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<Vec<_>>>(),
+            ExprList::Exprs(exprs) => {
+                let exprs = exprs.into_owned();
+
+                exprs
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>>>()
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::ExprList,
+        crate::{
+            ast::Expr, ast_builder::col, parse_sql::parse_comma_separated_exprs, result::Result,
+            translate::translate_expr,
+        },
+    };
+
+    fn test(actual: ExprList, expected: &str) {
+        let parsed = parse_comma_separated_exprs(expected).expect(expected);
+        let expected = parsed
+            .iter()
+            .map(translate_expr)
+            .collect::<Result<Vec<Expr>>>();
+
+        assert_eq!(actual.try_into(), expected);
+    }
+
+    #[test]
+    fn into_expr_list() {
+        let actual: ExprList = "1, a * 2, b".into();
+        let expected = "1, a * 2, b";
+        test(actual, expected);
+
+        let actual: ExprList = String::from("'hello' || 'world', col1").into();
+        let expected = "'hello' || 'world', col1";
+        test(actual, expected);
+
+        // Vec<Into<ExprNode>>
+        let actual: ExprList = vec!["id", "name"].into();
+        let expected = "id, name";
+        test(actual, expected);
+
+        // Vec<ExprNode>
+        let actual: ExprList = vec![col("id"), col("name")].into();
+        let expected = "id, name";
+        test(actual, expected);
+
+        // &Vec<ExprNode>
+        let actual = vec!["id", "name"];
+        let actual: ExprList = (&actual).into();
+        let expected = "id, name";
+        test(actual, expected);
+
+        // &[Into<ExprNode>]
+        let actual = vec!["rate / 10", "col1"];
+        let actual: ExprList = actual.as_slice().into();
+        let expected = "rate / 10, col1";
+        test(actual, expected);
+
+        // &[ExprNode]
+        let actual = vec![col("id"), col("name")];
+        let actual: ExprList = actual.as_slice().into();
+        let expected = "id, name";
+        test(actual, expected);
     }
 }

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -167,7 +167,7 @@ mod tests {
             .select()
             .group_by("city")
             .having("COUNT(name) < 100")
-            .order_by(ExprNode::Identifier("name".to_owned()))
+            .order_by(ExprNode::Identifier("name".into()))
             .limit(3)
             .offset(2)
             .build();


### PR DESCRIPTION
Update `ExprNode` & `ExprList` to accept both `String` and `&str` to build `ExprNode`.
Update `ExprList` to accept both owned vector and borrowed slice.

e.g. `ExprList`
```rust
        // Vec<Into<ExprNode>>
        let actual: ExprList = vec!["id", "name"].into();
        let expected = "id, name";
        test(actual, expected);

        // Vec<ExprNode>
        let actual: ExprList = vec![col("id"), col("name")].into();
        let expected = "id, name";
        test(actual, expected);

        // &Vec<ExprNode>
        let actual = vec!["id", "name"];
        let actual: ExprList = (&actual).into();
        let expected = "id, name";
        test(actual, expected);

        // &[Into<ExprNode>]
        let actual = vec!["rate / 10", "col1"];
        let actual: ExprList = actual.as_slice().into();
        let expected = "rate / 10, col1";
        test(actual, expected);

        // &[ExprNode]
        let actual = vec![col("id"), col("name")];
        let actual: ExprList = actual.as_slice().into();
        let expected = "id, name";
        test(actual, expected);
```