### PR TITLE
Replace `async-recursion` crate to `LocalBoxFuture`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,6 @@ utils = { package = "gluesql-utils", path = "../utils", version = "0.13.0" }
 
 regex = "1"
 async-trait = "0.1"
-async-recursion = "1"
 cfg-if = "1"
 futures-enum = "0.1.17"
 futures = "0.3"

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -23,257 +23,267 @@ use {
 
 pub use {error::EvaluateError, evaluated::Evaluated, stateless::evaluate_stateless};
 
-pub fn evaluate<'async_recursion, 'storage, 'context, 'aggregate, T: GStore>(
+pub fn evaluate<'storage, 'context, 'aggregate, T: GStore>(
     storage: &'storage T,
     context: Option<Rc<RowContext<'context>>>,
     aggregated: Option<Rc<HashMap<&'aggregate Aggregate, Value>>>,
     expr: &'storage Expr,
-) -> LocalBoxFuture<'async_recursion, Result<Evaluated<'storage>>>
+) -> LocalBoxFuture<'storage, Result<Evaluated<'storage>>>
 where
-    'storage: 'async_recursion,
     'context: 'storage,
     'aggregate: 'storage,
 {
-    Box::pin(async move {
-        let eval = |expr| {
+    Box::pin(evaluate_inner(storage, context, aggregated, expr))
+}
+
+async fn evaluate_inner<'storage, 'context, 'aggregate, T: GStore>(
+    storage: &'storage T,
+    context: Option<Rc<RowContext<'context>>>,
+    aggregated: Option<Rc<HashMap<&'aggregate Aggregate, Value>>>,
+    expr: &'storage Expr,
+) -> Result<Evaluated<'storage>>
+where
+    'context: 'storage,
+    'aggregate: 'storage,
+{
+    let eval = |expr| {
+        let context = context.as_ref().map(Rc::clone);
+        let aggregated = aggregated.as_ref().map(Rc::clone);
+
+        evaluate(storage, context, aggregated, expr)
+    };
+
+    match expr {
+        Expr::Literal(ast_literal) => expr::literal(ast_literal),
+        Expr::TypedString { data_type, value } => {
+            expr::typed_string(data_type, Cow::Borrowed(value))
+        }
+        Expr::Identifier(ident) => {
+            let context = context.ok_or(EvaluateError::UnreachableEmptyContext)?;
+
+            match context.get_value(ident) {
+                Some(value) => Ok(value.clone()),
+                None => Err(EvaluateError::ValueNotFound(ident.to_owned()).into()),
+            }
+            .map(Evaluated::from)
+        }
+        Expr::Nested(expr) => eval(expr).await,
+        Expr::CompoundIdentifier { alias, ident } => {
+            let table_alias = &alias;
+            let column = &ident;
+            let context = context.ok_or(EvaluateError::UnreachableEmptyContext)?;
+
+            match context.get_alias_value(table_alias, column) {
+                Some(value) => Ok(value.clone()),
+                None => Err(EvaluateError::ValueNotFound(column.to_string()).into()),
+            }
+            .map(Evaluated::from)
+        }
+        Expr::Subquery(query) => {
+            let evaluations = select(storage, query, context.as_ref().map(Rc::clone))
+                .await?
+                .map(|row| {
+                    let value = match row? {
+                        Row::Vec { values, .. } => values,
+                        Row::Map(_) => {
+                            return Err(EvaluateError::SchemalessProjectionForSubQuery.into());
+                        }
+                    }
+                    .into_iter()
+                    .next();
+
+                    Ok::<_, Error>(value)
+                })
+                .take(2)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            if evaluations.len() > 1 {
+                return Err(EvaluateError::MoreThanOneRowReturned.into());
+            }
+
+            let value = evaluations
+                .into_iter()
+                .next()
+                .flatten()
+                .unwrap_or(Value::Null);
+
+            Ok(Evaluated::from(value))
+        }
+        Expr::BinaryOp { op, left, right } => {
+            let left = eval(left).await?;
+            let right = eval(right).await?;
+
+            expr::binary_op(op, left, right)
+        }
+        Expr::UnaryOp { op, expr } => {
+            let v = eval(expr).await?;
+
+            expr::unary_op(op, v)
+        }
+        Expr::Aggregate(aggr) => match aggregated
+            .as_ref()
+            .and_then(|aggregated| aggregated.get(aggr.as_ref()))
+        {
+            Some(value) => Ok(Evaluated::from(value.clone())),
+            None => Err(EvaluateError::UnreachableEmptyAggregateValue(*aggr.clone()).into()),
+        },
+        Expr::Function(func) => {
             let context = context.as_ref().map(Rc::clone);
             let aggregated = aggregated.as_ref().map(Rc::clone);
 
-            evaluate(storage, context, aggregated, expr)
-        };
+            evaluate_function(storage, context, aggregated, func).await
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            let negated = *negated;
+            let target = eval(expr).await?;
 
-        match expr {
-            Expr::Literal(ast_literal) => expr::literal(ast_literal),
-            Expr::TypedString { data_type, value } => {
-                expr::typed_string(data_type, Cow::Borrowed(value))
-            }
-            Expr::Identifier(ident) => {
-                let context = context.ok_or(EvaluateError::UnreachableEmptyContext)?;
-
-                match context.get_value(ident) {
-                    Some(value) => Ok(value.clone()),
-                    None => Err(EvaluateError::ValueNotFound(ident.to_owned()).into()),
-                }
-                .map(Evaluated::from)
-            }
-            Expr::Nested(expr) => eval(expr).await,
-            Expr::CompoundIdentifier { alias, ident } => {
-                let table_alias = &alias;
-                let column = &ident;
-                let context = context.ok_or(EvaluateError::UnreachableEmptyContext)?;
-
-                match context.get_alias_value(table_alias, column) {
-                    Some(value) => Ok(value.clone()),
-                    None => Err(EvaluateError::ValueNotFound(column.to_string()).into()),
-                }
-                .map(Evaluated::from)
-            }
-            Expr::Subquery(query) => {
-                let evaluations = select(storage, query, context.as_ref().map(Rc::clone))
-                    .await?
-                    .map(|row| {
-                        let value = match row? {
-                            Row::Vec { values, .. } => values,
-                            Row::Map(_) => {
-                                return Err(EvaluateError::SchemalessProjectionForSubQuery.into());
-                            }
-                        }
-                        .into_iter()
-                        .next();
-
-                        Ok::<_, Error>(value)
-                    })
-                    .take(2)
-                    .try_collect::<Vec<_>>()
-                    .await?;
-
-                if evaluations.len() > 1 {
-                    return Err(EvaluateError::MoreThanOneRowReturned.into());
-                }
-
-                let value = evaluations
-                    .into_iter()
-                    .next()
-                    .flatten()
-                    .unwrap_or(Value::Null);
-
-                Ok(Evaluated::from(value))
-            }
-            Expr::BinaryOp { op, left, right } => {
-                let left = eval(left).await?;
-                let right = eval(right).await?;
-
-                expr::binary_op(op, left, right)
-            }
-            Expr::UnaryOp { op, expr } => {
-                let v = eval(expr).await?;
-
-                expr::unary_op(op, v)
-            }
-            Expr::Aggregate(aggr) => match aggregated
-                .as_ref()
-                .and_then(|aggregated| aggregated.get(aggr.as_ref()))
-            {
-                Some(value) => Ok(Evaluated::from(value.clone())),
-                None => Err(EvaluateError::UnreachableEmptyAggregateValue(*aggr.clone()).into()),
-            },
-            Expr::Function(func) => {
-                let context = context.as_ref().map(Rc::clone);
-                let aggregated = aggregated.as_ref().map(Rc::clone);
-
-                evaluate_function(storage, context, aggregated, func).await
-            }
-            Expr::InList {
-                expr,
-                list,
-                negated,
-            } => {
-                let negated = *negated;
-                let target = eval(expr).await?;
-
-                stream::iter(list)
-                    .then(eval)
-                    .try_filter(|evaluated| ready(evaluated == &target))
-                    .try_next()
-                    .await
-                    .map(|v| v.is_some() ^ negated)
-                    .map(Value::Bool)
-                    .map(Evaluated::from)
-            }
-            Expr::InSubquery {
-                expr,
-                subquery,
-                negated,
-            } => {
-                let target = eval(expr).await?;
-
-                select(storage, subquery, context)
-                    .await?
-                    .map(|row| {
-                        let value = match row? {
-                            Row::Vec { values, .. } => values,
-                            Row::Map(_) => {
-                                return Err(EvaluateError::SchemalessProjectionForInSubQuery.into());
-                            }
-                        }
-                        .into_iter()
-                        .next()
-                        .unwrap_or(Value::Null);
-
-                        Ok(Evaluated::from(value))
-                    })
-                    .try_filter(|evaluated| ready(evaluated == &target))
-                    .try_next()
-                    .await
-                    .map(|v| v.is_some() ^ negated)
-                    .map(Value::Bool)
-                    .map(Evaluated::from)
-            }
-            Expr::Between {
-                expr,
-                negated,
-                low,
-                high,
-            } => {
-                let target = eval(expr).await?;
-                let low = eval(low).await?;
-                let high = eval(high).await?;
-
-                expr::between(target, *negated, low, high)
-            }
-            Expr::Like {
-                expr,
-                negated,
-                pattern,
-            } => {
-                let target = eval(expr).await?;
-                let pattern = eval(pattern).await?;
-                let evaluated = target.like(pattern, true)?;
-
-                Ok(match negated {
-                    true => Evaluated::from(Value::Bool(
-                        evaluated == Evaluated::Literal(Literal::Boolean(false)),
-                    )),
-                    false => evaluated,
-                })
-            }
-            Expr::ILike {
-                expr,
-                negated,
-                pattern,
-            } => {
-                let target = eval(expr).await?;
-                let pattern = eval(pattern).await?;
-                let evaluated = target.like(pattern, false)?;
-
-                Ok(match negated {
-                    true => Evaluated::from(Value::Bool(
-                        evaluated == Evaluated::Literal(Literal::Boolean(false)),
-                    )),
-                    false => evaluated,
-                })
-            }
-            Expr::Exists { subquery, negated } => select(storage, subquery, context)
-                .await?
+            stream::iter(list)
+                .then(eval)
+                .try_filter(|evaluated| ready(evaluated == &target))
                 .try_next()
                 .await
                 .map(|v| v.is_some() ^ negated)
                 .map(Value::Bool)
-                .map(Evaluated::from),
-            Expr::IsNull(expr) => {
-                let v = eval(expr).await?.is_null();
+                .map(Evaluated::from)
+        }
+        Expr::InSubquery {
+            expr,
+            subquery,
+            negated,
+        } => {
+            let target = eval(expr).await?;
 
-                Ok(Evaluated::from(Value::Bool(v)))
-            }
-            Expr::IsNotNull(expr) => {
-                let v = eval(expr).await?.is_null();
-
-                Ok(Evaluated::from(Value::Bool(!v)))
-            }
-            Expr::Case {
-                operand,
-                when_then,
-                else_result,
-            } => {
-                let operand = match operand {
-                    Some(op) => eval(op).await?,
-                    None => Evaluated::from(Value::Bool(true)),
-                };
-
-                for (when, then) in when_then.iter() {
-                    let when = eval(when).await?;
-
-                    if when.eq(&operand) {
-                        return eval(then).await;
+            select(storage, subquery, context)
+                .await?
+                .map(|row| {
+                    let value = match row? {
+                        Row::Vec { values, .. } => values,
+                        Row::Map(_) => {
+                            return Err(EvaluateError::SchemalessProjectionForInSubQuery.into());
+                        }
                     }
-                }
+                    .into_iter()
+                    .next()
+                    .unwrap_or(Value::Null);
 
-                match else_result {
-                    Some(er) => eval(er).await,
-                    None => Ok(Evaluated::from(Value::Null)),
+                    Ok(Evaluated::from(value))
+                })
+                .try_filter(|evaluated| ready(evaluated == &target))
+                .try_next()
+                .await
+                .map(|v| v.is_some() ^ negated)
+                .map(Value::Bool)
+                .map(Evaluated::from)
+        }
+        Expr::Between {
+            expr,
+            negated,
+            low,
+            high,
+        } => {
+            let target = eval(expr).await?;
+            let low = eval(low).await?;
+            let high = eval(high).await?;
+
+            expr::between(target, *negated, low, high)
+        }
+        Expr::Like {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr).await?;
+            let pattern = eval(pattern).await?;
+            let evaluated = target.like(pattern, true)?;
+
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
+        }
+        Expr::ILike {
+            expr,
+            negated,
+            pattern,
+        } => {
+            let target = eval(expr).await?;
+            let pattern = eval(pattern).await?;
+            let evaluated = target.like(pattern, false)?;
+
+            Ok(match negated {
+                true => Evaluated::from(Value::Bool(
+                    evaluated == Evaluated::Literal(Literal::Boolean(false)),
+                )),
+                false => evaluated,
+            })
+        }
+        Expr::Exists { subquery, negated } => select(storage, subquery, context)
+            .await?
+            .try_next()
+            .await
+            .map(|v| v.is_some() ^ negated)
+            .map(Value::Bool)
+            .map(Evaluated::from),
+        Expr::IsNull(expr) => {
+            let v = eval(expr).await?.is_null();
+
+            Ok(Evaluated::from(Value::Bool(v)))
+        }
+        Expr::IsNotNull(expr) => {
+            let v = eval(expr).await?.is_null();
+
+            Ok(Evaluated::from(Value::Bool(!v)))
+        }
+        Expr::Case {
+            operand,
+            when_then,
+            else_result,
+        } => {
+            let operand = match operand {
+                Some(op) => eval(op).await?,
+                None => Evaluated::from(Value::Bool(true)),
+            };
+
+            for (when, then) in when_then.iter() {
+                let when = eval(when).await?;
+
+                if when.eq(&operand) {
+                    return eval(then).await;
                 }
             }
-            Expr::ArrayIndex { obj, indexes } => {
-                let obj = eval(obj).await?;
-                let indexes = try_join_all(indexes.iter().map(eval)).await?;
-                expr::array_index(obj, indexes)
-            }
-            Expr::Interval {
-                expr,
-                leading_field,
-                last_field,
-            } => {
-                let value = eval(expr)
-                    .await
-                    .and_then(Value::try_from)
-                    .map(String::from)?;
 
-                Interval::try_from_literal(&value, *leading_field, *last_field)
-                    .map(Value::Interval)
-                    .map(Evaluated::from)
+            match else_result {
+                Some(er) => eval(er).await,
+                None => Ok(Evaluated::from(Value::Null)),
             }
         }
-    })
+        Expr::ArrayIndex { obj, indexes } => {
+            let obj = eval(obj).await?;
+            let indexes = try_join_all(indexes.iter().map(eval)).await?;
+            expr::array_index(obj, indexes)
+        }
+        Expr::Interval {
+            expr,
+            leading_field,
+            last_field,
+        } => {
+            let value = eval(expr)
+                .await
+                .and_then(Value::try_from)
+                .map(String::from)?;
+
+            Interval::try_from_literal(&value, *leading_field, *last_field)
+                .map(Value::Interval)
+                .map(Evaluated::from)
+        }
+    }
 }
 
 async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -354,123 +354,125 @@ pub async fn fetch_columns<T: GStore>(
     Ok(columns)
 }
 
-pub fn fetch_relation_columns<'async_recursion, 'storage, T: GStore>(
+pub fn fetch_relation_columns<'storage, T: GStore>(
     storage: &'storage T,
     table_factor: &'storage TableFactor,
-) -> LocalBoxFuture<'async_recursion, Result<Option<Vec<String>>>>
-where
-    'storage: 'async_recursion,
-{
-    Box::pin(async move {
-        match table_factor {
-            TableFactor::Table { name, alias, .. } => {
-                let columns = fetch_columns(storage, name).await?;
-                match (columns, alias) {
-                    (columns, None) => Ok(columns),
-                    (None, Some(_)) => Ok(None),
-                    (Some(columns), Some(alias)) if alias.columns.len() > columns.len() => {
+) -> LocalBoxFuture<'storage, Result<Option<Vec<String>>>> {
+    Box::pin(fetch_relation_columns_inner(storage, table_factor))
+}
+
+async fn fetch_relation_columns_inner<'storage, T: GStore>(
+    storage: &'storage T,
+    table_factor: &'storage TableFactor,
+) -> Result<Option<Vec<String>>> {
+    match table_factor {
+        TableFactor::Table { name, alias, .. } => {
+            let columns = fetch_columns(storage, name).await?;
+            match (columns, alias) {
+                (columns, None) => Ok(columns),
+                (None, Some(_)) => Ok(None),
+                (Some(columns), Some(alias)) if alias.columns.len() > columns.len() => {
+                    Err(FetchError::TooManyColumnAliases(
+                        name.to_string(),
+                        columns.len(),
+                        alias.columns.len(),
+                    )
+                    .into())
+                }
+                (Some(columns), Some(alias)) => Ok(Some(
+                    alias
+                        .columns
+                        .iter()
+                        .cloned()
+                        .chain(columns[alias.columns.len()..columns.len()].to_vec())
+                        .collect(),
+                )),
+            }
+        }
+        TableFactor::Series { .. } => Ok(Some(vec!["N".to_owned()])),
+        TableFactor::Dictionary { dict, .. } => Ok(Some(match dict {
+            Dictionary::GlueObjects => vec![
+                "OBJECT_NAME".to_owned(),
+                "OBJECT_TYPE".to_owned(),
+                "CREATED".to_owned(),
+            ],
+            Dictionary::GlueTables => vec!["TABLE_NAME".to_owned()],
+            Dictionary::GlueTableColumns => vec![
+                "TABLE_NAME".to_owned(),
+                "COLUMN_NAME".to_owned(),
+                "COLUMN_ID".to_owned(),
+            ],
+            Dictionary::GlueIndexes => vec![
+                "TABLE_NAME".to_owned(),
+                "INDEX_NAME".to_owned(),
+                "ORDER".to_owned(),
+                "EXPRESSION".to_owned(),
+                "UNIQUENESS".to_owned(),
+            ],
+        })),
+        TableFactor::Derived {
+            subquery: Query { body, .. },
+            alias:
+                TableAlias {
+                    columns: alias_columns,
+                    name,
+                },
+        } => match body {
+            SetExpr::Select(statement) => {
+                let Select {
+                    from:
+                        TableWithJoins {
+                            relation, joins, ..
+                        },
+                    projection,
+                    ..
+                } = statement.as_ref();
+
+                let labels = fetch_labels(storage, relation, joins, projection).await?;
+                match labels {
+                    None => Ok(None),
+                    Some(labels) if alias_columns.is_empty() => Ok(Some(labels)),
+                    Some(labels) if alias_columns.len() > labels.len() => {
                         Err(FetchError::TooManyColumnAliases(
                             name.to_string(),
-                            columns.len(),
-                            alias.columns.len(),
+                            labels.len(),
+                            alias_columns.len(),
                         )
                         .into())
                     }
-                    (Some(columns), Some(alias)) => Ok(Some(
-                        alias
-                            .columns
+                    Some(labels) => Ok(Some(
+                        alias_columns
                             .iter()
                             .cloned()
-                            .chain(columns[alias.columns.len()..columns.len()].to_vec())
+                            .chain(labels[alias_columns.len()..labels.len()].to_vec())
                             .collect(),
                     )),
                 }
             }
-            TableFactor::Series { .. } => Ok(Some(vec!["N".to_owned()])),
-            TableFactor::Dictionary { dict, .. } => Ok(Some(match dict {
-                Dictionary::GlueObjects => vec![
-                    "OBJECT_NAME".to_owned(),
-                    "OBJECT_TYPE".to_owned(),
-                    "CREATED".to_owned(),
-                ],
-                Dictionary::GlueTables => vec!["TABLE_NAME".to_owned()],
-                Dictionary::GlueTableColumns => vec![
-                    "TABLE_NAME".to_owned(),
-                    "COLUMN_NAME".to_owned(),
-                    "COLUMN_ID".to_owned(),
-                ],
-                Dictionary::GlueIndexes => vec![
-                    "TABLE_NAME".to_owned(),
-                    "INDEX_NAME".to_owned(),
-                    "ORDER".to_owned(),
-                    "EXPRESSION".to_owned(),
-                    "UNIQUENESS".to_owned(),
-                ],
-            })),
-            TableFactor::Derived {
-                subquery: Query { body, .. },
-                alias:
-                    TableAlias {
-                        columns: alias_columns,
-                        name,
-                    },
-            } => match body {
-                SetExpr::Select(statement) => {
-                    let Select {
-                        from:
-                            TableWithJoins {
-                                relation, joins, ..
-                            },
-                        projection,
-                        ..
-                    } = statement.as_ref();
-
-                    let labels = fetch_labels(storage, relation, joins, projection).await?;
-                    match labels {
-                        None => Ok(None),
-                        Some(labels) if alias_columns.is_empty() => Ok(Some(labels)),
-                        Some(labels) if alias_columns.len() > labels.len() => {
-                            Err(FetchError::TooManyColumnAliases(
-                                name.to_string(),
-                                labels.len(),
-                                alias_columns.len(),
-                            )
-                            .into())
-                        }
-                        Some(labels) => Ok(Some(
-                            alias_columns
-                                .iter()
-                                .cloned()
-                                .chain(labels[alias_columns.len()..labels.len()].to_vec())
-                                .collect(),
-                        )),
-                    }
+            SetExpr::Values(Values(values_list)) => {
+                let total_len = values_list[0].len();
+                let alias_len = alias_columns.len();
+                if alias_len > total_len {
+                    return Err(FetchError::TooManyColumnAliases(
+                        name.into(),
+                        total_len,
+                        alias_len,
+                    )
+                    .into());
                 }
-                SetExpr::Values(Values(values_list)) => {
-                    let total_len = values_list[0].len();
-                    let alias_len = alias_columns.len();
-                    if alias_len > total_len {
-                        return Err(FetchError::TooManyColumnAliases(
-                            name.into(),
-                            total_len,
-                            alias_len,
-                        )
-                        .into());
-                    }
-                    let labels = (alias_len + 1..=total_len)
-                        .into_iter()
-                        .map(|i| format!("column{}", i));
-                    let labels = alias_columns
-                        .iter()
-                        .cloned()
-                        .chain(labels)
-                        .collect::<Vec<_>>();
+                let labels = (alias_len + 1..=total_len)
+                    .into_iter()
+                    .map(|i| format!("column{}", i));
+                let labels = alias_columns
+                    .iter()
+                    .cloned()
+                    .chain(labels)
+                    .collect::<Vec<_>>();
 
-                    Ok(Some(labels))
-                }
-            },
-        }
-    })
+                Ok(Some(labels))
+            }
+        },
+    }
 }
 
 async fn fetch_join_columns<'a, T: GStore>(

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -107,112 +107,124 @@ fn sort_stateless(rows: Vec<Result<Row>>, order_by: &[OrderByExpr]) -> Result<Ve
     Ok(sorted)
 }
 
-pub fn select_with_labels<'async_recursion, 'storage, T: GStore>(
+pub fn select_with_labels<'storage, 'context, T: GStore>(
     storage: &'storage T,
     query: &'storage Query,
-    filter_context: Option<Rc<RowContext<'storage>>>,
+    filter_context: Option<Rc<RowContext<'context>>>,
 ) -> LocalBoxFuture<
-    'async_recursion,
+    'storage,
     Result<(
         Option<Vec<String>>,
         impl TryStream<Ok = Row, Error = Error, Item = Result<Row>> + 'storage,
     )>,
 >
 where
-    'storage: 'async_recursion,
+    'context: 'storage,
 {
-    Box::pin(async move {
-        let Select {
-            from: table_with_joins,
-            selection: where_clause,
-            projection,
-            group_by,
-            having,
-        } = match &query.body {
-            SetExpr::Select(statement) => statement.as_ref(),
-            SetExpr::Values(Values(values_list)) => {
-                let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-                let (rows, labels) = rows_with_labels(values_list);
-                let rows = sort_stateless(rows, &query.order_by)?;
-                let rows = stream::iter(rows);
-                let rows = limit.apply(rows);
+    Box::pin(select_with_labels_inner(storage, query, filter_context))
+}
 
-                return Ok((Some(labels), rows));
-            }
-        };
+async fn select_with_labels_inner<'storage, 'context, T: GStore>(
+    storage: &'storage T,
+    query: &'storage Query,
+    filter_context: Option<Rc<RowContext<'context>>>,
+) -> Result<(
+    Option<Vec<String>>,
+    impl TryStream<Ok = Row, Error = Error, Item = Result<Row>> + 'storage,
+)>
+where
+    'context: 'storage,
+{
+    let Select {
+        from: table_with_joins,
+        selection: where_clause,
+        projection,
+        group_by,
+        having,
+    } = match &query.body {
+        SetExpr::Select(statement) => statement.as_ref(),
+        SetExpr::Values(Values(values_list)) => {
+            let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
+            let (rows, labels) = rows_with_labels(values_list);
+            let rows = sort_stateless(rows, &query.order_by)?;
+            let rows = stream::iter(rows);
+            let rows = limit.apply(rows);
 
-        let TableWithJoins { relation, joins } = &table_with_joins;
-        let rows = fetch_relation_rows(storage, relation, &None)
-            .await?
-            .map(move |row| {
-                let row = row?;
-                let alias = get_alias(relation);
+            return Ok((Some(labels), rows));
+        }
+    };
 
-                Ok(RowContext::new(alias, Cow::Owned(row), None))
-            });
+    let TableWithJoins { relation, joins } = &table_with_joins;
+    let rows = fetch_relation_rows(storage, relation, &None)
+        .await?
+        .map(move |row| {
+            let row = row?;
+            let alias = get_alias(relation);
 
-        let join = Join::new(storage, joins, filter_context.as_ref().map(Rc::clone));
-        let aggregate = Aggregator::new(
-            storage,
-            projection,
-            group_by,
-            having.as_ref(),
-            filter_context.as_ref().map(Rc::clone),
-        );
-        let filter = Rc::new(Filter::new(
-            storage,
-            where_clause.as_ref(),
-            filter_context.as_ref().map(Rc::clone),
-            None,
-        ));
-        let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
-        let sort = Sort::new(
-            storage,
-            filter_context.as_ref().map(Rc::clone),
-            &query.order_by,
-        );
-
-        let rows = join.apply(rows).await?;
-        let rows = rows.try_filter_map(move |project_context| {
-            let filter = Rc::clone(&filter);
-
-            async move {
-                filter
-                    .check(Rc::clone(&project_context))
-                    .await
-                    .map(|pass| pass.then_some(project_context))
-            }
+            Ok(RowContext::new(alias, Cow::Owned(row), None))
         });
 
-        let rows = aggregate.apply(rows).await?;
+    let join = Join::new(storage, joins, filter_context.as_ref().map(Rc::clone));
+    let aggregate = Aggregator::new(
+        storage,
+        projection,
+        group_by,
+        having.as_ref(),
+        filter_context.as_ref().map(Rc::clone),
+    );
+    let filter = Rc::new(Filter::new(
+        storage,
+        where_clause.as_ref(),
+        filter_context.as_ref().map(Rc::clone),
+        None,
+    ));
+    let limit = Limit::new(query.limit.as_ref(), query.offset.as_ref())?;
+    let sort = Sort::new(
+        storage,
+        filter_context.as_ref().map(Rc::clone),
+        &query.order_by,
+    );
 
-        let labels = fetch_labels(storage, relation, joins, projection)
-            .await?
-            .map(Rc::from);
+    let rows = join.apply(rows).await?;
+    let rows = rows.try_filter_map(move |project_context| {
+        let filter = Rc::clone(&filter);
 
-        let project = Rc::new(Project::new(storage, filter_context, projection));
-        let project_labels = labels.as_ref().map(Rc::clone);
-        let rows = rows.and_then(move |aggregate_context| {
-            let labels = project_labels.as_ref().map(Rc::clone);
-            let project = Rc::clone(&project);
-            let AggregateContext { aggregated, next } = aggregate_context;
-            let aggregated = aggregated.map(Rc::new);
+        async move {
+            filter
+                .check(Rc::clone(&project_context))
+                .await
+                .map(|pass| pass.then_some(project_context))
+        }
+    });
 
-            async move {
-                let row = project
-                    .apply(aggregated.as_ref().map(Rc::clone), labels, Rc::clone(&next))
-                    .await?;
+    let rows = aggregate.apply(rows).await?;
 
-                Ok((aggregated, next, row))
-            }
-        });
+    let labels = fetch_labels(storage, relation, joins, projection)
+        .await?
+        .map(Rc::from);
 
-        let rows = sort.apply(rows, get_alias(relation)).await?;
-        let rows = limit.apply(rows);
-        let labels = labels.map(|labels| labels.iter().cloned().collect());
+    let project = Rc::new(Project::new(storage, filter_context, projection));
+    let project_labels = labels.as_ref().map(Rc::clone);
+    let rows = rows.and_then(move |aggregate_context| {
+        let labels = project_labels.as_ref().map(Rc::clone);
+        let project = Rc::clone(&project);
+        let AggregateContext { aggregated, next } = aggregate_context;
+        let aggregated = aggregated.map(Rc::new);
 
-        Ok((labels, rows))
-    })
+        async move {
+            let row = project
+                .apply(aggregated.as_ref().map(Rc::clone), labels, Rc::clone(&next))
+                .await?;
+
+            Ok((aggregated, next, row))
+        }
+    });
+
+    let rows = sort.apply(rows, get_alias(relation)).await?;
+    let rows = limit.apply(rows);
+    let labels = labels.map(|labels| labels.iter().cloned().collect());
+
+    Ok((labels, rows))
 }
 
 pub async fn select<'a, T: GStore>(

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -9,8 +9,10 @@ use {
         result::Result,
         store::Store,
     },
-    async_recursion::async_recursion,
-    futures::stream::{self, StreamExt, TryStreamExt},
+    futures::{
+        future::LocalBoxFuture,
+        stream::{self, StreamExt, TryStreamExt},
+    },
     std::collections::HashMap,
 };
 
@@ -167,59 +169,71 @@ async fn scan_join<T: Store>(storage: &T, join: &Join) -> Result<HashMap<String,
     Ok(schema_list)
 }
 
-#[async_recursion(?Send)]
-async fn scan_table_factor<T: Store>(
-    storage: &T,
-    table_factor: &TableFactor,
-) -> Result<HashMap<String, Schema>> {
-    match table_factor {
-        TableFactor::Table { name, .. } => {
-            let schema = storage.fetch_schema(name).await?;
-            let schema_list: HashMap<String, Schema> = schema.map_or_else(HashMap::new, |schema| {
-                HashMap::from([(name.to_owned(), schema)])
-            });
+fn scan_table_factor<'async_recursion, 'storage, T: Store>(
+    storage: &'storage T,
+    table_factor: &'storage TableFactor,
+) -> LocalBoxFuture<'async_recursion, Result<HashMap<String, Schema>>>
+where
+    'storage: 'async_recursion,
+{
+    Box::pin(async move {
+        match table_factor {
+            TableFactor::Table { name, .. } => {
+                let schema = storage.fetch_schema(name).await?;
+                let schema_list: HashMap<String, Schema> = schema
+                    .map_or_else(HashMap::new, |schema| {
+                        HashMap::from([(name.to_owned(), schema)])
+                    });
 
-            Ok(schema_list)
+                Ok(schema_list)
+            }
+            TableFactor::Derived { subquery, .. } => scan_query(storage, subquery).await,
+            TableFactor::Series { .. } | TableFactor::Dictionary { .. } => Ok(HashMap::new()),
         }
-        TableFactor::Derived { subquery, .. } => scan_query(storage, subquery).await,
-        TableFactor::Series { .. } | TableFactor::Dictionary { .. } => Ok(HashMap::new()),
-    }
+    })
 }
 
-#[async_recursion(?Send)]
-async fn scan_expr<T: Store>(storage: &T, expr: &Expr) -> Result<HashMap<String, Schema>> {
-    let schema_list = match expr.into() {
-        PlanExpr::None | PlanExpr::Identifier(_) | PlanExpr::CompoundIdentifier { .. } => {
-            HashMap::new()
-        }
-        PlanExpr::Expr(expr) => scan_expr(storage, expr).await?,
-        PlanExpr::TwoExprs(expr, expr2) => scan_expr(storage, expr)
-            .await?
-            .into_iter()
-            .chain(scan_expr(storage, expr2).await?)
-            .collect(),
-        PlanExpr::ThreeExprs(expr, expr2, expr3) => scan_expr(storage, expr)
-            .await?
-            .into_iter()
-            .chain(scan_expr(storage, expr2).await?)
-            .chain(scan_expr(storage, expr3).await?)
-            .collect(),
-        PlanExpr::MultiExprs(exprs) => stream::iter(exprs)
-            .then(|expr| scan_expr(storage, expr))
-            .try_collect::<Vec<HashMap<String, Schema>>>()
-            .await?
-            .into_iter()
-            .flatten()
-            .collect(),
-        PlanExpr::Query(query) => scan_query(storage, query).await?,
-        PlanExpr::QueryAndExpr { query, expr } => scan_query(storage, query)
-            .await?
-            .into_iter()
-            .chain(scan_expr(storage, expr).await?)
-            .collect(),
-    };
+fn scan_expr<'async_recursion, 'storage, T: Store>(
+    storage: &'storage T,
+    expr: &'storage Expr,
+) -> LocalBoxFuture<'async_recursion, Result<HashMap<String, Schema>>>
+where
+    'storage: 'async_recursion,
+{
+    Box::pin(async move {
+        let schema_list = match expr.into() {
+            PlanExpr::None | PlanExpr::Identifier(_) | PlanExpr::CompoundIdentifier { .. } => {
+                HashMap::new()
+            }
+            PlanExpr::Expr(expr) => scan_expr(storage, expr).await?,
+            PlanExpr::TwoExprs(expr, expr2) => scan_expr(storage, expr)
+                .await?
+                .into_iter()
+                .chain(scan_expr(storage, expr2).await?)
+                .collect(),
+            PlanExpr::ThreeExprs(expr, expr2, expr3) => scan_expr(storage, expr)
+                .await?
+                .into_iter()
+                .chain(scan_expr(storage, expr2).await?)
+                .chain(scan_expr(storage, expr3).await?)
+                .collect(),
+            PlanExpr::MultiExprs(exprs) => stream::iter(exprs)
+                .then(|expr| scan_expr(storage, expr))
+                .try_collect::<Vec<HashMap<String, Schema>>>()
+                .await?
+                .into_iter()
+                .flatten()
+                .collect(),
+            PlanExpr::Query(query) => scan_query(storage, query).await?,
+            PlanExpr::QueryAndExpr { query, expr } => scan_query(storage, query)
+                .await?
+                .into_iter()
+                .chain(scan_expr(storage, expr).await?)
+                .collect(),
+        };
 
-    Ok(schema_list)
+        Ok(schema_list)
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the process of attaching `Send` and `Sync`, it is difficult to solve if there are lifetime and `async-recursion` macros together.

Replace with `LocalBoxFuture`.