### PR TITLE
Replace double quote to single quote

### DIFF
--- a/core/src/ast/ast_literal.rs
+++ b/core/src/ast/ast_literal.rs
@@ -19,8 +19,8 @@ impl ToSql for AstLiteral {
         match self {
             AstLiteral::Boolean(b) => b.to_string().to_uppercase(),
             AstLiteral::Number(n) => n.to_string(),
-            AstLiteral::QuotedString(qs) => format!(r#""{qs}""#),
-            AstLiteral::HexString(hs) => format!(r#""{hs}""#),
+            AstLiteral::QuotedString(qs) => format!("'{qs}'"),
+            AstLiteral::HexString(hs) => format!("'{hs}'"),
             AstLiteral::Null => "NULL".to_owned(),
         }
     }
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!("TRUE", AstLiteral::Boolean(true).to_sql());
         assert_eq!("123", AstLiteral::Number(BigDecimal::from(123)).to_sql());
         assert_eq!(
-            r#""hello""#,
+            "'hello'",
             AstLiteral::QuotedString("hello".to_owned()).to_sql()
         );
         assert_eq!("NULL", AstLiteral::Null.to_sql());

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -153,7 +153,7 @@ impl ToSql for Expr {
             },
             Expr::Nested(expr) => format!("({})", expr.to_sql()),
             Expr::Literal(s) => s.to_sql(),
-            Expr::TypedString { data_type, value } => format!("{data_type} \"{value}\""),
+            Expr::TypedString { data_type, value } => format!("{data_type} '{value}'"),
             Expr::Case {
                 operand,
                 when_then,
@@ -274,7 +274,7 @@ mod tests {
         assert_eq!("id IS NOT NULL", Expr::IsNotNull(id_expr).to_sql());
 
         assert_eq!(
-            r#"INT "1""#,
+            "INT '1'",
             Expr::TypedString {
                 data_type: DataType::Int,
                 value: "1".to_owned()
@@ -310,7 +310,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"id LIKE "%abc""#,
+            "id LIKE '%abc'",
             Expr::Like {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 negated: false,
@@ -319,7 +319,7 @@ mod tests {
             .to_sql()
         );
         assert_eq!(
-            r#"id NOT LIKE "%abc""#,
+            "id NOT LIKE '%abc'",
             Expr::Like {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 negated: true,
@@ -329,7 +329,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"id ILIKE "%abc_""#,
+            "id ILIKE '%abc_'",
             Expr::ILike {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 negated: false,
@@ -338,7 +338,7 @@ mod tests {
             .to_sql()
         );
         assert_eq!(
-            r#"id NOT ILIKE "%abc_""#,
+            "id NOT ILIKE '%abc_'",
             Expr::ILike {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 negated: true,
@@ -348,7 +348,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"id IN ("a", "b", "c")"#,
+            "id IN ('a', 'b', 'c')",
             Expr::InList {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 list: vec![
@@ -362,7 +362,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"id NOT IN ("a", "b", "c")"#,
+            "id NOT IN ('a', 'b', 'c')",
             Expr::InList {
                 expr: Box::new(Expr::Identifier("id".to_owned())),
                 list: vec![
@@ -511,13 +511,11 @@ mod tests {
 
         assert_eq!(
             trim(
-                r#"                                                                           
-                CASE id
-                  WHEN 1 THEN "a"
-                  WHEN 2 THEN "b"
-                  ELSE "c"
-                END
-                "#,
+                "CASE id
+                  WHEN 1 THEN 'a'
+                  WHEN 2 THEN 'b'
+                  ELSE 'c'
+                END",
             ),
             Expr::Case {
                 operand: Some(Box::new(Expr::Identifier("id".to_owned()))),
@@ -564,7 +562,7 @@ mod tests {
             .to_sql()
         );
         assert_eq!(
-            r#"INTERVAL "3-5" HOUR TO MINUTE"#,
+            "INTERVAL '3-5' HOUR TO MINUTE",
             &Expr::Interval {
                 expr: Box::new(Expr::Literal(AstLiteral::QuotedString("3-5".to_owned()))),
                 leading_field: Some(DateTimeField::Hour),

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -274,7 +274,7 @@ impl ToSql for Function {
                 sub_expr,
             } => format!("POSITION({} IN {})", sub_expr.to_sql(), from_expr.to_sql()),
             Function::Extract { field, expr } => {
-                format!(r#"EXTRACT({field} FROM "{}")"#, expr.to_sql())
+                format!("EXTRACT({field} FROM '{}')", expr.to_sql())
             }
             Function::Ascii(e) => format!("ASCII({})", e.to_sql()),
             Function::Chr(e) => format!("CHR({})", e.to_sql()),
@@ -341,7 +341,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"LOWER("Bye")"#,
+            "LOWER('Bye')",
             &Expr::Function(Box::new(Function::Lower(Expr::Literal(
                 AstLiteral::QuotedString("Bye".to_owned())
             ))))
@@ -349,7 +349,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"UPPER("Hi")"#,
+            "UPPER('Hi')",
             &Expr::Function(Box::new(Function::Upper(Expr::Literal(
                 AstLiteral::QuotedString("Hi".to_owned())
             ))))
@@ -357,7 +357,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"LEFT("GlueSQL", 2)"#,
+            "LEFT('GlueSQL', 2)",
             &Expr::Function(Box::new(Function::Left {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("2").unwrap()))
@@ -366,7 +366,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"RIGHT("GlueSQL", 3)"#,
+            "RIGHT('GlueSQL', 3)",
             &Expr::Function(Box::new(Function::Right {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("3").unwrap()))
@@ -399,7 +399,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"LPAD("GlueSQL", 2)"#,
+            "LPAD('GlueSQL', 2)",
             &Expr::Function(Box::new(Function::Lpad {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("2").unwrap())),
@@ -409,7 +409,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"LPAD("GlueSQL", 10, "Go")"#,
+            "LPAD('GlueSQL', 10, 'Go')",
             &Expr::Function(Box::new(Function::Lpad {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("10").unwrap())),
@@ -419,7 +419,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"RPAD("GlueSQL", 10)"#,
+            "RPAD('GlueSQL', 10)",
             &Expr::Function(Box::new(Function::Rpad {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("10").unwrap())),
@@ -429,7 +429,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"RPAD("GlueSQL", 10, "Go")"#,
+            "RPAD('GlueSQL', 10, 'Go')",
             &Expr::Function(Box::new(Function::Rpad {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 size: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("10").unwrap())),
@@ -498,7 +498,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TRIM("*" FROM name)"#,
+            "TRIM('*' FROM name)",
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -508,7 +508,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TRIM(BOTH "*" FROM name)"#,
+            "TRIM(BOTH '*' FROM name)",
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -518,7 +518,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TRIM(LEADING "*" FROM name)"#,
+            "TRIM(LEADING '*' FROM name)",
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -673,7 +673,7 @@ mod tests {
         assert_eq!("PI()", &Expr::Function(Box::new(Function::Pi())).to_sql());
 
         assert_eq!(
-            r#"LTRIM("   HI ")"#,
+            "LTRIM('   HI ')",
             &Expr::Function(Box::new(Function::Ltrim {
                 expr: Expr::Literal(AstLiteral::QuotedString("   HI ".to_owned())),
                 chars: None
@@ -682,7 +682,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"LTRIM("*IMPORTANT", "*")"#,
+            "LTRIM('*IMPORTANT', '*')",
             &Expr::Function(Box::new(Function::Ltrim {
                 expr: Expr::Literal(AstLiteral::QuotedString("*IMPORTANT".to_owned())),
                 chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -691,7 +691,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"RTRIM("   HI ")"#,
+            "RTRIM('   HI ')",
             &Expr::Function(Box::new(Function::Rtrim {
                 expr: Expr::Literal(AstLiteral::QuotedString("   HI ".to_owned())),
                 chars: None
@@ -700,7 +700,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"RTRIM("IMPORTANT*", "*")"#,
+            "RTRIM('IMPORTANT*', '*')",
             &Expr::Function(Box::new(Function::Rtrim {
                 expr: Expr::Literal(AstLiteral::QuotedString("IMPORTANT*".to_owned())),
                 chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -717,7 +717,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"REPEAT("Ha", 8)"#,
+            "REPEAT('Ha', 8)",
             &Expr::Function(Box::new(Function::Repeat {
                 expr: Expr::Literal(AstLiteral::QuotedString("Ha".to_owned())),
                 num: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("8").unwrap()))
@@ -734,7 +734,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"SUBSTR("GlueSQL", 2)"#,
+            "SUBSTR('GlueSQL', 2)",
             &Expr::Function(Box::new(Function::Substr {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 start: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("2").unwrap())),
@@ -744,7 +744,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"SUBSTR("GlueSQL", 1, 3)"#,
+            "SUBSTR('GlueSQL', 1, 3)",
             &Expr::Function(Box::new(Function::Substr {
                 expr: Expr::Literal(AstLiteral::QuotedString("GlueSQL".to_owned())),
                 start: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("1").unwrap())),
@@ -756,7 +756,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"UNWRAP(nested, "a.foo")"#,
+            "UNWRAP(nested, 'a.foo')",
             &Expr::Function(Box::new(Function::Unwrap {
                 expr: Expr::Identifier("nested".to_owned()),
                 selector: Expr::Literal(AstLiteral::QuotedString("a.foo".to_owned()))
@@ -770,7 +770,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"FORMAT(DATE "2022-10-12", "%Y-%m")"#,
+            "FORMAT(DATE '2022-10-12', '%Y-%m')",
             &Expr::Function(Box::new(Function::Format {
                 expr: Expr::TypedString {
                     data_type: DataType::Date,
@@ -782,7 +782,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TO_DATE("2022-10-12", "%Y-%m-%d")"#,
+            "TO_DATE('2022-10-12', '%Y-%m-%d')",
             &Expr::Function(Box::new(Function::ToDate {
                 expr: Expr::Literal(AstLiteral::QuotedString("2022-10-12".to_owned())),
                 format: Expr::Literal(AstLiteral::QuotedString("%Y-%m-%d".to_owned()))
@@ -791,7 +791,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TO_TIMESTAMP("2022-10-12 00:34:23", "%Y-%m-%d %H:%M:%S")"#,
+            "TO_TIMESTAMP('2022-10-12 00:34:23', '%Y-%m-%d %H:%M:%S')",
             &Expr::Function(Box::new(Function::ToTimestamp {
                 expr: Expr::Literal(AstLiteral::QuotedString("2022-10-12 00:34:23".to_owned())),
                 format: Expr::Literal(AstLiteral::QuotedString("%Y-%m-%d %H:%M:%S".to_owned()))
@@ -800,7 +800,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TO_TIME("00:34:23", "%H:%M:%S")"#,
+            "TO_TIME('00:34:23', '%H:%M:%S')",
             &Expr::Function(Box::new(Function::ToTime {
                 expr: Expr::Literal(AstLiteral::QuotedString("00:34:23".to_owned())),
                 format: Expr::Literal(AstLiteral::QuotedString("%H:%M:%S".to_owned()))
@@ -809,7 +809,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"POSITION("cup" IN "cupcake")"#,
+            "POSITION('cup' IN 'cupcake')",
             &Expr::Function(Box::new(Function::Position {
                 from_expr: Expr::Literal(AstLiteral::QuotedString("cupcake".to_owned())),
                 sub_expr: Expr::Literal(AstLiteral::QuotedString("cup".to_owned())),
@@ -818,7 +818,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"ASCII("H")"#,
+            "ASCII('H')",
             &Expr::Function(Box::new(Function::Ascii(Expr::Literal(
                 AstLiteral::QuotedString("H".to_owned())
             ))))
@@ -834,7 +834,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"EXTRACT(MINUTE FROM "2022-05-05 01:02:03")"#,
+            "EXTRACT(MINUTE FROM '2022-05-05 01:02:03')",
             &Expr::Function(Box::new(Function::Extract {
                 field: DateTimeField::Minute,
                 expr: Expr::Identifier("2022-05-05 01:02:03".to_owned())

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn to_sql_insert() {
         assert_eq!(
-            r#"INSERT INTO Test (id, num, name) VALUES (1, 2, "Hello");"#,
+            "INSERT INTO Test (id, num, name) VALUES (1, 2, 'Hello');",
             Statement::Insert {
                 table_name: "Test".into(),
                 columns: vec!["id".to_owned(), "num".to_owned(), "name".to_owned()],
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn to_sql_update() {
         assert_eq!(
-            r#"UPDATE Foo SET id = 4, color = "blue";"#,
+            "UPDATE Foo SET id = 4, color = 'blue';",
             Statement::Update {
                 table_name: "Foo".into(),
                 assignments: vec![
@@ -305,7 +305,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"UPDATE Foo SET name = "first" WHERE a > b;"#,
+            "UPDATE Foo SET name = 'first' WHERE a > b;",
             Statement::Update {
                 table_name: "Foo".into(),
                 assignments: vec![Assignment {
@@ -334,7 +334,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"DELETE FROM Foo WHERE item = "glue";"#,
+            "DELETE FROM Foo WHERE item = 'glue';",
             Statement::Delete {
                 table_name: "Foo".into(),
                 selection: Some(Expr::BinaryOp {

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -460,7 +460,7 @@ mod tests {
         .to_sql();
         assert_eq!(actual, expected);
 
-        let actual = r#"VALUES (1, "glue", 3), (2, "sql", 2)"#.to_owned();
+        let actual = "VALUES (1, 'glue', 3), (2, 'sql', 2)".to_owned();
         let expected = SetExpr::Values(Values(vec![
             vec![
                 Expr::Literal(AstLiteral::Number(BigDecimal::from_str("1").unwrap())),
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn to_sql_select() {
-        let actual = r#"SELECT * FROM FOO AS F GROUP BY name HAVING name = "glue""#.to_owned();
+        let actual = "SELECT * FROM FOO AS F GROUP BY name HAVING name = 'glue'".to_owned();
         let expected = Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {
@@ -504,7 +504,7 @@ mod tests {
         .to_sql();
         assert_eq!(actual, expected);
 
-        let actual = r#"SELECT * FROM FOO WHERE name = "glue""#.to_owned();
+        let actual = "SELECT * FROM FOO WHERE name = 'glue'".to_owned();
         let expected = Select {
             projection: vec![SelectItem::Wildcard],
             from: TableWithJoins {

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -125,7 +125,7 @@ mod tests {
 
         assert_eq!(
             schema.to_ddl(),
-            "CREATE TABLE User (id INT, name TEXT NULL DEFAULT \"glue\");"
+            "CREATE TABLE User (id INT, name TEXT NULL DEFAULT 'glue');"
         )
     }
 

--- a/test-suite/src/dictionary_index.rs
+++ b/test-suite/src/dictionary_index.rs
@@ -22,7 +22,7 @@ test_case!(ditionary_index, async move {
             TABLE_NAME       | INDEX_NAME                  | ORDER             | EXPRESSION               | UNIQUENESS;
             Str              | Str                         | Str               | Str                      | Bool;
             "Bar".to_owned()   "PRIMARY".to_owned()          "BOTH".to_owned()   "id".to_owned()            true;
-            "Bar".to_owned()   "Bar_name_concat".to_owned()  "BOTH".to_owned()   "name + \"_\"".to_owned()  false;
+            "Bar".to_owned()   "Bar_name_concat".to_owned()  "BOTH".to_owned()   "name + '_'".to_owned()  false;
             "Foo".to_owned()   "Foo_id".to_owned()           "BOTH".to_owned()   "id".to_owned()            false;
             "Foo".to_owned()   "Foo_id_2".to_owned()         "BOTH".to_owned()   "id + 2".to_owned()        false
         ))


### PR DESCRIPTION
## Goal
### Let's use single quote only for sql literal string
```sql
SELECT 'literal';
```

## Todo
- [x] refactor: replace double quote to single quote

## Next
- fix translate to handle double qoute for Identifier