### PR TITLE
Replace `double quotes` to `identifier`

### DIFF
--- a/core/src/ast_builder/expr/binary_op.rs
+++ b/core/src/ast_builder/expr/binary_op.rs
@@ -96,7 +96,7 @@ mod tests {
         let expected = "amount % 30";
         test_expr(actual, expected);
 
-        let actual = text("hello").concat(r#""world""#);
+        let actual = text("hello").concat("'world'");
         let expected = "'hello' || 'world'";
         test_expr(actual, expected);
 
@@ -121,7 +121,7 @@ mod tests {
         test_expr(actual, expected);
 
         let actual = col("id").neq("'abcde'");
-        let expected = r#"id != "abcde""#;
+        let expected = "id != 'abcde'";
         test_expr(actual, expected);
 
         let actual = (col("id").gt(num(10))).and(col("id").lt(num(20)));

--- a/core/src/ast_builder/expr/case.rs
+++ b/core/src/ast_builder/expr/case.rs
@@ -72,13 +72,13 @@ mod tests {
             .when_then(num(1), text("a"))
             .when_then(2, text("b"))
             .or_else(text("c"));
-        let expected = r#"
+        let expected = "
             CASE id
-              WHEN 1 THEN "a"
-              WHEN 2 THEN "b"
-              ELSE "c"
+              WHEN 1 THEN 'a'
+              WHEN 2 THEN 'b'
+              ELSE 'c'
             END
-            "#;
+            ";
         test_expr(actual, expected);
 
         let actual = col("id")
@@ -87,12 +87,12 @@ mod tests {
             .when_then(true, text("a"))
             .when_then(false, text("b"))
             .end();
-        let expected = r#"
+        let expected = "
             CASE id > 10
-              WHEN True THEN "a"
-              WHEN False THEN "b"
+              WHEN True THEN 'a'
+              WHEN False THEN 'b'
             END
-            "#;
+            ";
         test_expr(actual, expected);
     }
 

--- a/core/src/ast_builder/expr/function.rs
+++ b/core/src/ast_builder/expr/function.rs
@@ -1239,11 +1239,11 @@ mod tests {
     #[test]
     fn function_position() {
         let actual = position(expr("cake"), text("ke"));
-        let expected = r#"POSITION("ke" IN cake)"#;
+        let expected = "POSITION('ke' IN cake)";
         test_expr(actual, expected);
 
         let actual = text("rice").position(text("cake"));
-        let expected = r#"POSITION("cake" IN "rice")"#;
+        let expected = "POSITION('cake' IN 'rice')";
         test_expr(actual, expected);
     }
 

--- a/core/src/data/interval/mod.rs
+++ b/core/src/data/interval/mod.rs
@@ -295,10 +295,7 @@ impl Interval {
                 format!("{:?}", to),
             )
             .into()),
-            (None, _) => {
-                println!("here");
-                Err(IntervalError::Unreachable.into())
-            }
+            (None, _) => Err(IntervalError::Unreachable.into()),
         }
     }
 }

--- a/core/src/data/interval/mod.rs
+++ b/core/src/data/interval/mod.rs
@@ -295,7 +295,10 @@ impl Interval {
                 format!("{:?}", to),
             )
             .into()),
-            (None, _) => Err(IntervalError::Unreachable.into()),
+            (None, _) => {
+                println!("here");
+                Err(IntervalError::Unreachable.into())
+            }
         }
     }
 }

