### PR TITLE
Add WebStorage - support localStorage & sessionStorage for web browsers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,3 +118,6 @@ jobs:
           yarn build
           yarn test:firefox
           cd ../../../
+          cd storages/web-storage
+          wasm-pack test --headless --firefox
+          cd ../../

--- a/storages/web-storage/Cargo.toml
+++ b/storages/web-storage/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "gluesql-web-storage"
+version = "0.13.0"
+edition = "2021"
+authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
+description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
+license = "Apache-2.0"
+repository = "https://github.com/gluesql/gluesql"
+documentation = "https://docs.rs/gluesql/"
+
+[dependencies]
+gluesql-core = { path = "../../core", version = "0.13.0" }
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+gloo-storage = "0.2.2"
+uuid = { version = "1.2.2", features = ["v4"] }
+web-sys = { version = "0.3.60" }
+
+[dev-dependencies]
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
+wasm-bindgen-test = "0.3.33"
+
+[features]
+default = [
+	"alter-table",
+	"index",
+	"transaction",
+]
+
+alter-table = ["gluesql-core/alter-table"]
+index = ["gluesql-core/index"]
+transaction = ["gluesql-core/transaction"]

--- a/storages/web-storage/README.md
+++ b/storages/web-storage/README.md
@@ -1,0 +1,8 @@
+## 🚴 WebStorage
+* localStorage
+* sessionStorage
+
+### 🔬 Test in Headless Browsers with `wasm-pack test`
+```
+wasm-pack test --headless --firefox --chrome
+```

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_arch = "wasm32")]
 #![deny(clippy::str_to_string)]
 
 use {

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -1,0 +1,232 @@
+#![deny(clippy::str_to_string)]
+
+use {
+    async_trait::async_trait,
+    gloo_storage::{errors::StorageError, LocalStorage, SessionStorage, Storage},
+    gluesql_core::{
+        data::{Key, Schema},
+        result::{Error, MutResult, Result, TrySelf},
+        store::{DataRow, RowIter, Store, StoreMut},
+    },
+    serde::{Deserialize, Serialize},
+    uuid::Uuid,
+};
+
+/// gluesql-schema-names -> {Vec<String>}
+const TABLE_NAMES_PATH: &str = "gluesql-schema-names";
+
+/// gluesql-schema/{schema_name} -> {Schema}
+const SCHEMA_PATH: &str = "gluesql-schema";
+
+/// gluesql-data/{table_name} -> {Vec<DataRow>}
+const DATA_PATH: &str = "gluesql-data";
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum WebStorageType {
+    Local,
+    Session,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct WebStorage {
+    storage_type: WebStorageType,
+}
+
+impl Default for WebStorage {
+    fn default() -> WebStorage {
+        WebStorage {
+            storage_type: WebStorageType::Local,
+        }
+    }
+}
+
+impl WebStorage {
+    pub fn new(storage_type: WebStorageType) -> Self {
+        Self { storage_type }
+    }
+
+    pub fn raw(&self) -> web_sys::Storage {
+        match self.storage_type {
+            WebStorageType::Local => LocalStorage::raw(),
+            WebStorageType::Session => SessionStorage::raw(),
+        }
+    }
+
+    pub fn get<T>(&self, key: impl AsRef<str>) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let value = match self.storage_type {
+            WebStorageType::Local => LocalStorage::get(key),
+            WebStorageType::Session => SessionStorage::get(key),
+        };
+
+        match value {
+            Ok(value) => Ok(Some(value)),
+            Err(StorageError::KeyNotFound(_)) => Ok(None),
+            Err(e) => Err(Error::StorageMsg(e.to_string())),
+        }
+    }
+
+    pub fn set<T>(&self, key: impl AsRef<str>, value: T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        match self.storage_type {
+            WebStorageType::Local => LocalStorage::set(key, value),
+            WebStorageType::Session => SessionStorage::set(key, value),
+        }
+        .map_err(|e| Error::StorageMsg(e.to_string()))
+    }
+
+    pub fn delete(&self, key: impl AsRef<str>) {
+        match self.storage_type {
+            WebStorageType::Local => LocalStorage::delete(key),
+            WebStorageType::Session => SessionStorage::delete(key),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Store for WebStorage {
+    async fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
+        let mut table_names: Vec<String> = self.get(TABLE_NAMES_PATH)?.unwrap_or_default();
+        table_names.sort();
+
+        table_names
+            .iter()
+            .filter_map(|table_name| {
+                self.get(format!("{}/{}", SCHEMA_PATH, table_name))
+                    .transpose()
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+
+    async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
+        self.get(format!("{}/{}", SCHEMA_PATH, table_name))
+    }
+
+    async fn fetch_data(&self, table_name: &str, target: &Key) -> Result<Option<DataRow>> {
+        let path = format!("{}/{}", DATA_PATH, table_name);
+        let row = self
+            .get::<Vec<(Key, DataRow)>>(path)?
+            .unwrap_or_default()
+            .into_iter()
+            .find_map(|(key, row)| (&key == target).then_some(row));
+
+        Ok(row)
+    }
+
+    async fn scan_data(&self, table_name: &str) -> Result<RowIter> {
+        let path = format!("{}/{}", DATA_PATH, table_name);
+        let rows = self
+            .get::<Vec<(Key, DataRow)>>(path)?
+            .unwrap_or_default()
+            .into_iter()
+            .map(Ok);
+
+        Ok(Box::new(rows))
+    }
+}
+
+impl WebStorage {
+    pub fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
+        let mut table_names: Vec<String> = self.get(TABLE_NAMES_PATH)?.unwrap_or_default();
+        table_names.push(schema.table_name.clone());
+
+        self.set(TABLE_NAMES_PATH, table_names)?;
+        self.set(format!("{}/{}", SCHEMA_PATH, schema.table_name), schema)
+    }
+
+    pub fn delete_schema(&mut self, table_name: &str) -> Result<()> {
+        let mut table_names: Vec<String> = self.get(TABLE_NAMES_PATH)?.unwrap_or_default();
+        table_names
+            .iter()
+            .position(|name| name == table_name)
+            .map(|i| table_names.remove(i));
+
+        self.set(TABLE_NAMES_PATH, table_names)?;
+        self.delete(format!("{}/{}", SCHEMA_PATH, table_name));
+        self.delete(format!("{}/{}", DATA_PATH, table_name));
+
+        Ok(())
+    }
+
+    pub fn append_data(&mut self, table_name: &str, new_rows: Vec<DataRow>) -> Result<()> {
+        let path = format!("{}/{}", DATA_PATH, table_name);
+        let rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
+        let new_rows = new_rows.into_iter().map(|row| {
+            let key = Key::Uuid(Uuid::new_v4().as_u128());
+
+            (key, row)
+        });
+
+        let rows = rows.into_iter().chain(new_rows).collect::<Vec<_>>();
+
+        self.set(path, rows)
+    }
+
+    pub fn insert_data(&mut self, table_name: &str, new_rows: Vec<(Key, DataRow)>) -> Result<()> {
+        let path = format!("{}/{}", DATA_PATH, table_name);
+        let mut rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
+
+        for (key, row) in new_rows.into_iter() {
+            if let Some(i) = rows.iter().position(|(k, _)| k == &key) {
+                rows[i] = (key, row);
+            } else {
+                rows.push((key, row));
+            }
+        }
+
+        self.set(path, rows)
+    }
+
+    pub fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
+        let path = format!("{}/{}", DATA_PATH, table_name);
+        let mut rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
+
+        for key in keys.iter() {
+            if let Some(i) = rows.iter().position(|(k, _)| k == key) {
+                rows.remove(i);
+            }
+        }
+
+        self.set(path, rows)
+    }
+}
+
+#[async_trait(?Send)]
+impl StoreMut for WebStorage {
+    async fn insert_schema(mut self, schema: &Schema) -> MutResult<Self, ()> {
+        WebStorage::insert_schema(&mut self, schema).try_self(self)
+    }
+
+    async fn delete_schema(mut self, table_name: &str) -> MutResult<Self, ()> {
+        WebStorage::delete_schema(&mut self, table_name).try_self(self)
+    }
+
+    async fn append_data(mut self, table_name: &str, rows: Vec<DataRow>) -> MutResult<Self, ()> {
+        WebStorage::append_data(&mut self, table_name, rows).try_self(self)
+    }
+
+    async fn insert_data(
+        mut self,
+        table_name: &str,
+        rows: Vec<(Key, DataRow)>,
+    ) -> MutResult<Self, ()> {
+        WebStorage::insert_data(&mut self, table_name, rows).try_self(self)
+    }
+
+    async fn delete_data(mut self, table_name: &str, keys: Vec<Key>) -> MutResult<Self, ()> {
+        WebStorage::delete_data(&mut self, table_name, keys).try_self(self)
+    }
+}
+
+#[cfg(feature = "alter-table")]
+impl gluesql_core::store::AlterTable for WebStorage {}
+#[cfg(feature = "index")]
+impl gluesql_core::store::Index for WebStorage {}
+#[cfg(feature = "index")]
+impl gluesql_core::store::IndexMut for WebStorage {}
+#[cfg(feature = "transaction")]
+impl gluesql_core::store::Transaction for WebStorage {}

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -22,23 +22,16 @@ const SCHEMA_PATH: &str = "gluesql-schema";
 /// gluesql-data/{table_name} -> {Vec<DataRow>}
 const DATA_PATH: &str = "gluesql-data";
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Serialize, Deserialize)]
 pub enum WebStorageType {
+    #[default]
     Local,
     Session,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct WebStorage {
     storage_type: WebStorageType,
-}
-
-impl Default for WebStorage {
-    fn default() -> WebStorage {
-        WebStorage {
-            storage_type: WebStorageType::Local,
-        }
-    }
 }
 
 impl WebStorage {

--- a/storages/web-storage/tests/local_storage.rs
+++ b/storages/web-storage/tests/local_storage.rs
@@ -3,9 +3,8 @@ use {
     gluesql_core::prelude::Glue,
     gluesql_web_storage::{WebStorage, WebStorageType},
     test_suite::*,
+    wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure},
 };
-
-use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/storages/web-storage/tests/local_storage.rs
+++ b/storages/web-storage/tests/local_storage.rs
@@ -1,0 +1,32 @@
+use {
+    async_trait::async_trait,
+    gluesql_core::prelude::Glue,
+    gluesql_web_storage::{WebStorage, WebStorageType},
+    test_suite::*,
+};
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+struct LocalStorageTester {
+    glue: Glue<WebStorage>,
+}
+
+#[async_trait(?Send)]
+impl Tester<WebStorage> for LocalStorageTester {
+    async fn new(_: &str) -> Self {
+        let storage = WebStorage::new(WebStorageType::Local);
+        storage.raw().clear().unwrap();
+
+        let glue = Glue::new(storage);
+
+        LocalStorageTester { glue }
+    }
+
+    fn get_glue(&mut self) -> &mut Glue<WebStorage> {
+        &mut self.glue
+    }
+}
+
+generate_store_tests!(wasm_bindgen_test, LocalStorageTester);

--- a/storages/web-storage/tests/local_storage.rs
+++ b/storages/web-storage/tests/local_storage.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use {
     async_trait::async_trait,
     gluesql_core::prelude::Glue,

--- a/storages/web-storage/tests/session_storage.rs
+++ b/storages/web-storage/tests/session_storage.rs
@@ -3,9 +3,8 @@ use {
     gluesql_core::prelude::Glue,
     gluesql_web_storage::{WebStorage, WebStorageType},
     test_suite::*,
+    wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure},
 };
-
-use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/storages/web-storage/tests/session_storage.rs
+++ b/storages/web-storage/tests/session_storage.rs
@@ -1,0 +1,32 @@
+use {
+    async_trait::async_trait,
+    gluesql_core::prelude::Glue,
+    gluesql_web_storage::{WebStorage, WebStorageType},
+    test_suite::*,
+};
+
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+struct SessionStorageTester {
+    glue: Glue<WebStorage>,
+}
+
+#[async_trait(?Send)]
+impl Tester<WebStorage> for SessionStorageTester {
+    async fn new(_: &str) -> Self {
+        let storage = WebStorage::new(WebStorageType::Session);
+        storage.raw().clear().unwrap();
+
+        let glue = Glue::new(storage);
+
+        SessionStorageTester { glue }
+    }
+
+    fn get_glue(&mut self) -> &mut Glue<WebStorage> {
+        &mut self.glue
+    }
+}
+
+generate_store_tests!(wasm_bindgen_test, SessionStorageTester);

--- a/storages/web-storage/tests/session_storage.rs
+++ b/storages/web-storage/tests/session_storage.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use {
     async_trait::async_trait,
     gluesql_core::prelude::Glue,


### PR DESCRIPTION
WebStorage includes two storages
- localStorage
- sessionStorage

This PR only verifies the storage implementation.
It does not have gluesql javascript interface integration that will be done separately.