### PR TITLE
Support `GET_DDL` to extract DDL of Table and Index

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -135,6 +135,10 @@ pub enum Function {
     },
     Ascii(Expr),
     Chr(Expr),
+    GetDDL {
+        object_type: Expr,
+        object_name: Expr,
+    },
 }
 
 impl ToSql for Function {
@@ -278,6 +282,14 @@ impl ToSql for Function {
             }
             Function::Ascii(e) => format!("ASCII({})", e.to_sql()),
             Function::Chr(e) => format!("CHR({})", e.to_sql()),
+            Function::GetDDL {
+                object_type,
+                object_name,
+            } => format!(
+                "GET_DDL({} IN {})",
+                object_type.to_sql(),
+                object_name.to_sql()
+            ),
         }
     }
 }

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -450,5 +450,13 @@ async fn evaluate_function<'a>(
             let expr = eval(expr).await?;
             f::extract(field, expr)
         }
+        Function::GetDDL {
+            object_type,
+            object_name,
+        } => {
+            let object_type = eval(object_type).await?;
+            let object_name = eval(object_name).await?;
+            f::get_ddl(name, storage, object_type, object_name).await
+        }
     }
 }

--- a/core/src/executor/evaluate/stateless.rs
+++ b/core/src/executor/evaluate/stateless.rs
@@ -339,5 +339,14 @@ fn evaluate_function<'a>(
             let expr = eval(expr)?;
             f::extract(field, expr)
         }
+        Function::GetDDL {
+            object_type,
+            object_name,
+        } => {
+            // let object_type = eval(object_type)?;
+            // let object_name = eval(object_name)?;
+            // f::get_ddl(name, object_type, object_name)
+            todo!()
+        }
     }
 }

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -124,6 +124,10 @@ impl Function {
             | Self::Position {
                 from_expr: expr2,
                 sub_expr: expr,
+            }
+            | Self::GetDDL {
+                object_type: expr,
+                object_name: expr2,
             } => Exprs::Double([expr, expr2].into_iter()),
             Self::Lpad {
                 expr,

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -442,6 +442,17 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             let expr = translate_expr(args[0])?;
             Ok(Expr::Function(Box::new(Function::Chr(expr))))
         }
+        "GET_DDL" => {
+            check_len(name, args.len(), 2)?;
+
+            let object_type = translate_expr(args[0])?;
+            let object_name = translate_expr(args[1])?;
+
+            Ok(Expr::Function(Box::new(Function::GetDDL {
+                object_type,
+                object_name,
+            })))
+        }
         _ => Err(TranslateError::UnsupportedFunction(name).into()),
     }
 }

--- a/test-suite/src/function/get_ddl.rs
+++ b/test-suite/src/function/get_ddl.rs
@@ -1,0 +1,31 @@
+use {
+    crate::*,
+    gluesql_core::prelude::{Payload, Value::*},
+};
+
+test_case!(get_ddl, async move {
+    let test_cases = [
+        ("CREATE TABLE Foo (no INT)", Ok(Payload::Create)),
+        (
+            "SELECT GET_DDL('TABLE', 'Foo')",
+            Ok(select!(
+                "GET_DDL('TABLE', 'Foo')"
+                Str;
+                "CREATE TABLE Foo (no INT)".to_owned()
+            )),
+        ),
+        ("CREATE TABLE Bar (no INT PRIMARY KEY)", Ok(Payload::Create)),
+        (
+            "SELECT GET_DDL('TABLE', 'Bar')",
+            Ok(select!(
+                "GET_DDL('TABLE', 'Bar')"
+                Str;
+                "CREATE TABLE Bar (no INT PRIMARY KEY)".to_owned()
+            )),
+        ),
+    ];
+
+    for (sql, expected) in test_cases {
+        test!(sql, expected);
+    }
+});

--- a/test-suite/src/function/mod.rs
+++ b/test-suite/src/function/mod.rs
@@ -12,6 +12,7 @@ pub mod floor;
 pub mod format;
 pub mod gcd_lcm;
 pub mod generate_uuid;
+pub mod get_ddl;
 pub mod ifnull;
 pub mod left_right;
 pub mod lpad_rpad;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -166,6 +166,7 @@ macro_rules! generate_store_tests {
             function_generate_uuid,
             function::generate_uuid::generate_uuid
         );
+        glue!(function_get_ddl, function::get_ddl::get_ddl);
         glue!(type_match, type_match::type_match);
         glue!(dictionary, dictionary::dictionary);
 


### PR DESCRIPTION
# 🚧 Draft yet

## Goal
### 1. Extract DDL of a Table by literal name
```sql
gluesql> CREATE TABLE Foo (no INT);
gluesql> SELECT GET_DDL('TABLE', 'Foo');
```
| GET_DDL('TABLE', 'Foo')   |
|---------------------------|
| CREATE TABLE Foo (no INT) |
```sql
gluesql> CREATE TABLE Bar (no INT PRIMARY KEY);
gluesql> SELECT GET_DDL('TABLE', 'Bar');
```
| GET_DDL('TABLE', 'Bar')                                 |
|---------------------------------------------------------|
| CREATE TABLE Bar (no INT PRIMARY KEY NOT NULL NOT NULL) |

### 2. Extract DDL of a INDEX by literal name
```sql
gluesql> CREATE INDEX Foo_no ON Foo (no INT);
gluesql> SELECT GET_DDL('INDEX', 'Foo_no');
```
| GET_DDL('INDEX', 'Foo_no')   |
|---------------------------|
| CREATE INDEX Foo_no ON Foo (no INT) |

### 3. Thanks to `GLUE_OBJECTS` #924, we can extract DDL of all objects. 
```sql
gluesql> SELECT GET_DDL(OBJECT_TYPE, OBJECT_NAME) FROM GLUE_OBJECTS;
```
| GET_DDL(OBJECT_TYPE, OBJECT_NAME)    |
|---------------------------|
| ??? |
| ??? |

## Todo
- [x] implement GET_DDL base
- [x] GET_DDL for TABLE
- [ ] Fix  duplicated NOT NULL issue at `to_sql`
- [ ] GET_DDL for INDEX
- [ ] add E2E test to extract all objects in database

## Next
- Support gluedump to export whole database