### PR TITLE
Refactor CreateTable.columns from `Vec<ColumnDef>` to `Option<Vec<ColumnDef>>`

### DIFF
--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -184,7 +184,7 @@ impl ToSql for Statement {
                                     .collect::<Vec<_>>()
                                     .join(", ")
                             })
-                            .unwrap_or("".to_owned());
+                            .unwrap_or_else(|| "".to_owned());
 
                         Some(format!("({columns})"))
                     }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -35,7 +35,7 @@ impl Schema {
     pub fn to_ddl(self) -> String {
         let Schema {
             table_name,
-            column_defs: columns,
+            column_defs,
             indexes,
             engine,
             ..
@@ -44,7 +44,7 @@ impl Schema {
         let create_table = Statement::CreateTable {
             if_not_exists: false,
             name: table_name.clone(),
-            columns: columns.unwrap_or_default(),
+            columns: column_defs,
             engine,
             source: None,
         }

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -102,7 +102,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                 Some(column_defs)
             }
         },
-        None if column_defs.is_some() => column_defs.map(|s| s.to_vec()),
+        None if column_defs.is_some() => column_defs.map(<[ColumnDef]>::to_vec),
         None => None,
     };
 

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -19,7 +19,7 @@ use {
 pub async fn create_table<T: GStore + GStoreMut>(
     storage: &mut T,
     target_table_name: &str,
-    column_defs: &[ColumnDef],
+    column_defs: Option<&[ColumnDef]>,
     if_not_exists: bool,
     source: &Option<Box<Query>>,
     engine: &Option<String>,
@@ -102,7 +102,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                 Some(column_defs)
             }
         },
-        None if !column_defs.is_empty() => Some(column_defs.to_vec()),
+        None if column_defs.is_some() => column_defs.map(|s| s.to_vec()),
         None => None,
     };
 

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -120,7 +120,7 @@ pub async fn execute<T: GStore + GStoreMut>(
         } => create_table(
             storage,
             name,
-            columns.as_ref().map(|v| v.as_slice()),
+            columns.as_ref().map(Vec::as_slice),
             *if_not_exists,
             source,
             engine,

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -117,9 +117,16 @@ pub async fn execute<T: GStore + GStoreMut>(
             source,
             engine,
             ..
-        } => create_table(storage, name, columns, *if_not_exists, source, engine)
-            .await
-            .map(|_| Payload::Create),
+        } => create_table(
+            storage,
+            name,
+            columns.as_ref().map(|v| v.as_slice()),
+            *if_not_exists,
+            source,
+            engine,
+        )
+        .await
+        .map(|_| Payload::Create),
         Statement::DropTable {
             names, if_exists, ..
         } => drop_table(storage, names, *if_exists)


### PR DESCRIPTION
## Goal
```diff
CreateTable {                                                                                     
    if_not_exists: bool,                                                                          
    name: String,                                                                                 
    Optional schema                                                                           
-  columns: Vec<ColumnDef>,
+  columns: Option<Vec<ColumnDef>>,                                                              
    source: Option<Box<Query>>,                                                                   
    engine: Option<String>,                                                                       
},                          
```

## Todo
Refactor CreateTable.columns from Vec<ColumnDef> to Option<Vec<ColumnDef>>

## Next
- implement `from_ddl()`