### PR TITLE
Change rust pkg lib example to use MemoryStorage

### DIFF
--- a/pkg/rust/src/lib.rs
+++ b/pkg/rust/src/lib.rs
@@ -9,11 +9,11 @@
 //! ## Examples
 //!
 //! ```
-//! # #[cfg(feature = "sled-storage")]
+//! # #[cfg(feature = "memory-storage")]
 //! # fn main() {
 //! use gluesql::prelude::*;
 //!
-//! let storage = SledStorage::new("data/doc-db").unwrap();
+//! let storage = MemoryStorage::default();
 //! let mut glue = Glue::new(storage);
 //!     
 //! let sqls = vec![
@@ -26,11 +26,11 @@
 //!
 //! for sql in sqls {
 //!     let output = glue.execute(sql).unwrap();
-//!     println!("{:?}", output)
+//!     println!("{:?}", output);
 //! }
 //! # }
 //!
-//! # #[cfg(not(feature = "sled-storage"))]
+//! # #[cfg(not(feature = "memory-storage"))]
 //! # fn main() {}
 //! ```
 //!


### PR DESCRIPTION
Current pkg example uses SledStorage and it leaves `data/doc-db` data after runs.
This can cause some issues when we do change to the codes which requires migration.
Rather than adding file removal code to lib example, it would be good to simply have minimal example using MemoryStorage.
MemoryStorage does not leave any of persistent data so there cannot be any migration issue.