### PR TITLE
Improve duplicate column names validation

### DIFF
--- a/core/src/executor/alter/error.rs
+++ b/core/src/executor/alter/error.rs
@@ -28,4 +28,7 @@ pub enum AlterError {
 
     #[error("identifier not found: {0:#?}")]
     IdentifierNotFound(Expr),
+
+    #[error("duplicate column name: {0}")]
+    DuplicateColumnName(String),
 }

--- a/core/src/executor/alter/mod.rs
+++ b/core/src/executor/alter/mod.rs
@@ -4,7 +4,7 @@ mod index;
 mod table;
 mod validate;
 
-use validate::validate;
+use validate::{validate, validate_column_names};
 
 #[cfg(feature = "alter-table")]
 pub use alter_table::alter_table;

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -1,5 +1,5 @@
 use {
-    super::{validate, AlterError},
+    super::{validate, validate_column_names, AlterError},
     crate::{
         ast::{ColumnDef, Query, SetExpr, TableFactor, Values},
         data::{Schema, TableError},
@@ -110,23 +110,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
             created: Utc::now().naive_utc(),
         };
 
-        // validate dupplicate column names
-        let dupplicate_column = schema
-            .column_defs
-            .iter()
-            .enumerate()
-            .find(|(i, base_column)| {
-                schema
-                    .column_defs
-                    .iter()
-                    .skip(i + 1)
-                    .any(|target_column| base_column.name == target_column.name)
-            })
-            .map(|(_, column)| &column.name);
-
-        if let Some(v) = dupplicate_column {
-            return Err(AlterError::DuplicateColumnName(v.to_owned()).into());
-        }
+        validate_column_names(&schema.column_defs)?;
 
         for column_def in &schema.column_defs {
             validate(column_def)?;

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -110,6 +110,24 @@ pub async fn create_table<T: GStore + GStoreMut>(
             created: Utc::now().naive_utc(),
         };
 
+        // validate dupplicate column names
+        let dupplicate_column = schema
+            .column_defs
+            .iter()
+            .enumerate()
+            .find(|(i, base_column)| {
+                schema
+                    .column_defs
+                    .iter()
+                    .skip(i + 1)
+                    .any(|target_column| base_column.name == target_column.name)
+            })
+            .map(|(_, column)| &column.name);
+
+        if let Some(v) = dupplicate_column {
+            return Err(AlterError::DuplicateColumnName(v.to_owned()).into());
+        }
+
         for column_def in &schema.column_defs {
             validate(column_def)?;
         }

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -39,3 +39,21 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
 
     Ok(())
 }
+
+pub fn validate_column_names(column_defs: &Vec<ColumnDef>) -> Result<()> {
+    let dupplicate_colum_name = column_defs
+        .iter()
+        .enumerate()
+        .find(|(i, base_column)| {
+            column_defs
+                .iter()
+                .skip(i + 1)
+                .any(|target_column| base_column.name == target_column.name)
+        })
+        .map(|(_, column)| &column.name);
+
+    match dupplicate_colum_name {
+        Some(v) => Err(AlterError::DuplicateColumnName(v.to_owned()).into()),
+        None => Ok(()),
+    }
+}

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -40,7 +40,7 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
     Ok(())
 }
 
