### PR TITLE
Support `Schema::from_ddl(ddl: &str) -> String`

### DIFF
--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -15,7 +15,7 @@ pub use {
     key::{Key, KeyError},
     literal::{Literal, LiteralError},
     row::{Row, RowError},
-    schema::{Schema, SchemaIndex, SchemaIndexOrd},
+    schema::{Schema, SchemaIndex, SchemaIndexOrd, SchemaParseError},
     string_ext::{StringExt, StringExtError},
     table::{get_alias, get_index, TableError},
     value::{NumericBinaryOperator, Value, ValueError},

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -271,6 +271,14 @@ mod tests {
     }
 
     #[test]
+    fn invalid_ddl() {
+        let invalid_ddl = "DROP TABLE Users";
+        let actual = Schema::from_ddl(invalid_ddl);
+        assert_eq!(actual, Err(SchemaParseError::CannotParseDDL.into()));
+    }
+
+    #[test]
+    #[cfg(feature = "index")]
     fn table_with_index() {
         let schema = Schema {
             table_name: "User".to_owned(),
@@ -307,30 +315,17 @@ mod tests {
             engine: None,
             created: Utc::now().naive_utc(),
         };
-
         let ddl = "CREATE TABLE User (id INT NOT NULL, name TEXT NOT NULL);
 CREATE INDEX User_id ON User (id);
 CREATE INDEX User_name ON User (name);";
-        assert_eq!(schema.to_ddl(), ddl,);
+        assert_eq!(schema.to_ddl(), ddl);
 
-        #[cfg(feature = "index")]
         let actual = Schema::from_ddl(ddl).unwrap();
-        #[cfg(feature = "index")]
         assert_schema(actual, schema);
-    }
 
-    #[test]
-    fn invalid_ddl() {
-        let wrong_ddl = "DROP TABLE Users";
-        let actual = Schema::from_ddl(wrong_ddl);
-        assert_eq!(actual, Err(SchemaParseError::CannotParseDDL.into()));
-
-        #[cfg(feature = "index")]
         let index_should_not_be_first = "CREATE INDEX User_id ON User (id);
 CREATE TABLE User (id INT NOT NULL, name TEXT NOT NULL);";
-        #[cfg(feature = "index")]
         let actual = Schema::from_ddl(index_should_not_be_first);
-        #[cfg(feature = "index")]
         assert_eq!(actual, Err(SchemaParseError::CannotParseDDL.into()));
     }
 }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         ast::{ColumnDef, Expr, Statement, ToSql},
         prelude::{parse, translate},
-        result::{Error, Result},
+        result::Result,
     },
     chrono::{NaiveDateTime, Utc},
     serde::{Deserialize, Serialize},
