### PR TITLE
Fix `plan::validate` to handle `CTAS` and `ITAS` adding unit test

### DIFF
--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -202,8 +202,16 @@ fn validate_test() {
                 amount INTEGER
             );
         ");
-    let sql = "INSERT INTO Player VALUES(1, 'a');";
-    let (schema_map, statement) = plan(&storage, sql);
 
+    let sql = "INSERT INTO Player VALUES(1, 'a')";
+    let (schema_map, statement) = plan(&storage, sql);
+    assert!(contextualize_stmt(&schema_map, &statement).is_some());
+
+    let sql = "DROP TABLE Player";
+    let (schema_map, statement) = plan(&storage, sql);
+    assert!(contextualize_stmt(&schema_map, &statement).is_some());
+
+    let sql = "SELECT * FROM (SELECT * FROM SERIES(3))";
+    let (schema_map, statement) = plan(&storage, sql);
     assert!(contextualize_stmt(&schema_map, &statement).is_some());
 }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -171,36 +171,39 @@ fn contextualize_table_factor<'a>(
     .map(Rc::from)
 }
 
-#[test]
-fn validate_test() {
+#[cfg(test)]
+mod tests {
     use {
         crate::{
-            plan::{fetch_schema_map, mock::run},
+            plan::{fetch_schema_map, mock::run, validate},
             prelude::{parse, translate},
         },
         futures::executor::block_on,
     };
 
-    let storage = run("
+    #[test]
+    fn validate_test() {
+        let storage = run("
             CREATE TABLE Items (
                 id INTEGER,
                 name TEXT
             );
         ");
 
-    let cases = [
-        ("INSERT INTO Items VALUES(1, 'a')", true),
-        ("SELECT * FROM (SELECT * FROM Items) AS Sub", true),
-        ("SELECT * FROM SERIES(3)", true),
-        ("DROP TABLE Items", true),
-    ];
+        let cases = [
+            ("INSERT INTO Items VALUES(1, 'a')", true),
+            ("SELECT * FROM (SELECT * FROM Items) AS Sub", true),
+            ("SELECT * FROM SERIES(3)", true),
+            ("DROP TABLE Items", true),
+        ];
 
-    for (sql, expected) in cases {
-        let parsed = parse(sql).expect(sql).into_iter().next().unwrap();
-        let statement = translate(&parsed).unwrap();
-        let schema_map = block_on(fetch_schema_map(&storage, &statement)).unwrap();
-        let actual = validate(&schema_map, &statement).is_ok();
+        for (sql, expected) in cases {
+            let parsed = parse(sql).expect(sql).into_iter().next().unwrap();
+            let statement = translate(&parsed).unwrap();
+            let schema_map = block_on(fetch_schema_map(&storage, &statement)).unwrap();
+            let actual = validate(&schema_map, &statement).is_ok();
 
-        assert_eq!(actual, expected)
+            assert_eq!(actual, expected)
+        }
     }
 }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -5,7 +5,7 @@ use {
         data::Schema,
         result::Result,
     },
-    std::{collections::HashMap, ops::Deref, rc::Rc},
+    std::{collections::HashMap, rc::Rc},
 };
 
 type SchemaMap = HashMap<String, Schema>;
@@ -14,7 +14,7 @@ pub fn validate(schema_map: &SchemaMap, statement: &Statement) -> Result<()> {
     let query = match statement {
         Statement::Query(query) => Some(query),
         Statement::Insert { source, .. } => Some(source),
-        Statement::CreateTable { source, .. } => source.as_ref().map(Deref::deref),
+        Statement::CreateTable { source, .. } => source.as_deref(),
         _ => None,
     };
 

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -192,26 +192,25 @@ fn validate_test() {
     }
 
     let storage = run("
-            CREATE TABLE Player (
+            CREATE TABLE Items (
                 id INTEGER,
                 name TEXT
             );
-            CREATE TABLE PlayerItem (
-                user_id INTEGER,
-                item_id INTEGER,
-                amount INTEGER
-            );
         ");
 
-    let sql = "INSERT INTO Player VALUES(1, 'a')";
+    let sql = "INSERT INTO Items VALUES(1, 'a')";
     let (schema_map, statement) = plan(&storage, sql);
     assert!(contextualize_stmt(&schema_map, &statement).is_some());
 
-    let sql = "DROP TABLE Player";
+    let sql = "SELECT * FROM (SELECT * FROM Items) AS Sub";
     let (schema_map, statement) = plan(&storage, sql);
     assert!(contextualize_stmt(&schema_map, &statement).is_some());
 
-    let sql = "SELECT * FROM (SELECT * FROM SERIES(3))";
+    let sql = "SELECT * FROM SERIES(3)";
+    let (schema_map, statement) = plan(&storage, sql);
+    assert!(contextualize_stmt(&schema_map, &statement).is_none());
+
+    let sql = "DROP TABLE Items";
     let (schema_map, statement) = plan(&storage, sql);
     assert!(contextualize_stmt(&schema_map, &statement).is_some());
 }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -121,9 +121,6 @@ fn contextualize_query<'a>(schema_map: &'a SchemaMap, query: &'a Query) -> Optio
                 .map(|Join { relation, .. }| contextualize_table_factor(schema_map, relation))
                 .fold(None, Context::concat);
 
-            println!("table{by_table:#?}");
-            println!("join{by_joins:#?}");
-            println!("schema_map{schema_map:#?}");
             Context::concat(by_table, by_joins)
         }
         SetExpr::Values(_) => None,

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -41,7 +41,6 @@ pub fn validate(schema_map: &SchemaMap, statement: &Statement) -> Result<()> {
     Ok(())
 }
 
-#[derive(PartialEq, Debug)]
 enum Context<'a> {
     Data {
         labels: Option<Vec<&'a String>>,

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -276,6 +276,14 @@ test_case!(project, async move {
             PlanError::ColumnReferenceAmbiguous("id".to_owned()).into(),
         ),
         (
+            "INSERT INTO Users SELECT id FROM Users A JOIN Users B on A.id = B.id",
+            PlanError::ColumnReferenceAmbiguous("id".to_owned()).into(),
+        ),
+        (
+            "CREATE TABLE Ids AS SELECT id FROM Users A JOIN Users B on A.id = B.id",
+            PlanError::ColumnReferenceAmbiguous("id".to_owned()).into(),
+        ),
+        (
             "SELECT * FROM ProjectUser, ProjectItem",
             TranslateError::TooManyTables.into(),
         ),


### PR DESCRIPTION
## Goal
Include source queries of `CTAS` and `ITAS` at `plane::validate`
```sql
CREATE TABLE Ids AS SELECT id FROM Users A JOIN Users B on A.id = B.id;
INSERT INTO Users SELECT id FROM Users A JOIN Users B on A.id = B.id;
```
## Todo
- [x] add unit test cases
- [x] add E2E test cases
- [x] fix plan::validate to handle `CTAS` and `ITAS`
- [x] fix fetch_schema_map to handle `CTAS`

## Next
- Right after implementing implicit join or update join, they should be validated as well
