### PR TITLE
Add NumericNode to handle numeric value inputs in AST builder

### DIFF
--- a/core/src/ast_builder/error.rs
+++ b/core/src/ast_builder/error.rs
@@ -1,0 +1,7 @@
+use {serde::Serialize, std::fmt::Debug, thiserror::Error};
+
+#[derive(Error, Serialize, Debug, PartialEq)]
+pub enum AstBuilderError {
+    #[error("failed to parse numeric value: {0}")]
+    FailedToParseNumeric(String),
+}

--- a/core/src/ast_builder/expr/numeric.rs
+++ b/core/src/ast_builder/expr/numeric.rs
@@ -1,0 +1,127 @@
+use {
+    crate::{
+        ast::AstLiteral,
+        ast_builder::AstBuilderError,
+        result::{Error, Result},
+    },
+    bigdecimal::BigDecimal,
+    std::{borrow::Cow, str::FromStr},
+};
+
+#[derive(Clone)]
+pub enum NumericNode<'a> {
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    Str(Cow<'a, str>),
+}
+
+macro_rules! impl_from {
+    ($type: path, $name: ident) => {
+        impl<'a> From<$type> for NumericNode<'a> {
+            fn from(v: $type) -> Self {
+                NumericNode::$name(v)
+            }
+        }
+    };
+}
+
+impl_from!(i8, I8);
+impl_from!(i16, I16);
+impl_from!(i32, I32);
+impl_from!(i64, I64);
+impl_from!(u8, U8);
+impl_from!(u16, U16);
+impl_from!(u32, U32);
+impl_from!(u64, U64);
+impl_from!(f32, F32);
+impl_from!(f64, F64);
+
+impl<'a> From<String> for NumericNode<'a> {
+    fn from(v: String) -> Self {
+        Self::Str(Cow::Owned(v))
+    }
+}
+
+impl<'a> From<&'a str> for NumericNode<'a> {
+    fn from(v: &'a str) -> Self {
+        Self::Str(Cow::Borrowed(v))
+    }
+}
+
+impl<'a> TryFrom<NumericNode<'a>> for AstLiteral {
+    type Error = Error;
+
+    fn try_from(node: NumericNode<'a>) -> Result<Self> {
+        match node {
+            NumericNode::I8(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::I16(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::I32(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::I64(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::U8(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::U16(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::U32(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::U64(v) => Ok(AstLiteral::Number(v.into())),
+            NumericNode::F32(v) => BigDecimal::try_from(v)
+                .map_err(|_| AstBuilderError::FailedToParseNumeric(v.to_string()).into())
+                .map(AstLiteral::Number),
+            NumericNode::F64(v) => BigDecimal::try_from(v)
+                .map_err(|_| AstBuilderError::FailedToParseNumeric(v.to_string()).into())
+                .map(AstLiteral::Number),
+            NumericNode::Str(v) => BigDecimal::from_str(&v)
+                .map_err(|_| AstBuilderError::FailedToParseNumeric(v.into_owned()).into())
+                .map(AstLiteral::Number),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{
+            ast::AstLiteral,
+            ast_builder::{AstBuilderError, NumericNode},
+        },
+        bigdecimal::BigDecimal,
+        std::str::FromStr,
+    };
+
+    #[test]
+    fn numeric() {
+        let num = |n| Ok(AstLiteral::Number(BigDecimal::from_str(n).unwrap()));
+
+        assert_eq!(NumericNode::from(1_i8).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_i16).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_i32).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_i64).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_u8).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_u16).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_u32).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1_u64).try_into(), num("1"));
+        assert_eq!(NumericNode::from(1.23_f32).try_into(), num("1.23"));
+        assert_eq!(NumericNode::from(4.56_f64).try_into(), num("4.56"));
+        assert_eq!(NumericNode::from(4.56_f64).try_into(), num("4.56"));
+        assert_eq!(NumericNode::from("123.456").try_into(), num("123.456"));
+        assert_eq!(NumericNode::from("1.6".to_owned()).try_into(), num("1.6"));
+
+        assert_eq!(
+            AstLiteral::try_from(NumericNode::from(f32::NAN)),
+            Err(AstBuilderError::FailedToParseNumeric(f32::NAN.to_string()).into()),
+        );
+        assert_eq!(
+            AstLiteral::try_from(NumericNode::from(f64::NAN)),
+            Err(AstBuilderError::FailedToParseNumeric(f64::NAN.to_string()).into()),
+        );
+        assert_eq!(
+            AstLiteral::try_from(NumericNode::from("not a number")),
+            Err(AstBuilderError::FailedToParseNumeric("not a number".to_owned()).into()),
+        );
+    }
+}

--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -8,6 +8,7 @@ mod create_table;
 mod data_type;
 mod delete;
 mod drop_table;
+mod error;
 mod execute;
 mod expr;
 mod expr_list;
@@ -35,6 +36,7 @@ pub use {
     data_type::DataTypeNode,
     delete::DeleteNode,
     drop_table::DropTableNode,
+    error::AstBuilderError,
     execute::Execute,
     expr_list::ExprList,
     insert::InsertNode,
@@ -54,8 +56,8 @@ pub use {
 
 /// Available expression builder functions
 pub use expr::{
-    case, col, date, exists, expr, factorial, minus, nested, not, not_exists, null, num, plus,
-    subquery, text, time, timestamp, ExprNode,
+    case, col, date, exists, expr, factorial, minus, nested, not, not_exists, null, num,
+    numeric::NumericNode, plus, subquery, text, time, timestamp, ExprNode,
 };
 
 #[cfg(feature = "alter-table")]

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        ast_builder::AstBuilderError,
         data::{
             IntervalError, KeyError, LiteralError, RowError, StringExtError, TableError, ValueError,
         },
@@ -36,6 +37,9 @@ pub enum Error {
 
     #[error(transparent)]
     Translate(#[from] TranslateError),
+
+    #[error(transparent)]
+    AstBuilder(#[from] AstBuilderError),
 
     #[cfg(feature = "alter-table")]
     #[error(transparent)]
@@ -92,6 +96,7 @@ impl PartialEq for Error {
             (Parser(e), Parser(e2)) => e == e2,
             (StorageMsg(e), StorageMsg(e2)) => e == e2,
             (Translate(e), Translate(e2)) => e == e2,
+            (AstBuilder(e), AstBuilder(e2)) => e == e2,
             #[cfg(feature = "alter-table")]
             (AlterTable(e), AlterTable(e2)) => e == e2,
             #[cfg(feature = "index")]

--- a/test-suite/src/ast_builder/basic.rs
+++ b/test-suite/src/ast_builder/basic.rs
@@ -83,4 +83,12 @@ test_case!(basic, async move {
     let actual = table("Foo").drop_table().execute(glue).await;
     let expected = Ok(Payload::DropTable);
     assert_eq!(actual, expected, "drop table");
+
+    let actual = table("Foo")
+        .select()
+        .filter(num("NAN").gt(300))
+        .execute(glue)
+        .await;
+    let expected = Err(AstBuilderError::FailedToParseNumeric("NAN".to_owned()).into());
+    assert_eq!(actual, expected, "error");
 });


### PR DESCRIPTION
Now, `num` AST builder sugar function supports multiple different types including i64, f64, and &str.

e.g.
```rust
num("1.23");
num(100_i64);
num(300_i32);
num(1.234);
```

cc. @ShaddyDC 