### PR TITLE
Modify default ColumnOption from NOT NULL to NULL

### DIFF
--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -66,13 +66,13 @@ impl Row {
             return Err(RowError::TooManyValues.into());
         }
 
-        // if let Some(wrong_column_name) = columns.iter().find(|column_name| {
-        //     !column_defs
-        //         .iter()
-        //         .any(|column_def| &&column_def.name == column_name)
-        // }) {
-        //     return Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into());
-        // }
+        if let Some(wrong_column_name) = columns.iter().find(|column_name| {
+            !column_defs
+                .iter()
+                .any(|column_def| &&column_def.name == column_name)
+        }) {
+            return Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into());
+        }
 
         let columns = if columns.is_empty() {
             Columns::All(column_defs.iter().map(|ColumnDef { name, .. }| name))
@@ -81,10 +81,19 @@ impl Row {
         };
 
         let column_name_value_list = columns.zip(values.iter()).collect::<Vec<(_, _)>>();
+        // let column_name_value_list = columns.zip(values.iter());
+        // let a = column_name_value_list.fold(Vec::new(), |mut acc, cur| {
+        //     acc.push(cur);
+
+        //     acc
+        // });
+
+        // todo!();
 
         /*
-        A B C D E
-        x y z N e
+        A B C
+        \ V \
+
         column_name, column_def.name, value
         Y =>
         N => definately Err
@@ -119,23 +128,47 @@ impl Row {
                     ..
                 } = column_def;
 
+                /*
+                insert into T (B) values(2);
+                insert into T (X) values(2);
+
+                A => 1) is A? => value 2) default? default 3) nullable? null 4) check name exists in table
+                not found, no default, not null
+
+                */
+
                 let value = column_name_value_list
                     .iter()
                     .find(|(name, _)| name == &def_name)
                     .map(|(_, value)| value);
 
+                // match (value, column_def.get_default()) {
+                //     (Some(&expr), _) | (None, Some(expr)) => {
+                //         evaluate_stateless(None, expr)?.try_into_value(data_type, *nullable)
+                //     }
+                //     (None, None) => {
+                //         let known_column = column_name_value_list.iter().any(|(name, _)| {
+                //             column_defs
+                //                 .iter()
+                //                 .any(|column_def| &&column_def.name == name)
+                //         });
+
+                //         match known_column {
+                //             true => Ok(Value::Null),
+                //             false => {
+                //                 Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into())
+                //             }
+                //         }
+                //     }
+                // }
+
                 match (value, column_def.get_default(), nullable) {
                     (Some(&expr), _, _) | (None, Some(expr), _) => {
-                        println!("here");
                         evaluate_stateless(None, expr)?.try_into_value(data_type, *nullable)
                     }
-                    (None, None, true) => {
-                        println!("here2");
-                        Ok(Value::Null)
-                    }
+                    (None, None, true) => Ok(Value::Null),
                     (None, None, false) => {
-                        unreachable!();
-                        // Err(RowError::LackOfRequiredColumn(def_name.to_owned()).into())
+                        Err(RowError::LackOfRequiredColumn(def_name.to_owned()).into())
                     }
                 }
             })

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -15,6 +15,9 @@ pub enum RowError {
     #[error("lack of required column: {0}")]
     LackOfRequiredColumn(String),
 
+    #[error("wrong column name: {0}")]
+    WrongColumnName(String),
+
     #[error("column and values not matched")]
     ColumnAndValuesNotMatched,
 
@@ -63,6 +66,14 @@ impl Row {
             return Err(RowError::TooManyValues.into());
         }
 
+        if let Some(wrong_column_name) = columns.iter().find(|column_name| {
+            !column_defs
+                .iter()
+                .any(|column_def| &&column_def.name == column_name)
+        }) {
+            return Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into());
+        }
+
         let columns = if columns.is_empty() {
             Columns::All(column_defs.iter().map(|ColumnDef { name, .. }| name))
         } else {
@@ -92,7 +103,8 @@ impl Row {
                     }
                     (None, None, true) => Ok(Value::Null),
                     (None, None, false) => {
-                        Err(RowError::LackOfRequiredColumn(def_name.to_owned()).into())
+                        unreachable!();
+                        // Err(RowError::LackOfRequiredColumn(def_name.to_owned()).into())
                     }
                 }
             })

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -81,42 +81,6 @@ impl Row {
         };
 
         let column_name_value_list = columns.zip(values.iter()).collect::<Vec<(_, _)>>();