-pub fn validate_column_names(column_defs: &Vec<ColumnDef>) -> Result<()> {
+pub fn validate_column_names(column_defs: &[ColumnDef]) -> Result<()> {
     let duplicate_colum_name = column_defs
         .iter()
         .enumerate()

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -41,7 +41,7 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
 }
 
 pub fn validate_column_names(column_defs: &Vec<ColumnDef>) -> Result<()> {
-    let dupplicate_colum_name = column_defs
+    let duplicate_colum_name = column_defs
         .iter()
         .enumerate()
         .find(|(i, base_column)| {
@@ -52,7 +52,7 @@ pub fn validate_column_names(column_defs: &Vec<ColumnDef>) -> Result<()> {
         })
         .map(|(_, column)| &column.name);
 
-    match dupplicate_colum_name {
+    match duplicate_colum_name {
         Some(v) => Err(AlterError::DuplicateColumnName(v.to_owned()).into()),
         None => Ok(()),
     }

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -20,7 +20,7 @@ pub enum AlterTableError {
     #[error("Default value is required: {0:#?}")]
     DefaultValueRequired(ColumnDef),
 
-    #[error("Adding column already exists: {0}")]
+    #[error("Column already exists: {0}")]
     ColumnAlreadyExists(String),
 
     #[error("Dropping column not found: {0}")]

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -21,7 +21,7 @@ pub enum AlterTableError {
     DefaultValueRequired(ColumnDef),
 
     #[error("Adding column already exists: {0}")]
-    AddingColumnAlreadyExists(String),
+    ColumnAlreadyExists(String),
 
     #[error("Dropping column not found: {0}")]
     DroppingColumnNotFound(String),

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -20,8 +20,8 @@ pub enum AlterTableError {
     #[error("Default value is required: {0:#?}")]
     DefaultValueRequired(ColumnDef),
 
-    #[error("Column already exists: {0}")]
-    AlreadyExistsColumn(String),
+    #[error("Already existing column: {0}")]
+    AlreadyExistingColumn(String),
 
     #[error("Dropping column not found: {0}")]
     DroppingColumnNotFound(String),

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -21,7 +21,7 @@ pub enum AlterTableError {
     DefaultValueRequired(ColumnDef),
 
     #[error("Column already exists: {0}")]
-    ColumnAlreadyExists(String),
+    AlreadyExistsColumn(String),
 
     #[error("Dropping column not found: {0}")]
     DroppingColumnNotFound(String),

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -40,7 +40,7 @@ impl MemoryStorage {
             .iter()
             .any(|ColumnDef { name, .. }| name == new_column_name)
         {
-            return Err(AlterTableError::ColumnAlreadyExists(new_column_name.to_owned()).into());
+            return Err(AlterTableError::AlreadyExistingColumn(new_column_name.to_owned()).into());
         }
 
         let mut column_def = item
@@ -69,7 +69,7 @@ impl MemoryStorage {
         {
             let adding_column = column_def.name.to_owned();
 
-            return Err(AlterTableError::ColumnAlreadyExists(adding_column).into());
+            return Err(AlterTableError::AlreadyExistingColumn(adding_column).into());
         }
 
         let ColumnDef {

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -34,6 +34,15 @@ impl MemoryStorage {
             .get_mut(table_name)
             .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()))?;
 
+        if item
+            .schema
+            .column_defs
+            .iter()
+            .any(|ColumnDef { name, .. }| name == new_column_name)
+        {
+            return Err(AlterTableError::ColumnAlreadyExists(new_column_name.to_string()).into());
+        }
+
         let mut column_def = item
             .schema
             .column_defs
@@ -60,7 +69,7 @@ impl MemoryStorage {
         {
             let adding_column = column_def.name.to_owned();
 
-            return Err(AlterTableError::AddingColumnAlreadyExists(adding_column).into());
+            return Err(AlterTableError::ColumnAlreadyExists(adding_column).into());
         }
 
         let ColumnDef {

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -40,7 +40,7 @@ impl MemoryStorage {
             .iter()
             .any(|ColumnDef { name, .. }| name == new_column_name)
         {
-            return Err(AlterTableError::ColumnAlreadyExists(new_column_name.to_string()).into());
+            return Err(AlterTableError::ColumnAlreadyExists(new_column_name.to_owned()).into());
         }
 
         let mut column_def = item

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -169,7 +169,7 @@ impl AlterTable for SledStorage {
                 .any(|ColumnDef { name, .. }| name == new_column_name)
             {
                 return Err(
-                    AlterTableError::ColumnAlreadyExists(new_column_name.to_owned()).into(),
+                    AlterTableError::AlreadyExistingColumn(new_column_name.to_owned()).into(),
                 )
                 .map_err(ConflictableTransactionError::Abort);
             }
@@ -263,7 +263,7 @@ impl AlterTable for SledStorage {
             {
                 let adding_column = column_def.name.to_owned();
 
-                return Err(AlterTableError::ColumnAlreadyExists(adding_column).into())
+                return Err(AlterTableError::AlreadyExistingColumn(adding_column).into())
                     .map_err(ConflictableTransactionError::Abort);
             }
 

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -169,7 +169,7 @@ impl AlterTable for SledStorage {
                 .any(|ColumnDef { name, .. }| name == new_column_name)
             {
                 return Err(
-                    AlterTableError::ColumnAlreadyExists(new_column_name.to_string()).into(),
+                    AlterTableError::ColumnAlreadyExists(new_column_name.to_owned()).into(),
                 )
                 .map_err(ConflictableTransactionError::Abort);
             }

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -164,6 +164,16 @@ impl AlterTable for SledStorage {
                 .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()).into())
                 .map_err(ConflictableTransactionError::Abort)?;
 
+            if column_defs
+                .iter()
+                .any(|ColumnDef { name, .. }| name == new_column_name)
+            {
+                return Err(
+                    AlterTableError::ColumnAlreadyExists(new_column_name.to_string()).into(),
+                )
+                .map_err(ConflictableTransactionError::Abort);
+            }
+
             let i = column_defs
                 .iter()
                 .position(|column_def| column_def.name == old_column_name)
@@ -253,7 +263,7 @@ impl AlterTable for SledStorage {
             {
                 let adding_column = column_def.name.to_owned();
 
-                return Err(AlterTableError::AddingColumnAlreadyExists(adding_column).into())
+                return Err(AlterTableError::ColumnAlreadyExists(adding_column).into())
                     .map_err(ConflictableTransactionError::Abort);
             }
 

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -37,7 +37,7 @@ test_case!(alter_table_rename, async move {
         (
             // Cannot rename to duplicated column name
             "ALTER TABLE Bar RENAME COLUMN name TO new_id",
-            Err(AlterTableError::ColumnAlreadyExists("new_id".to_owned()).into()),
+            Err(AlterTableError::AlreadyExistingColumn("new_id".to_owned()).into()),
         ),
     ];
 
@@ -63,7 +63,7 @@ test_case!(alter_table_add_drop, async move {
         ),
         (
             "ALTER TABLE Foo ADD COLUMN id INTEGER",
-            Err(AlterTableError::ColumnAlreadyExists("id".to_owned()).into()),
+            Err(AlterTableError::AlreadyExistingColumn("id".to_owned()).into()),
         ),
         (
             "ALTER TABLE Foo ADD COLUMN amount INTEGER DEFAULT 10",

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -10,9 +10,12 @@ use {
 
 test_case!(alter_table_rename, async move {
     let test_cases = [
-        ("CREATE TABLE Foo (id INTEGER);", Ok(Payload::Create)),
         (
-            "INSERT INTO Foo VALUES (1), (2), (3);",
+            "CREATE TABLE Foo (id INTEGER, name TEXT);",
+            Ok(Payload::Create),
+        ),
+        (
+            "INSERT INTO Foo VALUES (1, 'a'), (2, 'b'), (3, 'c');",
             Ok(Payload::Insert(3)),
         ),
         ("SELECT id FROM Foo", Ok(select!(id; I64; 1; 2; 3))),
@@ -30,6 +33,11 @@ test_case!(alter_table_rename, async move {
         (
             "ALTER TABLE Bar RENAME COLUMN hello TO idid",
             Err(AlterTableError::RenamingColumnNotFound.into()),
+        ),
+        (
+            // Cannot rename to duplicated column name
+            "ALTER TABLE Bar RENAME COLUMN name TO new_id",
+            Err(AlterTableError::ColumnAlreadyExists("new_id".to_owned()).into()),
         ),
     ];
 
@@ -55,7 +63,7 @@ test_case!(alter_table_add_drop, async move {
         ),
         (
             "ALTER TABLE Foo ADD COLUMN id INTEGER",
-            Err(AlterTableError::AddingColumnAlreadyExists("id".to_owned()).into()),
+            Err(AlterTableError::ColumnAlreadyExists("id".to_owned()).into()),
         ),
         (
             "ALTER TABLE Foo ADD COLUMN amount INTEGER DEFAULT 10",

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -129,6 +129,11 @@ test_case!(create_table, async move {
             "CREATE TABLE TargetTableWithData2 AS SELECT * FROM NonExistentTable",
             Err(AlterError::CtasSourceTableNotFound("NonExistentTable".to_owned()).into()),
         ),
+        (
+            // Cannot create table with duplicate column name
+            "CREATE TABLE DuplicateColumns (id INT, id INT)",
+            Err(AlterError::DuplicateColumnName("id".to_owned()).into()),
+        ),
     ];
 
     for (sql, expected) in test_cases {


### PR DESCRIPTION
## Goal
### 1. CREATE TABLE with duplicate column name should get Error
```sql
gluesql> CREATE TABLE Item (id INT, id INT);
[error] duplicate column name: id
```
### 2. RENAME COLUMN with duplicated column name should get Error
```sql
gluesql> CREATE TABLE Item (id INT, name TEXT);
Table created

gluesql> ALTER TABLE Item RENAME COLUMN name to id;
[error] column already exists: id
```
### 3. ADD COLUMN already has validation.

## Todo
- [x] implement validate_column_names
- [x] add validation to `rename_column` at sled-storage, memory-storage
- [x] rename `AddColumnAlreadyExists` to `ColumnAlreadyExists`