### PR TITLE
Remove data::RowError,

### DIFF
--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -14,7 +14,7 @@ pub use {
     interval::{Interval, IntervalError},
     key::{Key, KeyError},
     literal::{Literal, LiteralError},
-    row::{Row, RowError},
+    row::Row,
     schema::{Schema, SchemaIndex, SchemaIndexOrd},
     string_ext::{StringExt, StringExtError},
     table::{get_alias, get_index, TableError},

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -1,18 +1,7 @@
 use {
-    crate::{data::Value, result::Result},
-    serde::Serialize,
+    crate::data::Value,
     std::{fmt::Debug, rc::Rc},
-    thiserror::Error,
 };
-
-#[derive(Error, Serialize, Debug, PartialEq, Eq)]
-pub enum RowError {
-    #[error("VALUES lists must all be the same length")]
-    NumberOfValuesDifferent,
-
-    #[error("conflict! row cannot be empty")]
-    ConflictOnEmptyRow,
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Row {
@@ -30,13 +19,6 @@ impl Row {
             .iter()
             .position(|column| column == ident)
             .and_then(|index| self.values.get(index))
-    }
-
-    pub fn take_first_value(self) -> Result<Value> {
-        self.values
-            .into_iter()
-            .next()
-            .ok_or_else(|| RowError::ConflictOnEmptyRow.into())
     }
 
     pub fn len(&self) -> usize {

--- a/core/src/executor/mod.rs
+++ b/core/src/executor/mod.rs
@@ -20,6 +20,7 @@ pub use {
     execute::{ExecuteError, Payload, PayloadVariable},
     fetch::FetchError,
     insert::InsertError,
+    select::SelectError,
     sort::SortError,
     update::UpdateError,
     validate::ValidateError,

--- a/core/src/executor/select/error.rs
+++ b/core/src/executor/select/error.rs
@@ -1,0 +1,7 @@
+use {serde::Serialize, std::fmt::Debug, thiserror::Error};
+
+#[derive(Error, Serialize, Debug, PartialEq, Eq)]
+pub enum SelectError {
+    #[error("VALUES lists must all be the same length")]
+    NumberOfValuesDifferent,
+}

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -1,4 +1,7 @@
+mod error;
 mod project;
+
+pub use error::SelectError;
 
 use {
     self::project::Project,
@@ -14,7 +17,7 @@ use {
     },
     crate::{
         ast::{Expr, OrderByExpr, Query, Select, SetExpr, TableWithJoins, Values},
-        data::{get_alias, Row, RowError},
+        data::{get_alias, Row},
         prelude::{DataType, Value},
         result::{Error, Result},
         store::GStore,
@@ -41,7 +44,7 @@ fn rows_with_labels(exprs_list: &[Vec<Expr>]) -> (Vec<Result<Row>>, Vec<String>)
                 .collect::<Vec<Option<DataType>>>(),
             move |column_types, exprs| {
                 if exprs.len() != first_len {
-                    return Some(Err(RowError::NumberOfValuesDifferent.into()));
+                    return Some(Err(SelectError::NumberOfValuesDifferent.into()));
                 }
 
                 let values = column_types

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -1,12 +1,10 @@
 use {
     crate::{
         ast_builder::AstBuilderError,
-        data::{
-            IntervalError, KeyError, LiteralError, RowError, StringExtError, TableError, ValueError,
-        },
+        data::{IntervalError, KeyError, LiteralError, StringExtError, TableError, ValueError},
         executor::{
             AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, InsertError,
-            SortError, UpdateError, ValidateError,
+            SelectError, SortError, UpdateError, ValidateError,
         },
         plan::PlanError,
         store::{GStore, GStoreMut},
@@ -56,6 +54,8 @@ pub enum Error {
     #[error(transparent)]
     Fetch(#[from] FetchError),
     #[error(transparent)]
+    Select(#[from] SelectError),
+    #[error(transparent)]
     Evaluate(#[from] EvaluateError),
     #[error(transparent)]
     Aggregate(#[from] AggregateError),
@@ -65,8 +65,6 @@ pub enum Error {
     Insert(#[from] InsertError),
     #[error(transparent)]
     Update(#[from] UpdateError),
-    #[error(transparent)]
-    Row(#[from] RowError),
     #[error(transparent)]
     Table(#[from] TableError),
     #[error(transparent)]
@@ -104,12 +102,12 @@ impl PartialEq for Error {
             (Execute(e), Execute(e2)) => e == e2,
             (Alter(e), Alter(e2)) => e == e2,
             (Fetch(e), Fetch(e2)) => e == e2,
+            (Select(e), Select(e2)) => e == e2,
             (Evaluate(e), Evaluate(e2)) => e == e2,
             (Aggregate(e), Aggregate(e2)) => e == e2,
             (Sort(e), Sort(e2)) => e == e2,
             (Insert(e), Insert(e2)) => e == e2,
             (Update(e), Update(e2)) => e == e2,
-            (Row(e), Row(e2)) => e == e2,
             (Table(e), Table(e2)) => e == e2,
             (Validate(e), Validate(e2)) => e == e2,
             (Key(e), Key(e2)) => e == e2,

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -3,8 +3,8 @@ use {
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType::{Boolean, Int, Text},
-        data::{Literal, RowError, ValueError},
-        executor::{FetchError, InsertError},
+        data::{Literal, ValueError},
+        executor::{FetchError, InsertError, SelectError},
         prelude::{DataType, Payload, Value::*},
     },
     std::borrow::Cow,
@@ -68,11 +68,11 @@ test_case!(values, async move {
         ),
         (
             "VALUES (1), (2, 'b')",
-            Err(RowError::NumberOfValuesDifferent.into()),
+            Err(SelectError::NumberOfValuesDifferent.into()),
         ),
         (
             "VALUES (1, 'a'), (2)",
-            Err(RowError::NumberOfValuesDifferent.into()),
+            Err(SelectError::NumberOfValuesDifferent.into()),
         ),
         (
             "VALUES (1, 'a'), (2, 3)",


### PR DESCRIPTION
- Move `RowError::NumberOfValuesDifferent` to `SelectError`.
- Remove `RowError::ConflictOnEmptyRow` by making evaluate module to handle this.
This `ConflictOnEmptyRow` error is now just hidden by evaluate and that might be not an ideal solution.
We need `NonEmptyVec` struct for this. (`Vec<SelectItem>` to `NonEmptyVec<SelectItem>` for projection)