### PR TITLE
Expose wasm-pack's init function argument to users

### DIFF
--- a/pkg/javascript/gluesql.js
+++ b/pkg/javascript/gluesql.js
@@ -2,15 +2,15 @@ import init, { Glue } from './dist/web/gluesql_js.js';
 
 let loaded = false;
 
-async function load() {
-  await init();
+async function load(module_or_path) {
+  await init(module_or_path);
 
   loaded = true;
 }
 
-export async function gluesql() {
+export async function gluesql(module_or_path) {
   if (!loaded) {
-    await load();
+    await load(module_or_path);
   }
 
   return new Glue();


### PR DESCRIPTION
Some users need to be able to use the `module_or_path` argument of the function `init` that `wasm-pack` generates. In my case, it enables loading the WASM module in an environment that is neither the browser nor node (edge). This modification can fix WASM loading issues for other users too.