### PR TITLE
Reorder project in ASTBuilder (project -> ordery_by -> limit,offset)

### DIFF
--- a/core/src/ast_builder/insert.rs
+++ b/core/src/ast_builder/insert.rs
@@ -91,7 +91,7 @@ mod tests {
 
         let actual = table("Foo")
             .insert()
-            .as_select(table("Bar").select().limit(10).project("id, name"))
+            .as_select(table("Bar").select().project("id, name").limit(10))
             .build();
         let expected = r#"INSERT INTO Foo SELECT id, name FROM Bar LIMIT 10"#;
         test(actual, expected);

--- a/core/src/ast_builder/query.rs
+++ b/core/src/ast_builder/query.rs
@@ -229,7 +229,7 @@ mod test {
         let expected = "SELECT * FROM FOO GROUP BY city HAVING COUNT(name) < 100 OFFSET 1 LIMIT 3";
         test_query(actual, expected);
 
-        let actual = table("FOO").select().limit(10).project("id, name").into();
+        let actual = table("FOO").select().project("id, name").limit(10).into();
         let expected = r#"SELECT id, name FROM FOO LIMIT 10"#;
         test_query(actual, expected);
 

--- a/core/src/ast_builder/select/limit.rs
+++ b/core/src/ast_builder/select/limit.rs
@@ -20,6 +20,7 @@ pub enum PrevNode<'a> {
     HashJoin(HashJoinNode<'a>),
     Filter(FilterNode<'a>),
     OrderBy(OrderByNode<'a>),
+    ProjectNode(Box<ProjectNode<'a>>),
 }
 
 impl<'a> Prebuild for PrevNode<'a> {
@@ -33,6 +34,7 @@ impl<'a> Prebuild for PrevNode<'a> {
             Self::HashJoin(node) => node.prebuild(),
             Self::Filter(node) => node.prebuild(),
             Self::OrderBy(node) => node.prebuild(),
+            Self::ProjectNode(node) => node.prebuild(),
         }
     }
 }
@@ -82,6 +84,12 @@ impl<'a> From<FilterNode<'a>> for PrevNode<'a> {
 impl<'a> From<OrderByNode<'a>> for PrevNode<'a> {
     fn from(node: OrderByNode<'a>) -> Self {
         PrevNode::OrderBy(node)
+    }
+}
+
+impl<'a> From<ProjectNode<'a>> for PrevNode<'a> {
+    fn from(node: ProjectNode<'a>) -> Self {
+        PrevNode::ProjectNode(Box::new(node))
     }
 }
 

--- a/core/src/ast_builder/select/limit.rs
+++ b/core/src/ast_builder/select/limit.rs
@@ -3,8 +3,7 @@ use {
     crate::{
         ast_builder::{
             ExprNode, FilterNode, GroupByNode, HashJoinNode, HavingNode, JoinConstraintNode,
-            JoinNode, OrderByNode, ProjectNode, QueryNode, SelectItemList, SelectNode,
-            TableFactorNode,
+            JoinNode, OrderByNode, ProjectNode, QueryNode, SelectNode, TableFactorNode,
         },
         result::Result,
     },
@@ -105,10 +104,6 @@ impl<'a> LimitNode<'a> {
             prev_node: prev_node.into(),
             expr: expr.into(),
         }
-    }
-
-    pub fn project<T: Into<SelectItemList<'a>>>(self, select_items: T) -> ProjectNode<'a> {
-        ProjectNode::new(self, select_items)
     }
 
     pub fn alias_as(self, table_alias: &'a str) -> TableFactorNode {

--- a/core/src/ast_builder/select/offset.rs
+++ b/core/src/ast_builder/select/offset.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         ast_builder::{
             ExprNode, FilterNode, GroupByNode, HashJoinNode, HavingNode, JoinConstraintNode,
-            JoinNode, OffsetLimitNode, OrderByNode, ProjectNode, QueryNode, SelectItemList,
-            SelectNode, TableFactorNode,
+            JoinNode, OffsetLimitNode, OrderByNode, ProjectNode, QueryNode, SelectNode,
+            TableFactorNode,
         },
         result::Result,
     },
@@ -109,10 +109,6 @@ impl<'a> OffsetNode<'a> {
 
     pub fn limit<T: Into<ExprNode<'a>>>(self, expr: T) -> OffsetLimitNode<'a> {
         OffsetLimitNode::new(self, expr)
-    }
-
-    pub fn project<T: Into<SelectItemList<'a>>>(self, select_items: T) -> ProjectNode<'a> {
-        ProjectNode::new(self, select_items)
     }
 
     pub fn alias_as(self, table_alias: &'a str) -> TableFactorNode {

--- a/core/src/ast_builder/select/offset.rs
+++ b/core/src/ast_builder/select/offset.rs
@@ -20,6 +20,7 @@ pub enum PrevNode<'a> {
     HashJoin(HashJoinNode<'a>),
     Filter(FilterNode<'a>),
     OrderBy(OrderByNode<'a>),
+    ProjectNode(Box<ProjectNode<'a>>),
 }
 
 impl<'a> Prebuild for PrevNode<'a> {
@@ -33,6 +34,7 @@ impl<'a> Prebuild for PrevNode<'a> {
             Self::HashJoin(node) => node.prebuild(),
             Self::Filter(node) => node.prebuild(),
             Self::OrderBy(node) => node.prebuild(),
+            Self::ProjectNode(node) => node.prebuild(),
         }
     }
 }
@@ -82,6 +84,12 @@ impl<'a> From<FilterNode<'a>> for PrevNode<'a> {
 impl<'a> From<OrderByNode<'a>> for PrevNode<'a> {
     fn from(node: OrderByNode<'a>) -> Self {
         PrevNode::OrderBy(node)
+    }
+}
+
+impl<'a> From<ProjectNode<'a>> for PrevNode<'a> {
+    fn from(node: ProjectNode<'a>) -> Self {
+        PrevNode::ProjectNode(Box::new(node))
     }
 }
 

--- a/core/src/ast_builder/select/offset_limit.rs
+++ b/core/src/ast_builder/select/offset_limit.rs
@@ -1,9 +1,7 @@
 use {
     super::{NodeData, Prebuild},
     crate::{
-        ast_builder::{
-            ExprNode, OffsetNode, ProjectNode, QueryNode, SelectItemList, TableFactorNode,
-        },
+        ast_builder::{ExprNode, OffsetNode, QueryNode, TableFactorNode},
         result::Result,
     },
 };
@@ -39,10 +37,6 @@ impl<'a> OffsetLimitNode<'a> {
             prev_node: prev_node.into(),
             expr: expr.into(),
         }
-    }
-
-    pub fn project<T: Into<SelectItemList<'a>>>(self, select_items: T) -> ProjectNode<'a> {
-        ProjectNode::new(self, select_items)
     }
 
     pub fn alias_as(self, table_alias: &'a str) -> TableFactorNode {
@@ -87,9 +81,9 @@ mod tests {
             .select()
             .group_by("city")
             .having("COUNT(name) < 100")
+            .project("city")
             .offset(1)
             .limit(3)
-            .project("city")
             .build();
         let expected = "
             SELECT city FROM Bar

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         ast_builder::{
             ExprNode, FilterNode, GroupByNode, HashJoinNode, HavingNode, JoinConstraintNode,
-            JoinNode, LimitNode, OffsetNode, OrderByExprList, ProjectNode, QueryNode,
-            SelectItemList, SelectNode, TableFactorNode,
+            JoinNode, LimitNode, OffsetNode, OrderByExprList, ProjectNode, QueryNode, SelectNode,
+            TableFactorNode,
         },
         result::Result,
     },
@@ -108,10 +108,6 @@ impl<'a> OrderByNode<'a> {
 
     pub fn limit<T: Into<ExprNode<'a>>>(self, expr: T) -> LimitNode<'a> {
         LimitNode::new(self, expr)
-    }
-
-    pub fn project<T: Into<SelectItemList<'a>>>(self, select_items: T) -> ProjectNode<'a> {
-        ProjectNode::new(self, select_items)
     }
 
     pub fn alias_as(self, table_alias: &'a str) -> TableFactorNode {

--- a/core/src/ast_builder/select/order_by.rs
+++ b/core/src/ast_builder/select/order_by.rs
@@ -19,6 +19,7 @@ pub enum PrevNode<'a> {
     JoinNode(JoinNode<'a>),
     JoinConstraint(JoinConstraintNode<'a>),
     HashJoin(Box<HashJoinNode<'a>>),
+    ProjectNode(Box<ProjectNode<'a>>),
 }
 
 impl<'a> Prebuild for PrevNode<'a> {
@@ -31,6 +32,7 @@ impl<'a> Prebuild for PrevNode<'a> {
             Self::JoinNode(node) => node.prebuild(),
             Self::JoinConstraint(node) => node.prebuild(),
             Self::HashJoin(node) => node.prebuild(),
+            Self::ProjectNode(node) => node.prebuild(),
         }
     }
 }
@@ -74,6 +76,12 @@ impl<'a> From<JoinConstraintNode<'a>> for PrevNode<'a> {
 impl<'a> From<HashJoinNode<'a>> for PrevNode<'a> {
     fn from(node: HashJoinNode<'a>) -> Self {
         PrevNode::HashJoin(Box::new(node))
+    }
+}
+
+impl<'a> From<ProjectNode<'a>> for PrevNode<'a> {
+    fn from(node: ProjectNode<'a>) -> Self {
+        PrevNode::ProjectNode(Box::new(node))
     }
 }
 

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -24,7 +24,6 @@ pub enum PrevNode<'a> {
     JoinConstraint(Box<JoinConstraintNode<'a>>),
     HashJoin(HashJoinNode<'a>),
     Filter(FilterNode<'a>),
-    OrderBy(OrderByNode<'a>),
 }
 
 impl<'a> Prebuild for PrevNode<'a> {
@@ -40,7 +39,6 @@ impl<'a> Prebuild for PrevNode<'a> {
             Self::JoinConstraint(node) => node.prebuild(),
             Self::HashJoin(node) => node.prebuild(),
             Self::Filter(node) => node.prebuild(),
-            Self::OrderBy(node) => node.prebuild(),
         }
     }
 }
@@ -102,12 +100,6 @@ impl<'a> From<HashJoinNode<'a>> for PrevNode<'a> {
 impl<'a> From<FilterNode<'a>> for PrevNode<'a> {
     fn from(node: FilterNode<'a>) -> Self {
         PrevNode::Filter(node)
-    }
-}
-
-impl<'a> From<OrderByNode<'a>> for PrevNode<'a> {
-    fn from(node: OrderByNode<'a>) -> Self {
-        PrevNode::OrderBy(node)
     }
 }
 

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -249,12 +249,12 @@ mod tests {
         test(actual, expected);
 
         // limit node -> project node -> build
-        let actual = table("Item").select().limit(10).project("*").build();
+        let actual = table("Item").select().project("*").limit(10).build();
         let expected = "SELECT * FROM Item LIMIT 10";
         test(actual, expected);
 
         // offset node -> project node -> build
-        let actual = table("Item").select().offset(10).project("*").build();
+        let actual = table("Item").select().project("*").offset(10).build();
         let expected = "SELECT * FROM Item OFFSET 10";
         test(actual, expected);
 

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -1,3 +1,5 @@
+use crate::ast_builder::OrderByExprList;
+
 use {
     super::{NodeData, Prebuild},
     crate::{
@@ -135,6 +137,10 @@ impl<'a> ProjectNode<'a> {
     pub fn alias_as(self, table_alias: &'a str) -> TableFactorNode {
         QueryNode::ProjectNode(self).alias_as(table_alias)
     }
+
+    pub fn order_by<T: Into<OrderByExprList<'a>>>(self, order_by_exprs: T) -> OrderByNode<'a> {
+        OrderByNode::new(self, order_by_exprs)
+    }
 }
 
 impl<'a> Prebuild for ProjectNode<'a> {
@@ -265,8 +271,8 @@ mod tests {
         // order by node -> project node -> build
         let actual = table("Foo")
             .select()
-            .order_by("id asc")
             .project("id")
+            .order_by("id asc")
             .build();
         let expected = "SELECT id FROM Foo ORDER BY id asc";
         test(actual, expected);

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -1,12 +1,10 @@
-use crate::ast_builder::{ExprNode, OrderByExprList};
-
 use {
     super::{NodeData, Prebuild},
     crate::{
         ast_builder::{
-            FilterNode, GroupByNode, HashJoinNode, HavingNode, JoinConstraintNode, JoinNode,
-            LimitNode, OffsetLimitNode, OffsetNode, OrderByNode, QueryNode, SelectItemList,
-            SelectNode, TableFactorNode,
+            ExprNode, FilterNode, GroupByNode, HashJoinNode, HavingNode, JoinConstraintNode,
+            JoinNode, LimitNode, OffsetLimitNode, OffsetNode, OrderByExprList, OrderByNode,
+            QueryNode, SelectItemList, SelectNode, TableFactorNode,
         },
         result::Result,
     },

--- a/core/src/ast_builder/select/project.rs
+++ b/core/src/ast_builder/select/project.rs
@@ -1,4 +1,4 @@
-use crate::ast_builder::OrderByExprList;
+use crate::ast_builder::{ExprNode, OrderByExprList};
 
 use {
     super::{NodeData, Prebuild},
@@ -133,6 +133,14 @@ impl<'a> ProjectNode<'a> {
     pub fn order_by<T: Into<OrderByExprList<'a>>>(self, order_by_exprs: T) -> OrderByNode<'a> {
         OrderByNode::new(self, order_by_exprs)
     }
+
+    pub fn offset<T: Into<ExprNode<'a>>>(self, expr: T) -> OffsetNode<'a> {
+        OffsetNode::new(self, expr)
+    }
+
+    pub fn limit<T: Into<ExprNode<'a>>>(self, expr: T) -> LimitNode<'a> {
+        LimitNode::new(self, expr)
+    }
 }
 
 impl<'a> Prebuild for ProjectNode<'a> {
@@ -253,9 +261,9 @@ mod tests {
         // offset limit node -> project node -> build
         let actual = table("Operator")
             .select()
+            .project("name")
             .offset(3)
             .limit(10)
-            .project("name")
             .build();
         let expected = "SELECT name FROM Operator LIMIT 10 OFFSET 3";
         test(actual, expected);

--- a/test-suite/src/ast_builder/select.rs
+++ b/test-suite/src/ast_builder/select.rs
@@ -140,8 +140,8 @@ test_case!(select, async move {
     // order by
     let actual = table("Item")
         .select()
-        .order_by("price DESC")
         .project("name, price")
+        .order_by("price DESC")
         .execute(glue)
         .await;
     let expected = Ok(select!(

--- a/test-suite/src/ast_builder/select.rs
+++ b/test-suite/src/ast_builder/select.rs
@@ -158,10 +158,10 @@ test_case!(select, async move {
     // offset, limit
     let actual = table("Item")
         .select()
+        .project("name, price")
         .order_by("price DESC")
         .offset(1)
         .limit(2)
-        .project("name, price")
         .execute(glue)
         .await;
     let expected = Ok(select!(


### PR DESCRIPTION
## Goal
Currently, the execution order of `ASTBuilder` is different with `Core`
Let's sync the order to `project -> ordery_by -> limit,offset`

### Before
```
order_by -> limit,offset -> project
```
### After
```
project -> order_by -> limit,offset
```
## Todo
- [x] Add `order_by`, `limit`, `offset`  to ProjectNode
- [x] Remove `project` from `OrderByNode`, `LimitNode`, `OffsetNode`, `OffsetLimitNode`