### PR TITLE
Support printing results of all Statements including DDL and TCL

### DIFF
--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -102,6 +102,14 @@ impl<'a, W: Write> Print<W> {
         };
 
         match payload {
+            Payload::Create => self.write("Table created")?,
+            Payload::DropTable => self.write("Table dropped")?,
+            Payload::AlterTable => self.write("Table altered")?,
+            Payload::CreateIndex => self.write("Index created")?,
+            Payload::DropIndex => self.write("Index dropped")?,
+            Payload::Commit => self.write("Commit completed")?,
+            Payload::Rollback => self.write("Rollback completed")?,
+            Payload::StartTransaction => self.write("Transaction started")?,
             Payload::Insert(n) => affected(*n, "inserted")?,
             Payload::Delete(n) => affected(*n, "deleted")?,
             Payload::Update(n) => affected(*n, "updated")?,
@@ -164,7 +172,6 @@ impl<'a, W: Write> Print<W> {
                     }
                 }
             }
-            _ => {}
         };
 
         Ok(())
@@ -304,6 +311,14 @@ mod tests {
             };
         }
 
+        test!(&Payload::Create, "Table created");
+        test!(&Payload::DropTable, "Table dropped");
+        test!(&Payload::AlterTable, "Table altered");
+        test!(&Payload::CreateIndex, "Index created");
+        test!(&Payload::DropIndex, "Index dropped");
+        test!(&Payload::Commit, "Commit completed");
+        test!(&Payload::Rollback, "Rollback completed");
+        test!(&Payload::StartTransaction, "Transaction started");
         test!(&Payload::Insert(0), "0 row inserted");
         test!(&Payload::Insert(1), "1 row inserted");
         test!(&Payload::Insert(7), "7 rows inserted");


### PR DESCRIPTION
## Goal
### Print results of all Statements including DDL and TCL
- It would be helpful to watch the progress of executing lots of sqls in file.
```sql
gluesql> CREATE TABLE User (id INT);
Table created

gluesql> ALTER TABLE User ADD COLUMN name TEXT NULL;
Table altered

gluesql> CREATE INDEX User_id ON User (id);
Index created

gluesql> DROP INDEX User.User_id;
Index dropped

gluesql> DROP TABLE User;
Table dropped

gluesql> BEGIN;
Transaction started

gluesql> COMMIT;
Commit completed

gluesql> BEGIN;
Transaction started

gluesql> ROLLBACK;
Rollback completed
```

## Todo
- [x] cover all payloads on cli::print