-        // let column_name_value_list = columns.zip(values.iter());
-        // let a = column_name_value_list.fold(Vec::new(), |mut acc, cur| {
-        //     acc.push(cur);
-
-        //     acc
-        // });
-
-        // todo!();
-
-        /*
-        A B C
-        \ V \
-
-        column_name, column_def.name, value
-        Y =>
-        N => definately Err
-        */
-        // column_name_value_list.iter().map(|(name, value)| {
-        //     if let Some(column_def) = column_defs
-        //         .iter()
-        //         .find(|column_def| name == &&column_def.name)
-        //     {
-        //         let ColumnDef {
-        //             name: def_name,
-        //             data_type,
-        //             nullable,
-        //             ..
-        //         } = column_def;
-
-        //         return match (column_def.get_default(), nullable) {
-        //             (None, true) => Ok(Value::Null),
-        //             (None, false) =>
-        //             (Some(&expr), _) => todo!(),
-        //         };
-        //     }
-        // });
 
         column_defs
             .iter()
@@ -128,39 +92,10 @@ impl Row {
                     ..
                 } = column_def;
 
-                /*
-                insert into T (B) values(2);
-                insert into T (X) values(2);
-
-                A => 1) is A? => value 2) default? default 3) nullable? null 4) check name exists in table
-                not found, no default, not null
-
-                */
-
                 let value = column_name_value_list
                     .iter()
                     .find(|(name, _)| name == &def_name)
                     .map(|(_, value)| value);
