### PR TITLE
Make MemoryStorage Store trait features optional,

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,10 @@ jobs:
           cargo test --all-features --lib --bins --tests --examples --verbose -- --skip sled_transaction_timeout
           cargo test sled_transaction_timeout --verbose -- --test-threads=1
           cargo test --benches
+          cd storages/memory-storage
+          cargo test --verbose --no-default-features
+          cargo test --verbose --no-default-features --features alter-table
+          cd ../../
 
   run_examples:
     name: Run examples

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -9,20 +9,23 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.13.0", features = [
-	"alter-table",
-	"index",
-	"transaction",
-] }
+gluesql-core = { path = "../../core", version = "0.13.0" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 indexmap = { version = "1.8", features = ["serde"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
+tokio = { version = "1", features = ["rt", "macros"] }
+futures = "0.3"
+
+[features]
+default = [
 	"alter-table",
 	"index",
 	"transaction",
-] }
-tokio = { version = "1", features = ["rt", "macros"] }
-futures = "0.3"
+]
+
+alter-table = ["gluesql-core/alter-table", "test-suite/alter-table"]
+index = ["gluesql-core/index", "test-suite/index"]
+transaction = ["gluesql-core/transaction", "test-suite/transaction"]

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alter-table")]
+
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/src/index.rs
+++ b/storages/memory-storage/src/index.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "index")]
+
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/src/transaction.rs
+++ b/storages/memory-storage/src/transaction.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "transaction")]
+
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -19,20 +19,24 @@ impl Tester<MemoryStorage> for MemoryTester {
 
 generate_store_tests!(tokio::test, MemoryTester);
 
+#[cfg(feature = "alter-table")]
 generate_alter_table_tests!(tokio::test, MemoryTester);
 
+#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! exec {
     ($glue: ident $sql: literal) => {
         $glue.execute($sql).unwrap();
     };
 }
 
+#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! test {
     ($glue: ident $sql: literal, $result: expr) => {
         assert_eq!($glue.execute($sql), $result);
     };
 }
 
+#[cfg(feature = "index")]
 #[test]
 fn memory_storage_index() {
     use futures::executor::block_on;
@@ -73,6 +77,7 @@ fn memory_storage_index() {
     );
 }
 
+#[cfg(feature = "transaction")]
 #[test]
 fn memory_storage_transaction() {
     use gluesql_core::{prelude::Glue, result::Error};

--- a/test-suite/src/dictionary.rs
+++ b/test-suite/src/dictionary.rs
@@ -20,11 +20,12 @@ test_case!(dictionary, async move {
 
     test!("SHOW TABLES", tables(Vec::new()));
 
-    run!("CREATE TABLE Foo (id INTEGER);");
+    run!("CREATE TABLE Foo (id INTEGER, name TEXT NULL, type TEXT NULL);");
     test!("SHOW TABLES", tables(vec!["Foo"]));
 
     run!("CREATE TABLE Zoo (id INTEGER);");
-    run!("CREATE TABLE Bar (id INTEGER);");
+    run!("CREATE TABLE Bar (id INTEGER, name TEXT NULL);");
+
     test!("SHOW TABLES", tables(vec!["Bar", "Foo", "Zoo"]));
 
     test!(
@@ -51,9 +52,6 @@ test_case!(dictionary, async move {
         ))
     );
 
-    run!("ALTER TABLE Bar ADD COLUMN name TEXT NULL");
-    run!("ALTER TABLE Foo ADD COLUMN name TEXT NULL");
-    run!("ALTER TABLE Foo ADD COLUMN type TEXT NULL");
     test!(
         "SELECT * FROM GLUE_TABLE_COLUMNS",
         Ok(select!(


### PR DESCRIPTION
Update memory-storage/Cargo.toml to handle alter-table, index and transaction features as optional.
Fix test-suite/ dictionary not to use the codes which require alter-table feature.
Update rust.yml workflow to test memory-storage without features and with alter-table feature.