@@ -104,10 +104,7 @@ impl Schema {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let create_table = statements
-            .get(0)
-            .map(Ok::<_, Error>)
-            .unwrap_or_else(|| Err(SchemaParseError::CannotParseDDL.into()))?;
+        let create_table = statements.get(0).ok_or(SchemaParseError::CannotParseDDL)?;
         let create_table = translate(create_table)?;
 
         match create_table {

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -72,6 +72,7 @@ impl Schema {
     }
 
     pub fn from_ddl(ddl: &str) -> Result<Schema> {
+        let created = Utc::now().naive_utc();
         let statements = parse(ddl)?;
 
         let indexes = statements
@@ -94,7 +95,7 @@ impl Schema {
                             name,
                             expr,
                             order,
-                            created: Utc::now().naive_utc(),
+                            created,
                         };
 
                         Ok(index)
@@ -118,7 +119,7 @@ impl Schema {
                 column_defs: columns,
                 indexes,
                 engine,
-                created: Utc::now().naive_utc(),
+                created,
             }),
             _ => Err(SchemaParseError::CannotParseDDL.into()),
         }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -40,10 +40,10 @@ pub struct Schema {
 }
 
 impl Schema {
-    pub fn to_ddl(self) -> String {
+    pub fn to_ddl(&self) -> String {
         let Schema {
             table_name,
-            column_defs: columns,
+            column_defs,
             indexes,
             engine,
             ..
@@ -51,9 +51,9 @@ impl Schema {
 
         let create_table = Statement::CreateTable {
             if_not_exists: false,
-            name: table_name.clone(),
-            columns: columns.unwrap_or_default(),
-            engine,
+            name: table_name.to_owned(),
+            columns: column_defs.to_owned().unwrap_or_default(),
+            engine: engine.to_owned(),
             source: None,
         }
         .to_sql();
@@ -158,7 +158,7 @@ mod tests {
         };
 
         let ddl = "CREATE TABLE User (id INT NOT NULL, name TEXT NULL DEFAULT 'glue');";
-        assert_eq!(schema.clone().to_ddl(), ddl);
+        assert_eq!(schema.to_ddl(), ddl);
 
         let actual = from_ddl(ddl.to_string()).unwrap();
         assert_schema(actual, schema);
@@ -171,7 +171,7 @@ mod tests {
             created: Utc::now().naive_utc(),
         };
         let ddl = "CREATE TABLE Test;";
-        assert_eq!(schema.clone().to_ddl(), ddl);
+        assert_eq!(schema.to_ddl(), ddl);
 
         let actual = from_ddl(ddl.to_string()).unwrap();
         assert_schema(actual, schema);

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -155,7 +155,7 @@ mod tests {
         crate::{
             ast::{AstLiteral, ColumnDef, ColumnUniqueOption, Expr},
             chrono::Utc,
-            data::{Schema, SchemaIndex, SchemaIndexOrd},
+            data::{Schema, SchemaIndex},
             prelude::DataType,
         },
     };
@@ -280,6 +280,8 @@ mod tests {
     #[test]
     #[cfg(feature = "index")]
     fn table_with_index() {
+        use crate::data::SchemaIndexOrd;
+
         let schema = Schema {
             table_name: "User".to_owned(),
             column_defs: Some(vec![

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -2,7 +2,8 @@ use {
     crate::{
         ast_builder::AstBuilderError,
         data::{
-            IntervalError, KeyError, LiteralError, RowError, StringExtError, TableError, ValueError,
+            IntervalError, KeyError, LiteralError, RowError, SchemaParseError, StringExtError,
+            TableError, ValueError,
         },
         executor::{
             AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, InsertError,
@@ -16,7 +17,6 @@ use {
     thiserror::Error as ThisError,
 };
 
-use crate::data::schema::SchemaParseError;
 #[cfg(feature = "alter-table")]
 use crate::store::AlterTableError;
 

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -122,6 +122,7 @@ impl PartialEq for Error {
             (Interval(e), Interval(e2)) => e == e2,
             (StringExt(e), StringExt(e2)) => e == e2,
             (Plan(e), Plan(e2)) => e == e2,
+            (Schema(e), Schema(e2)) => e == e2,
             _ => false,
         }
     }

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -16,6 +16,7 @@ use {
     thiserror::Error as ThisError,
 };
 
+use crate::data::schema::SchemaParseError;
 #[cfg(feature = "alter-table")]
 use crate::store::AlterTableError;
 
@@ -84,6 +85,8 @@ pub enum Error {
     StringExt(#[from] StringExtError),
     #[error(transparent)]
     Plan(#[from] PlanError),
+    #[error(transparent)]
+    Schema(#[from] SchemaParseError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
## Goal
Currently we can convert `Schema` to  `DDL String` by `Schema::to_ddl(self) -> String`
In this PR, reverse conversion  `DDL String`(CREATE TABLE & CREATE INDEX) to `Schema` will be supported by
```rs
Schema::from_ddl(ddl: &str) -> String
```

## Todo
- [x] replace Schema::to_ddl(`self`) to Schema::to_ddl(`&self`)
- [x] Add SchemaParseError::CannotParseDDL 
- [x] implement `Schema::from_ddl(ddl: &str) -> String`
