### PR TITLE
Move ast::ColumnOption::Default variant to ColumnDef

### DIFF
--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -27,13 +27,13 @@ pub struct ColumnDef {
     pub name: String,
     pub data_type: DataType,
     pub nullable: bool,
+    /// `DEFAULT <restricted-expr>`
+    pub default: Option<Expr>,
     pub options: Vec<ColumnOption>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ColumnOption {
-    /// `DEFAULT <restricted-expr>`
-    Default(Expr),
     /// `{ PRIMARY KEY | UNIQUE }`
     Unique { is_primary: bool },
 }
@@ -68,6 +68,7 @@ impl ToSql for ColumnDef {
             name,
             data_type,
             nullable,
+            default,
             options,
         } = self;
         {
@@ -75,16 +76,21 @@ impl ToSql for ColumnDef {
                 true => "NULL",
                 false => "NOT NULL",
             };
-
+            let default = default.as_ref().map(ToSql::to_sql);
             let options = options
                 .iter()
                 .map(|option| option.to_sql())
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            format!("{name} {data_type} {nullable} {options}")
-                .trim_end()
-                .to_owned()
+            let column_def = format!("{name} {data_type} {nullable}");
+
+            match (default, options.is_empty()) {
+                (None, true) => column_def,
+                (None, false) => format!("{column_def} {options}"),
+                (Some(default), true) => format!("{column_def} DEFAULT {default}"),
+                (Some(default), false) => format!("{column_def} DEFAULT {default} {options}"),
+            }
         }
     }
 }
@@ -92,7 +98,6 @@ impl ToSql for ColumnDef {
 impl ToSql for ColumnOption {
     fn to_sql(&self) -> String {
         match self {
-            ColumnOption::Default(expr) => format!("DEFAULT {}", expr.to_sql()),
             ColumnOption::Unique { is_primary } => match is_primary {
                 true => "PRIMARY KEY".to_owned(),
                 false => "UNIQUE".to_owned(),
@@ -113,6 +118,7 @@ mod tests {
                 name: "name".to_owned(),
                 data_type: DataType::Text,
                 nullable: false,
+                default: None,
                 options: vec![ColumnOption::Unique { is_primary: false }]
             }
             .to_sql()
@@ -124,6 +130,7 @@ mod tests {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
                 nullable: true,
+                default: None,
                 options: Vec::new()
             }
             .to_sql()
@@ -135,6 +142,7 @@ mod tests {
                 name: "id".to_owned(),
                 data_type: DataType::Int,
                 nullable: false,
+                default: None,
                 options: vec![ColumnOption::Unique { is_primary: true }]
             }
             .to_sql()
@@ -146,9 +154,8 @@ mod tests {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
                 nullable: false,
-                options: vec![ColumnOption::Default(Expr::Literal(AstLiteral::Boolean(
-                    false
-                )))]
+                default: Some(Expr::Literal(AstLiteral::Boolean(false))),
+                options: Vec::new(),
             }
             .to_sql()
         );

--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -159,5 +159,17 @@ mod tests {
             }
             .to_sql()
         );
+
+        assert_eq!(
+            "accepted BOOLEAN NOT NULL DEFAULT FALSE UNIQUE",
+            ColumnDef {
+                name: "accepted".to_owned(),
+                data_type: DataType::Boolean,
+                nullable: false,
+                default: Some(Expr::Literal(AstLiteral::Boolean(false))),
+                options: vec![ColumnOption::Unique { is_primary: false }],
+            }
+            .to_sql()
+        );
     }
 }

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -235,7 +235,7 @@ impl ToSql for Assignment {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "alter-table")]
-    use crate::ast::{AlterTableOperation, ColumnOption};
+    use crate::ast::AlterTableOperation;
 
     #[cfg(feature = "index")]
     use crate::ast::OrderByExpr;
@@ -371,18 +371,21 @@ mod tests {
                         name: "id".to_owned(),
                         data_type: DataType::Int,
                         nullable: false,
+                        default: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "num".to_owned(),
                         data_type: DataType::Int,
                         nullable: true,
+                        default: None,
                         options: Vec::new()
                     },
                     ColumnDef {
                         name: "name".to_owned(),
                         data_type: DataType::Text,
                         nullable: false,
+                        default: None,
                         options: vec![]
                     }
                 ],
@@ -463,9 +466,10 @@ mod tests {
                         name: "amount".to_owned(),
                         data_type: DataType::Int,
                         nullable: false,
-                        options: vec![ColumnOption::Default(Expr::Literal(AstLiteral::Number(
+                        default: Some(Expr::Literal(AstLiteral::Number(
                             BigDecimal::from_str("10").unwrap()
-                        )))]
+                        ))),
+                        options: Vec::new(),
                     }
                 }
             }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -1,5 +1,5 @@
 use {
-    crate::ast::{ColumnDef, ColumnOption, Expr, Statement, ToSql},
+    crate::ast::{ColumnDef, Expr, Statement, ToSql},
     chrono::NaiveDateTime,
     serde::{Deserialize, Serialize},
     std::{fmt::Debug, iter},
@@ -61,18 +61,8 @@ impl Schema {
     }
 }
 
