### PR TITLE
Refactor: remove `ColumnOptionDef`

### DIFF
--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -26,13 +26,7 @@ pub enum AlterTableOperation {
 pub struct ColumnDef {
     pub name: String,
     pub data_type: DataType,
-    pub options: Vec<ColumnOptionDef>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ColumnOptionDef {
-    pub name: Option<String>,
-    pub option: ColumnOption,
+    pub options: Vec<ColumnOption>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -75,7 +75,7 @@ impl ToSql for ColumnDef {
         {
             let options = options
                 .iter()
-                .map(|ColumnOptionDef { option, .. }| option.to_sql())
+                .map(|option| option.to_sql())
                 .collect::<Vec<_>>()
                 .join(" ");
             format!("{name} {data_type} {options}")
@@ -101,7 +101,7 @@ impl ToSql for ColumnOption {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{AstLiteral, ColumnDef, ColumnOption, ColumnOptionDef, DataType, Expr, ToSql};
+    use crate::ast::{AstLiteral, ColumnDef, ColumnOption, DataType, Expr, ToSql};
 
     #[test]
     fn to_sql_column_def() {
@@ -110,10 +110,7 @@ mod tests {
             ColumnDef {
                 name: "name".to_owned(),
                 data_type: DataType::Text,
-                options: vec![ColumnOptionDef {
-                    name: None,
-                    option: ColumnOption::Unique { is_primary: false }
-                }]
+                options: vec![ColumnOption::Unique { is_primary: false }]
             }
             .to_sql()
         );
@@ -123,10 +120,7 @@ mod tests {
             ColumnDef {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
-                options: vec![ColumnOptionDef {
-                    name: None,
-                    option: ColumnOption::Null
-                }]
+                options: vec![ColumnOption::Null]
             }
             .to_sql()
         );
@@ -137,14 +131,8 @@ mod tests {
                 name: "id".to_owned(),
                 data_type: DataType::Int,
                 options: vec![
-                    ColumnOptionDef {
-                        name: None,
-                        option: ColumnOption::NotNull
-                    },
-                    ColumnOptionDef {
-                        name: None,
-                        option: ColumnOption::Unique { is_primary: true }
-                    }
+                    ColumnOption::NotNull,
+                    ColumnOption::Unique { is_primary: true }
                 ]
             }
             .to_sql()
@@ -155,10 +143,9 @@ mod tests {
             ColumnDef {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
-                options: vec![ColumnOptionDef {
-                    name: None,
-                    option: ColumnOption::Default(Expr::Literal(AstLiteral::Boolean(false)))
-                }]
+                options: vec![ColumnOption::Default(Expr::Literal(AstLiteral::Boolean(
+                    false
+                )))]
             }
             .to_sql()
         );

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -370,7 +370,7 @@ mod tests {
                     ColumnDef {
                         name: "num".to_owned(),
                         data_type: DataType::Int,
-                        options: vec![option: ColumnOption::Null]
+                        options: vec![ColumnOption::Null]
                     },
                     ColumnDef {
                         name: "name".to_owned(),

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -236,9 +236,9 @@ mod tests {
 
     use {
         crate::ast::{
-            Assignment, AstLiteral, BinaryOperator, ColumnDef, ColumnOption, ColumnOptionDef,
-            DataType, Expr, Query, Select, SelectItem, SetExpr, Statement, TableFactor,
-            TableWithJoins, ToSql, Values, Variable,
+            Assignment, AstLiteral, BinaryOperator, ColumnDef, ColumnOption, DataType, Expr, Query,
+            Select, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins, ToSql, Values,
+            Variable,
         },
         bigdecimal::BigDecimal,
         std::str::FromStr,
@@ -370,10 +370,7 @@ mod tests {
                     ColumnDef {
                         name: "num".to_owned(),
                         data_type: DataType::Int,
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::Null
-                        }]
+                        options: vec![option: ColumnOption::Null]
                     },
                     ColumnDef {
                         name: "name".to_owned(),
@@ -457,12 +454,9 @@ mod tests {
                     column_def: ColumnDef {
                         name: "amount".to_owned(),
                         data_type: DataType::Int,
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::Default(Expr::Literal(AstLiteral::Number(
-                                BigDecimal::from_str("10").unwrap()
-                            )))
-                        }]
+                        options: vec![ColumnOption::Default(Expr::Literal(AstLiteral::Number(
+                            BigDecimal::from_str("10").unwrap()
+                        )))]
                     }
                 }
             }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -1,5 +1,5 @@
 use {
-    crate::ast::{ColumnDef, ColumnOption, ColumnOptionDef, Expr},
+    crate::ast::{ColumnDef, ColumnOption, Expr},
     chrono::NaiveDateTime,
     serde::{Deserialize, Serialize},
     std::fmt::Debug,
@@ -40,15 +40,13 @@ impl ColumnDefExt for ColumnDef {
     fn is_nullable(&self) -> bool {
         self.options
             .iter()
-            .any(|ColumnOptionDef { option, .. }| option == &ColumnOption::Null)
+            .any(|option| option == &ColumnOption::Null)
     }
 
     fn get_default(&self) -> Option<&Expr> {
-        self.options
-            .iter()
-            .find_map(|ColumnOptionDef { option, .. }| match option {
-                ColumnOption::Default(expr) => Some(expr),
-                _ => None,
-            })
+        self.options.iter().find_map(|option| match option {
+            ColumnOption::Default(expr) => Some(expr),
+            _ => None,
+        })
     }
 }

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -1,7 +1,7 @@
 use {
     super::{validate, AlterError},
     crate::{
-        ast::{ColumnDef, ColumnOption, ColumnOptionDef, Query, SetExpr, TableFactor, Values},
+        ast::{ColumnDef, ColumnOption, Query, SetExpr, TableFactor, Values},
         data::{Schema, TableError},
         executor::{evaluate_stateless, select::select},
         prelude::{DataType, Value},
@@ -42,10 +42,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                         let column_def = ColumnDef {
                             name: "N".into(),
                             data_type: DataType::Int,
-                            options: vec![ColumnOptionDef {
-                                name: None,
-                                option: ColumnOption::NotNull,
-                            }],
+                            options: vec![ColumnOption::NotNull],
                         };
 
                         vec![column_def]
@@ -94,10 +91,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                         .map(|(i, data_type)| ColumnDef {
                             name: format!("column{}", i + 1),
                             data_type,
-                            options: vec![ColumnOptionDef {
-                                name: None,
-                                option: ColumnOption::Null,
-                            }],
+                            options: vec![ColumnOption::Null],
                         })
                         .collect::<Vec<_>>();
 

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -1,7 +1,7 @@
 use {
     super::AlterError,
     crate::{
-        ast::{ColumnDef, ColumnOption, ColumnOptionDef, DataType},
+        ast::{ColumnDef, ColumnOption, DataType},
         executor::evaluate_stateless,
         result::Result,
     },
@@ -19,7 +19,7 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
     if matches!(data_type, DataType::Float | DataType::Map)
         && options
             .iter()
-            .any(|ColumnOptionDef { option, .. }| matches!(option, ColumnOption::Unique { .. }))
+            .any(|option| matches!(option, ColumnOption::Unique { .. }))
     {
         return Err(AlterError::UnsupportedDataTypeForUniqueColumn(
             name.to_owned(),
@@ -28,12 +28,10 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
         .into());
     }
 
-    let default = options
-        .iter()
-        .find_map(|ColumnOptionDef { option, .. }| match option {
-            ColumnOption::Default(expr) => Some(expr),
-            _ => None,
-        });
+    let default = options.iter().find_map(|option| match option {
+        ColumnOption::Default(expr) => Some(expr),
+        _ => None,
+    });
 
     if let Some(expr) = default {
         evaluate_stateless(None, expr)?;

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -8,9 +8,8 @@ use {
     },
     crate::{
         ast::{
-            ColumnDef, ColumnOption, ColumnOptionDef, DataType, Dictionary, Expr, Query,
-            SelectItem, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins, Values,
-            Variable,
+            ColumnDef, ColumnOption, DataType, Dictionary, Expr, Query, SelectItem, SetExpr,
+            Statement, TableAlias, TableFactor, TableWithJoins, Values, Variable,
         },
         data::{Key, Row, Schema},
         executor::limit::Limit,
@@ -229,9 +228,9 @@ pub async fn execute<T: GStore + GStoreMut>(
                     .iter()
                     .enumerate()
                     .find(|(_, ColumnDef { options, .. })| {
-                        options.iter().any(|ColumnOptionDef { option, .. }| {
-                            option == &ColumnOption::Unique { is_primary: true }
-                        })
+                        options
+                            .iter()
+                            .any(|option| option == &ColumnOption::Unique { is_primary: true })
                     })
                     .map(|(i, _)| i);
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -223,9 +223,8 @@ pub async fn fetch_relation_rows<'a>(
                                 |ColumnDef { name, options, .. }| {
                                     options
                                         .iter()
-                                        .any(|column_option_def| {
-                                            column_option_def.option
-                                                == ColumnOption::Unique { is_primary: true }
+                                        .any(|option| {
+                                            option == &ColumnOption::Unique { is_primary: true }
                                         })
                                         .then_some(name)
                                 },

--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -4,7 +4,7 @@ use {
         evaluate::{evaluate, Evaluated},
     },
     crate::{
-        ast::{Assignment, ColumnDef, ColumnOption, ColumnOptionDef},
+        ast::{Assignment, ColumnDef, ColumnOption},
         data::{schema::ColumnDefExt, Row, Value},
         result::Result,
         store::GStore,
@@ -51,9 +51,9 @@ impl<'a> Update<'a> {
                     return false;
                 }
 
-                options.iter().any(|ColumnOptionDef { option, .. }| {
-                    option == &ColumnOption::Unique { is_primary: true }
-                })
+                options
+                    .iter()
+                    .any(|option| option == &ColumnOption::Unique { is_primary: true })
             }) {
                 return Err(UpdateError::UpdateOnPrimaryKeyNotSupported(id.to_owned()).into());
             }

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -192,7 +192,7 @@ fn fetch_all_unique_columns(column_defs: &[ColumnDef]) -> Vec<(usize, String)> {
             table_col
                 .options
                 .iter()
-                .any(|opt_def| matches!(opt_def.option, ColumnOption::Unique { .. }))
+                .any(|option| matches!(option, ColumnOption::Unique { .. }))
                 .then_some((i, table_col.name.to_owned()))
         })
         .collect()

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -1,10 +1,7 @@
 use {
     super::context::Context,
     crate::{
-        ast::{
-            ColumnDef, ColumnOption, ColumnOptionDef, Expr, Function, Query, TableAlias,
-            TableFactor,
-        },
+        ast::{ColumnDef, ColumnOption, Expr, Function, Query, TableAlias, TableFactor},
         data::Schema,
     },
     std::rc::Rc,
@@ -211,9 +208,7 @@ pub trait Planner<'a> {
             .find_map(|ColumnDef { name, options, .. }| {
                 options
                     .iter()
-                    .any(|ColumnOptionDef { option, .. }| {
-                        matches!(option, ColumnOption::Unique { is_primary: true })
-                    })
+                    .any(|option| matches!(option, ColumnOption::Unique { is_primary: true }))
                     .then(|| name.as_str())
             });
 

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -79,9 +79,8 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
 fn translate_column_option_def(
     sql_column_option_def: &SqlColumnOptionDef,
 ) -> Result<Vec<ColumnOption>> {
-    let SqlColumnOptionDef { name, option } = sql_column_option_def;
+    let SqlColumnOptionDef { option, .. } = sql_column_option_def;
 
-    let name = name.as_ref().map(|name| name.value.to_owned());
     let option = match option {
         SqlColumnOption::Null => Ok(ColumnOption::Null),
         SqlColumnOption::NotNull => Ok(ColumnOption::NotNull),

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -1,7 +1,7 @@
 use {
     super::{data_type::translate_data_type, expr::translate_expr, TranslateError},
     crate::{
-        ast::{ColumnDef, ColumnOption, ColumnOptionDef},
+        ast::{ColumnDef, ColumnOption},
         result::Result,
     },
     sqlparser::ast::{
@@ -72,9 +72,13 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
     })
 }
 
+/// Translate `ColumnOptionDef` to `ColumnOption`.
+///
+/// `sql-parser` parses column option as `{ name, option }` type,
+/// but in here we only need `option`.
 fn translate_column_option_def(
     sql_column_option_def: &SqlColumnOptionDef,
-) -> Result<Vec<ColumnOptionDef>> {
+) -> Result<Vec<ColumnOption>> {
     let SqlColumnOptionDef { name, option } = sql_column_option_def;
 
     let name = name.as_ref().map(|name| name.value.to_owned());
@@ -87,18 +91,12 @@ fn translate_column_option_def(
         }
         SqlColumnOption::Unique { .. } => {
             return Ok(vec![
-                ColumnOptionDef {
-                    name: name.clone(),
-                    option: ColumnOption::Unique { is_primary: true },
-                },
-                ColumnOptionDef {
-                    name,
-                    option: ColumnOption::NotNull,
-                },
+                ColumnOption::Unique { is_primary: true },
+                ColumnOption::NotNull,
             ]);
         }
         _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
     }?;
 
-    Ok(vec![ColumnOptionDef { name, option }])
+    Ok(vec![option])
 }

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -72,7 +72,7 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
     })
 }
 
-/// Translate `ColumnOptionDef` to `ColumnOption`.
+/// Translate [`SqlColumnOptionDef`] to [`ColumnOption`].
 ///
 /// `sql-parser` parses column option as `{ name, option }` type,
 /// but in here we only need `option`.


### PR DESCRIPTION
## Resolves #981 

This PR removes the type `ColumnOptionDef`, replacing its role with `ColumnOption`.  (Details in #981)
Overall functionality won't change, only the translation from `sqlparser` to `gluesql` has been changed a bit.