-
-                // match (value, column_def.get_default()) {
-                //     (Some(&expr), _) | (None, Some(expr)) => {
-                //         evaluate_stateless(None, expr)?.try_into_value(data_type, *nullable)
-                //     }
-                //     (None, None) => {
-                //         let known_column = column_name_value_list.iter().any(|(name, _)| {
-                //             column_defs
-                //                 .iter()
-                //                 .any(|column_def| &&column_def.name == name)
-                //         });
-
-                //         match known_column {
-                //             true => Ok(Value::Null),
-                //             false => {
-                //                 Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into())
-                //             }
-                //         }
-                //     }
-                // }
 
                 match (value, column_def.get_default(), nullable) {
                     (Some(&expr), _, _) | (None, Some(expr), _) => {

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -66,13 +66,13 @@ impl Row {
             return Err(RowError::TooManyValues.into());
         }
 
-        if let Some(wrong_column_name) = columns.iter().find(|column_name| {
-            !column_defs
-                .iter()
-                .any(|column_def| &&column_def.name == column_name)
-        }) {
-            return Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into());
-        }
+        // if let Some(wrong_column_name) = columns.iter().find(|column_name| {
+        //     !column_defs
+        //         .iter()
+        //         .any(|column_def| &&column_def.name == column_name)
+        // }) {
+        //     return Err(RowError::WrongColumnName(wrong_column_name.to_owned()).into());
+        // }
 
         let columns = if columns.is_empty() {
             Columns::All(column_defs.iter().map(|ColumnDef { name, .. }| name))
@@ -81,6 +81,33 @@ impl Row {
         };
 
         let column_name_value_list = columns.zip(values.iter()).collect::<Vec<(_, _)>>();
+
+        /*
+        A B C D E
+        x y z N e
+        column_name, column_def.name, value
+        Y =>
+        N => definately Err
+        */
+        // column_name_value_list.iter().map(|(name, value)| {
+        //     if let Some(column_def) = column_defs
+        //         .iter()
+        //         .find(|column_def| name == &&column_def.name)
+        //     {
+        //         let ColumnDef {
+        //             name: def_name,
+        //             data_type,
+        //             nullable,
+        //             ..
+        //         } = column_def;
+
+        //         return match (column_def.get_default(), nullable) {
+        //             (None, true) => Ok(Value::Null),
+        //             (None, false) =>
+        //             (Some(&expr), _) => todo!(),
+        //         };
+        //     }
+        // });
 
         column_defs
             .iter()
@@ -99,9 +126,13 @@ impl Row {
 
                 match (value, column_def.get_default(), nullable) {
                     (Some(&expr), _, _) | (None, Some(expr), _) => {
+                        println!("here");
                         evaluate_stateless(None, expr)?.try_into_value(data_type, *nullable)
                     }
-                    (None, None, true) => Ok(Value::Null),
+                    (None, None, true) => {
+                        println!("here2");
+                        Ok(Value::Null)
+                    }
                     (None, None, false) => {
                         unreachable!();
                         // Err(RowError::LackOfRequiredColumn(def_name.to_owned()).into())

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -59,9 +59,10 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
         ..
     } = sql_column_def;
 
-    let nullable = options
-        .iter()
-        .any(|SqlColumnOptionDef { option, .. }| option == &SqlColumnOption::Null);
+    let nullable = !options.iter().any(|SqlColumnOptionDef { option, .. }| {
+        option == &SqlColumnOption::NotNull
+            || option == &SqlColumnOption::Unique { is_primary: true }
+    });
 
     Ok(ColumnDef {
         name: name.value.to_owned(),

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -52,7 +52,7 @@ test_case!(alter_table_add_drop, async move {
         ("INSERT INTO Foo VALUES (1), (2);", Ok(Payload::Insert(2))),
         ("SELECT * FROM Foo;", Ok(select!(id; I64; 1; 2))),
         (
-            "ALTER TABLE Foo ADD COLUMN amount INTEGER",
+            "ALTER TABLE Foo ADD COLUMN amount INTEGER NOT NULL",
             Err(AlterTableError::DefaultValueRequired(ColumnDef {
                 name: "amount".to_owned(),
                 data_type: DataType::Int,

--- a/test-suite/src/nullable.rs
+++ b/test-suite/src/nullable.rs
@@ -8,7 +8,7 @@ test_case!(nullable, async move {
         "
 CREATE TABLE Test (
     id INTEGER NULL,
-    num INTEGER,
+    num INTEGER NOT NULL,
     name TEXT
 )"
     );

--- a/test-suite/src/validate/types.rs
+++ b/test-suite/src/validate/types.rs
@@ -10,7 +10,7 @@ use {
 
 test_case!(types, async move {
     run!("CREATE TABLE TableB (id BOOLEAN);");
-    run!("CREATE TABLE TableC (uid INTEGER, null_val INTEGER NULL);");
+    run!("CREATE TABLE TableC (uid INTEGER NOT NULL, null_val INTEGER NULL);");
     run!("INSERT INTO TableB VALUES (FALSE);");
     run!("INSERT INTO TableC VALUES (1, NULL);");
 

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -12,6 +12,7 @@ use {
 
 test_case!(values, async move {
     run!("CREATE TABLE TableA (id INTEGER);");
+    run!("CREATE TABLE TableB (id INTEGER NOT NULL);");
     run!("INSERT INTO TableA (id) VALUES (1);");
     run!("INSERT INTO TableA (id) VALUES (9);");
 
@@ -161,8 +162,12 @@ test_case!(values, async move {
             "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
             Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
         ),
+        // (
+        //     "INSERT INTO TableA (id2) VALUES (1);",
+        //     Err(RowError::WrongColumnName("id2".to_owned()).into()),
+        // ),
         (
-            "INSERT INTO TableA (id2) VALUES (1);",
+            "INSERT INTO TableB (id2) VALUES (1);",
             Err(RowError::WrongColumnName("id2".to_owned()).into()),
         ),
         (

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -163,7 +163,7 @@ test_case!(values, async move {
         ),
         (
             "INSERT INTO TableA (id2) VALUES (1);",
-            Err(RowError::LackOfRequiredColumn("id".to_owned()).into()),
+            Err(RowError::WrongColumnName("id2".to_owned()).into()),
         ),
         (
             "INSERT INTO TableA (id) VALUES ('test2', 3)",

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -12,7 +12,7 @@ use {
 
 test_case!(values, async move {
     run!("CREATE TABLE TableA (id INTEGER);");
-    run!("CREATE TABLE TableB (id INTEGER NOT NULL);");
+    run!("CREATE TABLE TableB (id INTEGER NOT NULL, name TEXT NOT NULL);");
     run!("INSERT INTO TableA (id) VALUES (1);");
     run!("INSERT INTO TableA (id) VALUES (9);");
 
@@ -162,13 +162,13 @@ test_case!(values, async move {
             "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS Derived(id, name, dummy)",
             Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
         ),
-        // (
-        //     "INSERT INTO TableA (id2) VALUES (1);",
-        //     Err(RowError::WrongColumnName("id2".to_owned()).into()),
-        // ),
         (
-            "INSERT INTO TableB (id2) VALUES (1);",
+            "INSERT INTO TableA (id2) VALUES (1);",
             Err(RowError::WrongColumnName("id2".to_owned()).into()),
+        ),
+        (
+            "INSERT INTO TableB (id) VALUES (1);",
+            Err(RowError::LackOfRequiredColumn("name".to_owned()).into()),
         ),
         (
             "INSERT INTO TableA (id) VALUES ('test2', 3)",

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -11,10 +11,7 @@ use {
 };
 
 test_case!(values, async move {
-    run!("CREATE TABLE TableA (id INTEGER);");
-    run!("CREATE TABLE TableB (id INTEGER NOT NULL, name TEXT NOT NULL);");
-    run!("INSERT INTO TableA (id) VALUES (1);");
-    run!("INSERT INTO TableA (id) VALUES (9);");
+    run!("CREATE TABLE Items (id INTEGER NOT NULL, name TEXT, status TEXT DEFAULT 'ACTIVE' NOT NULL);");
 
     let test_cases = [
         (
@@ -163,19 +160,23 @@ test_case!(values, async move {
             Err(FetchError::TooManyColumnAliases("Derived".into(), 2, 3).into()),
         ),
         (
-            "INSERT INTO TableA (id2) VALUES (1);",
+            "INSERT INTO Items (id) VALUES (1);",
+            Ok(Payload::Insert(1))
+        ),
+        (
+            "INSERT INTO Items (id2) VALUES (1);",
             Err(RowError::WrongColumnName("id2".to_owned()).into()),
         ),
         (
-            "INSERT INTO TableB (id) VALUES (1);",
-            Err(RowError::LackOfRequiredColumn("name".to_owned()).into()),
+            "INSERT INTO Items (name) VALUES ('glue');",
+            Err(RowError::LackOfRequiredColumn("id".to_owned()).into()),
         ),
         (
-            "INSERT INTO TableA (id) VALUES ('test2', 3)",
+            "INSERT INTO Items (id) VALUES (3, 'sql')",
             Err(RowError::ColumnAndValuesNotMatched.into()),
         ),
         (
-            "INSERT INTO TableA VALUES (100), (100, 200);",
+            "INSERT INTO Items VALUES (100, 'a', 'b', 1);",
             Err(RowError::TooManyValues.into()),
         ),
         (


### PR DESCRIPTION
To resolve #974 

## Goal
For better user experience, Let's modify default ColumnDef.nullable from `false` to `true`
```sql
CREATE TABLE Items (id INT);
```
### Before
| TABLE_NAME | COLUMN_NAME | NULLABLE |
|------------|-------------|-----------|
| Items        | id          | NOT NULL         |

### After
| TABLE_NAME | COLUMN_NAME | NULLABLE |
|------------|-------------|-----------|
| Items        | id          | NULL         |

## Todo
- [x] modify default ColumnDef.nullable from `false` to `true`
- [x] add Column name validation and RowErr::WrongColumnName)