-impl ColumnDef {
-    pub fn get_default(&self) -> Option<&Expr> {
-        self.options.iter().find_map(|option| match option {
-            ColumnOption::Default(expr) => Some(expr),
-            _ => None,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-
     use crate::{
         ast::{AstLiteral, ColumnDef, ColumnOption, Expr},
         chrono::Utc,
@@ -89,15 +79,15 @@ mod tests {
                     name: "id".to_owned(),
                     data_type: DataType::Int,
                     nullable: false,
+                    default: None,
                     options: Vec::new(),
                 },
                 ColumnDef {
                     name: "name".to_owned(),
                     data_type: DataType::Text,
                     nullable: true,
-                    options: vec![ColumnOption::Default(Expr::Literal(
-                        AstLiteral::QuotedString("glue".to_owned()),
-                    ))],
+                    default: Some(Expr::Literal(AstLiteral::QuotedString("glue".to_owned()))),
+                    options: Vec::new(),
                 },
             ],
             indexes: Vec::new(),
@@ -118,6 +108,7 @@ mod tests {
                 name: "id".to_owned(),
                 data_type: DataType::Int,
                 nullable: false,
+                default: None,
                 options: vec![ColumnOption::Unique { is_primary: true }],
             }],
             indexes: Vec::new(),
@@ -139,12 +130,14 @@ mod tests {
                     name: "id".to_owned(),
                     data_type: DataType::Int,
                     nullable: false,
+                    default: None,
                     options: Vec::new(),
                 },
                 ColumnDef {
                     name: "name".to_owned(),
                     data_type: DataType::Text,
                     nullable: false,
+                    default: None,
                     options: Vec::new(),
                 },
             ],

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -43,6 +43,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                             name: "N".into(),
                             data_type: DataType::Int,
                             nullable: false,
+                            default: None,
                             options: Vec::new(),
                         };
 
@@ -93,6 +94,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                             name: format!("column{}", i + 1),
                             data_type,
                             nullable: true,
+                            default: None,
                             options: Vec::new(),
                         })
                         .collect::<Vec<_>>();

--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -10,6 +10,7 @@ use {
 pub fn validate(column_def: &ColumnDef) -> Result<()> {
     let ColumnDef {
         data_type,
+        default,
         options,
         name,
         ..
@@ -27,11 +28,6 @@ pub fn validate(column_def: &ColumnDef) -> Result<()> {
         )
         .into());
     }
-
-    let default = options.iter().find_map(|option| match option {
-        ColumnOption::Default(expr) => Some(expr),
-        _ => None,
-    });
 
     if let Some(expr) = default {
         evaluate_stateless(None, expr)?;

--- a/core/src/executor/insert.rs
+++ b/core/src/executor/insert.rs
@@ -201,7 +201,7 @@ fn fill_values(
                 .find(|(name, _)| name == &def_name)
                 .map(|(_, value)| value);
 
-            match (value, column_def.get_default(), nullable) {
+            match (value, &column_def.default, nullable) {
                 (Some(&expr), _, _) | (None, Some(expr), _) => {
                     evaluate_stateless(None, expr)?.try_into_value(data_type, *nullable)
                 }

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -213,7 +213,6 @@ fn fetch_specified_unique_columns(
                     ColumnOption::Unique { .. } => specified_columns
                         .iter()
                         .any(|specified_col| specified_col == &table_col.name),
-                    _ => false,
                 })
                 .then_some((i, table_col.name.to_owned()))
         })

--- a/core/src/plan/mock.rs
+++ b/core/src/plan/mock.rs
@@ -182,6 +182,7 @@ mod tests {
                     name: "new_col".to_owned(),
                     data_type: DataType::Boolean,
                     nullable: false,
+                    default: None,
                     options: Vec::new(),
                 },
             ));

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -100,10 +100,9 @@ fn translate_column_option_def(
 
     match option {
         SqlColumnOption::Null | SqlColumnOption::NotNull | SqlColumnOption::Default(_) => Ok(None),
-        SqlColumnOption::Unique { is_primary } if !is_primary => {
-            Ok(Some(ColumnOption::Unique { is_primary: false }))
-        }
-        SqlColumnOption::Unique { .. } => Ok(Some(ColumnOption::Unique { is_primary: true })),
+        SqlColumnOption::Unique { is_primary } => Ok(Some(ColumnOption::Unique {
+            is_primary: *is_primary,
+        })),
         _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
     }
 }

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -76,10 +76,10 @@ impl MemoryStorage {
         let ColumnDef {
             data_type,
             nullable,
+            default,
             ..
         } = column_def;
 
-        let default = column_def.get_default();
         let value = match (default, nullable) {
             (Some(expr), _) => {
                 let evaluated = gluesql_core::executor::evaluate_stateless(None, expr)?;

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -183,6 +183,7 @@ impl AlterTable for SledStorage {
             let ColumnDef {
                 data_type,
                 nullable,
+                default,
                 options,
                 ..
             } = column_defs[i].clone();
@@ -191,6 +192,7 @@ impl AlterTable for SledStorage {
                 name: new_column_name.to_owned(),
                 data_type,
                 nullable,
+                default,
                 options,
             };
             let column_defs = Vector::from(column_defs).update(i, column_def).into();
@@ -270,10 +272,10 @@ impl AlterTable for SledStorage {
             let ColumnDef {
                 data_type,
                 nullable,
+                default,
                 ..
             } = column_def;
 
-            let default = column_def.get_default();
             let value = match (default, nullable) {
                 (Some(expr), _) => {
                     let evaluated = evaluate_stateless(None, expr)

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -61,6 +61,7 @@ test_case!(alter_table_add_drop, async move {
                 name: "amount".to_owned(),
                 data_type: DataType::Int,
                 nullable: false,
+                default: None,
                 options: vec![],
             })
             .into()),


### PR DESCRIPTION
Each `ColumnDef` can have at most one `ColumnOption::Default` but current ast structure allows `ColumnDef` to have multiple `Default`s.
Resolve this by adding `default` field to `ColumnDef` and remove `ColumnOption::Default`.

---
It can also be applied to `ColumnOption::Unique` which is the last enum variant of `ColumnOption`.