### PR TITLE
Remove ColumnDefExt trait in data::Schema,

### DIFF
--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ast::{ColumnDef, Expr},
-        data::{schema::ColumnDefExt, Value},
+        data::Value,
         executor::evaluate_stateless,
         result::Result,
     },

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -30,20 +30,14 @@ pub struct Schema {
     pub created: NaiveDateTime,
 }
 
-pub trait ColumnDefExt {
-    fn is_nullable(&self) -> bool;
-
-    fn get_default(&self) -> Option<&Expr>;
-}
-
-impl ColumnDefExt for ColumnDef {
-    fn is_nullable(&self) -> bool {
+impl ColumnDef {
+    pub fn is_nullable(&self) -> bool {
         self.options
             .iter()
             .any(|option| option == &ColumnOption::Null)
     }
 
-    fn get_default(&self) -> Option<&Expr> {
+    pub fn get_default(&self) -> Option<&Expr> {
         self.options.iter().find_map(|option| match option {
             ColumnOption::Default(expr) => Some(expr),
             _ => None,

--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -5,7 +5,7 @@ use {
     },
     crate::{
         ast::{Assignment, ColumnDef, ColumnOption},
-        data::{schema::ColumnDefExt, Row, Value},
+        data::{Row, Value},
         result::Result,
         store::GStore,
     },

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -3,7 +3,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         ast::ColumnDef,
-        data::{schema::ColumnDefExt, Value},
+        data::Value,
         result::{MutResult, Result, TrySelf},
         store::AlterTable,
         store::AlterTableError,

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -9,10 +9,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         ast::ColumnDef,
-        data::{
-            schema::{ColumnDefExt, Schema},
-            Row, Value,
-        },
+        data::{schema::Schema, Row, Value},
         executor::evaluate_stateless,
         result::{MutResult, Result, TrySelf},
         store::{AlterTable, AlterTableError},


### PR DESCRIPTION
ast::ColumnDef is in the same crate so it is not necessary to expand using extra trait. Replace ColumnDefExt to use adding direct impl to ast::ColumnDef.