--- a/core/src/data/interval/string.rs
+++ b/core/src/data/interval/string.rs
@@ -15,8 +15,6 @@ impl TryFrom<&str> for Interval {
 
     fn try_from(s: &str) -> Result<Self> {
         let parsed = parse_interval(s)?;
-        println!("{parsed:?}");
-        // println!("{leading_field:?}:{last_field:?}");
 
         match translate_expr(&parsed)? {
             Expr::Interval {

--- a/core/src/data/interval/string.rs
+++ b/core/src/data/interval/string.rs
@@ -15,6 +15,8 @@ impl TryFrom<&str> for Interval {
 
     fn try_from(s: &str) -> Result<Self> {
         let parsed = parse_interval(s)?;
+        println!("{parsed:?}");
+        // println!("{leading_field:?}:{last_field:?}");
 
         match translate_expr(&parsed)? {
             Expr::Interval {

--- a/core/src/data/key.rs
+++ b/core/src/data/key.rs
@@ -288,23 +288,20 @@ mod tests {
         );
 
         assert_eq!(
-            convert(r#""Hello World""#),
+            convert("'Hello World'"),
             Ok(Key::Str("Hello World".to_owned()))
         );
         assert_eq!(
             convert("X'1234'"),
             Ok(Key::Bytea(hex::decode("1234").unwrap())),
         );
-        assert!(matches!(convert(r#"DATE "2022-03-03""#), Ok(Key::Date(_))));
-        assert!(matches!(convert(r#"TIME "12:30:00""#), Ok(Key::Time(_))));
+        assert!(matches!(convert("DATE '2022-03-03'"), Ok(Key::Date(_))));
+        assert!(matches!(convert("TIME '12:30:00'"), Ok(Key::Time(_))));
         assert!(matches!(
-            convert(r#"TIMESTAMP "2022-03-03 12:30:00Z""#),
+            convert("TIMESTAMP '2022-03-03 12:30:00Z'"),
             Ok(Key::Timestamp(_))
         ));
-        assert!(matches!(
-            convert(r#"INTERVAL "1" DAY"#),
-            Ok(Key::Interval(_))
-        ));
+        assert!(matches!(convert("INTERVAL '1' DAY"), Ok(Key::Interval(_))));
         assert!(matches!(convert("GENERATE_UUID()"), Ok(Key::Uuid(_))));
 
         // None
@@ -323,9 +320,9 @@ mod tests {
             Key::try_from(Value::List(Vec::default())),
             Err(KeyError::ListTypeKeyNotSupported.into())
         );
-        assert_eq!(convert(r#"POSITION("PORK" IN "MEAT")"#), Ok(Key::I64(0)));
+        assert_eq!(convert("POSITION('PORK' IN 'MEAT')"), Ok(Key::I64(0)));
         assert_eq!(
-            convert(r#"EXTRACT(SECOND FROM INTERVAL "8" SECOND)"#),
+            convert("EXTRACT(SECOND FROM INTERVAL '8' SECOND)"),
             Ok(Key::I64(8))
         );
     }

--- a/core/src/data/value/convert.rs
+++ b/core/src/data/value/convert.rs
@@ -1268,11 +1268,11 @@ mod tests {
     #[test]
     fn try_into_interval() {
         assert_eq!(
-            (&Value::Str("\"+22-10\" YEAR TO MONTH".to_owned())).try_into() as Result<I>,
+            (&Value::Str("'+22-10' YEAR TO MONTH".to_owned())).try_into() as Result<I>,
             Ok(I::Month(274))
         );
         assert_eq!(
-            I::try_from(&Value::Str("\"+22-10\" YEAR TO MONTH".to_owned())),
+            I::try_from(&Value::Str("'+22-10' YEAR TO MONTH".to_owned())),
             Ok(I::Month(274))
         );
     }

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -759,7 +759,7 @@ mod tests {
         );
         test!(
             DataType::Interval,
-            text!(r#""+22-10" YEAR TO MONTH"#),
+            text!("'+22-10' YEAR TO MONTH"),
             Value::Interval(I::Month(274))
         );
         test!(

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -202,8 +202,8 @@ mod tests {
         }
 
         // PlanExpr::None
-        test!(r#"DATE "2011-01-09""#, true);
-        test!(r#""hello world""#, true);
+        test!("DATE '2011-01-09'", true);
+        test!("'hello world'", true);
 
         // PlanExpr::Identifier
         test!("id", true);
@@ -222,12 +222,12 @@ mod tests {
         test!("-10", true);
         test!("rate!", true);
         test!("-wow", false);
-        test!(r#"("hello" || "world")"#, true);
+        test!("('hello' || 'world')", true);
         test!("(name)", true);
         test!("(1 + cat)", false);
         test!("CAST(id AS DECIMAL)", true);
         test!("CAST(Hello.world AS BOOLEAN)", false);
-        test!(r#"EXTRACT(YEAR FROM DATE "2022-03-01")"#, true);
+        test!("EXTRACT(YEAR FROM DATE '2022-03-01')", true);
         test!("EXTRACT(YEAR FROM rate)", true);
         test!("EXTRACT(HOUR FROM virtual_env)", false);
         test!("rate IS NULL", true);
@@ -260,7 +260,7 @@ mod tests {
         test!("id IN (lab, 101)", false);
         test!("tree IN (something, 101)", false);
         test!("ROUND(1.54)", true);
-        test!(r#"TRIM(LEADING "a" FROM name)"#, true);
+        test!("TRIM(LEADING 'a' FROM name)", true);
         test!("LOWER(icecream)", false);
 
         // PlanExpr::Query

--- a/core/src/plan/expr/mod.rs
+++ b/core/src/plan/expr/mod.rs
@@ -165,13 +165,13 @@ mod tests {
 
         let actual = expr("name LIKE '_foo%'");
         let target = expr("name");
-        let pattern = expr(r#""_foo%""#);
+        let pattern = expr("'_foo%'");
         let expected = PlanExpr::TwoExprs(&target, &pattern);
         test!(actual, expected);
 
         let actual = expr("name ILIKE '_foo%'");
         let target = expr("name");
-        let pattern = expr(r#""_foo%""#);
+        let pattern = expr("'_foo%'");
         let expected = PlanExpr::TwoExprs(&target, &pattern);
         test!(actual, expected);
 

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -25,7 +25,13 @@ use {
 pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
     match sql_expr {
         SqlExpr::Identifier(ident) => match ident.quote_style {
-            Some(_) => Ok(Expr::Literal(AstLiteral::QuotedString(ident.value.clone()))),
+            Some(qoute_style) => {
+                match qoute_style {
+                    '"' => Ok(Expr::Identifier(ident.value.clone())),
+                    // Ok(Expr::Literal(AstLiteral::QuotedString(ident.value.clone()))),
+                    _ => unreachable!(),
+                }
+            }
             None => Ok(Expr::Identifier(ident.value.clone())),
         },
         SqlExpr::CompoundIdentifier(idents) => (idents.len() == 2)

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -7,7 +7,7 @@ use {
         translate_idents, translate_query, TranslateError,
     },
     crate::{
-        ast::{AstLiteral, Expr, OrderByExpr},
+        ast::{Expr, OrderByExpr},
         result::Result,
         translate::function::translate_trim,
     },
@@ -24,16 +24,7 @@ use {
 /// In `GlueSQL`, if an argument is received wrapped in `( )` in the sql statement, the standard is set to translate in the form of `Expr::Function(Box<Function::Cast>)` rather than `Expr::Cast`.
 pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
     match sql_expr {
-        SqlExpr::Identifier(ident) => match ident.quote_style {
-            Some(qoute_style) => {
-                match qoute_style {
-                    '"' => Ok(Expr::Identifier(ident.value.clone())),
-                    // Ok(Expr::Literal(AstLiteral::QuotedString(ident.value.clone()))),
-                    _ => unreachable!(),
-                }
-            }
-            None => Ok(Expr::Identifier(ident.value.clone())),
-        },
+        SqlExpr::Identifier(ident) => Ok(Expr::Identifier(ident.value.clone())),
         SqlExpr::CompoundIdentifier(idents) => (idents.len() == 2)
             .then(|| Expr::CompoundIdentifier {
                 alias: idents[0].value.clone(),

--- a/pkg/rust/examples/hello_world.rs
+++ b/pkg/rust/examples/hello_world.rs
@@ -30,7 +30,7 @@ mod hello_world {
         */
         let queries = "
           CREATE TABLE greet (name TEXT);
-          INSERT INTO greet VALUES (\"World\");
+          INSERT INTO greet VALUES ('World');
         ";
 
         glue.execute(queries).expect("Execution failed");

--- a/pkg/rust/examples/sled_multi_threaded.rs
+++ b/pkg/rust/examples/sled_multi_threaded.rs
@@ -25,7 +25,7 @@ mod sled_multi_threaded {
         let insert_storage = storage.clone();
         let insert_thread = thread::spawn(move || {
             let mut glue = Glue::new(insert_storage);
-            let query = "INSERT INTO greet (name) VALUES (\"Foo\")";
+            let query = "INSERT INTO greet (name) VALUES ('Foo')";
 
             glue.execute(query).unwrap();
         });

--- a/storages/sled-storage/benches/sled_benchmark.rs
+++ b/storages/sled-storage/benches/sled_benchmark.rs
@@ -37,8 +37,8 @@ pub fn bench_insert(c: &mut Criterion) {
     c.bench_function("insert_one", |b| {
         b.iter(|| {
             let query_str = format!(
-                "INSERT INTO Testing \
-            VALUES ({:#}, \"Testing 1\", \"Testing 2\", \"Testing 3\");",
+                "INSERT INTO Testing 
+                 VALUES ({:#}, 'Testing 1', 'Testing 2', 'Testing 3');",
                 &id
             );
             id += 1;
@@ -75,8 +75,8 @@ pub fn bench_select(c: &mut Criterion) {
 
         for i in 0..ITEM_SIZE {
             sqls += &*format!(
-                "INSERT INTO Testing \
-            VALUES ({:#}, \"Testing 1\", \"Testing 2\", \"Testing 3\");",
+                "INSERT INTO Testing
+                 VALUES ({:#}, 'Testing 1', 'Testing 2', 'Testing 3');",
                 &i
             );
         }
@@ -152,10 +152,10 @@ pub fn bench_select_tainted(c: &mut Criterion) {
 
         for i in 0..ITEM_SIZE {
             sqls += &*format!(
-                "INSERT INTO Testing \
-            VALUES ({0:#}, \"Testing 1\", \"Testing 2\", \"Testing 3\");\
-                INSERT INTO TestingTainted \
-            VALUES ({0:#}, \"Testing_tainted 1\", \"Testing_tainted 2\", \"Testing_tainted 3\");",
+                "INSERT INTO Testing
+                 VALUES ({0:#}, 'Testing 1', 'Testing 2', 'Testing 3');
+                 INSERT INTO TestingTainted
+                 VALUES ({0:#}, 'Testing_tainted 1', 'Testing_tainted 2', 'Testing_tainted 3');",
                 &i
             );
         }

--- a/test-suite/src/aggregate/error.rs
+++ b/test-suite/src/aggregate/error.rs
@@ -59,12 +59,12 @@ test_case!(error_group_by, async move {
     run!(
         "
         INSERT INTO Item (id, quantity, city, ratio) VALUES
-            (1,   10,   \"Seoul\",  0.2),
-            (2,    0,   \"Dhaka\",  0.9),
-            (3, NULL, \"Beijing\",  1.1),
-            (3,   30, \"Daejeon\",  3.2),
-            (4,   11,   \"Seoul\",   11),
-            (5,   24, \"Seattle\", 6.11);
+            (1,   10,   'Seoul',  0.2),
+            (2,    0,   'Dhaka',  0.9),
+            (3, NULL, 'Beijing',  1.1),
+            (3,   30, 'Daejeon',  3.2),
+            (4,   11,   'Seoul',   11),
+            (5,   24, 'Seattle', 6.11);
     "
     );
     test!(

--- a/test-suite/src/aggregate/group_by.rs
+++ b/test-suite/src/aggregate/group_by.rs
@@ -14,12 +14,12 @@ test_case!(group_by, async move {
     run!(
         "
         INSERT INTO Item (id, quantity, city, ratio) VALUES
-            (1,   10,   \"Seoul\",  0.2),
-            (2,    0,   \"Dhaka\",  0.9),
-            (3, NULL, \"Beijing\",  1.1),
-            (3,   30, \"Daejeon\",  3.2),
-            (4,   11,   \"Seoul\",   11),
-            (5,   24, \"Seattle\", 6.11);
+            (1,   10,   'Seoul',  0.2),
+            (2,    0,   'Dhaka',  0.9),
+            (3, NULL, 'Beijing',  1.1),
+            (3,   30, 'Daejeon',  3.2),
+            (4,   11,   'Seoul',   11),
+            (5,   24, 'Seattle', 6.11);
     "
     );
 

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -11,45 +11,45 @@ use {
 test_case!(create_table, async move {
     let test_cases = [
         (
-            r#"
+            "
         CREATE TABLE CreateTable1 (
             id INTEGER NULL,
             num INTEGER,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
         CREATE TABLE CreateTable1 (
             id INTEGER NULL,
             num INTEGER,
             name TEXT
-        )"#,
+        )",
             Err(AlterError::TableAlreadyExists("CreateTable1".to_owned()).into()),
         ),
         (
-            r#"
+            "
         CREATE TABLE IF NOT EXISTS CreateTable2 (
             id INTEGER NULL,
             num INTEGER,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
         CREATE TABLE IF NOT EXISTS CreateTable2 (
             id2 INTEGER NULL,
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO CreateTable2 VALUES (NULL, 1, "1");"#,
+            "INSERT INTO CreateTable2 VALUES (NULL, 1, '1');",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"INSERT INTO CreateTable2 VALUES (2, 2, "2");"#,
+            "INSERT INTO CreateTable2 VALUES (2, 2, '2');",
             Ok(Payload::Insert(1)),
         ),
         (
@@ -65,11 +65,11 @@ test_case!(create_table, async move {
             Err(TranslateError::UnsupportedColumnOption("CHECK (true)".to_owned()).into()),
         ),
         (
-            r#"
+            "
         CREATE TABLE CreateTable3 (
             id INTEGER,
             ratio FLOAT UNIQUE
-        )"#,
+        )",
             Err(AlterError::UnsupportedDataTypeForUniqueColumn(
                 "ratio".to_owned(),
                 gluesql_core::ast::DataType::Float,

--- a/test-suite/src/alter/drop_indexed.rs
+++ b/test-suite/src/alter/drop_indexed.rs
@@ -54,21 +54,21 @@ test_case!(drop_indexed_table, async move {
 
 test_case!(drop_indexed_column, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO Test
             (id, num, name)
         VALUES
-            (1, 2, "Hello");
-    "#
+            (1, 2, 'Hello');
+    "
     );
 
     // create indexes
@@ -121,8 +121,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             1     2     "Hello".to_owned()
         )),
-        idx!(idx_binary_op, Eq, r#""1Hello""#),
-        r#"SELECT id, num, name FROM Test WHERE id || name = "1Hello""#
+        idx!(idx_binary_op, Eq, "'1Hello'"),
+        "SELECT id, num, name FROM Test WHERE id || name = '1Hello'"
     );
 
     test_idx!(
@@ -151,8 +151,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             1     2     "Hello".to_owned()
         )),
-        idx!(idx_cast, Eq, r#""1""#),
-        r#"SELECT id, num, name FROM Test WHERE CAST(id AS TEXT) = "1""#
+        idx!(idx_cast, Eq, "'1'"),
+        "SELECT id, num, name FROM Test WHERE CAST(id AS TEXT) = '1'"
     );
 
     test!(

--- a/test-suite/src/alter/drop_table.rs
+++ b/test-suite/src/alter/drop_table.rs
@@ -8,16 +8,16 @@ use {
 };
 
 test_case!(drop_table, async move {
-    let create_sql = r#"
+    let create_sql = "
 CREATE TABLE DropTable (
     id INT,
     num INT,
     name TEXT
-)"#;
+)";
 
     run!(create_sql);
 
-    let sqls = ["INSERT INTO DropTable (id, num, name) VALUES (1, 2, \"Hello\")"];
+    let sqls = ["INSERT INTO DropTable (id, num, name) VALUES (1, 2, 'Hello')"];
 
     for sql in sqls {
         run!(sql);
@@ -38,12 +38,12 @@ CREATE TABLE DropTable (
             Err(AlterError::TableNotFound("DropTable".to_owned()).into()),
         ),
         (
-            r#"
+            "
 CREATE TABLE DropTable (
     id INT,
     num INT,
     name TEXT
-)"#,
+)",
             Ok(Payload::Create),
         ),
         ("DROP TABLE IF EXISTS DropTable;", Ok(Payload::DropTable)),
@@ -62,21 +62,21 @@ CREATE TABLE DropTable (
             Err(TranslateError::UnsupportedStatement("DROP VIEW DropTable".to_owned()).into()),
         ),
         (
-            r#"
+            "
         CREATE TABLE DropTable1 (
             id INT,
             num INT,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
         CREATE TABLE DropTable2 (
             id INT,
             num INT,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         ("DROP TABLE DropTable1, DropTable2;", Ok(Payload::DropTable)),
@@ -89,21 +89,21 @@ CREATE TABLE DropTable (
             Err(FetchError::TableNotFound("DropTable2".to_owned()).into()),
         ),
         (
-            r#"
+            "
         CREATE TABLE DropTable1 (
             id INT,
             num INT,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
         CREATE TABLE DropTable2 (
             id INT,
             num INT,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (
@@ -119,12 +119,12 @@ CREATE TABLE DropTable (
             Err(FetchError::TableNotFound("DropTable2".to_owned()).into()),
         ),
         (
-            r#"
+            "
         CREATE TABLE DropTable1 (
             id INT,
             num INT,
             name TEXT
-        )"#,
+        )",
             Ok(Payload::Create),
         ),
         (

--- a/test-suite/src/arithmetic/error.rs
+++ b/test-suite/src/arithmetic/error.rs
@@ -22,11 +22,11 @@ test_case!(error, async move {
     run!(
         "
         INSERT INTO Arith (id, num, name) VALUES
-            (1, 6, \"A\"),
-            (2, 8, \"B\"),
-            (3, 4, \"C\"),
-            (4, 2, \"D\"),
-            (5, 3, \"E\");
+            (1, 6, 'A'),
+            (2, 8, 'B'),
+            (3, 4, 'C'),
+            (4, 2, 'D'),
+            (5, 3, 'E');
     "
     );
 
@@ -113,7 +113,7 @@ test_case!(error, async move {
             LiteralError::DivisorShouldNotBeZero.into(),
         ),
         (
-            r#"SELECT * FROM Arith WHERE TRUE AND "hello""#,
+            "SELECT * FROM Arith WHERE TRUE AND 'hello'",
             EvaluateError::BooleanTypeRequired(format!(
                 "{:?}",
                 Literal::Text(Cow::Owned("hello".to_owned()))

--- a/test-suite/src/arithmetic/on_where.rs
+++ b/test-suite/src/arithmetic/on_where.rs
@@ -14,11 +14,11 @@ test_case!(on_where, async move {
     run!(
         "
         INSERT INTO Arith (id, num, name) VALUES
-            (1, 6, \"A\"),
-            (2, 8, \"B\"),
-            (3, 4, \"C\"),
-            (4, 2, \"D\"),
-            (5, 3, \"E\");
+            (1, 6, 'A'),
+            (2, 8, 'B'),
+            (3, 4, 'C'),
+            (4, 2, 'D'),
+            (5, 3, 'E');
     "
     );
 

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -21,9 +21,9 @@ CREATE TABLE TestA (
 )"#
     );
 
-    run!("INSERT INTO Test (id, num, name) VALUES (1, 2, \"Hello\")");
-    run!("INSERT INTO Test (id, num, name) VALUES (1, 9, \"World\")");
-    run!("INSERT INTO Test (id, num, name) VALUES (3, 4, \"Great\"), (4, 7, \"Job\")");
+    run!("INSERT INTO Test (id, num, name) VALUES (1, 2, 'Hello')");
+    run!("INSERT INTO Test (id, num, name) VALUES (1, 9, 'World')");
+    run!("INSERT INTO Test (id, num, name) VALUES (3, 4, 'Great'), (4, 7, 'Job')");
     run!("INSERT INTO TestA (id, num, name) SELECT id, num, name FROM Test");
 
     run!("CREATE TABLE TestB (id INTEGER);");

--- a/test-suite/src/blend.rs
+++ b/test-suite/src/blend.rs
@@ -36,9 +36,9 @@ test_case!(blend, async move {
     let insert_sqls = [
         "
         INSERT INTO BlendUser (id, name) VALUES
-            (1, \"Taehoon\"),
-            (2,    \"Mike\"),
-            (3,   \"Jorno\");
+            (1, 'Taehoon'),
+            (2,    'Mike'),
+            (3,   'Jorno');
         ",
         "
         INSERT INTO BlendItem (id, player_id, quantity) VALUES

--- a/test-suite/src/case.rs
+++ b/test-suite/src/case.rs
@@ -13,23 +13,23 @@ test_case!(case, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
             INSERT INTO 
             Item (id, name)
             VALUES
-                (1, "Harry"), (2, "Ron"), (3, "Hermione");
-            "#,
+                (1, 'Harry'), (2, 'Ron'), (3, 'Hermione');
+            ",
             Ok(Payload::Insert(3)),
         ),
         (
-            r#"
+            "
             SELECT CASE id
                 WHEN 1 THEN name
                 WHEN 2 THEN name 
                 WHEN 4 THEN name 
-                ELSE "Malfoy" END
+                ELSE 'Malfoy' END
             AS case FROM Item;
-            "#,
+            ",
             Ok(select!(
                 case
                 Str;
@@ -39,14 +39,14 @@ test_case!(case, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT CASE id
                 WHEN 1 THEN name
                 WHEN 2 THEN name 
                 WHEN 4 THEN name 
                 END
             AS case FROM Item;
-            "#,
+            ",
             Ok(select_with_null!(
                 "case";
                 Str("Harry".to_owned());
@@ -55,14 +55,14 @@ test_case!(case, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT CASE
-                WHEN name = "Harry" THEN id
-                WHEN name = "Ron" THEN id
-                WHEN name = "Hermione" THEN id
+                WHEN name = 'Harry' THEN id
+                WHEN name = 'Ron' THEN id
+                WHEN name = 'Hermione' THEN id
                 ELSE 404 END
             AS case FROM Item;
-            "#,
+            ",
             Ok(select!(
                 case
                 I64;
@@ -72,14 +72,14 @@ test_case!(case, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT CASE
-                WHEN name = "Harry" THEN id
-                WHEN name = "Ron" THEN id 
-                WHEN name = "Hermion" THEN id 
+                WHEN name = 'Harry' THEN id
+                WHEN name = 'Ron' THEN id 
+                WHEN name = 'Hermion' THEN id 
                 END
             AS case FROM Item;
-            "#,
+            ",
             Ok(select_with_null!(
                 "case";
                 I64(1);
@@ -88,13 +88,13 @@ test_case!(case, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT CASE
-                WHEN (name = "Harry") OR (name = "Ron") THEN (id + 1)
-                WHEN name = ("Hermi" || "one") THEN (id + 2)
+                WHEN (name = 'Harry') OR (name = 'Ron') THEN (id + 1)
+                WHEN name = ('Hermi' || 'one') THEN (id + 2)
                 ELSE 404 END
             AS case FROM Item;
-            "#,
+            ",
             Ok(select!(
                 case
                 I64;
@@ -104,14 +104,14 @@ test_case!(case, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT CASE 1 COLLATE Item
-                WHEN name = "Harry" THEN id
-                WHEN name = "Ron" THEN id 
-                WHEN "Hermione" THEN id 
+                WHEN name = 'Harry' THEN id
+                WHEN name = 'Ron' THEN id 
+                WHEN 'Hermione' THEN id 
                 END
             AS case FROM Item;
-            "#,
+            ",
             Err(TranslateError::UnsupportedExpr("1 COLLATE Item".to_owned()).into()),
         ),
         (

--- a/test-suite/src/concat.rs
+++ b/test-suite/src/concat.rs
@@ -12,17 +12,17 @@ test_case!(concat, async move {
         );
     "
     );
-    run!(r#"INSERT INTO Concat VALUES (1, 2.3, TRUE, "Foo", NULL);"#);
+    run!("INSERT INTO Concat VALUES (1, 2.3, TRUE, 'Foo', NULL);");
 
     test!(
-        r#"
+        "
         SELECT
             text || text AS value_value,
-            text || "Bar" AS value_literal,
-            "Bar" || text AS literal_value,
-            "Foo" || "Bar" AS literal_literal
+            text || 'Bar' AS value_literal,
+            'Bar' || text AS literal_value,
+            'Foo' || 'Bar' AS literal_literal
         FROM Concat;
-        "#,
+        ",
         Ok(select!(
             value_value         | value_literal       | literal_value       | literal_literal
             Str                 | Str                 | Str                 | Str;
@@ -62,13 +62,13 @@ test_case!(concat, async move {
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             1 || 2.3 AS int_float,
             2.3 || TRUE AS float_bool,
-            FALSE || "Foo" AS bool_text,
-            1 || "Bar" AS int_text
+            FALSE || 'Foo' AS bool_text,
+            1 || 'Bar' AS int_text
         FROM
-            Concat;"#,
+            Concat;",
         Ok(select!(
             int_float         | float_bool           | bool_text             | int_text
             Str               | Str                  | Str                   | Str;
@@ -77,12 +77,12 @@ test_case!(concat, async move {
     );
 
     test!(
-        r#"SELECT
-            1 || id || CAST(rate * 10 AS INT) || "Bar" AS Case1,
+        "SELECT
+            1 || id || CAST(rate * 10 AS INT) || 'Bar' AS Case1,
             id || flag || 3.5 || text AS Case2,
-            flag || "wow" || null_value AS Case3
+            flag || 'wow' || null_value AS Case3
         FROM
-            Concat;"#,
+            Concat;",
         Ok(select_with_null!(
             Case1                     | Case2                         | Case3;
             Str("1123Bar".to_owned())   Str("1TRUE3.5Foo".to_owned())   Null

--- a/test-suite/src/data_type/date.rs
+++ b/test-suite/src/data_type/date.rs
@@ -2,21 +2,21 @@ use {crate::*, gluesql_core::prelude::Value::*};
 
 test_case!(date, async move {
     run!(
-        r#"
+        "
 CREATE TABLE DateLog (
     id INTEGER,
     date1 DATE,
     date2 DATE,
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
 INSERT INTO DateLog VALUES
-    (1, "2020-06-11", "2021-03-01"),
-    (2, "2020-09-30", "1989-01-01"),
-    (3, "2021-05-01", "2021-05-01");
-"#
+    (1, '2020-06-11', '2021-03-01'),
+    (2, '2020-09-30', '1989-01-01'),
+    (3, '2021-05-01', '2021-05-01');
+"
     );
 
     macro_rules! date {
@@ -56,7 +56,7 @@ INSERT INTO DateLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM DateLog WHERE date1 = DATE "2020-06-11";"#,
+        "SELECT * FROM DateLog WHERE date1 = DATE '2020-06-11';",
         Ok(select!(
             id  | date1               | date2
             I64 | Date                | Date;
@@ -65,7 +65,7 @@ INSERT INTO DateLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM DateLog WHERE date2 < "2000-01-01";"#,
+        "SELECT * FROM DateLog WHERE date2 < '2000-01-01';",
         Ok(select!(
             id  | date1               | date2
             I64 | Date                | Date;
@@ -74,7 +74,7 @@ INSERT INTO DateLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM DateLog WHERE "1999-01-03" < DATE "2000-01-01";"#,
+        "SELECT * FROM DateLog WHERE '1999-01-03' < DATE '2000-01-01';",
         Ok(select!(
             id  | date1               | date2
             I64 | Date                | Date;
@@ -93,12 +93,12 @@ INSERT INTO DateLog VALUES
     };
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
             date1 - date2 AS date_sub,
-            date1 - INTERVAL "1" DAY AS sub,
-            date2 + INTERVAL "1" MONTH AS add
-        FROM DateLog;"#,
+            date1 - INTERVAL '1' DAY AS sub,
+            date2 + INTERVAL '1' MONTH AS add
+        FROM DateLog;",
         Ok(select!(
             id  | date_sub     | sub                    | add
             I64 | Interval     | Timestamp              | Timestamp;
@@ -109,7 +109,7 @@ INSERT INTO DateLog VALUES
     );
 
     test!(
-        r#"INSERT INTO DateLog VALUES (1, "12345-678", "2021-05-01")"#,
+        "INSERT INTO DateLog VALUES (1, '12345-678', '2021-05-01')",
         Err(gluesql_core::data::ValueError::FailedToParseDate("12345-678".to_owned()).into())
     );
 });

--- a/test-suite/src/data_type/interval.rs
+++ b/test-suite/src/data_type/interval.rs
@@ -8,25 +8,25 @@ use {
 
 test_case!(interval, async move {
     run!(
-        r#"
+        "
 CREATE TABLE IntervalLog (
     id INTEGER,
     interval1 INTERVAL,
     interval2 INTERVAL,
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
 INSERT INTO IntervalLog VALUES
-    (1, INTERVAL "1-2" YEAR TO MONTH,         INTERVAL 30 MONTH),
-    (2, INTERVAL 12 DAY,                      INTERVAL "35" HOUR),
-    (3, INTERVAL "12" MINUTE,                 INTERVAL 300 SECOND),
-    (4, INTERVAL "-3 14" DAY TO HOUR,         INTERVAL "3 12:30" DAY TO MINUTE),
-    (5, INTERVAL "3 14:00:00" DAY TO SECOND,  INTERVAL "3 12:30:12.1324" DAY TO SECOND),
-    (6, INTERVAL "12:00" HOUR TO MINUTE,      INTERVAL "-12:30:12" HOUR TO SECOND),
-    (7, INTERVAL "-1000-11" YEAR TO MONTH,    INTERVAL "-30:11" MINUTE TO SECOND);
-"#
+    (1, INTERVAL '1-2' YEAR TO MONTH,         INTERVAL 30 MONTH),
+    (2, INTERVAL 12 DAY,                      INTERVAL '35' HOUR),
+    (3, INTERVAL '12' MINUTE,                 INTERVAL 300 SECOND),
+    (4, INTERVAL '-3 14' DAY TO HOUR,         INTERVAL '3 12:30' DAY TO MINUTE),
+    (5, INTERVAL '3 14:00:00' DAY TO SECOND,  INTERVAL '3 12:30:12.1324' DAY TO SECOND),
+    (6, INTERVAL '12:00' HOUR TO MINUTE,      INTERVAL '-12:30:12' HOUR TO SECOND),
+    (7, INTERVAL '-1000-11' YEAR TO MONTH,    INTERVAL '-30:11' MINUTE TO SECOND);
+"
     );
 
     test!(
@@ -45,11 +45,11 @@ INSERT INTO IntervalLog VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
             interval1 * 2 AS i1,
-            interval2 - INTERVAL "-3" YEAR AS i2
-        FROM IntervalLog WHERE id = 1"#,
+            interval2 - INTERVAL '-3' YEAR AS i2
+        FROM IntervalLog WHERE id = 1",
         Ok(select!(
             id  | i1            | i2
             I64 | Interval      | Interval;
@@ -58,12 +58,12 @@ INSERT INTO IntervalLog VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
             interval1 / 3 AS i1,
             interval2 - INTERVAL 3600 SECOND AS i2,
             INTERVAL 20 + 10 SECOND + INTERVAL 10 SECOND * 3 AS i3
-        FROM IntervalLog WHERE id = 2;"#,
+        FROM IntervalLog WHERE id = 2;",
         Ok(select!(
             id  | i1         | i2           | i3
             I64 | Interval   | Interval     | Interval;
@@ -72,57 +72,57 @@ INSERT INTO IntervalLog VALUES
     );
 
     test!(
-        r#"INSERT INTO IntervalLog VALUES (1, INTERVAL "20:00" MINUTE TO HOUR, INTERVAL "1-2" YEAR TO MONTH)"#,
+        "INSERT INTO IntervalLog VALUES (1, INTERVAL '20:00' MINUTE TO HOUR, INTERVAL '1-2' YEAR TO MONTH)",
         Err(IntervalError::UnsupportedRange("Minute".to_owned(), "Hour".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "1" YEAR + INTERVAL "1" HOUR FROM IntervalLog;"#,
+        "SELECT INTERVAL '1' YEAR + INTERVAL '1' HOUR FROM IntervalLog;",
         Err(IntervalError::AddBetweenYearToMonthAndHourToSecond.into())
     );
 
     test!(
-        r#"SELECT INTERVAL "1" YEAR - INTERVAL "1" HOUR FROM IntervalLog;"#,
+        "SELECT INTERVAL '1' YEAR - INTERVAL '1' HOUR FROM IntervalLog;",
         Err(IntervalError::SubtractBetweenYearToMonthAndHourToSecond.into())
     );
 
     test!(
-        r#"SELECT INTERVAL "1.4" YEAR FROM IntervalLog;"#,
+        "SELECT INTERVAL '1.4' YEAR FROM IntervalLog;",
         Err(IntervalError::FailedToParseInteger("1.4".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "1.4ab" HOUR FROM IntervalLog;"#,
+        "SELECT INTERVAL '1.4ab' HOUR FROM IntervalLog;",
         Err(IntervalError::FailedToParseDecimal("1.4ab".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111:34" HOUR TO MINUTE FROM IntervalLog;"#,
+        "SELECT INTERVAL '111:34' HOUR TO MINUTE FROM IntervalLog;",
         Err(IntervalError::FailedToParseTime("111:34".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111" YEAR TO MONTH FROM IntervalLog;"#,
+        "SELECT INTERVAL '111' YEAR TO MONTH FROM IntervalLog;",
         Err(IntervalError::FailedToParseYearToMonth("111".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111" DAY TO HOUR FROM IntervalLog;"#,
+        "SELECT INTERVAL '111' DAY TO HOUR FROM IntervalLog;",
         Err(IntervalError::FailedToParseDayToHour("111".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111" DAY TO HOUR FROM IntervalLog;"#,
+        "SELECT INTERVAL '111' DAY TO HOUR FROM IntervalLog;",
         Err(IntervalError::FailedToParseDayToHour("111".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111" DAY TO MINUTE FROM IntervalLog;"#,
+        "SELECT INTERVAL '111' DAY TO MINUTE FROM IntervalLog;",
         Err(IntervalError::FailedToParseDayToMinute("111".to_owned()).into())
     );
 
     test!(
-        r#"SELECT INTERVAL "111" DAY TO Second FROM IntervalLog;"#,
+        "SELECT INTERVAL '111' DAY TO Second FROM IntervalLog;",
         Err(IntervalError::FailedToParseDayToSecond("111".to_owned()).into())
     );
 });

--- a/test-suite/src/data_type/list.rs
+++ b/test-suite/src/data_type/list.rs
@@ -8,17 +8,17 @@ use {
 
 test_case!(list, async move {
     run!(
-        r#"
+        "
 CREATE TABLE ListType (
     id INTEGER,
     items LIST
-)"#
+)"
     );
 
     run!(
         r#"
 INSERT INTO ListType VALUES
-    (1, "[1, 2, 3]"),
+    (1, '[1, 2, 3]'),
     (2, '["hello", "world", 30, true, [9,8]]'),
     (3, '[{ "foo": 100, "bar": [true, 0,[10.5, false] ] }, 10, 20]');
 "#
@@ -32,19 +32,19 @@ INSERT INTO ListType VALUES
         Ok(select_with_null!(
             id     | items;
             I64(1)   l("[1,2,3]");
-            I64(2)   l(r#"["hello","world",30,true,[9,8]]"#);
+            I64(2)   l("['hello','world',30,true,[9,8]]");
             I64(3)   l(r#"[{"foo":100, "bar": [true, 0, [10.5, false]]},10,20]"#)
         ))
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            UNWRAP(items, "1") AS foo,
-            UNWRAP(items, "0.foo") + 100 AS bar,
-            UNWRAP(items, "4") AS a,
-            UNWRAP(items, "0.bar.2.0") + UNWRAP(items, "2") AS b
-        FROM ListType"#,
+            UNWRAP(items, '1') AS foo,
+            UNWRAP(items, '0.foo') + 100 AS bar,
+            UNWRAP(items, '4') AS a,
+            UNWRAP(items, '0.bar.2.0') + UNWRAP(items, '2') AS b
+        FROM ListType",
         Ok(select_with_null!(
             id     | foo        | bar      | a             | b;
             I64(1)   I64(2)       Null       Null            Null;
@@ -75,29 +75,29 @@ INSERT INTO ListType VALUES
     }
 
     run!(
-        r#"
+        "
 CREATE TABLE ListType2 (
     id INTEGER,
     items LIST
-)"#
+)"
     );
 
     run!(
         r#"
 INSERT INTO ListType2 VALUES
-    (1, '[1, 2, 3, { "hi": "bye" }]'),
-    (2, '["one", "two", "three", [100, 200]]'),
-    (3, '["first", "second", "third", { "foo": true, "bar": false }]');
+    (1, '[1, 2, 3, { "hi": 'bye' }]'),
+    (2, '['one', 'two', 'three', [100, 200]]'),
+    (3, '['first', 'second', 'third', { "foo": true, "bar": false }]');
 "#
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            items["0"] AS foo,
-            items["1"] AS bar,
-            items["3"]["0"] AS hundred
-        FROM ListType2"#,
+            items['0'] AS foo,
+            items['1'] AS bar,
+            items['3']['0'] AS hundred
+        FROM ListType2",
         Ok(select_with_null!(
             id     | foo        | bar        | hundred;
             I64(1)   I64(1)       I64(2)       Null;
@@ -107,7 +107,7 @@ INSERT INTO ListType2 VALUES
     );
 
     test!(
-        r#"SELECT id, items["not"]["list"] AS foo FROM ListType2"#,
+        r#"SELECT id, items['not']['list'] AS foo FROM ListType2"#,
         Err(ValueError::SelectorRequiresMapOrListTypes.into())
     );
 
@@ -120,7 +120,7 @@ INSERT INTO ListType2 VALUES
         Err(ValueError::JsonArrayTypeRequired.into())
     );
     test!(
-        r#"INSERT INTO ListType VALUES (1, '{{ ok [1, 2, 3] }');"#,
+        "INSERT INTO ListType VALUES (1, '{{ ok [1, 2, 3] }');",
         Err(ValueError::InvalidJsonString.into())
     );
 });

--- a/test-suite/src/data_type/list.rs
+++ b/test-suite/src/data_type/list.rs
@@ -20,7 +20,7 @@ CREATE TABLE ListType (
 INSERT INTO ListType VALUES
     (1, '[1, 2, 3]'),
     (2, '["hello", "world", 30, true, [9,8]]'),
-    (3, '[{ "foo": 100, "bar": [true, 0,[10.5, false] ] }, 10, 20]');
+    (3, '[{ "foo": 100, "bar": [true, 0, [10.5, false] ] }, 10, 20]');
 "#
     );
 
@@ -32,7 +32,7 @@ INSERT INTO ListType VALUES
         Ok(select_with_null!(
             id     | items;
             I64(1)   l("[1,2,3]");
-            I64(2)   l("['hello','world',30,true,[9,8]]");
+            I64(2)   l(r#"["hello","world",30,true,[9,8]]"#);
             I64(3)   l(r#"[{"foo":100, "bar": [true, 0, [10.5, false]]},10,20]"#)
         ))
     );
@@ -85,9 +85,9 @@ CREATE TABLE ListType2 (
     run!(
         r#"
 INSERT INTO ListType2 VALUES
-    (1, '[1, 2, 3, { "hi": 'bye' }]'),
-    (2, '['one', 'two', 'three', [100, 200]]'),
-    (3, '['first', 'second', 'third', { "foo": true, "bar": false }]');
+    (1, '[1, 2, 3, { "hi": "bye" }]'),
+    (2, '["one", "two", "three", [100, 200]]'),
+    (3, '["first", "second", "third", { "foo": true, "bar": false }]');
 "#
     );
 

--- a/test-suite/src/data_type/map.rs
+++ b/test-suite/src/data_type/map.rs
@@ -9,11 +9,11 @@ use {
 
 test_case!(map, async move {
     run!(
-        r#"
+        "
 CREATE TABLE MapType (
-    id INTEGER NULL DEFAULT UNWRAP(NULL, "a"),
+    id INTEGER NULL DEFAULT UNWRAP(NULL, 'a'),
     nested MAP
-)"#
+)"
     );
 
     run!(
@@ -37,13 +37,13 @@ INSERT INTO MapType VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            UNWRAP(nested, "a.foo") || ".yeah" AS foo,
+            UNWRAP(nested, 'a.foo') || '.yeah' AS foo,
             UNWRAP(nested, 'a.b.c.d') as good,
             UNWRAP(nested, 'a.b.c.d') * 2 as good2,
-            UNWRAP(nested, "a.b") as b
-        FROM MapType"#,
+            UNWRAP(nested, 'a.b') as b
+        FROM MapType",
         Ok(select_with_null!(
             id     | foo          | good    | good2   | b;
             I64(1)   Null           Null      Null      Null;
@@ -53,20 +53,20 @@ INSERT INTO MapType VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            UNWRAP(NULL, "a.b") as foo,
+            UNWRAP(NULL, 'a.b') as foo,
             UNWRAP(nested, NULL) as bar
-        FROM MapType LIMIT 1"#,
+        FROM MapType LIMIT 1",
         Ok(select_with_null!(id | foo | bar; I64(1) Null Null))
     );
 
     run!(
-        r#"
+        "
 CREATE TABLE MapType2 (
     id INTEGER,
     nested MAP
-)"#
+)"
     );
 
     run!(
@@ -79,7 +79,7 @@ INSERT INTO MapType2 VALUES
     );
 
     test!(
-        r#"SELECT id, nested["b"] as b FROM MapType2"#,
+        "SELECT id, nested['b'] as b FROM MapType2",
         Ok(select_with_null!(
             id     | b;
             I64(1)   I64(10);
@@ -90,9 +90,9 @@ INSERT INTO MapType2 VALUES
 
     test! {
         name: "select index expr without alias",
-        sql: r#"SELECT id, nested["b"] FROM MapType2"#,
+        sql: "SELECT id, nested['b'] FROM MapType2",
         expected: Ok(select_with_null!(
-            id     | r#"nested["b"]"#;
+            id     | "nested['b']";
             I64(1)   I64(10);
             I64(2)   I64(20);
             I64(3)   I64(30)
@@ -101,12 +101,12 @@ INSERT INTO MapType2 VALUES
 
     test! {
         name: "index expr with non-existent key from MapType Value returns Null",
-        sql: r#"SELECT
+        sql: "SELECT
             id,
-            nested["a"]["red"] AS fruit,
-            nested["a"]["blue"] + nested["b"] as sum,
-            nested["c"] AS c
-        FROM MapType2"#,
+            nested['a']['red'] AS fruit,
+            nested['a']['blue'] + nested['b'] as sum,
+            nested['c'] AS c
+        FROM MapType2",
         expected: Ok(select_with_null!(
                 id     | fruit        | sum      | c;
                 I64(1)   s("apple")     I64(11)    Null;
@@ -116,27 +116,27 @@ INSERT INTO MapType2 VALUES
     }
 
     test!(
-        r#"SELECT UNWRAP("abc", "a.b.c") FROM MapType"#,
+        "SELECT UNWRAP('abc', 'a.b.c') FROM MapType",
         Err(EvaluateError::FunctionRequiresMapValue("UNWRAP".to_owned()).into())
     );
     test!(
-        r#"SELECT UNWRAP(id, "a.b.c") FROM MapType"#,
+        "SELECT UNWRAP(id, 'a.b.c') FROM MapType",
         Err(ValueError::SelectorRequiresMapOrListTypes.into())
     );
     test!(
-        r#"SELECT id, nested["a"]["blue"]["first"] FROM MapType2"#,
+        "SELECT id, nested['a']['blue']['first'] FROM MapType2",
         Err(ValueError::SelectorRequiresMapOrListTypes.into())
     );
     test!(
-        r#"SELECT id FROM MapType GROUP BY nested"#,
+        "SELECT id FROM MapType GROUP BY nested",
         Err(KeyError::MapTypeKeyNotSupported.into())
     );
     test!(
-        r#"INSERT INTO MapType VALUES (1, '{{ ok [1, 2, 3] }');"#,
+        "INSERT INTO MapType VALUES (1, '{{ ok [1, 2, 3] }');",
         Err(ValueError::InvalidJsonString.into())
     );
     test!(
-        r#"INSERT INTO MapType VALUES (1, '[1, 2, 3]');"#,
+        "INSERT INTO MapType VALUES (1, '[1, 2, 3]');",
         Err(ValueError::JsonObjectTypeRequired.into())
     );
 });

--- a/test-suite/src/data_type/sql_types.rs
+++ b/test-suite/src/data_type/sql_types.rs
@@ -16,9 +16,9 @@ test_case!(sql_types, async move {
         INSERT INTO Item
             (id,   content, verified, ratio)
         VALUES
-            ( 1, \"Hello\",     True,   0.1),
-            ( 1, \"World\",    False,   0.9),
-            ( 1,    'test',    False,   0.0);
+            ( 1, 'Hello',     True,   0.1),
+            ( 1, 'World',    False,   0.9),
+            ( 1, 'test',    False,   0.0);
     "
     );
 
@@ -27,14 +27,11 @@ test_case!(sql_types, async move {
         (1, "SELECT * FROM Item WHERE verified = True;"),
         (1, "SELECT * FROM Item WHERE ratio > 0.5;"),
         (1, "SELECT * FROM Item WHERE ratio = 0.1;"),
-        (
-            1,
-            "UPDATE Item SET content=\"Foo\" WHERE content=\"World\";",
-        ),
-        (0, "SELECT * FROM Item WHERE content=\"World\";"),
-        (1, "SELECT * FROM Item WHERE content=\"Foo\";"),
+        (1, "UPDATE Item SET content='Foo' WHERE content='World';"),
+        (0, "SELECT * FROM Item WHERE content='World';"),
         (1, "SELECT * FROM Item WHERE content='Foo';"),
-        (1, "UPDATE Item SET id = 11 WHERE content=\"Foo\";"),
+        (1, "SELECT * FROM Item WHERE content='Foo';"),
+        (1, "UPDATE Item SET id = 11 WHERE content='Foo';"),
         (1, "UPDATE Item SET id = 14 WHERE content='Foo';"),
         (3, "SELECT * FROM Item;"),
     ];

--- a/test-suite/src/data_type/time.rs
+++ b/test-suite/src/data_type/time.rs
@@ -16,12 +16,12 @@ CREATE TABLE TimeLog (
     );
 
     run!(
-        r#"
+        "
 INSERT INTO TimeLog VALUES
-    (1, "12:30:00", "13:31:01.123"),
-    (2, "9:2:1", "AM 08:02:01.001"),
-    (3, "PM 2:59", "9:00:00 AM");
-"#
+    (1, '12:30:00', '13:31:01.123'),
+    (2, '9:2:1', 'AM 08:02:01.001'),
+    (3, 'PM 2:59', '9:00:00 AM');
+"
     );
 
     let t = |hour: u32, min: u32, sec: u32, milli: u32| {
@@ -64,7 +64,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimeLog WHERE time1 = TIME "14:59:00""#,
+        "SELECT * FROM TimeLog WHERE time1 = TIME '14:59:00'",
         Ok(select!(
             id  | time1           | time2
             I64 | Time            | Time;
@@ -73,7 +73,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimeLog WHERE time1 < "1:00 PM""#,
+        "SELECT * FROM TimeLog WHERE time1 < '1:00 PM'",
         Ok(select!(
             id  | time1           | time2
             I64 | Time            | Time;
@@ -83,7 +83,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimeLog WHERE TIME "23:00:00.123" > "PM 1:00";"#,
+        "SELECT * FROM TimeLog WHERE TIME '23:00:00.123' > 'PM 1:00';",
         Ok(select!(
             id  | time1           | time2
             I64 | Time            | Time;
@@ -94,12 +94,12 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
         id,
         time1 - time2 AS time_sub,
-        time1 + INTERVAL "1" HOUR AS add,
-        time2 - INTERVAL "250" MINUTE AS sub
-        FROM TimeLog;"#,
+        time1 + INTERVAL '1' HOUR AS add,
+        time2 - INTERVAL '250' MINUTE AS sub
+        FROM TimeLog;",
         Ok(select!(
             id  | time_sub                      | add             | sub
             I64 | Interval                      | Time            | Time;
@@ -110,10 +110,10 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            DATE "2021-01-05" + time2 AS timestamp
-        FROM TimeLog LIMIT 1;"#,
+            DATE '2021-01-05' + time2 AS timestamp
+        FROM TimeLog LIMIT 1;",
         Ok(select!(
             id  | timestamp
             I64 | Timestamp;
@@ -122,7 +122,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimeLog WHERE time1 > time2 + INTERVAL "1" YEAR"#,
+        "SELECT * FROM TimeLog WHERE time1 > time2 + INTERVAL '1' YEAR",
         Err(IntervalError::AddYearOrMonthToTime {
             time: t(13, 31, 1, 123).to_string(),
             interval: gluesql_core::data::Interval::years(1).into(),
@@ -131,7 +131,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimeLog WHERE time1 > time2 - INTERVAL "1-2" YEAR TO MONTH"#,
+        "SELECT * FROM TimeLog WHERE time1 > time2 - INTERVAL '1-2' YEAR TO MONTH",
         Err(IntervalError::SubtractYearOrMonthToTime {
             time: t(13, 31, 1, 123).to_string(),
             interval: gluesql_core::data::Interval::months(14).into(),
@@ -140,7 +140,7 @@ INSERT INTO TimeLog VALUES
     );
 
     test!(
-        r#"INSERT INTO TimeLog VALUES (1, "12345-678", "20:05:01")"#,
+        "INSERT INTO TimeLog VALUES (1, '12345-678', '20:05:01')",
         Err(ValueError::FailedToParseTime("12345-678".to_owned()).into())
     );
 });

--- a/test-suite/src/data_type/timestamp.rs
+++ b/test-suite/src/data_type/timestamp.rs
@@ -5,21 +5,21 @@ use {
 
 test_case!(timestamp, async move {
     run!(
-        r#"
+        "
 CREATE TABLE TimestampLog (
     id INTEGER,
     t1 TIMESTAMP,
     t2 TIMESTAMP,
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
 INSERT INTO TimestampLog VALUES
-    (1, "2020-06-11 11:23:11Z",           "2021-03-01"),
-    (2, "2020-09-30 12:00:00 -07:00",     "1989-01-01T00:01:00+09:00"),
-    (3, "2021-04-30T07:00:00.1234-17:00", "2021-05-01T09:00:00.1234+09:00");
-"#
+    (1, '2020-06-11 11:23:11Z',           '2021-03-01'),
+    (2, '2020-09-30 12:00:00 -07:00',     '1989-01-01T00:01:00+09:00'),
+    (3, '2021-04-30T07:00:00.1234-17:00', '2021-05-01T09:00:00.1234+09:00');
+"
     );
 
     macro_rules! t {
@@ -58,7 +58,7 @@ INSERT INTO TimestampLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimestampLog WHERE t1 = "2020-06-11T14:23:11+0300";"#,
+        "SELECT * FROM TimestampLog WHERE t1 = '2020-06-11T14:23:11+0300';",
         Ok(select!(
             id  | t1                        | t2
             I64 | Timestamp                 | Timestamp;
@@ -67,7 +67,7 @@ INSERT INTO TimestampLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimestampLog WHERE t2 < TIMESTAMP "2000-01-01";"#,
+        "SELECT * FROM TimestampLog WHERE t2 < TIMESTAMP '2000-01-01';",
         Ok(select!(
             id  | t1                        | t2
             I64 | Timestamp                 | Timestamp;
@@ -76,7 +76,7 @@ INSERT INTO TimestampLog VALUES
     );
 
     test!(
-        r#"SELECT * FROM TimestampLog WHERE TIMESTAMP "1999-01-03" < "2000-01-01";"#,
+        "SELECT * FROM TimestampLog WHERE TIMESTAMP '1999-01-03' < '2000-01-01';",
         Ok(select!(
             id  | t1                             | t2
             I64 | Timestamp                      | Timestamp;
@@ -98,11 +98,11 @@ INSERT INTO TimestampLog VALUES
     );
 
     test!(
-        r#"SELECT
+        "SELECT
             id,
-            t1 - INTERVAL "1" DAY AS sub,
-            t2 + INTERVAL "1" MONTH AS add
-        FROM TimestampLog;"#,
+            t1 - INTERVAL '1' DAY AS sub,
+            t2 + INTERVAL '1' MONTH AS add
+        FROM TimestampLog;",
         Ok(select!(
             id  | sub                            | add
             I64 | Timestamp                      | Timestamp;
@@ -113,7 +113,7 @@ INSERT INTO TimestampLog VALUES
     );
 
     test!(
-        r#"INSERT INTO TimestampLog VALUES (1, "12345-678", "2021-05-01")"#,
+        "INSERT INTO TimestampLog VALUES (1, '12345-678', '2021-05-01')",
         Err(ValueError::FailedToParseTimestamp("12345-678".to_owned()).into())
     );
 });

--- a/test-suite/src/default.rs
+++ b/test-suite/src/default.rs
@@ -67,16 +67,16 @@ test_case!(default, async move {
     }
 
     test!(
-        r#"
+        "
         CREATE TABLE TestExpr (
             id INTEGER,
-            date DATE DEFAULT DATE "2020-01-01",
+            date DATE DEFAULT DATE '2020-01-01',
             num INTEGER DEFAULT -(-1 * +2),
-            flag BOOLEAN DEFAULT CAST("TRUE" AS BOOLEAN),
+            flag BOOLEAN DEFAULT CAST('TRUE' AS BOOLEAN),
             flag2 BOOLEAN DEFAULT 1 IN (1, 2, 3),
             flag3 BOOLEAN DEFAULT 10 BETWEEN 1 AND 2,
             flag4 BOOLEAN DEFAULT (1 IS NULL OR NULL IS NOT NULL)
-        )"#,
+        )",
         Ok(Payload::Create)
     );
 

--- a/test-suite/src/filter.rs
+++ b/test-suite/src/filter.rs
@@ -22,17 +22,17 @@ test_case!(filter, async move {
     let insert_sqls = [
         "
         INSERT INTO Boss (id, name, strength) VALUES
-            (1,    \"Amelia\", 10.10),
-            (2,      \"Doll\", 20.20),
-            (3, \"Gascoigne\", 30.30),
-            (4,   \"Gehrman\", 40.40),
-            (5,     \"Maria\", 50.50);
+            (1,    'Amelia', 10.10),
+            (2,      'Doll', 20.20),
+            (3, 'Gascoigne', 30.30),
+            (4,   'Gehrman', 40.40),
+            (5,     'Maria', 50.50);
         ",
         "
         INSERT INTO Hunter (id, name) VALUES
-            (1, \"Gascoigne\"),
-            (2,   \"Gehrman\"),
-            (3,     \"Maria\");
+            (1, 'Gascoigne'),
+            (2,   'Gehrman'),
+            (3,     'Maria');
         ",
     ];
 

--- a/test-suite/src/function/ascii.rs
+++ b/test-suite/src/function/ascii.rs
@@ -5,7 +5,7 @@ use {
 
 test_case!(ascii, async move {
     test!(
-        r#"VALUES(ASCII("A"))"#,
+        "VALUES(ASCII('A'))",
         Ok(select!(
             column1
             I64;
@@ -13,7 +13,7 @@ test_case!(ascii, async move {
         ))
     );
     test!(
-        r#"VALUES(ASCII("AB"))"#,
+        "VALUES(ASCII('AB'))",
         Err(EvaluateError::AsciiFunctionRequiresSingleCharacterValue.into())
     );
     run!(
@@ -24,7 +24,7 @@ test_case!(ascii, async move {
         );
     "
     );
-    run!(r#"INSERT INTO Ascii VALUES (1, "F");"#);
+    run!("INSERT INTO Ascii VALUES (1, 'F');");
     test!(
         r#"select ascii(text) as ascii from Ascii;"#,
         Ok(select!(
@@ -35,7 +35,7 @@ test_case!(ascii, async move {
     );
 
     test!(
-        r#"select ascii("a") as ascii from Ascii;"#,
+        "select ascii('a') as ascii from Ascii;",
         Ok(select!(
            ascii
            I64;
@@ -44,7 +44,7 @@ test_case!(ascii, async move {
     );
 
     test!(
-        r#"select ascii("A") as ascii from Ascii;"#,
+        "select ascii('A') as ascii from Ascii;",
         Ok(select!(
            ascii
            I64;
@@ -53,22 +53,22 @@ test_case!(ascii, async move {
     );
 
     test!(
-        r#"select ascii("ab") as ascii from Ascii;"#,
+        "select ascii('ab') as ascii from Ascii;",
         Err(EvaluateError::AsciiFunctionRequiresSingleCharacterValue.into())
     );
 
     test!(
-        r#"select ascii("AB") as ascii from Ascii;"#,
+        "select ascii('AB') as ascii from Ascii;",
         Err(EvaluateError::AsciiFunctionRequiresSingleCharacterValue.into())
     );
 
     test!(
-        r#"select ascii("") as ascii from Ascii;"#,
+        "select ascii('') as ascii from Ascii;",
         Err(EvaluateError::AsciiFunctionRequiresSingleCharacterValue.into())
     );
 
     test!(
-        r#"select ascii("ukjhg") as ascii from Ascii;"#,
+        "select ascii('ukjhg') as ascii from Ascii;",
         Err(EvaluateError::AsciiFunctionRequiresSingleCharacterValue.into())
     );
 
@@ -78,7 +78,7 @@ test_case!(ascii, async move {
     );
 
     test!(
-        r#"select ascii("ㄱ") as ascii from Ascii;"#,
+        "select ascii('ㄱ') as ascii from Ascii;",
         Err(EvaluateError::NonAsciiCharacterNotAllowed.into())
     );
 
@@ -92,7 +92,7 @@ test_case!(ascii, async move {
         .into())
     );
 
-    run!(r#"INSERT INTO Ascii VALUES (1, "Foo");"#);
+    run!("INSERT INTO Ascii VALUES (1, 'Foo');");
 
     test!(
         r#"select ascii(text) as ascii from Ascii;"#,

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -241,20 +241,20 @@ test_case!(cast_literal, async move {
         ),
         (
             "SELECT
-            CAST('\"1-2\" YEAR TO MONTH' as INTERVAL) as stoi_1,
-            CAST('\"12\" DAY' as INTERVAL) as stoi_2,
-            CAST('\"12\" MINUTE' as INTERVAL) as stoi_3,
-            CAST('\"-3 14\" DAY TO HOUR' as INTERVAL) as stoi_4,
-            CAST('\"3 14:00:00\" DAY TO SECOND' as INTERVAL) as stoi_5,
-            CAST('\"12:00\" HOUR TO MINUTE' as INTERVAL) as stoi_6,
-            CAST('\"-1000-11\" YEAR TO MONTH' as INTERVAL) as stoi_7,
-            CAST('\"30' MONTH\" as INTERVAL) as stoi_8,
-            CAST('\"35' HOUR\" as INTERVAL) as stoi_9,
-            CAST('\"300' SECOND\" as INTERVAL) as stoi_10,
-            CAST('\"3 12:30\" DAY TO MINUTE' as INTERVAL) as stoi_11,
-            CAST('\"3 12:30:12.1324\" DAY TO SECOND' as INTERVAL) as stoi_12,
-            CAST('\"-12:30:12\" HOUR TO SECOND' as INTERVAL) as stoi_13,
-            CAST('\"-30:11\" MINUTE TO SECOND' as INTERVAL) as stoi_14
+            CAST('''1-2'' YEAR TO MONTH' as INTERVAL) as stoi_1,
+            CAST('''12'' DAY' as INTERVAL) as stoi_2,
+            CAST('''12'' MINUTE' as INTERVAL) as stoi_3,
+            CAST('''-3 14'' DAY TO HOUR' as INTERVAL) as stoi_4,
+            CAST('''3 14:00:00'' DAY TO SECOND' as INTERVAL) as stoi_5,
+            CAST('''12:00'' HOUR TO MINUTE' as INTERVAL) as stoi_6,
+            CAST('''-1000-11'' YEAR TO MONTH' as INTERVAL) as stoi_7,
+            CAST('''30'' MONTH' as INTERVAL) as stoi_8,
+            CAST('''35'' HOUR' as INTERVAL) as stoi_9,
+            CAST('''300'' SECOND' as INTERVAL) as stoi_10,
+            CAST('''3 12:30'' DAY TO MINUTE' as INTERVAL) as stoi_11,
+            CAST('''3 12:30:12.1324'' DAY TO SECOND' as INTERVAL) as stoi_12,
+            CAST('''-12:30:12'' HOUR TO SECOND' as INTERVAL) as stoi_13,
+            CAST('''-30:11'' MINUTE TO SECOND' as INTERVAL) as stoi_14
             FROM Item",
             Ok(select!(
             stoi_1|stoi_2|stoi_3|stoi_4|stoi_5|stoi_6|stoi_7|stoi_8|stoi_9|stoi_10|stoi_11|stoi_12|stoi_13|stoi_14
@@ -384,13 +384,13 @@ test_case!(cast_value, async move {
         (
             "
         INSERT INTO IntervalLog VALUES
-        (1, '1-2 YEAR TO MONTH',         '30 MONTH'),
-        (2, '12 DAY',                    '35 HOUR'),
-        (3, '12 MINUTE',                 '300 SECOND'),
-        (4, '-3 14 DAY TO HOUR',         '3 12:30 DAY TO MINUTE'),
-        (5, '3 14:00:00 DAY TO SECOND',  '3 12:30:12.1324 DAY TO SECOND'),
-        (6, '12:00 HOUR TO MINUTE',      '-12:30:12 HOUR TO SECOND'),
-        (7, '-1000-11 YEAR TO MONTH',    '-30:11 MINUTE TO SECOND');
+        (1, '''1-2'' YEAR TO MONTH',         '''30'' MONTH'),
+        (2, '''12'' DAY',                    '''35'' HOUR'),
+        (3, '''12'' MINUTE',                 '''300'' SECOND'),
+        (4, '''-3 14'' DAY TO HOUR',         '''3 12:30'' DAY TO MINUTE'),
+        (5, '''3 14:00:00'' DAY TO SECOND',  '''3 12:30:12.1324'' DAY TO SECOND'),
+        (6, '''12:00'' HOUR TO MINUTE',      '''-12:30:12'' HOUR TO SECOND'),
+        (7, '''-1000-11'' YEAR TO MONTH',    '''-30:11'' MINUTE TO SECOND');
     ",
             Ok(Payload::Insert(7)),
         ),

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -16,7 +16,7 @@ use {
 test_case!(cast_literal, async move {
     let test_cases = [
         ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
-        (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),
+        ("INSERT INTO Item VALUES ('1')", Ok(Payload::Insert(1))),
         (
             "CREATE TABLE test (mytext Text, myint8 Int8, myint Int, myfloat Float, mydec Decimal, mybool Boolean, mydate Date)",
             Ok(Payload::Create),
@@ -26,213 +26,213 @@ test_case!(cast_literal, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO utest VALUES ("foobar", 2, 2, 2.0, 2.0, true, "2001-09-11")"#,
+            "INSERT INTO utest VALUES ('foobar', 2, 2, 2.0, 2.0, true, '2001-09-11')",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"INSERT INTO test VALUES ("foobar", -2, 2, 2.0, 2.0, true, "2001-09-11")"#,
+            "INSERT INTO test VALUES ('foobar', -2, 2, 2.0, 2.0, true, '2001-09-11')",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"SELECT CAST("TRUE" AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST('TRUE' AS BOOLEAN) AS cast FROM Item",
             Ok(select!(cast Bool; true)),
         ),
         (
-            r#"SELECT CAST(1 AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST(1 AS BOOLEAN) AS cast FROM Item",
             Ok(select!(cast Bool; true)),
         ),
         (
-            r#"SELECT CAST("asdf" AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST('asdf' AS BOOLEAN) AS cast FROM Item",
             Err(ValueError::LiteralCastToBooleanFailed("asdf".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(3 AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST(3 AS BOOLEAN) AS cast FROM Item",
             Err(ValueError::LiteralCastToBooleanFailed("3".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(NULL AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS BOOLEAN) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST("1" AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST('1' AS INTEGER) AS cast FROM Item",
             Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST("foo" AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS INTEGER) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToIntegerFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(1.1 AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST(1.1 AS INTEGER) AS cast FROM Item",
             Err(ValueError::LiteralCastToDataTypeFailed(DataType::Int, "1.1".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(TRUE AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST(TRUE AS INTEGER) AS cast FROM Item",
             Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST(NULL AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS INTEGER) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(255 AS INT8) AS cast FROM Item"#,
+            "SELECT CAST(255 AS INT8) AS cast FROM Item",
             Err(ValueError::LiteralCastToInt8Failed("255".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST("foo" AS UINT8) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS UINT8) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToUnsignedInt8Failed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(-1 AS UINT8) AS cast FROM Item"#,
+            "SELECT CAST(-1 AS UINT8) AS cast FROM Item",
             Err(ValueError::LiteralCastToUnsignedInt8Failed("-1".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST("foo" AS UINT16) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS UINT16) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToUint16Failed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(-1 AS UINT16) AS cast FROM Item"#,
+            "SELECT CAST(-1 AS UINT16) AS cast FROM Item",
             Err(ValueError::LiteralCastToUint16Failed("-1".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST("1.1" AS FLOAT) AS cast FROM Item"#,
+            "SELECT CAST('1.1' AS FLOAT) AS cast FROM Item",
             Ok(select!(cast F64; 1.1)),
         ),
         (
-            r#"SELECT CAST(1 AS FLOAT) AS cast FROM Item"#,
+            "SELECT CAST(1 AS FLOAT) AS cast FROM Item",
             Ok(select!(cast F64; 1.0)),
         ),
         (
-            r#"SELECT CAST("foo" AS FLOAT) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS FLOAT) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToFloatFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(TRUE AS FLOAT) AS cast FROM Item"#,
+            "SELECT CAST(TRUE AS FLOAT) AS cast FROM Item",
             Ok(select!(cast F64; 1.0)),
         ),
         (
-            r#"SELECT CAST(NULL AS FLOAT) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS FLOAT) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(true AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(true AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(1,0))),
         ),
         (
-            r#"SELECT CAST(false AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(false AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(0,0))),
         ),
         (
-            r#"SELECT CAST(number AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(number AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(1,0))),
         ),
         (
-            r#"SELECT CAST("1.1" AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST('1.1' AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(11,1))),
         ),
         (
-            r#"SELECT CAST(1 AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(1 AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(10, 1))),
         ),
         (
-            r#"SELECT CAST(-1 AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(-1 AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(-10, 1))),
         ),
         (
-            r#"SELECT CAST("foo" AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS Decimal) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToDecimalFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(NULL AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS Decimal) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(true AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(true AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(1,0))),
         ),
         (
-            r#"SELECT CAST(false AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(false AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(0,0))),
         ),
         (
-            r#"SELECT CAST(number AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(number AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(1,0))),
         ),
         (
-            r#"SELECT CAST("1.1" AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST('1.1' AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(11,1))),
         ),
         (
-            r#"SELECT CAST(1 AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(1 AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(10, 1))),
         ),
         (
-            r#"SELECT CAST(-1 AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(-1 AS Decimal) AS cast FROM Item",
             Ok(select!(cast Decimal; Decimal::new(-10, 1))),
         ),
         (
-            r#"SELECT CAST("foo" AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST('foo' AS Decimal) AS cast FROM Item",
             Err(ValueError::LiteralCastFromTextToDecimalFailed("foo".to_owned()).into()),
         ),
         (
-            r#"SELECT CAST(NULL AS Decimal) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS Decimal) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(mytext AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(mytext AS Decimal) AS cast FROM test",
             Err(ValueError::ImpossibleCast.into()),
         ),
         (
-            r#"SELECT CAST(myint8 AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(myint8 AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(-2,0))),
         ),
         (
-            r#"SELECT CAST(myuint8 AS Decimal) AS cast FROM utest"#,
+            "SELECT CAST(myuint8 AS Decimal) AS cast FROM utest",
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (
-            r#"SELECT CAST(myint AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(myint AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (
-            r#"SELECT CAST(myfloat AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(myfloat AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (
-            r#"SELECT CAST(mydec AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(mydec AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(2,0))),
         ),
         (
-            r#"SELECT CAST(mybool AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(mybool AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(1,0))),
         ),
 
         (
-            r#"SELECT CAST(not(mybool) AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(not(mybool) AS Decimal) AS cast FROM test",
             Ok(select!(cast Decimal; Decimal::new(0,0))),
         ),
 
         (
-            r#"SELECT CAST(mydate AS Decimal) AS cast FROM test"#,
+            "SELECT CAST(mydate AS Decimal) AS cast FROM test",
             Err(ValueError::ImpossibleCast.into()),
         ),
         (
-            r#"SELECT CAST(1 AS TEXT) AS cast FROM Item"#,
+            "SELECT CAST(1 AS TEXT) AS cast FROM Item",
             Ok(select!(cast Str; "1".to_owned())),
         ),
         (
-            r#"SELECT CAST(1.1 AS TEXT) AS cast FROM Item"#,
+            "SELECT CAST(1.1 AS TEXT) AS cast FROM Item",
             Ok(select!(cast Str; "1.1".to_owned())),
         ),
         (
-            r#"SELECT CAST(TRUE AS TEXT) AS cast FROM Item"#,
+            "SELECT CAST(TRUE AS TEXT) AS cast FROM Item",
             Ok(select!(cast Str; "TRUE".to_owned())),
         ),
         (
-            r#"SELECT CAST(NULL AS TEXT) AS cast FROM Item"#,
+            "SELECT CAST(NULL AS TEXT) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(NULL AS INTERVAL) FROM Item"#,
+            "SELECT CAST(NULL AS INTERVAL) FROM Item",
             Err(ValueError::UnimplementedLiteralCast {
                 data_type: gluesql_core::ast::DataType::Interval,
                 literal: format!("{:?}", gluesql_core::data::Literal::Null),
@@ -240,22 +240,22 @@ test_case!(cast_literal, async move {
             .into()),
         ),
         (
-            r#"SELECT
-            CAST("'1-2' YEAR TO MONTH" as INTERVAL) as stoi_1,
-            CAST("'12' DAY" as INTERVAL) as stoi_2,
-            CAST("'12' MINUTE" as INTERVAL) as stoi_3,
-            CAST("'-3 14' DAY TO HOUR" as INTERVAL) as stoi_4,
-            CAST("'3 14:00:00' DAY TO SECOND" as INTERVAL) as stoi_5,
-            CAST("'12:00' HOUR TO MINUTE" as INTERVAL) as stoi_6,
-            CAST("'-1000-11' YEAR TO MONTH" as INTERVAL) as stoi_7,
-            CAST("'30' MONTH" as INTERVAL) as stoi_8,
-            CAST("'35' HOUR" as INTERVAL) as stoi_9,
-            CAST("'300' SECOND" as INTERVAL) as stoi_10,
-            CAST("'3 12:30' DAY TO MINUTE" as INTERVAL) as stoi_11,
-            CAST("'3 12:30:12.1324' DAY TO SECOND" as INTERVAL) as stoi_12,
-            CAST("'-12:30:12' HOUR TO SECOND" as INTERVAL) as stoi_13,
-            CAST("'-30:11' MINUTE TO SECOND" as INTERVAL) as stoi_14
-            FROM Item"#,
+            "SELECT
+            CAST('\"1-2\" YEAR TO MONTH' as INTERVAL) as stoi_1,
+            CAST('\"12\" DAY' as INTERVAL) as stoi_2,
+            CAST('\"12\" MINUTE' as INTERVAL) as stoi_3,
+            CAST('\"-3 14\" DAY TO HOUR' as INTERVAL) as stoi_4,
+            CAST('\"3 14:00:00\" DAY TO SECOND' as INTERVAL) as stoi_5,
+            CAST('\"12:00\" HOUR TO MINUTE' as INTERVAL) as stoi_6,
+            CAST('\"-1000-11\" YEAR TO MONTH' as INTERVAL) as stoi_7,
+            CAST('\"30' MONTH\" as INTERVAL) as stoi_8,
+            CAST('\"35' HOUR\" as INTERVAL) as stoi_9,
+            CAST('\"300' SECOND\" as INTERVAL) as stoi_10,
+            CAST('\"3 12:30\" DAY TO MINUTE' as INTERVAL) as stoi_11,
+            CAST('\"3 12:30:12.1324\" DAY TO SECOND' as INTERVAL) as stoi_12,
+            CAST('\"-12:30:12\" HOUR TO SECOND' as INTERVAL) as stoi_13,
+            CAST('\"-30:11\" MINUTE TO SECOND' as INTERVAL) as stoi_14
+            FROM Item",
             Ok(select!(
             stoi_1|stoi_2|stoi_3|stoi_4|stoi_5|stoi_6|stoi_7|stoi_8|stoi_9|stoi_10|stoi_11|stoi_12|stoi_13|stoi_14
             Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval|Interval;
@@ -284,7 +284,7 @@ test_case!(cast_literal, async move {
             Ok(select_with_null!(cast; Value::Date(NaiveDate::from_ymd_opt(2021, 8, 25).unwrap()))),
         ),
         (
-            r#"SELECT CAST('2021-08-025' AS DATE) FROM Item"#,
+            "SELECT CAST('2021-08-025' AS DATE) FROM Item",
             Err(ValueError::LiteralCastToDateFailed("2021-08-025".to_owned()).into()),
         ),
         (
@@ -339,63 +339,63 @@ test_case!(cast_value, async move {
 
     let test_cases = [
         (
-            r#"
+            "
             CREATE TABLE Item (
                 id INTEGER NULL,
                 flag BOOLEAN,
                 ratio FLOAT NULL,
                 number TEXT
-            )"#,
+            )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES (0, TRUE, NULL, "1")"#,
+            "INSERT INTO Item VALUES (0, TRUE, NULL, '1')",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"SELECT CAST(LOWER(number) AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST(LOWER(number) AS INTEGER) AS cast FROM Item",
             Ok(select!(cast I64; 1)),
         ),
         (
-            r#"SELECT CAST(id AS BOOLEAN) AS cast FROM Item"#,
+            "SELECT CAST(id AS BOOLEAN) AS cast FROM Item",
             Ok(select!(cast Bool; false)),
         ),
         (
-            r#"SELECT CAST(flag AS TEXT) AS cast FROM Item"#,
+            "SELECT CAST(flag AS TEXT) AS cast FROM Item",
             Ok(select!(cast Str; "TRUE".to_owned())),
         ),
         (
-            r#"SELECT CAST(ratio AS INTEGER) AS cast FROM Item"#,
+            "SELECT CAST(ratio AS INTEGER) AS cast FROM Item",
             Ok(select_with_null!(cast; Null)),
         ),
         (
-            r#"SELECT CAST(number AS BOOLEAN) FROM Item"#,
+            "SELECT CAST(number AS BOOLEAN) FROM Item",
             Err(ValueError::ImpossibleCast.into()),
         ),
         (
-            r#"
-    CREATE TABLE IntervalLog (
+            "
+        CREATE TABLE IntervalLog (
         id INTEGER,
         interval_str_1 TEXT,
         interval_str_2 TEXT,
-    )"#,
+    )",
             Ok(Payload::Create),
         ),
         (
-            r#"
-    INSERT INTO IntervalLog VALUES
-        (1, '"1-2" YEAR TO MONTH',         '"30" MONTH'),
-        (2, '"12" DAY',                    '"35" HOUR'),
-        (3, '"12" MINUTE',                 '"300" SECOND'),
-        (4, '"-3 14" DAY TO HOUR',         '"3 12:30" DAY TO MINUTE'),
-        (5, '"3 14:00:00" DAY TO SECOND',  '"3 12:30:12.1324" DAY TO SECOND'),
-        (6, '"12:00" HOUR TO MINUTE',      '"-12:30:12" HOUR TO SECOND'),
-        (7, '"-1000-11" YEAR TO MONTH',    '"-30:11" MINUTE TO SECOND');
-    "#,
+            "
+        INSERT INTO IntervalLog VALUES
+        (1, '1-2 YEAR TO MONTH',         '30 MONTH'),
+        (2, '12 DAY',                    '35 HOUR'),
+        (3, '12 MINUTE',                 '300 SECOND'),
+        (4, '-3 14 DAY TO HOUR',         '3 12:30 DAY TO MINUTE'),
+        (5, '3 14:00:00 DAY TO SECOND',  '3 12:30:12.1324 DAY TO SECOND'),
+        (6, '12:00 HOUR TO MINUTE',      '-12:30:12 HOUR TO SECOND'),
+        (7, '-1000-11 YEAR TO MONTH',    '-30:11 MINUTE TO SECOND');
+    ",
             Ok(Payload::Insert(7)),
         ),
         (
-            r#"SELECT id, CAST(interval_str_1 as INTERVAL) as stoi_1, CAST(interval_str_2 as INTERVAL) as stoi_2 FROM IntervalLog;"#,
+            "SELECT id, CAST(interval_str_1 as INTERVAL) as stoi_1, CAST(interval_str_2 as INTERVAL) as stoi_2 FROM IntervalLog;",
             Ok(select!(
             id  | stoi_1          | stoi_2
             I64 | Interval            | Interval;

--- a/test-suite/src/function/chr.rs
+++ b/test-suite/src/function/chr.rs
@@ -5,7 +5,7 @@ use {
 
 test_case!(chr, async move {
     test!(
-        r#"VALUES(CHR(70))"#,
+        "VALUES(CHR(70))",
         Ok(select!(
             column1
             Str;
@@ -13,7 +13,7 @@ test_case!(chr, async move {
         ))
     );
     test!(
-        r#"VALUES(CHR(7070))"#,
+        "VALUES(CHR(7070))",
         Err(EvaluateError::ChrFunctionRequiresIntegerValueInRange0To255.into())
     );
     run!(
@@ -24,10 +24,10 @@ test_case!(chr, async move {
         );
     "
     );
-    run!(r#"INSERT INTO Chr VALUES (1, 70);"#);
+    run!("INSERT INTO Chr VALUES (1, 70);");
 
     test!(
-        r#"select chr(num) as chr from Chr;"#,
+        "select chr(num) as chr from Chr;",
         Ok(select!(
             chr
             Str;
@@ -36,7 +36,7 @@ test_case!(chr, async move {
     );
 
     test!(
-        r#"select chr(65) as chr from Chr;"#,
+        "select chr(65) as chr from Chr;",
         Ok(select!(
            chr
            Str;
@@ -45,18 +45,18 @@ test_case!(chr, async move {
     );
 
     test!(
-        r#"select chr(532) as chr from Chr;"#,
+        "select chr(532) as chr from Chr;",
         Err(EvaluateError::ChrFunctionRequiresIntegerValueInRange0To255.into())
     );
     test!(
-        r#"select chr("ukjhg") as chr from Chr;"#,
+        "select chr('ukjhg') as chr from Chr;",
         Err(EvaluateError::FunctionRequiresIntegerValue("CHR".to_owned()).into())
     );
 
-    run!(r#"INSERT INTO Chr VALUES (1, 4345);"#);
+    run!("INSERT INTO Chr VALUES (1, 4345);");
 
     test!(
-        r#"select chr(num) as chr from Chr;"#,
+        "select chr(num) as chr from Chr;",
         Err(EvaluateError::ChrFunctionRequiresIntegerValueInRange0To255.into())
     );
 });

--- a/test-suite/src/function/concat.rs
+++ b/test-suite/src/function/concat.rs
@@ -15,10 +15,10 @@ test_case!(concat, async move {
         );
     "
     );
-    run!(r#"INSERT INTO Concat VALUES (1, 2.3, TRUE, "Foo", NULL);"#);
+    run!("INSERT INTO Concat VALUES (1, 2.3, TRUE, 'Foo', NULL);");
 
     test!(
-        r#"select concat("ab", "cd") as myc from Concat;"#,
+        "select concat('ab', 'cd') as myc from Concat;",
         Ok(select!(
            myc
            Str;
@@ -27,7 +27,7 @@ test_case!(concat, async move {
     );
 
     test!(
-        r#"select concat("ab", "cd", "ef") as myconcat from Concat;"#,
+        "select concat('ab', 'cd', 'ef') as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -36,12 +36,12 @@ test_case!(concat, async move {
     );
 
     test!(
-        r#"select concat("ab", "cd", NULL, "ef") as myconcat from Concat;"#,
+        "select concat('ab', 'cd', NULL, 'ef') as myconcat from Concat;",
         Ok(select_with_null!(myconcat; Null))
     );
 
     test!(
-        r#"select concat() as myconcat from Concat;"#,
+        "select concat() as myconcat from Concat;",
         Err(TranslateError::FunctionArgsLengthNotMatchingMin {
             name: "CONCAT".to_owned(),
             expected_minimum: 1,
@@ -51,13 +51,13 @@ test_case!(concat, async move {
     );
 
     test!(
-        r#"select concat(DATE "2020-06-11", DATE "2020-16-3") as myconcat from Concat;"#,
+        "select concat(DATE '2020-06-11', DATE '2020-16-3') as myconcat from Concat;",
         Err(ValueError::FailedToParseDate("2020-16-3".to_owned()).into())
     );
 
     // test with non string arguments
     test!(
-        r#"select concat(123, 456, 3.14) as myconcat from Concat;"#,
+        "select concat(123, 456, 3.14) as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -66,7 +66,7 @@ test_case!(concat, async move {
     );
     // test with zero arguments
     test!(
-        r#"select concat() as myconcat from Concat;"#,
+        "select concat() as myconcat from Concat;",
         Err(TranslateError::FunctionArgsLengthNotMatchingMin {
             name: "CONCAT".to_owned(),
             expected_minimum: 1,

--- a/test-suite/src/function/concat_ws.rs
+++ b/test-suite/src/function/concat_ws.rs
@@ -5,7 +5,7 @@ use {
 
 test_case!(concat_ws, async move {
     test!(
-        r#"VALUES(CONCAT_WS(",", "AB", "CD", "EF"))"#,
+        "VALUES(CONCAT_WS(',', 'AB', 'CD', 'EF'))",
         Ok(select!(
             column1
             Str;
@@ -23,10 +23,10 @@ test_case!(concat_ws, async move {
         );
     "
     );
-    run!(r#"INSERT INTO Concat VALUES (1, TRUE, "Foo", NULL);"#);
+    run!("INSERT INTO Concat VALUES (1, TRUE, 'Foo', NULL);");
 
     test!(
-        r#"select concat_ws("/", id, flag, null_value, text) as myc from Concat;"#,
+        "select concat_ws('/', id, flag, null_value, text) as myc from Concat;",
         Ok(select!(
            myc
            Str;
@@ -35,7 +35,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws("", "ab", "cd") as myc from Concat;"#,
+        "select concat_ws('', 'ab', 'cd') as myc from Concat;",
         Ok(select!(
            myc
            Str;
@@ -44,7 +44,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws("", "ab", "cd", "ef") as myconcat from Concat;"#,
+        "select concat_ws('', 'ab', 'cd', 'ef') as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -53,7 +53,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws(",", "ab", "cd", "ef") as myconcat from Concat;"#,
+        "select concat_ws(',', 'ab', 'cd', 'ef') as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -62,7 +62,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws("/", "ab", "cd", "ef") as myconcat from Concat;"#,
+        "select concat_ws('/', 'ab', 'cd', 'ef') as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -71,7 +71,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws("", "ab", "cd", NULL, "ef") as myconcat from Concat;"#,
+        "select concat_ws('', 'ab', 'cd', NULL, 'ef') as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -80,7 +80,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws("", 123, 456, 3.14) as myconcat from Concat;"#,
+        "select concat_ws('', 123, 456, 3.14) as myconcat from Concat;",
         Ok(select!(
            myconcat
            Str;
@@ -89,7 +89,7 @@ test_case!(concat_ws, async move {
     );
 
     test!(
-        r#"select concat_ws() as myconcat from Concat;"#,
+        "select concat_ws() as myconcat from Concat;",
         Err(TranslateError::FunctionArgsLengthNotMatchingMin {
             name: "CONCAT_WS".to_owned(),
             expected_minimum: 2,

--- a/test-suite/src/function/div_mod.rs
+++ b/test-suite/src/function/div_mod.rs
@@ -19,12 +19,12 @@ test_case!(div_mod, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
             INSERT INTO 
                 FloatDiv (dividend, divisor) 
             VALUES 
                 (12.0, 3.0), (12.34, 56.78), (-12.3, 4.0)
-            "#,
+            ",
             Ok(Payload::Insert(3)),
         ),
         (
@@ -47,7 +47,7 @@ test_case!(div_mod, async move {
             Err(EvaluateError::DivisorShouldNotBeZero.into()),
         ),
         (
-            r#"SELECT DIV(1.0, "dividend") AS quotient FROM FloatDiv"#,
+            "SELECT DIV(1.0, 'dividend') AS quotient FROM FloatDiv",
             Err(EvaluateError::FunctionRequiresFloatOrIntegerValue("DIV".to_owned()).into()),
         ),
         (
@@ -73,12 +73,12 @@ test_case!(div_mod, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
             INSERT INTO 
                 IntDiv (dividend, divisor) 
             VALUES 
                 (12, 3), (12, 7), (12, 34), (-12, 7)
-            "#,
+            ",
             Ok(Payload::Insert(4)),
         ),
         (
@@ -111,13 +111,13 @@ test_case!(div_mod, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"
+            "
             INSERT INTO 
                 MixDiv (dividend, divisor) 
             VALUES 
                 (12, 3.0), (12, 34.0), (12, -5.2),
                 (12, NULL), (NULL, 34.0), (NULL, NULL)
-            "#,
+            ",
             Ok(Payload::Insert(6)),
         ),
         (

--- a/test-suite/src/function/extract.rs
+++ b/test-suite/src/function/extract.rs
@@ -17,7 +17,7 @@ use {
 test_case!(extract, async move {
     let test_cases = [
         ("CREATE TABLE Item (number TEXT)", Ok(Payload::Create)),
-        (r#"INSERT INTO Item VALUES ("1")"#, Ok(Payload::Insert(1))),
+        ("INSERT INTO Item VALUES ('1')", Ok(Payload::Insert(1))),
         (
             r#"SELECT EXTRACT(HOUR FROM TIMESTAMP '2016-12-31 13:30:15') as extract FROM Item"#,
             Ok(select!("extract" I64; 13)),
@@ -51,27 +51,27 @@ test_case!(extract, async move {
             Ok(select!("extract" I64; 6)),
         ),
         (
-            r#"SELECT EXTRACT(YEAR FROM INTERVAL "3" YEAR) as extract FROM Item"#,
+            "SELECT EXTRACT(YEAR FROM INTERVAL '3' YEAR) as extract FROM Item",
             Ok(select!("extract" I64; 3)),
         ),
         (
-            r#"SELECT EXTRACT(MONTH FROM INTERVAL "4" MONTH) as extract FROM Item"#,
+            "SELECT EXTRACT(MONTH FROM INTERVAL '4' MONTH) as extract FROM Item",
             Ok(select!("extract" I64; 4)),
         ),
         (
-            r#"SELECT EXTRACT(DAY FROM INTERVAL "5" DAY) as extract FROM Item"#,
+            "SELECT EXTRACT(DAY FROM INTERVAL '5' DAY) as extract FROM Item",
             Ok(select!("extract" I64; 5)),
         ),
         (
-            r#"SELECT EXTRACT(HOUR FROM INTERVAL "6" HOUR) as extract FROM Item"#,
+            "SELECT EXTRACT(HOUR FROM INTERVAL '6' HOUR) as extract FROM Item",
             Ok(select!("extract" I64; 6)),
         ),
         (
-            r#"SELECT EXTRACT(MINUTE FROM INTERVAL "7" MINUTE) as extract FROM Item"#,
+            "SELECT EXTRACT(MINUTE FROM INTERVAL '7' MINUTE) as extract FROM Item",
             Ok(select!("extract" I64; 7)),
         ),
         (
-            r#"SELECT EXTRACT(SECOND FROM INTERVAL "8" SECOND) as extract FROM Item"#,
+            "SELECT EXTRACT(SECOND FROM INTERVAL '8' SECOND) as extract FROM Item",
             Ok(select!("extract" I64; 8)),
         ),
         (
@@ -83,7 +83,7 @@ test_case!(extract, async move {
             .into()),
         ),
         (
-            r#"SELECT EXTRACT(HOUR FROM INTERVAL "7" YEAR) as extract FROM Item"#,
+            "SELECT EXTRACT(HOUR FROM INTERVAL '7' YEAR) as extract FROM Item",
             Err(IntervalError::FailedToExtract.into()),
         ),
         (
@@ -95,7 +95,7 @@ test_case!(extract, async move {
             .into()),
         ),
         (
-            r#"SELECT EXTRACT(microseconds FROM "2011-01-1") FROM Item;"#,
+            "SELECT EXTRACT(microseconds FROM '2011-01-1') FROM Item;",
             Err(TranslateError::UnsupportedDateTimeField("MICROSECONDS".to_owned()).into()),
         ),
     ];

--- a/test-suite/src/function/format.rs
+++ b/test-suite/src/function/format.rs
@@ -5,7 +5,7 @@ test_case!(format, async move {
 
     let test_cases = vec![
         (
-            r#"VALUES(FORMAT(DATE "2017-06-15", "%Y-%m"))"#,
+            "VALUES(FORMAT(DATE '2017-06-15', '%Y-%m'))",
             Ok(select!(
                 column1
                 Str;
@@ -13,7 +13,7 @@ test_case!(format, async move {
             )),
         ),
         (
-            r#"SELECT FORMAT(DATE "2017-06-15","%Y-%m") AS date"#,
+            "SELECT FORMAT(DATE '2017-06-15','%Y-%m') AS date",
             Ok(select!(
                 date
                 Str;
@@ -21,7 +21,7 @@ test_case!(format, async move {
             )),
         ),
         (
-            r#"SELECT FORMAT(TIMESTAMP "2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S") AS timestamp"#,
+            "SELECT FORMAT(TIMESTAMP '2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%S') AS timestamp",
             Ok(select!(
                 timestamp
                 Str;
@@ -29,7 +29,7 @@ test_case!(format, async move {
             )),
         ),
         (
-            r#"SELECT FORMAT(TIME "23:56:04","%H:%M") AS time"#,
+            "SELECT FORMAT(TIME '23:56:04','%H:%M') AS time",
             Ok(select!(
                 time
                 Str;
@@ -37,11 +37,11 @@ test_case!(format, async move {
             )),
         ),
         (
-            r#"SELECT 
-                FORMAT(TIMESTAMP "2015-09-05 23:56:04", "%Y") AS year
-               ,FORMAT(TIMESTAMP "2015-09-05 23:56:04", "%m") AS month
-               ,FORMAT(TIMESTAMP "2015-09-05 23:56:04", "%d") AS day
-            "#,
+            "SELECT 
+                FORMAT(TIMESTAMP '2015-09-05 23:56:04', '%Y') AS year
+               ,FORMAT(TIMESTAMP '2015-09-05 23:56:04', '%m') AS month
+               ,FORMAT(TIMESTAMP '2015-09-05 23:56:04', '%d') AS day
+            ",
             Ok(select!(
             year              | month           | day;
             Str               | Str             | Str;
@@ -49,7 +49,7 @@ test_case!(format, async move {
             )),
         ),
         (
-            r#"SELECT FORMAT("2015-09-05 23:56:04", "%Y-%m-%d %H") AS timestamp"#,
+            "SELECT FORMAT('2015-09-05 23:56:04', '%Y-%m-%d %H') AS timestamp",
             Err(
                 EvaluateError::UnsupportedExprForFormatFunction("2015-09-05 23:56:04".to_owned())
                     .into(),

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -9,19 +9,19 @@ use {
 test_case!(gcd_lcm, async move {
     let test_cases = [
         (
-            r#"
-        CREATE TABLE GcdI64 (
+            "
+            CREATE TABLE GcdI64 (
             left INTEGER NULL DEFAULT GCD(3, 4),
             right INTEGER NULL DEFAULT LCM(10, 2)
-         )"#,
+         )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO GcdI64 VALUES (0, 3), (2,4), (6,8), (3,5), (1, NULL), (NULL, 1);"#,
+            "INSERT INTO GcdI64 VALUES (0, 3), (2,4), (6,8), (3,5), (1, NULL), (NULL, 1);",
             Ok(Payload::Insert(6)),
         ),
         (
-            r#"SELECT GCD(left, right) AS test FROM GcdI64"#,
+            "SELECT GCD(left, right) AS test FROM GcdI64",
             Ok(select_with_null!(
                 test;
                 I64(3);
@@ -33,39 +33,39 @@ test_case!(gcd_lcm, async move {
             )),
         ),
         (
-            r#"
-        CREATE TABLE GcdStr (
+            "
+            CREATE TABLE GcdStr (
             left TEXT,
             right INTEGER
-         )"#,
+         )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO GcdStr VALUES ("TEXT", 0);"#,
+            "INSERT INTO GcdStr VALUES ('TEXT', 0);",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"SELECT GCD(left, right) AS test FROM GcdStr"#,
+            "SELECT GCD(left, right) AS test FROM GcdStr",
             Err(EvaluateError::FunctionRequiresIntegerValue("GCD".to_owned()).into()),
         ),
         (
-            r#"SELECT GCD(right, left) AS test FROM GcdStr"#,
+            "SELECT GCD(right, left) AS test FROM GcdStr",
             Err(EvaluateError::FunctionRequiresIntegerValue("GCD".to_owned()).into()),
         ),
         (
-            r#"
-        CREATE TABLE LcmI64 (
+            "
+            CREATE TABLE LcmI64 (
             left INTEGER NULL DEFAULT true,
             right INTEGER NULL DEFAULT true
-         )"#,
+         )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO LcmI64 VALUES (0, 3), (2,4), (6,8), (3,5), (1, NULL), (NULL, 1);"#,
+            "INSERT INTO LcmI64 VALUES (0, 3), (2,4), (6,8), (3,5), (1, NULL), (NULL, 1);",
             Ok(Payload::Insert(6)),
         ),
         (
-            r#"SELECT LCM(left, right) AS test FROM LcmI64"#,
+            "SELECT LCM(left, right) AS test FROM LcmI64",
             Ok(select_with_null!(
                 test;
                 I64(0);
@@ -77,23 +77,23 @@ test_case!(gcd_lcm, async move {
             )),
         ),
         (
-            r#"
-        CREATE TABLE LcmStr (
+            "
+            CREATE TABLE LcmStr (
             left TEXT,
             right INTEGER
-         )"#,
+         )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO LcmStr VALUES ("TEXT", 0);"#,
+            "INSERT INTO LcmStr VALUES ('TEXT', 0);",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"SELECT LCM(left, right) AS test FROM LcmStr"#,
+            "SELECT LCM(left, right) AS test FROM LcmStr",
             Err(EvaluateError::FunctionRequiresIntegerValue("LCM".to_owned()).into()),
         ),
         (
-            r#"SELECT LCM(right, left) AS test FROM LcmStr"#,
+            "SELECT LCM(right, left) AS test FROM LcmStr",
             Err(EvaluateError::FunctionRequiresIntegerValue("LCM".to_owned()).into()),
         ),
     ];

--- a/test-suite/src/function/ifnull.rs
+++ b/test-suite/src/function/ifnull.rs
@@ -8,60 +8,60 @@ use {
 test_case!(ifnull, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE SingleItem (id integer null, int8 int8 null, dec decimal null, 
+            "CREATE TABLE SingleItem (id integer null, int8 int8 null, dec decimal null,
                                         dt date null, mystring Text null,
                                         mybool Boolean null, myfloat float null,
-                                        mytime time null, mytimestamp timestamp null)"#,
+                                        mytime time null, mytimestamp timestamp null)",
             Payload::Create,
         ),
         (
-            r#"INSERT INTO SingleItem VALUES (0, 1, 2, "2022-05-23", "this is a string", true, 3.15,
-                          "01:02:03", "1970-01-01 00:00:00 -00:00")"#,
+            "INSERT INTO SingleItem VALUES (0, 1, 2, '2022-05-23', 'this is a string', true, 3.15,
+                          '01:02:03', '1970-01-01 00:00:00 -00:00')",
             Payload::Insert(1),
         ),
         (
-            r#"INSERT INTO SingleItem VALUES (null, null, null, null, null, null, null, null, null)"#,
+            "INSERT INTO SingleItem VALUES (null, null, null, null, null, null, null, null, null)",
             Payload::Insert(1),
         ),
         (
-            r#"SELECT IFNULL(id, 1) AS myid, IFNULL(int8, 2) AS int8, IFNULL(dec, 3) 
-            FROM SingleItem WHERE id IS NOT NULL"#,
+            "SELECT IFNULL(id, 1) AS myid, IFNULL(int8, 2) AS int8, IFNULL(dec, 3)
+            FROM SingleItem WHERE id IS NOT NULL",
             select!("myid" | "int8" | "IFNULL(dec, 3)"; I64 | I8 | Decimal; 0 1 Decimal::from(2i8)),
         ),
         (
-            r#"SELECT ifnull(id, 1) AS ID, IFNULL(int8, 2) AS INT8, IFNULL(dec, 3) 
-            FROM SingleItem WHERE id IS NULL"#,
+            "SELECT ifnull(id, 1) AS ID, IFNULL(int8, 2) AS INT8, IFNULL(dec, 3)
+            FROM SingleItem WHERE id IS NULL",
             select!("ID" | "INT8" | "IFNULL(dec, 3)"; I64 | I64 | I64; 1  2 3),
         ),
         (
-            r#"SELECT ifnull(dt, "2000-01-01") AS mydate, ifnull(mystring, "blah") AS name 
-            FROM SingleItem WHERE id IS NOT NULL"#,
+            "SELECT ifnull(dt, '2000-01-01') AS mydate, ifnull(mystring, 'blah') AS name
+            FROM SingleItem WHERE id IS NOT NULL",
             select!("mydate" | "name"; Date | Str; NaiveDate::from_ymd_opt(2022,5,23).unwrap() "this is a string".to_owned()),
         ),
         (
-            r#"SELECT IFNULL(dt, "2000-01-01") AS mydate, IFNULL(mystring, "blah") AS name 
-            FROM SingleItem where id is null"#,
+            "SELECT IFNULL(dt, '2000-01-01') AS mydate, IFNULL(mystring, 'blah') AS name
+            FROM SingleItem where id is null",
             select!("mydate" | "name"; Str | Str; "2000-01-01".to_owned() "blah".to_owned()),
         ),
         (
-            r#"SELECT IFNULL(mybool, "YES") AS mybool, IFNULL(myfloat, "NO") AS myfloat 
-            FROM SingleItem WHERE id IS NOT NULL"#,
+            "SELECT IFNULL(mybool, 'YES') AS mybool, IFNULL(myfloat, 'NO') AS myfloat
+            FROM SingleItem WHERE id IS NOT NULL",
             select!("mybool" | "myfloat"; Bool | F64; true 3.15),
         ),
         (
-            r#"SELECT IFNULL(mybool, "YES") AS mybool, IFNULL(myfloat, "NO") AS myfloat 
-            FROM SingleItem WHERE id IS NULL"#,
+            "SELECT IFNULL(mybool, 'YES') AS mybool, IFNULL(myfloat, 'NO') AS myfloat
+            FROM SingleItem WHERE id IS NULL",
             select!("mybool" | "myfloat"; Str | Str; "YES".to_owned() "NO".to_owned()),
         ),
         (
-            r#"SELECT IFNULL(mytime, "YES") AS mybool, IFNULL(mytimestamp, "NO") AS myfloat 
-            FROM SingleItem WHERE id IS NOT NULL"#,
+            "SELECT IFNULL(mytime, 'YES') AS mybool, IFNULL(mytimestamp, 'NO') AS myfloat
+            FROM SingleItem WHERE id IS NOT NULL",
             select!("mybool" | "myfloat"; Time | Timestamp; 
                     NaiveTime::from_hms_opt(1, 2, 3).unwrap() NaiveDateTime::from_timestamp_opt(0, 0).unwrap()),
         ),
         (
-            r#"SELECT IFNULL(mytime, "YES") AS mybool, IFNULL(mytimestamp, "NO") AS myfloat 
-            FROM SingleItem WHERE id IS NULL"#,
+            "SELECT IFNULL(mytime, 'YES') AS mybool, IFNULL(mytimestamp, 'NO') AS myfloat
+            FROM SingleItem WHERE id IS NULL",
             select!("mybool" | "myfloat"; Str | Str; "YES".to_owned() "NO".to_owned()),
         ),
     ];

--- a/test-suite/src/function/left_right.rs
+++ b/test-suite/src/function/left_right.rs
@@ -10,32 +10,26 @@ use {
 test_case!(left_right, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT LEFT("abc", 1))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT LEFT('abc', 1))",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES ("Blop mc blee"), ("B"), ("Steven the &long named$ folken!")"#,
+            "INSERT INTO Item VALUES ('Blop mc blee'), ('B'), ('Steven the &long named$ folken!')",
             Ok(Payload::Insert(3)),
         ),
         ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
-        (
-            r#"INSERT INTO SingleItem VALUES (0)"#,
-            Ok(Payload::Insert(1)),
-        ),
+        ("INSERT INTO SingleItem VALUES (0)", Ok(Payload::Insert(1))),
         (
             "CREATE TABLE NullName (name TEXT NULL)",
             Ok(Payload::Create),
         ),
-        (
-            r#"INSERT INTO NullName VALUES (NULL)"#,
-            Ok(Payload::Insert(1)),
-        ),
+        ("INSERT INTO NullName VALUES (NULL)", Ok(Payload::Insert(1))),
         (
             "CREATE TABLE NullNumber (number INTEGER NULL)",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO NullNumber VALUES (NULL)"#,
+            "INSERT INTO NullNumber VALUES (NULL)",
             Ok(Payload::Insert(1)),
         ),
         (
@@ -43,11 +37,11 @@ test_case!(left_right, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO NullableName VALUES ('name')"#,
+            "INSERT INTO NullableName VALUES ('name')",
             Ok(Payload::Insert(1)),
         ),
         (
-            r#"SELECT LEFT(name, 3) AS test FROM Item"#,
+            "SELECT LEFT(name, 3) AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -57,7 +51,7 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT RIGHT(name, 10) AS test FROM Item"#,
+            "SELECT RIGHT(name, 10) AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -67,7 +61,7 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT LEFT((name || 'bobbert'), 10) AS test FROM Item"#,
+            "SELECT LEFT((name || 'bobbert'), 10) AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -77,7 +71,7 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT LEFT('blue', 10) AS test FROM SingleItem"#,
+            "SELECT LEFT('blue', 10) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -85,7 +79,7 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT LEFT("blunder", 3) AS test FROM SingleItem"#,
+            "SELECT LEFT('blunder', 3) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -93,19 +87,19 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT LEFT(name, 3) AS test FROM NullName"#,
+            "SELECT LEFT(name, 3) AS test FROM NullName",
             Ok(select_with_null!(test; Null)),
         ),
         (
-            r#"SELECT LEFT('Words', number) AS test FROM NullNumber"#,
+            "SELECT LEFT('Words', number) AS test FROM NullNumber",
             Ok(select_with_null!(test; Null)),
         ),
         (
-            r#"SELECT LEFT(name, number) AS test FROM NullNumber INNER JOIN NullName ON 1 = 1"#,
+            "SELECT LEFT(name, number) AS test FROM NullNumber INNER JOIN NullName ON 1 = 1",
             Ok(select_with_null!(test; Null)),
         ),
         (
-            r#"SELECT LEFT(name, 1) AS test FROM NullableName"#,
+            "SELECT LEFT(name, 1) AS test FROM NullableName",
             Ok(select!(
                 "test"
                 Str;
@@ -113,7 +107,7 @@ test_case!(left_right, async move {
             )),
         ),
         (
-            r#"SELECT RIGHT(name, 10, 10) AS test FROM SingleItem"#,
+            "SELECT RIGHT(name, 10, 10) AS test FROM SingleItem",
             Err(TranslateError::FunctionArgsLengthNotMatching {
                 name: "RIGHT".to_owned(),
                 expected: 2,
@@ -122,7 +116,7 @@ test_case!(left_right, async move {
             .into()),
         ),
         (
-            r#"SELECT RIGHT(name) AS test FROM SingleItem"#,
+            "SELECT RIGHT(name) AS test FROM SingleItem",
             Err(TranslateError::FunctionArgsLengthNotMatching {
                 name: "RIGHT".to_owned(),
                 expected: 2,
@@ -131,7 +125,7 @@ test_case!(left_right, async move {
             .into()),
         ),
         (
-            r#"SELECT RIGHT() AS test FROM SingleItem"#,
+            "SELECT RIGHT() AS test FROM SingleItem",
             Err(TranslateError::FunctionArgsLengthNotMatching {
                 name: "RIGHT".to_owned(),
                 expected: 2,
@@ -140,15 +134,15 @@ test_case!(left_right, async move {
             .into()),
         ),
         (
-            r#"SELECT RIGHT(1, 1) AS test FROM SingleItem"#,
+            "SELECT RIGHT(1, 1) AS test FROM SingleItem",
             Err(EvaluateError::FunctionRequiresStringValue("RIGHT".to_owned()).into()),
         ),
         (
-            r#"SELECT RIGHT('Words', 1.1) AS test FROM SingleItem"#,
+            "SELECT RIGHT('Words', 1.1) AS test FROM SingleItem",
             Err(EvaluateError::FunctionRequiresIntegerValue("RIGHT".to_owned()).into()),
         ),
         (
-            r#"SELECT RIGHT('Words', -4) AS test FROM SingleItem"#,
+            "SELECT RIGHT('Words', -4) AS test FROM SingleItem",
             Err(EvaluateError::FunctionRequiresUSizeValue("RIGHT".to_owned()).into()),
         ),
     ];

--- a/test-suite/src/function/lpad_rpad.rs
+++ b/test-suite/src/function/lpad_rpad.rs
@@ -10,27 +10,21 @@ use {
 test_case!(lpad_rpad, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT LPAD("a", 5) || LPAD("b", 3))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT LPAD('a', 5) || LPAD('b', 3))",
             Ok(Payload::Create),
         ),
-        (
-            r#"INSERT INTO Item VALUES ("hello")"#,
-            Ok(Payload::Insert(1)),
-        ),
+        ("INSERT INTO Item VALUES ('hello')", Ok(Payload::Insert(1))),
         (
             "CREATE TABLE NullName (name TEXT NULL)",
             Ok(Payload::Create),
         ),
-        (
-            r#"INSERT INTO NullName VALUES (NULL)"#,
-            Ok(Payload::Insert(1)),
-        ),
+        ("INSERT INTO NullName VALUES (NULL)", Ok(Payload::Insert(1))),
         (
             "CREATE TABLE NullNumber (number INTEGER NULL)",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO NullNumber VALUES (NULL)"#,
+            "INSERT INTO NullNumber VALUES (NULL)",
             Ok(Payload::Insert(1)),
         ),
         (

--- a/test-suite/src/function/ltrim_rtrim.rs
+++ b/test-suite/src/function/ltrim_rtrim.rs
@@ -12,15 +12,15 @@ use {
 test_case!(ltrim_rtrim, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT RTRIM(LTRIM("   abc   ")))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT RTRIM(LTRIM('   abc   ')))",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES (" zzzytest"), ("testxxzx ")"#,
+            "INSERT INTO Item VALUES (' zzzytest'), ('testxxzx ')",
             Ok(Payload::Insert(2)),
         ),
         (
-            r#"SELECT LTRIM(name) AS test FROM Item"#,
+            "SELECT LTRIM(name) AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -29,7 +29,7 @@ test_case!(ltrim_rtrim, async move {
             )),
         ),
         (
-            r#"SELECT LTRIM(name, ' xyz') AS test FROM Item"#,
+            "SELECT LTRIM(name, ' xyz') AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -38,7 +38,7 @@ test_case!(ltrim_rtrim, async move {
             )),
         ),
         (
-            r#"SELECT RTRIM(name) AS test FROM Item"#,
+            "SELECT RTRIM(name) AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -47,7 +47,7 @@ test_case!(ltrim_rtrim, async move {
             )),
         ),
         (
-            r#"SELECT RTRIM(name, 'xyz ') AS test FROM Item"#,
+            "SELECT RTRIM(name, 'xyz ') AS test FROM Item",
             Ok(select!(
                 "test"
                 Str;
@@ -56,51 +56,48 @@ test_case!(ltrim_rtrim, async move {
             )),
         ),
         (
-            r#"SELECT LTRIM(1) AS test FROM Item"#,
+            "SELECT LTRIM(1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("LTRIM".to_owned()).into()),
         ),
         (
-            r#"SELECT LTRIM(name, 1) AS test FROM Item"#,
+            "SELECT LTRIM(name, 1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("LTRIM".to_owned()).into()),
         ),
         (
-            r#"SELECT RTRIM(1) AS test FROM Item"#,
+            "SELECT RTRIM(1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("RTRIM".to_owned()).into()),
         ),
         (
-            r#"SELECT RTRIM(name, 1) AS test FROM Item"#,
+            "SELECT RTRIM(name, 1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("RTRIM".to_owned()).into()),
         ),
         (
             "CREATE TABLE NullTest (name TEXT null)",
             Ok(Payload::Create),
         ),
+        ("INSERT INTO NullTest VALUES (null)", Ok(Payload::Insert(1))),
         (
-            r#"INSERT INTO NullTest VALUES (null)"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"SELECT LTRIM(name) AS test FROM NullTest"#,
+            "SELECT LTRIM(name) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
-            r#"SELECT RTRIM(name) AS test FROM NullTest"#,
+            "SELECT RTRIM(name) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
-            r#"SELECT LTRIM(NULL, '123') AS test FROM NullTest"#,
+            "SELECT LTRIM(NULL, '123') AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
-            r#"SELECT LTRIM(name, NULL) AS test FROM NullTest"#,
+            "SELECT LTRIM(name, NULL) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
-            r#"SELECT RTRIM(NULL, '123') AS test FROM NullTest"#,
+            "SELECT RTRIM(NULL, '123') AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
-            r#"SELECT RTRIM(name, NULL) AS test FROM NullTest"#,
+            "SELECT RTRIM(name, NULL) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
     ];

--- a/test-suite/src/function/now.rs
+++ b/test-suite/src/function/now.rs
@@ -16,9 +16,9 @@ test_case!(now, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES
-                ("2021-10-13T06:42:40.364832862"),
-                ("9999-12-31T23:59:40.364832862");"#,
+            "INSERT INTO Item VALUES
+                ('2021-10-13T06:42:40.364832862'),
+                ('9999-12-31T23:59:40.364832862');",
             Ok(Payload::Insert(2)),
         ),
         (

--- a/test-suite/src/function/position.rs
+++ b/test-suite/src/function/position.rs
@@ -8,29 +8,23 @@ use {
 
 test_case!(position, async move {
     let test_cases = [
-        (r#"CREATE TABLE Food (name Text null)"#, Ok(Payload::Create)),
+        ("CREATE TABLE Food (name Text null)", Ok(Payload::Create)),
+        ("INSERT INTO Food VALUES ('pork')", Ok(Payload::Insert(1))),
+        ("INSERT INTO Food VALUES ('burger')", Ok(Payload::Insert(1))),
         (
-            r#"INSERT INTO Food VALUES ("pork")"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"INSERT INTO Food VALUES ("burger")"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"SELECT POSITION("e" IN name) AS test FROM Food"#,
+            "SELECT POSITION('e' IN name) AS test FROM Food",
             Ok(select!(test; I64; 0; 5)),
         ),
         (
-            r#"SELECT POSITION("s" IN "cheese") AS test"#,
+            "SELECT POSITION('s' IN 'cheese') AS test",
             Ok(select!(test; I64; 5)),
         ),
         (
-            r#"SELECT POSITION(NULL IN "cheese") AS test"#,
+            "SELECT POSITION(NULL IN 'cheese') AS test",
             Ok(select_with_null!(test; Null)),
         ),
         (
-            r#"SELECT POSITION(1 IN "cheese") AS test"#,
+            "SELECT POSITION(1 IN 'cheese') AS test",
             Err(EvaluateError::FunctionRequiresStringValue(String::from("POSITION")).into()),
         ),
     ];

--- a/test-suite/src/function/repeat.rs
+++ b/test-suite/src/function/repeat.rs
@@ -10,13 +10,10 @@ use {
 test_case!(repeat, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT REPEAT("hello", 2))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT REPEAT('hello', 2))",
             Ok(Payload::Create),
         ),
-        (
-            r#"INSERT INTO Item VALUES ("hello")"#,
-            Ok(Payload::Insert(1)),
-        ),
+        ("INSERT INTO Item VALUES ('hello')", Ok(Payload::Insert(1))),
         (
             "SELECT REPEAT(name, 2) AS test FROM Item",
             Ok(select!(
@@ -26,7 +23,7 @@ test_case!(repeat, async move {
             )),
         ),
         (
-            r#"SELECT REPEAT("abcd") AS test FROM Item"#,
+            "SELECT REPEAT('abcd') AS test FROM Item",
             Err(TranslateError::FunctionArgsLengthNotMatching {
                 name: "REPEAT".to_owned(),
                 expected: 2,
@@ -35,7 +32,7 @@ test_case!(repeat, async move {
             .into()),
         ),
         (
-            r#"SELECT REPEAT("abcd", 2, 2) AS test FROM Item"#,
+            "SELECT REPEAT('abcd', 2, 2) AS test FROM Item",
             Err(TranslateError::FunctionArgsLengthNotMatching {
                 name: "REPEAT".to_owned(),
                 expected: 2,
@@ -44,23 +41,20 @@ test_case!(repeat, async move {
             .into()),
         ),
         (
-            r#"SELECT REPEAT(1, 1) AS test FROM Item"#,
+            "SELECT REPEAT(1, 1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("REPEAT".to_owned()).into()),
         ),
         (
-            r#"SELECT REPEAT(name, null) AS test FROM Item"#,
+            "SELECT REPEAT(name, null) AS test FROM Item",
             Ok(select_with_null!(test; Value::Null)),
         ),
         (
             "CREATE TABLE NullTest (name TEXT null)",
             Ok(Payload::Create),
         ),
+        ("INSERT INTO NullTest VALUES (null)", Ok(Payload::Insert(1))),
         (
-            r#"INSERT INTO NullTest VALUES (null)"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"SELECT REPEAT(name, 2) AS test FROM NullTest"#,
+            "SELECT REPEAT(name, 2) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
     ];

--- a/test-suite/src/function/reverse.rs
+++ b/test-suite/src/function/reverse.rs
@@ -13,7 +13,7 @@ test_case!(reverse, async move {
             Ok(Payload::Create),
         ),
         (
-            "INSERT INTO Item VALUES ('Let's meet')",
+            "INSERT INTO Item VALUES ('Let''s meet')",
             Ok(Payload::Insert(1)),
         ),
         (

--- a/test-suite/src/function/reverse.rs
+++ b/test-suite/src/function/reverse.rs
@@ -9,11 +9,11 @@ use {
 test_case!(reverse, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT REVERSE("world"))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT REVERSE('world'))",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES ("Let's meet")"#,
+            "INSERT INTO Item VALUES ('Let's meet')",
             Ok(Payload::Insert(1)),
         ),
         (
@@ -25,19 +25,16 @@ test_case!(reverse, async move {
             )),
         ),
         (
-            r#"SELECT REVERSE(1) AS test FROM Item"#,
+            "SELECT REVERSE(1) AS test FROM Item",
             Err(EvaluateError::FunctionRequiresStringValue("REVERSE".to_owned()).into()),
         ),
         (
             "CREATE TABLE NullTest (name TEXT null)",
             Ok(Payload::Create),
         ),
+        ("INSERT INTO NullTest VALUES (null)", Ok(Payload::Insert(1))),
         (
-            r#"INSERT INTO NullTest VALUES (null)"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"SELECT REVERSE(name) AS test FROM NullTest"#,
+            "SELECT REVERSE(name) AS test FROM NullTest",
             Ok(select_with_null!(test; Value::Null)),
         ),
     ];

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -9,11 +9,11 @@ use {
 test_case!(substr, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (name TEXT DEFAULT SUBSTR("abc", 0, 2))"#,
+            "CREATE TABLE Item (name TEXT DEFAULT SUBSTR('abc', 0, 2))",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES ("Blop mc blee"), ("B"), ("Steven the &long named$ folken!")"#,
+            "INSERT INTO Item VALUES ('Blop mc blee'), ('B'), ('Steven the &long named$ folken!')",
             Ok(Payload::Insert(3)),
         ),
         ("CREATE TABLE SingleItem (id INTEGER)", Ok(Payload::Create)),
@@ -76,7 +76,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", 0, 3) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', 0, 3) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -84,7 +84,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", 1, 3) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', 1, 3) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -92,7 +92,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", 1, 999) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', 1, 999) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -100,7 +100,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", -1000, 1003) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', -1000, 1003) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -108,7 +108,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", -1, 3) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', -1, 3) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -116,7 +116,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", -1, 4) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', -1, 4) AS test FROM SingleItem",
             Ok(select!(
                 "test"
                 Str;
@@ -124,7 +124,7 @@ test_case!(substr, async move {
             )),
         ),
         (
-            r#"SELECT SUBSTR("ABC", -1, NULL) AS test FROM SingleItem"#,
+            "SELECT SUBSTR('ABC', -1, NULL) AS test FROM SingleItem",
             Ok(select_with_null!(test; Null)),
         ),
         (

--- a/test-suite/src/function/to_date.rs
+++ b/test-suite/src/function/to_date.rs
@@ -10,7 +10,7 @@ test_case!(to_date, async move {
 
     let test_cases = vec![
         (
-            r#"VALUES(TO_DATE("2017-06-15", "%Y-%m-%d"))"#,
+            "VALUES(TO_DATE('2017-06-15', '%Y-%m-%d'))",
             Ok(select!(
                 column1
                 Date;
@@ -18,7 +18,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"VALUES(TO_TIMESTAMP("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S"))"#,
+            "VALUES(TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%S'))",
             Ok(select!(
                 column1
                 Timestamp;
@@ -26,7 +26,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"VALUES(TO_TIME("23:56:04", "%H:%M:%S"))"#,
+            "VALUES(TO_TIME('23:56:04', '%H:%M:%S'))",
             Ok(select!(
                 column1
                 Time;
@@ -34,7 +34,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"SELECT TO_DATE("2017-06-15","%Y-%m-%d") AS date"#,
+            "SELECT TO_DATE('2017-06-15','%Y-%m-%d') AS date",
             Ok(select!(
                 date
                 Date;
@@ -42,7 +42,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"SELECT TO_DATE("2017-jun-15","%Y-%b-%d") AS date"#,
+            "SELECT TO_DATE('2017-jun-15','%Y-%b-%d') AS date",
             Ok(select!(
                 date
                 Date;
@@ -50,7 +50,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"SELECT TO_TIME("23:56:04","%H:%M:%S") AS time"#,
+            "SELECT TO_TIME('23:56:04','%H:%M:%S') AS time",
             Ok(select!(
                 time
                 Time;
@@ -58,7 +58,7 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S") AS timestamp"#,
+            "SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%S') AS timestamp",
             Ok(select!(
                 timestamp
                 Timestamp;
@@ -66,43 +66,43 @@ test_case!(to_date, async move {
             )),
         ),
         (
-            r#"SELECT TO_DATE("2015-09-05", "%Y-%m") AS date"#,
+            "SELECT TO_DATE('2015-09-05', '%Y-%m') AS date",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::TooLong).into()),
         ),
         (
-            r#"SELECT TO_TIME("23:56", "%H:%M:%S") AS time"#,
+            "SELECT TO_TIME('23:56', '%H:%M:%S') AS time",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::TooShort).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-05 23", "%Y-%d %H") AS timestamp"#,
+            "SELECT TO_TIMESTAMP('2015-05 23', '%Y-%d %H') AS timestamp",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::NotEnough).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-14-05 23:56:12","%Y-%m-%d %H:%M:%S") AS timestamp;"#,
+            "SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%S') AS timestamp;",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::OutOfRange).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-14-05 23:56:12","%Y-%m-%d %H:%M:%%S") AS timestamp;"#,
+            "SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%%S') AS timestamp;",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::Invalid).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%M") AS timestamp"#,
+            "SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%M') AS timestamp",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::Impossible).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%") AS timestamp"#,
+            "SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%') AS timestamp",
             Err(EvaluateError::ChronoFormat(ChronoFormatError::BadFormat).into()),
         ),
         (
-            r#"SELECT TO_DATE(DATE "2017-06-15","%Y-%m-%d") AS date"#,
+            "SELECT TO_DATE(DATE '2017-06-15','%Y-%m-%d') AS date",
             Err(EvaluateError::FunctionRequiresStringValue("TO_DATE".to_owned()).into()),
         ),
         (
-            r#"SELECT TO_TIMESTAMP(TIMESTAMP "2015-09-05 23:56:04","%Y-%m-%d") AS date"#,
+            "SELECT TO_TIMESTAMP(TIMESTAMP '2015-09-05 23:56:04','%Y-%m-%d') AS date",
             Err(EvaluateError::FunctionRequiresStringValue("TO_TIMESTAMP".to_owned()).into()),
         ),
         (
-            r#"SELECT TO_TIME(TIME "23:56:04","%H:%M:%S") AS date"#,
+            "SELECT TO_TIME(TIME '23:56:04','%H:%M:%S') AS date",
             Err(EvaluateError::FunctionRequiresStringValue("TO_TIME".to_owned()).into()),
         ),
     ];

--- a/test-suite/src/function/trim.rs
+++ b/test-suite/src/function/trim.rs
@@ -9,17 +9,17 @@ use {
 test_case!(trim, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (
-                name TEXT DEFAULT TRIM(LEADING "a" FROM "aabc") || TRIM("   good  ")
-            )"#,
+            "CREATE TABLE Item (
+                name TEXT DEFAULT TRIM(LEADING 'a' FROM 'aabc') || TRIM('   good  ')
+            )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES
-                ("      Left blank"),
-                ("Right blank     "),
-                ("     Blank!     "),
-                ("Not Blank");"#,
+            "INSERT INTO Item VALUES
+                ('      Left blank'),
+                ('Right blank     '),
+                ('     Blank!     '),
+                ('Not Blank');",
             Ok(Payload::Insert(4)),
         ),
         (
@@ -54,14 +54,14 @@ test_case!(trim, async move {
             )),
         ),
         (
-            r#"SELECT TRIM(TRAILING NULL FROM name) FROM NullName;"#,
+            "SELECT TRIM(TRAILING NULL FROM name) FROM NullName;",
             Ok(select_with_null!(
                 "TRIM(TRAILING NULL FROM name)";
                 Value::Null
             )),
         ),
         (
-            r#"SELECT TRIM(LEADING NULL FROM name) FROM NullName;"#,
+            "SELECT TRIM(LEADING NULL FROM name) FROM NullName;",
             Ok(select_with_null!(
                 "TRIM(LEADING NULL FROM name)";
                 Value::Null
@@ -69,17 +69,17 @@ test_case!(trim, async move {
         ),
         ("CREATE TABLE Test (name TEXT)", Ok(Payload::Create)),
         (
-            r#"INSERT INTO Test VALUES 
-                    ("     blank     "), 
-                    ("xxxyzblankxyzxx"), 
-                    ("xxxyzblank     "),
-                    ("     blankxyzxx"),
-                    ("  xyzblankxyzxx"),
-                    ("xxxyzblankxyz  ");"#,
+            "INSERT INTO Test VALUES 
+                    ('     blank     '), 
+                    ('xxxyzblankxyzxx'), 
+                    ('xxxyzblank     '),
+                    ('     blankxyzxx'),
+                    ('  xyzblankxyzxx'),
+                    ('xxxyzblankxyz  ');",
             Ok(Payload::Insert(6)),
         ),
         (
-            r#"SELECT TRIM(BOTH 'xyz' FROM name) FROM Test;"#,
+            "SELECT TRIM(BOTH 'xyz' FROM name) FROM Test;",
             Ok(select!(
                 "TRIM(BOTH 'xyz' FROM name)"
                 Value::Str;
@@ -92,7 +92,7 @@ test_case!(trim, async move {
             )),
         ),
         (
-            r#"SELECT TRIM(LEADING 'xyz' FROM name) FROM Test;"#,
+            "SELECT TRIM(LEADING 'xyz' FROM name) FROM Test;",
             Ok(select!(
                 "TRIM(LEADING 'xyz' FROM name)"
                 Value::Str;

--- a/test-suite/src/function/upper_lower.rs
+++ b/test-suite/src/function/upper_lower.rs
@@ -10,18 +10,18 @@ use {
 test_case!(upper_lower, async move {
     let test_cases = [
         (
-            r#"CREATE TABLE Item (
-                name TEXT DEFAULT UPPER("abc"),
-                opt_name TEXT NULL DEFAULT LOWER("ABC")
-            )"#,
+            "CREATE TABLE Item (
+                name TEXT DEFAULT UPPER('abc'),
+                opt_name TEXT NULL DEFAULT LOWER('ABC')
+            )",
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Item VALUES ("abcd", "efgi"), ("Abcd", NULL), ("ABCD", "EfGi")"#,
+            "INSERT INTO Item VALUES ('abcd', 'efgi'), ('Abcd', NULL), ('ABCD', 'EfGi')",
             Ok(Payload::Insert(3)),
         ),
         (
-            r#"SELECT name FROM Item WHERE LOWER(name) = "abcd";"#,
+            "SELECT name FROM Item WHERE LOWER(name) = 'abcd';",
             Ok(select!(
                 name Str;
                 "abcd".to_owned();
@@ -40,12 +40,12 @@ test_case!(upper_lower, async move {
             )),
         ),
         (
-            r#"
+            "
             SELECT
-                LOWER("Abcd") as lower,
-                UPPER("abCd") as upper
+                LOWER('Abcd') as lower,
+                UPPER('abCd') as upper
             FROM Item LIMIT 1;
-            "#,
+            ",
             Ok(select!(
                 lower             | upper
                 Str               | Str;

--- a/test-suite/src/index/and.rs
+++ b/test-suite/src/index/and.rs
@@ -2,25 +2,25 @@ use {crate::*, gluesql_core::ast::IndexOperator::*, gluesql_core::prelude::*, Va
 
 test_case!(and, async move {
     run!(
-        r#"
+        "
 CREATE TABLE NullIdx (
     id INTEGER,
     date DATE,
     flag BOOLEAN
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO NullIdx
             (id, date, flag)
         VALUES
-            (1, "2020-03-20", True),
-            (2, "2021-01-01", True),
-            (3, "1989-02-01", False),
-            (4, "2002-06-11", True),
-            (5, "2030-03-01", False);
-    "#
+            (1, '2020-03-20', True),
+            (2, '2021-01-01', True),
+            (3, '1989-02-01', False),
+            (4, '2002-06-11', True),
+            (5, '2030-03-01', False);
+    "
     );
 
     test!(
@@ -45,13 +45,13 @@ CREATE TABLE NullIdx (
             3     date!("1989-02-01")   false;
             5     date!("2030-03-01")   false
         )),
-        idx!(idx_date, Lt, r#"DATE "2040-12-24""#),
-        r#"
+        idx!(idx_date, Lt, "DATE '2040-12-24'"),
+        "
         SELECT id, date, flag FROM NullIdx
         WHERE
-            date < DATE "2040-12-24"
+            date < DATE '2040-12-24'
             AND flag = false
-        "#
+        "
     );
 
     test_idx!(
@@ -60,13 +60,13 @@ CREATE TABLE NullIdx (
             I64 | Date                | Bool;
             3     date!("1989-02-01")   false
         )),
-        idx!(idx_date, Lt, r#"DATE "2020-12-24""#),
-        r#"
+        idx!(idx_date, Lt, "DATE '2020-12-24'"),
+        "
         SELECT * FROM NullIdx
         WHERE
             flag = False
-            AND date < DATE "2020-12-24"
-        "#
+            AND date < DATE '2020-12-24'
+        "
     );
 
     test_idx!(
@@ -76,14 +76,14 @@ CREATE TABLE NullIdx (
             3     date!("1989-02-01")   false;
             5     date!("2030-03-01")   false
         )),
-        idx!(idx_date, Lt, r#"DATE "2030-11-24""#),
-        r#"
+        idx!(idx_date, Lt, "DATE '2030-11-24'"),
+        "
         SELECT * FROM NullIdx
         WHERE
             flag = False
-            AND DATE "2030-11-24" > date
+            AND DATE '2030-11-24' > date
             AND id > 1
-        "#
+        "
     );
 
     test_idx!(
@@ -94,13 +94,13 @@ CREATE TABLE NullIdx (
             5     date!("2030-03-01")   false
         )),
         idx!(idx_id, Gt, "1"),
-        r#"
+        "
         SELECT * FROM NullIdx
         WHERE
             flag = False
             AND id > 1
-            AND DATE "2030-11-24" > date
-        "#
+            AND DATE '2030-11-24' > date
+        "
     );
 
     test_idx!(
@@ -110,12 +110,12 @@ CREATE TABLE NullIdx (
             5     date!("2030-03-01")   false
         )),
         idx!(),
-        r#"
+        "
         SELECT * FROM NullIdx
         WHERE
             flag = False
             AND id * 2 > 6
-        "#
+        "
     );
 
     test_idx!(
@@ -124,13 +124,13 @@ CREATE TABLE NullIdx (
             I64 | Date                | Bool;
             5     date!("2030-03-01")   false
         )),
-        idx!(idx_date, Eq, r#"DATE "2030-03-01""#),
-        r#"
+        idx!(idx_date, Eq, "DATE '2030-03-01'"),
+        "
         SELECT * FROM NullIdx
         WHERE
             flag = False
             AND id * 2 > 6
-            AND (date = DATE "2030-03-01" AND flag != True);
-        "#
+            AND (date = DATE '2030-03-01' AND flag != True);
+        "
     );
 });

--- a/test-suite/src/index/basic.rs
+++ b/test-suite/src/index/basic.rs
@@ -11,24 +11,24 @@ use {
 
 test_case!(basic, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO Test
             (id, num, name)
         VALUES
-            (1, 2, "Hello"),
-            (1, 17, "World"),
-            (11, 7, "Great"),
-            (4, 7, "Job");
-    "#
+            (1, 2, 'Hello'),
+            (1, 17, 'World'),
+            (11, 7, 'Great'),
+            (4, 7, 'Job');
+    "
     );
 
     test!("CREATE INDEX idx_id ON Test (id)", Ok(Payload::CreateIndex));
@@ -161,7 +161,7 @@ CREATE TABLE Test (
     );
 
     test!(
-        "INSERT INTO Test (id, num, name) VALUES (1, 30, \"New one\")",
+        "INSERT INTO Test (id, num, name) VALUES (1, 30, 'New one')",
         Ok(Payload::Insert(1))
     );
 
@@ -183,8 +183,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             1     30    "New one".to_owned()
         )),
-        idx!(idx_name, Eq, r#""New one""#),
-        r#"SELECT id, num, name FROM Test WHERE name = "New one""#
+        idx!(idx_name, Eq, "'New one'"),
+        "SELECT id, num, name FROM Test WHERE name = 'New one'"
     );
 
     test_idx!(

--- a/test-suite/src/index/expr.rs
+++ b/test-suite/src/index/expr.rs
@@ -9,21 +9,21 @@ use {
 
 test_case!(expr, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO Test
             (id, num, name)
         VALUES
-            (1, 2, "Hello");
-    "#
+            (1, 2, 'Hello');
+    "
     );
 
     test!("CREATE INDEX idx_id ON Test (id)", Ok(Payload::CreateIndex));
@@ -54,7 +54,7 @@ CREATE TABLE Test (
     );
 
     test!(
-        r#"INSERT INTO Test VALUES (4, 7, "Well");"#,
+        "INSERT INTO Test VALUES (4, 7, 'Well');",
         Ok(Payload::Insert(1))
     );
 
@@ -94,8 +94,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             1     2     "Hello".to_owned()
         )),
-        idx!(idx_binary_op, Eq, r#""2Hello""#),
-        r#"SELECT id, num, name FROM Test WHERE num || name = "2Hello""#
+        idx!(idx_binary_op, Eq, "'2Hello'"),
+        "SELECT id, num, name FROM Test WHERE num || name = '2Hello'"
     );
 
     test_idx!(
@@ -104,8 +104,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             1     2     "Hello".to_owned()
         )),
-        idx!(idx_binary_op, Eq, r#""2Hello""#),
-        r#"SELECT id, num, name FROM Test WHERE (num || name) = "2Hello""#
+        idx!(idx_binary_op, Eq, "'2Hello'"),
+        "SELECT id, num, name FROM Test WHERE (num || name) = '2Hello'"
     );
 
     test_idx!(
@@ -114,8 +114,8 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             4     7     "Well".to_owned()
         )),
-        idx!(idx_binary_op, Eq, r#""7Well""#),
-        r#"SELECT id, num, name FROM Test WHERE "7Well" = (num || name)"#
+        idx!(idx_binary_op, Eq, "'7Well'"),
+        "SELECT id, num, name FROM Test WHERE '7Well' = (num || name)"
     );
 
     test_idx!(
@@ -134,7 +134,7 @@ CREATE TABLE Test (
             I64 | I64 | Str;
             4     7     "Well".to_owned()
         )),
-        idx!(idx_cast, Eq, r#""4""#),
-        r#"SELECT id, num, name FROM Test WHERE CAST(id AS TEXT) = "4""#
+        idx!(idx_cast, Eq, "'4'"),
+        "SELECT id, num, name FROM Test WHERE CAST(id AS TEXT) = '4'"
     );
 });

--- a/test-suite/src/index/nested.rs
+++ b/test-suite/src/index/nested.rs
@@ -8,25 +8,25 @@ use {
 
 test_case!(nested, async move {
     run!(
-        r#"
+        "
 CREATE TABLE User (
     id INTEGER,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO User
             (id, num, name)
         VALUES
-            (1, 2, "Hello"),
-            (2, 4, "World"),
-            (3, 9, "Office"),
-            (4, 1, "Origin"),
-            (5, 2, "Builder");
-    "#
+            (1, 2, 'Hello'),
+            (2, 4, 'World'),
+            (3, 9, 'Office'),
+            (4, 1, 'Origin'),
+            (5, 2, 'Builder');
+    "
     );
 
     test!("CREATE INDEX idx_id ON User (id)", Ok(Payload::CreateIndex));

--- a/test-suite/src/index/null.rs
+++ b/test-suite/src/index/null.rs
@@ -6,25 +6,25 @@ use {
 
 test_case!(null, async move {
     run!(
-        r#"
+        "
 CREATE TABLE NullIdx (
     id INTEGER NULL,
     date DATE NULL,
     flag BOOLEAN NULL
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO NullIdx
             (id, date, flag)
         VALUES
             (NULL, NULL,         True),
-            (1,    "2020-03-20", True),
+            (1,    '2020-03-20', True),
             (2,    NULL,         NULL),
-            (3,    "1989-02-01", False),
+            (3,    '1989-02-01', False),
             (4,    NULL,         True);
-    "#
+    "
     );
 
     test!(
@@ -53,8 +53,8 @@ CREATE TABLE NullIdx (
             3     date!("1989-02-01")   false;
             1     date!("2020-03-20")   true
         )),
-        idx!(idx_date, Lt, r#"DATE "2040-12-24""#),
-        r#"SELECT id, date, flag FROM NullIdx WHERE date < DATE "2040-12-24""#
+        idx!(idx_date, Lt, "DATE '2040-12-24'"),
+        "SELECT id, date, flag FROM NullIdx WHERE date < DATE '2040-12-24'"
     );
 
     test_idx!(
@@ -64,8 +64,8 @@ CREATE TABLE NullIdx (
             I64(2)   Null   Null;
             I64(4)   Null   Bool(true)
         )),
-        idx!(idx_date, GtEq, r#"DATE "2040-12-24""#),
-        r#"SELECT id, date, flag FROM NullIdx WHERE date >= DATE "2040-12-24""#
+        idx!(idx_date, GtEq, "DATE '2040-12-24'"),
+        "SELECT id, date, flag FROM NullIdx WHERE date >= DATE '2040-12-24'"
     );
 
     test_idx!(

--- a/test-suite/src/index/order_by.rs
+++ b/test-suite/src/index/order_by.rs
@@ -2,22 +2,22 @@ use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(order_by, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER NULL,
     name TEXT,
-)"#
+)"
     );
     run!(
-        r#"
+        "
         INSERT INTO Test (id, num, name)
         VALUES
-            (1, 2,    "Hello"),
-            (1, 9,    "Wild"),
-            (3, NULL, "World"),
-            (4, 7,    "Monday");
-    "#
+            (1, 2,    'Hello'),
+            (1, 9,    'Wild'),
+            (3, NULL, 'World'),
+            (4, 7,    'Monday');
+    "
     );
 
     test!(
@@ -89,11 +89,11 @@ CREATE TABLE Test (
 
 test_case!(order_by_multi, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Multi (
     id INTEGER,
     num INTEGER
-)"#
+)"
     );
 
     run!(

--- a/test-suite/src/index/showindexes.rs
+++ b/test-suite/src/index/showindexes.rs
@@ -5,24 +5,24 @@ use {
 
 test_case!(showindexes, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO Test
             (id, num, name)
         VALUES
-            (1, 2, "Hello"),
-            (1, 17, "World"),
-            (11, 7, "Great"),
-            (4, 7, "Job");
-    "#
+            (1, 2, 'Hello'),
+            (1, 17, 'World'),
+            (11, 7, 'Great'),
+            (4, 7, 'Job');
+    "
     );
 
     test!("CREATE INDEX idx_id ON Test (id)", Ok(Payload::CreateIndex));

--- a/test-suite/src/index/value.rs
+++ b/test-suite/src/index/value.rs
@@ -7,22 +7,22 @@ use {
 
 test_case!(value, async move {
     run!(
-        r#"
+        "
 CREATE TABLE IdxValue (
     id INTEGER NULL,
     time TIME NULL,
     flag BOOLEAN
-)"#
+)"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO IdxValue
         VALUES
-            (NULL, "01:30 PM", True),
-            (1,    "12:10 AM", False),
+            (NULL, '01:30 PM', True),
+            (1,    '12:10 AM', False),
             (2,    NULL,       True);
-    "#
+    "
     );
 
     test!(
@@ -56,8 +56,8 @@ CREATE TABLE IdxValue (
             I64(1)   Time(t(0, 10))    Bool(false);
             Null     Time(t(13, 30))   Bool(true)
         )),
-        idx!(idx_time, LtEq, r#"TIME "13:30:00""#),
-        r#"SELECT * FROM IdxValue WHERE time <= TIME "13:30:00""#
+        idx!(idx_time, LtEq, "TIME '13:30:00'"),
+        "SELECT * FROM IdxValue WHERE time <= TIME '13:30:00'"
     );
 
     test_idx!(
@@ -65,8 +65,8 @@ CREATE TABLE IdxValue (
             id     | time           | flag;
             I64(1)   Time(t(0, 10))   Bool(false)
         )),
-        idx!(idx_flag, Eq, r#"("ABC" IS NULL)"#),
-        r#"SELECT * FROM IdxValue WHERE flag = ("ABC" IS NULL)"#
+        idx!(idx_flag, Eq, "('ABC' IS NULL)"),
+        "SELECT * FROM IdxValue WHERE flag = ('ABC' IS NULL)"
     );
 
     test_idx!(
@@ -95,8 +95,8 @@ CREATE TABLE IdxValue (
             I64 | Time      | Bool;
             1     t(0, 10)    false
         )),
-        idx!(idx_id, Eq, r#"CAST("1" AS INTEGER)"#),
-        r#"SELECT * FROM IdxValue WHERE id = CAST("1" AS INTEGER)"#
+        idx!(idx_id, Eq, "CAST('1' AS INTEGER)"),
+        "SELECT * FROM IdxValue WHERE id = CAST('1' AS INTEGER)"
     );
 
     test_idx!(

--- a/test-suite/src/insert.rs
+++ b/test-suite/src/insert.rs
@@ -5,17 +5,17 @@ use {
 
 test_case!(insert, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER DEFAULT 1,
     num INTEGER NULL,
     name TEXT
-)"#
+)"
     );
 
     test! {
         name: "basic insert - single item",
-        sql: r#"INSERT INTO Test (id, num, name) VALUES (1, 2, "Hi boo");"#,
+        sql: "INSERT INTO Test (id, num, name) VALUES (1, 2, 'Hi boo');",
         expected: Ok(Payload::Insert(1))
     };
 
@@ -31,17 +31,17 @@ CREATE TABLE Test (
     };
 
     test! {
-        sql: r#"INSERT INTO Test VALUES(17, 30, "Sullivan");"#,
+        sql: "INSERT INTO Test VALUES(17, 30, 'Sullivan');",
         expected: Ok(Payload::Insert(1))
     };
 
     test! {
-        sql: r#"INSERT INTO Test (num, name) VALUES (28, "Wazowski");"#,
+        sql: "INSERT INTO Test (num, name) VALUES (28, 'Wazowski');",
         expected: Ok(Payload:: Insert(1))
     };
 
     test! {
-        sql: r#"INSERT INTO Test (name) VALUES ("The end");"#,
+        sql: "INSERT INTO Test (name) VALUES ('The end');",
         expected: Ok(Payload:: Insert(1))
     };
 

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -34,11 +34,11 @@ test_case!(join, async move {
     let insert_sqls = [
         "
         INSERT INTO Player (id, name) VALUES
-            (1, \"Taehoon\"),
-            (2,    \"Mike\"),
-            (3,   \"Jorno\"),
-            (4,   \"Berry\"),
-            (5,    \"Hwan\");
+            (1, 'Taehoon'),
+            (2,    'Mike'),
+            (3,   'Jorno'),
+            (4,   'Berry'),
+            (5,    'Hwan');
         ",
         "
         INSERT INTO Item (id, quantity, player_id) VALUES
@@ -129,7 +129,7 @@ test_case!(join, async move {
             WHERE Player.id IN
                 (SELECT i2.player_id FROM Item i2
                  JOIN Item i3 ON i3.id = i2.id
-                 WHERE Player.name = \"Jorno\");"),
+                 WHERE Player.name = 'Jorno');"),
         // cartesian product tests
         (15, "SELECT * FROM Player INNER JOIN Item ON Player.id = Item.player_id;"),
         (25, "SELECT * FROM Player p1 LEFT JOIN Player p2 ON 1 = 1"),
@@ -169,11 +169,11 @@ test_case!(blend, async move {
     let insert_sqls = [
         "
         INSERT INTO Player (id, name) VALUES
-            (1, \"Taehoon\"),
-            (2,    \"Mike\"),
-            (3,   \"Jorno\"),
-            (4,   \"Berry\"),
-            (5,    \"Hwan\");
+            (1, 'Taehoon'),
+            (2,    'Mike'),
+            (3,   'Jorno'),
+            (4,   'Berry'),
+            (5,    'Hwan');
         ",
         "
         INSERT INTO Item (id, quantity, player_id) VALUES
@@ -253,9 +253,9 @@ test_case!(blend, async move {
 
     // To test `PlanError` while using `JOIN`
     run!("CREATE TABLE users (id INTEGER, name TEXT);");
-    run!(r#"INSERT INTO users (id, name) VALUES (1, "Harry");"#);
+    run!("INSERT INTO users (id, name) VALUES (1, 'Harry');");
     run!("CREATE TABLE testers (id INTEGER, nickname TEXT);");
-    run!(r#"INSERT INTO testers (id, nickname) VALUES (1, "Ron");"#);
+    run!("INSERT INTO testers (id, nickname) VALUES (1, 'Ron');");
 
     let error_cases = [
         (

--- a/test-suite/src/like_ilike.rs
+++ b/test-suite/src/like_ilike.rs
@@ -31,14 +31,14 @@ test_case!(like_ilike, async move {
     "
     );
     run!(
-        r#"
+        "
         INSERT INTO Item (id, name) VALUES
-            (1,    "Amelia"),
-            (2,      "Doll"),
-            (3, "Gascoigne"),
-            (4,   "Gehrman"),
-            (5,     "Maria");
-    "#
+            (1,    'Amelia'),
+            (2,      'Doll'),
+            (3, 'Gascoigne'),
+            (4,   'Gehrman'),
+            (5,     'Maria');
+    "
     );
 
     let test_cases = [

--- a/test-suite/src/migrate.rs
+++ b/test-suite/src/migrate.rs
@@ -17,17 +17,17 @@ test_case!(migrate, async move {
     "
     );
     run!(
-        r#"
+        "
         INSERT INTO Test (id, num, name) VALUES
-            (1,     2,     "Hello"),
-            (-(-1), 9,     "World"),
-            (+3,    2 * 2, "Great");
-        "#
+            (1,     2,     'Hello'),
+            (-(-1), 9,     'World'),
+            (+3,    2 * 2, 'Great');
+        "
     );
 
     let error_cases = [
         (
-            r#"INSERT INTO Test (id, num, name) VALUES (1.1, 1, "good");"#,
+            "INSERT INTO Test (id, num, name) VALUES (1.1, 1, 'good');",
             ValueError::FailedToParseNumber.into(),
         ),
         (

--- a/test-suite/src/nested_select.rs
+++ b/test-suite/src/nested_select.rs
@@ -27,11 +27,11 @@ test_case!(nested_select, async move {
     let insert_sqls = [
         "
         INSERT INTO Player (id, name) VALUES
-            (1, \"Taehoon\"),
-            (2,    \"Mike\"),
-            (3,   \"Jorno\"),
-            (4,   \"Berry\"),
-            (5,    \"Hwan\");
+            (1, 'Taehoon'),
+            (2,    'Mike'),
+            (3,   'Jorno'),
+            (4,   'Berry'),
+            (5,    'Hwan');
         ",
         "
         INSERT INTO Request (id, quantity, user_id) VALUES
@@ -74,7 +74,7 @@ test_case!(nested_select, async move {
         ),
         (4, "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request WHERE user_id IN (Player.id));"),
         (2, "SELECT * FROM Player WHERE id IN (SELECT user_id FROM Request WHERE quantity IN (6, 7, 8, 9));"),
-        (9, "SELECT * FROM Request WHERE user_id IN (SELECT id FROM Player WHERE name IN (\"Taehoon\", \"Hwan\"));"),
+        (9, "SELECT * FROM Request WHERE user_id IN (SELECT id FROM Player WHERE name IN ('Taehoon', 'Hwan'));"),
     ];
     for (num, sql) in select_sqls {
         count!(num, sql);

--- a/test-suite/src/nullable.rs
+++ b/test-suite/src/nullable.rs
@@ -5,19 +5,19 @@ use {
 
 test_case!(nullable, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER NULL,
     num INTEGER,
     name TEXT
-)"#
+)"
     );
     run!(
         "
         INSERT INTO Test (id, num, name) VALUES
-            (NULL, 2, \"Hello\"),
-            (   1, 9, \"World\"),
-            (   3, 4, \"Great\");
+            (NULL, 2, 'Hello'),
+            (   1, 9, 'World'),
+            (   3, 4, 'Great');
     "
     );
 
@@ -32,7 +32,7 @@ CREATE TABLE Test (
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE id IS NULL AND name = \'Hello\'",
+            "SELECT id, num FROM Test WHERE id IS NULL AND name = 'Hello'",
             select_with_null!(
                 id   | num;
                 Null   I64(2)
@@ -126,11 +126,11 @@ CREATE TABLE Test (
             ),
         ),
         (
-            "SELECT id, num FROM Test WHERE \"NULL\" IS NULL",
+            "SELECT id, num FROM Test WHERE 'NULL' IS NULL",
             select!(id | num),
         ),
         (
-            "SELECT id, num FROM Test WHERE \"NULL\" IS NOT NULL",
+            "SELECT id, num FROM Test WHERE 'NULL' IS NOT NULL",
             select_with_null!(
                 id     | num;
                 Null     I64(2);
@@ -231,7 +231,7 @@ CREATE TABLE Test (
             )),
         ),
         (
-            r#"INSERT INTO Test VALUES (1, NULL, "ok")"#,
+            "INSERT INTO Test VALUES (1, NULL, 'ok')",
             Err(ValueError::NullValueOnNotNullField.into()),
         ),
     ];
@@ -251,7 +251,7 @@ test_case!(nullable_text, async move {
     "
     );
 
-    run!("INSERT INTO Foo (id, name) VALUES (1, \"Hello\"), (2, Null);");
+    run!("INSERT INTO Foo (id, name) VALUES (1, 'Hello'), (2, Null);");
 });
 
 test_case!(nullable_implicit_insert, async move {

--- a/test-suite/src/order_by.rs
+++ b/test-suite/src/order_by.rs
@@ -5,23 +5,23 @@ use {
 
 test_case!(order_by, async move {
     run!(
-        r#"
+        "
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER,
     name TEXT NULL,
     rate FLOAT NULL
-)"#
+)"
     );
     run!(
-        r#"
+        "
         INSERT INTO Test (id, num, name, rate)
         VALUES
-            (1, 2, "Hello",    3.0),
+            (1, 2, 'Hello',    3.0),
             (1, 9, NULL,       NULL),
-            (3, 4, "World",    1.0),
-            (4, 7, "Thursday", NULL);
-    "#
+            (3, 4, 'World',    1.0),
+            (4, 7, 'Thursday', NULL);
+    "
     );
 
     test!(

--- a/test-suite/src/ordering.rs
+++ b/test-suite/src/ordering.rs
@@ -13,11 +13,11 @@ test_case!(ordering, async move {
     run!(
         "
         INSERT INTO Operator (id, name) VALUES
-            (1, \"Abstract\"),
-            (2,    \"Azzzz\"),
-            (3,     \"July\"),
-            (4,    \"Romeo\"),
-            (5,    \"Trade\");
+            (1, 'Abstract'),
+            (2,    'Azzzz'),
+            (3,     'July'),
+            (4,    'Romeo'),
+            (5,    'Trade');
     "
     );
 
@@ -37,11 +37,11 @@ test_case!(ordering, async move {
             5,
             "SELECT * FROM Operator o1 WHERE 3 > (SELECT MIN(id) FROM Operator WHERE o1.id < 100);",
         ),
-        (2, "SELECT * FROM Operator WHERE name < \"Azzzzzzzzzz\";"),
-        (1, "SELECT * FROM Operator WHERE name < \"Az\";"),
-        (5, "SELECT * FROM Operator WHERE name < \"zz\";"),
-        (5, "SELECT * FROM Operator WHERE \"aa\" < \"zz\";"),
-        (4, "SELECT * FROM Operator WHERE \"Romeo\" >= name;"),
+        (2, "SELECT * FROM Operator WHERE name < 'Azzzzzzzzzz';"),
+        (1, "SELECT * FROM Operator WHERE name < 'Az';"),
+        (5, "SELECT * FROM Operator WHERE name < 'zz';"),
+        (5, "SELECT * FROM Operator WHERE 'aa' < 'zz';"),
+        (4, "SELECT * FROM Operator WHERE 'Romeo' >= name;"),
         (
             1,
             "SELECT * FROM Operator WHERE (SELECT name FROM Operator LIMIT 1) >= name",
@@ -52,11 +52,11 @@ test_case!(ordering, async move {
         ),
         (
             5,
-            "SELECT * FROM Operator WHERE \"zz\" > (SELECT name FROM Operator LIMIT 1)",
+            "SELECT * FROM Operator WHERE 'zz' > (SELECT name FROM Operator LIMIT 1)",
         ),
         (
             5,
-            "SELECT * FROM Operator WHERE (SELECT name FROM Operator LIMIT 1) < \"zz\"",
+            "SELECT * FROM Operator WHERE (SELECT name FROM Operator LIMIT 1) < 'zz'",
         ),
         (5, "SELECT * FROM Operator WHERE NOT (1 != 1);"),
     ];

--- a/test-suite/src/series.rs
+++ b/test-suite/src/series.rs
@@ -102,9 +102,9 @@ test_case!(series, async move {
         ),
         (
             // SELECT without Table in Scalar subquery
-            r#"SELECT (SELECT "Hello")"#,
+            "SELECT (SELECT 'Hello')",
             Ok(select!(
-                r#"(SELECT "Hello")"#
+                "(SELECT 'Hello')"
                 Str;
                 "Hello".to_owned()
             )),

--- a/test-suite/src/transaction/basic.rs
+++ b/test-suite/src/transaction/basic.rs
@@ -12,16 +12,16 @@ test_case!(basic, async move {
     "
     );
     run!(
-        r#"
+        "
         INSERT INTO TxTest VALUES
-            (1, "Friday"),
-            (2, "Phone");
-    "#
+            (1, 'Friday'),
+            (2, 'Phone');
+    "
     );
 
     test!("BEGIN;", Ok(Payload::StartTransaction));
     test!(
-        r#"INSERT INTO TxTest VALUES (3, "New one");"#,
+        "INSERT INTO TxTest VALUES (3, 'New one');",
         Ok(Payload::Insert(1))
     );
     test!("ROLLBACK;", Ok(Payload::Rollback));
@@ -37,7 +37,7 @@ test_case!(basic, async move {
 
     test!("BEGIN;", Ok(Payload::StartTransaction));
     test!(
-        r#"INSERT INTO TxTest VALUES (3, "Vienna");"#,
+        "INSERT INTO TxTest VALUES (3, 'Vienna');",
         Ok(Payload::Insert(1))
     );
     test!(
@@ -111,7 +111,7 @@ test_case!(basic, async move {
     // UPDATE
     test!("BEGIN;", Ok(Payload::StartTransaction));
     test!(
-        r#"UPDATE TxTest SET name = "Sunday" WHERE id = 1;"#,
+        "UPDATE TxTest SET name = 'Sunday' WHERE id = 1;",
         Ok(Payload::Update(1))
     );
     test!(
@@ -135,7 +135,7 @@ test_case!(basic, async move {
     );
     test!("BEGIN;", Ok(Payload::StartTransaction));
     test!(
-        r#"UPDATE TxTest SET name = "Sunday" WHERE id = 1;"#,
+        "UPDATE TxTest SET name = 'Sunday' WHERE id = 1;",
         Ok(Payload::Update(1))
     );
     test!(

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -13,7 +13,7 @@ test_case!(unary_operator, async move {
             Ok(Payload::Create),
         ),
         (
-            r#"INSERT INTO Test VALUES (10, 10.5, "hello", -5, 1000, 20)"#,
+            "INSERT INTO Test VALUES (10, 10.5, 'hello', -5, 1000, 20)",
             Ok(Payload::Insert(1)),
         ),
         (

--- a/test-suite/src/update.rs
+++ b/test-suite/src/update.rs
@@ -10,44 +10,44 @@ use {
 
 test_case!(update, async move {
     run!(
-        r#"
+        "
         CREATE TABLE TableA (
             id INTEGER,
             num INTEGER,
             num2 INTEGER,
             name TEXT,
-        )"#
+        )"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO TableA (id, num, num2, name)
         VALUES
-            (1, 2, 4, "Hello"),
-            (1, 9, 5, "World"),
-            (3, 4, 7, "Great"),
-            (4, 7, 10, "Job");
-        "#
+            (1, 2, 4, 'Hello'),
+            (1, 9, 5, 'World'),
+            (3, 4, 7, 'Great'),
+            (4, 7, 10, 'Job');
+        "
     );
 
     run!(
-        r#"
+        "
         CREATE TABLE TableB (
             id INTEGER,
             num INTEGER,
             rank INTEGER,
-        )"#
+        )"
     );
 
     run!(
-        r#"
+        "
         INSERT INTO TableB (id, num, rank)
         VALUES
             (1, 2, 1),
             (1, 9, 2),
             (3, 4, 3),
             (4, 7, 4);
-        "#
+        "
     );
 
     let test_cases = [

--- a/test-suite/src/validate/types.rs
+++ b/test-suite/src/validate/types.rs
@@ -24,7 +24,7 @@ test_case!(types, async move {
             .into()),
         ),
         (
-            "INSERT INTO TableC (uid) VALUES (\"A\")",
+            "INSERT INTO TableC (uid) VALUES ('A')",
             Err(ValueError::IncompatibleLiteralForDataType {
                 data_type: DataType::Int,
                 literal: format!("{:?}", Literal::Text(Cow::Owned("A".to_owned()))),


### PR DESCRIPTION
# Goal
Currently, Both `double quotes` and `single quotes` evaluated as `literal string`.
From now, `Double quotes` will be evaluated as `identifier`.

### Before
```sql
gluesql> SELECT "name";
```
| "name" |
|--------|
| name   |

### After
```sql
gluesql> select "name";
[error] value not found: name
```
## Todo
- [x] handle double quotes as identifier at translate/expr
- [x] fix all test cases 