### PR TITLE
Update js/ Cargo.toml to use gloo-utils for serde handling

### DIFF
--- a/pkg/javascript/web/Cargo.toml
+++ b/pkg/javascript/web/Cargo.toml
@@ -15,12 +15,13 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.79" }
 wasm-bindgen-futures = "0.4.29"
 js-sys = "0.3"
 
 serde = "1"
 serde_json = "1"
+gloo-utils = { version = "0.1.6", features = ["serde"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/pkg/javascript/web/src/payload.rs
+++ b/pkg/javascript/web/src/payload.rs
@@ -1,10 +1,8 @@
 #![cfg(target_arch = "wasm32")]
 
 use {
-    gluesql_core::{
-        ast::ToSql,
-        prelude::{Payload, PayloadVariable},
-    },
+    gloo_utils::format::JsValueSerdeExt,
+    gluesql_core::prelude::{Payload, PayloadVariable},
     serde_json::{json, Value as Json},
     wasm_bindgen::prelude::JsValue,
 };

--- a/pkg/javascript/web/tests/payload.rs
+++ b/pkg/javascript/web/tests/payload.rs
@@ -3,6 +3,7 @@
 wasm_bindgen_test_configure!(run_in_browser);
 
 use {
+    gloo_utils::format::JsValueSerdeExt,
     gluesql_js::Glue,
     serde_json::{json, Value as Json},
     wasm_bindgen_futures::JsFuture,


### PR DESCRIPTION
Replace wasm-bindgen's deprecated APIs by gloo-utils