### PR TITLE
chore: Use rust-cache action to cache dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v2
       - run: rustup component add llvm-tools-preview
       - name: Install grcov
         uses: actions-rs/install@v0.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
           profile: minimal
           default: true
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
   clippy_core:
@@ -34,6 +35,7 @@ jobs:
           profile: minimal
           default: true
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cd core
           cargo clippy --no-default-features -- -D warnings
@@ -58,6 +60,7 @@ jobs:
           profile: minimal
           default: true
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo fmt -- --check
 
@@ -66,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-features --verbose
 
   run_tests:
@@ -73,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo test --all-features --lib --bins --tests --examples --verbose -- --skip sled_transaction_timeout
           cargo test sled_transaction_timeout --verbose -- --test-threads=1
@@ -87,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - run: |
           cargo run --package gluesql --example hello_world
           cargo run --package gluesql --example api_usage


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated GitHub Action workflows to cache dependencies using [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache). Caching dependencies speeds up workflow. For example, **Rustfmt** execution time was reduced from `2m 12s` to `21s`.