### PR TITLE
Remove Store trait related cfg features,

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   clippy_workspace:
-    name: Clippy (workspace) - Default Feature
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,31 +23,6 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
-
-  clippy_core:
-    name: Clippy (core) - per Powerset Features
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Add clippy
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          profile: minimal
-          default: true
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: |
-          cd core
-          cargo clippy --all-targets --no-default-features -- -D warnings
-          cargo clippy --all-targets --no-default-features --features alter-table -- -D warnings
-          cargo clippy --all-targets --no-default-features --features index -- -D warnings
-          cargo clippy --all-targets --no-default-features --features transaction -- -D warnings
-          cargo clippy --all-targets --no-default-features --features "alter-table index" -- -D warnings
-          cargo clippy --all-targets --no-default-features --features "alter-table transaction" -- -D warnings
-          cargo clippy --all-targets --no-default-features --features "index transaction" -- -D warnings
-          cargo clippy --all-targets --no-default-features --features "alter-table index transaction" -- -D warnings
-          cargo clippy --all-targets --all-features -- -D warnings
-          cd ../
 
   rust_fmt:
     name: Rustfmt
@@ -82,10 +57,6 @@ jobs:
           cargo test --all-features --lib --bins --tests --examples --verbose -- --skip sled_transaction_timeout
           cargo test sled_transaction_timeout --verbose -- --test-threads=1
           cargo test --benches
-          cd storages/memory-storage
-          cargo test --verbose --no-default-features
-          cargo test --verbose --no-default-features --features alter-table
-          cd ../../
 
   run_examples:
     name: Run examples

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-gluesql-core = { path = "../core", version = "0.13.1", features = ["alter-table"] }
+gluesql-core = { path = "../core", version = "0.13.1" }
 gluesql_sled_storage = { path = "../storages/sled-storage", version = "0.13.0" }
 gluesql_memory_storage = { path = "../storages/memory-storage", version = "0.13.0" }
 
@@ -25,4 +25,3 @@ itertools = "0.10"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
-

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,14 +37,3 @@ features = ["v4", "js"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1"
 features = ["v4"]
-
-[features]
-# optional: ALTER TABLE
-# you can include whether ALTER TABLE support or not for your custom database implementation.
-alter-table = []
-
-# optional: INDEX
-index = []
-
-# optional: TRANSACTION
-transaction = []

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -65,7 +65,6 @@ pub enum Statement {
         engine: Option<String>,
     },
     /// ALTER TABLE
-    #[cfg(feature = "alter-table")]
     AlterTable {
         /// Table name
         name: String,
@@ -79,30 +78,24 @@ pub enum Statement {
         names: Vec<String>,
     },
     /// CREATE INDEX
-    #[cfg(feature = "index")]
     CreateIndex {
         name: String,
         table_name: String,
         column: OrderByExpr,
     },
     /// DROP INDEX
-    #[cfg(feature = "index")]
     DropIndex {
         name: String,
         table_name: String,
     },
     /// START TRANSACTION, BEGIN
-    #[cfg(feature = "transaction")]
     StartTransaction,
     /// COMMIT
-    #[cfg(feature = "transaction")]
     Commit,
     /// ROLLBACK
-    #[cfg(feature = "transaction")]
     Rollback,
     /// SHOW VARIABLE
     ShowVariable(Variable),
-    #[cfg(feature = "index")]
     ShowIndexes(String),
 }
 
@@ -204,7 +197,6 @@ impl ToSql for Statement {
 
                 format!("{sql};")
             }
-            #[cfg(feature = "alter-table")]
             Statement::AlterTable { name, operation } => {
                 format!("ALTER TABLE {name} {};", operation.to_sql())
             }
@@ -215,7 +207,6 @@ impl ToSql for Statement {
                     false => format!("DROP TABLE {};", names),
                 }
             }
-            #[cfg(feature = "index")]
             Statement::CreateIndex {
                 name,
                 table_name,
@@ -223,21 +214,16 @@ impl ToSql for Statement {
             } => {
                 format!("CREATE INDEX {name} ON {table_name} {};", column.to_sql())
             }
-            #[cfg(feature = "index")]
             Statement::DropIndex { name, table_name } => {
                 format!("DROP INDEX {table_name}.{name};")
             }
-            #[cfg(feature = "transaction")]
             Statement::StartTransaction => "START TRANSACTION;".to_owned(),
-            #[cfg(feature = "transaction")]
             Statement::Commit => "COMMIT;".to_owned(),
-            #[cfg(feature = "transaction")]
             Statement::Rollback => "ROLLBACK;".to_owned(),
             Statement::ShowVariable(variable) => match variable {
                 Variable::Tables => "SHOW TABLES;".to_owned(),
                 Variable::Version => "SHOW VERSIONS;".to_owned(),
             },
-            #[cfg(feature = "index")]
             Statement::ShowIndexes(object_name) => {
                 format!("SHOW INDEXES FROM {object_name};")
             }
@@ -254,16 +240,11 @@ impl ToSql for Assignment {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alter-table")]
-    use crate::ast::AlterTableOperation;
-
-    #[cfg(feature = "index")]
-    use crate::ast::OrderByExpr;
-
     use {
         crate::ast::{
-            Assignment, AstLiteral, BinaryOperator, ColumnDef, DataType, Expr, Query, Select,
-            SelectItem, SetExpr, Statement, TableFactor, TableWithJoins, ToSql, Values, Variable,
+            AlterTableOperation, Assignment, AstLiteral, BinaryOperator, ColumnDef, DataType, Expr,
+            OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableFactor,
+            TableWithJoins, ToSql, Values, Variable,
         },
         bigdecimal::BigDecimal,
         std::str::FromStr,
@@ -542,7 +523,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "alter-table")]
     fn to_sql_alter_table() {
         assert_eq!(
             "ALTER TABLE Foo ADD COLUMN amount INT NOT NULL DEFAULT 10;",
@@ -642,7 +622,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "index")]
     fn to_sql_create_index() {
         assert_eq!(
             "CREATE INDEX idx_name ON Test LastName;",
@@ -659,7 +638,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "index")]
     fn to_sql_drop_index() {
         assert_eq!(
             "DROP INDEX Test.idx_id;",
@@ -672,7 +650,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "transaction")]
     fn to_sql_transaction() {
         assert_eq!("START TRANSACTION;", Statement::StartTransaction.to_sql());
         assert_eq!("COMMIT;", Statement::Commit.to_sql());
@@ -692,7 +669,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "index")]
     fn to_sql_show_indexes() {
         assert_eq!(
             "SHOW INDEXES FROM Test;",

--- a/core/src/ast_builder/alter_table.rs
+++ b/core/src/ast_builder/alter_table.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "alter-table")]
 use {
     super::Build,
     crate::{
@@ -133,7 +132,7 @@ impl Build for RenameTableNode {
     }
 }
 
-#[cfg(all(test, feature = "alter-table"))]
+#[cfg(test)]
 mod tests {
     use crate::ast_builder::{table, test, Build};
 

--- a/core/src/ast_builder/index.rs
+++ b/core/src/ast_builder/index.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "index")]
-
 use {
     super::Build,
     crate::{ast::Statement, result::Result},
@@ -59,7 +57,7 @@ impl Build for DropIndexNode {
     }
 }
 
-#[cfg(all(test, feature = "index"))]
+#[cfg(test)]
 mod tests {
     use crate::ast_builder::{table, test, Build};
 

--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alter-table")]
 mod alter_table;
 mod assignment;
 mod build;
@@ -12,7 +11,6 @@ mod error;
 mod execute;
 mod expr;
 mod expr_list;
-#[cfg(feature = "index")]
 mod index;
 mod insert;
 mod order_by_expr;
@@ -24,7 +22,6 @@ mod select_item_list;
 mod show_columns;
 mod table_factor;
 mod table_name;
-#[cfg(feature = "transaction")]
 mod transaction;
 mod update;
 
@@ -64,12 +61,10 @@ pub use expr::{
     numeric::NumericNode, plus, subquery, text, time, timestamp, ExprNode,
 };
 
-#[cfg(feature = "alter-table")]
 pub use alter_table::{
     AddColumnNode, AlterTableNode, DropColumnNode, RenameColumnNode, RenameTableNode,
 };
 
-#[cfg(feature = "index")]
 pub use {index::CreateIndexNode, index::DropIndexNode};
 
 /// Available aggregate or normal SQL functions
@@ -85,7 +80,6 @@ pub use expr::{
 };
 
 /// Functions for building transaction statements
-#[cfg(feature = "transaction")]
 pub use transaction::{begin, commit, rollback};
 
 #[cfg(test)]

--- a/core/src/ast_builder/table_name.rs
+++ b/core/src/ast_builder/table_name.rs
@@ -1,13 +1,8 @@
 use super::{
-    table_factor::TableType, CreateTableNode, DeleteNode, DropTableNode, InsertNode, SelectNode,
-    ShowColumnsNode, TableFactorNode, UpdateNode,
+    table_factor::TableType, AlterTableNode, CreateIndexNode, CreateTableNode, DeleteNode,
+    DropIndexNode, DropTableNode, InsertNode, OrderByExprNode, SelectNode, ShowColumnsNode,
+    TableFactorNode, UpdateNode,
 };
-
-#[cfg(feature = "alter-table")]
-use super::AlterTableNode;
-
-#[cfg(feature = "index")]
-use super::{CreateIndexNode, DropIndexNode, OrderByExprNode};
 
 #[derive(Clone, Debug)]
 pub struct TableNameNode {
@@ -65,12 +60,10 @@ impl<'a> TableNameNode {
         DropTableNode::new(self.table_name, true)
     }
 
-    #[cfg(feature = "index")]
     pub fn drop_index(self, name: &str) -> DropIndexNode {
         DropIndexNode::new(self.table_name, name.to_owned())
     }
 
-    #[cfg(feature = "index")]
     pub fn create_index<T: Into<OrderByExprNode<'a>>>(
         self,
         name: &str,
@@ -79,7 +72,6 @@ impl<'a> TableNameNode {
         CreateIndexNode::new(self.table_name, name.to_owned(), column.into())
     }
 
-    #[cfg(feature = "alter-table")]
     pub fn alter_table(self) -> AlterTableNode {
         AlterTableNode::new(self.table_name)
     }

--- a/core/src/ast_builder/transaction.rs
+++ b/core/src/ast_builder/transaction.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "transaction")]
-
 use crate::{ast::Statement, result::Result};
 
 pub fn begin() -> Result<Statement> {
@@ -12,7 +10,7 @@ pub fn rollback() -> Result<Statement> {
     Ok(Statement::Rollback)
 }
 
-#[cfg(all(test, feature = "transaction"))]
+#[cfg(test)]
 mod tests {
     use crate::ast_builder::{begin, commit, rollback, test};
 

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        ast::{ColumnDef, Expr, Statement, ToSql},
+        ast::{ColumnDef, Expr, OrderByExpr, Statement, ToSql},
         prelude::{parse, translate},
         result::Result,
     },
@@ -10,9 +10,6 @@ use {
     strum_macros::Display,
     thiserror::Error as ThisError,
 };
-
-#[cfg(feature = "index")]
-use crate::ast::OrderByExpr;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
@@ -81,7 +78,6 @@ impl Schema {
             .map(|create_index| {
                 let create_index = translate(create_index)?;
                 match create_index {
-                    #[cfg(feature = "index")]
                     Statement::CreateIndex {
                         name,
                         column: OrderByExpr { expr, asc },
@@ -262,7 +258,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "index")]
     fn table_with_index() {
         use crate::data::SchemaIndexOrd;
 

--- a/core/src/executor/alter/index.rs
+++ b/core/src/executor/alter/index.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "index")]
-
 use {
     super::AlterError,
     crate::{

--- a/core/src/executor/alter/mod.rs
+++ b/core/src/executor/alter/mod.rs
@@ -6,9 +6,9 @@ mod validate;
 
 use validate::{validate, validate_column_names};
 
-#[cfg(feature = "alter-table")]
-pub use alter_table::alter_table;
-pub use error::AlterError;
-#[cfg(feature = "index")]
-pub use index::create_index;
-pub use table::{create_table, drop_table};
+pub use {
+    alter_table::alter_table,
+    error::AlterError,
+    index::create_index,
+    table::{create_table, drop_table},
+};

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -101,22 +101,14 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
         }
         TableFactor::Table { name, .. } => {
             let rows = {
-                #[cfg(feature = "index")]
                 #[derive(Iterator)]
                 enum Rows<I1, I2, I3> {
                     Indexed(I1),
                     PrimaryKey(I2),
                     FullScan(I3),
                 }
-                #[cfg(not(feature = "index"))]
-                #[derive(Iterator)]
-                enum Rows<I1, I2> {
-                    PrimaryKey(I1),
-                    FullScan(I2),
-                }
 
                 match get_index(table_factor) {
-                    #[cfg(feature = "index")]
                     Some(IndexItem::NonClustered {
                         name: index_name,
                         asc,

--- a/core/src/executor/mod.rs
+++ b/core/src/executor/mod.rs
@@ -17,7 +17,7 @@ pub use {
     aggregate::AggregateError,
     alter::AlterError,
     evaluate::{evaluate_stateless, EvaluateError},
-    execute::{ExecuteError, Payload, PayloadVariable},
+    execute::{execute, ExecuteError, Payload, PayloadVariable},
     fetch::FetchError,
     insert::InsertError,
     select::SelectError,
@@ -25,8 +25,3 @@ pub use {
     update::UpdateError,
     validate::ValidateError,
 };
-
-#[cfg(not(feature = "transaction"))]
-pub use execute::execute;
-#[cfg(feature = "transaction")]
-pub use execute::execute_atomic as execute;

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -10,18 +10,13 @@ use {
             SelectError, SortError, UpdateError, ValidateError,
         },
         plan::PlanError,
+        store::{AlterTableError, IndexError},
         translate::TranslateError,
     },
     serde::Serialize,
     std::{error::Error as StdError, fmt::Debug, ops::ControlFlow},
     thiserror::Error as ThisError,
 };
-
-#[cfg(feature = "alter-table")]
-use crate::store::AlterTableError;
-
-#[cfg(feature = "index")]
-use crate::store::IndexError;
 
 #[derive(ThisError, Serialize, Debug)]
 pub enum Error {
@@ -41,14 +36,10 @@ pub enum Error {
     #[error(transparent)]
     AstBuilder(#[from] AstBuilderError),
 
-    #[cfg(feature = "alter-table")]
     #[error(transparent)]
     AlterTable(#[from] AlterTableError),
-
-    #[cfg(feature = "index")]
     #[error(transparent)]
     Index(#[from] IndexError),
-
     #[error(transparent)]
     Execute(#[from] ExecuteError),
     #[error(transparent)]
@@ -100,9 +91,7 @@ impl PartialEq for Error {
             (StorageMsg(e), StorageMsg(e2)) => e == e2,
             (Translate(e), Translate(e2)) => e == e2,
             (AstBuilder(e), AstBuilder(e2)) => e == e2,
-            #[cfg(feature = "alter-table")]
             (AlterTable(e), AlterTable(e2)) => e == e2,
-            #[cfg(feature = "index")]
             (Index(e), Index(e2)) => e == e2,
             (Execute(e), Execute(e2)) => e == e2,
             (Alter(e), Alter(e2)) => e == e2,

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -1,66 +1,20 @@
-use cfg_if::cfg_if;
-
-cfg_if! {
-    if #[cfg(feature = "alter-table")] {
-        mod alter_table;
-        pub use alter_table::{AlterTable, AlterTableError};
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "index")] {
-        mod index;
-        pub use index::{Index, IndexError, IndexMut};
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "transaction")] {
-        mod transaction;
-        pub use transaction::Transaction;
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "index")] {
-        pub trait GStore: Store + Index {}
-        impl<S: Store + Index> GStore for S {}
-    } else {
-        pub trait GStore: Store {}
-        impl<S: Store> GStore for S {}
-    }
-}
-
-cfg_if! {
-    if #[cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut: StoreMut + IndexMut + AlterTable + Transaction {}
-        impl<S: StoreMut + IndexMut + AlterTable+ Transaction> GStoreMut for S {}
-    } else if #[cfg(all(feature = "alter-table", feature = "index"))] {
-        pub trait GStoreMut: StoreMut + IndexMut + AlterTable {}
-        impl<S: StoreMut + IndexMut + AlterTable> GStoreMut for S {}
-    } else if #[cfg(all(feature = "alter-table", feature = "transaction"))] {
-        pub trait GStoreMut: StoreMut + Transaction + AlterTable {}
-        impl<S: StoreMut + Transaction + AlterTable> GStoreMut for S {}
-    } else if #[cfg(all(feature = "index", feature = "transaction"))] {
-        pub trait GStoreMut: StoreMut + IndexMut + Transaction {}
-        impl<S: StoreMut + IndexMut + Transaction> GStoreMut for S {}
-    } else if #[cfg(feature = "alter-table")] {
-        pub trait GStoreMut: StoreMut + AlterTable {}
-        impl<S: StoreMut + AlterTable> GStoreMut for S {}
-    } else if #[cfg(feature = "index")] {
-        pub trait GStoreMut: StoreMut + IndexMut {}
-        impl<S: StoreMut + IndexMut> GStoreMut for S {}
-    } else if #[cfg(feature = "transaction")] {
-        pub trait GStoreMut: StoreMut + Transaction {}
-        impl<S: StoreMut + Transaction> GStoreMut for S {}
-    } else {
-        pub trait GStoreMut: StoreMut {}
-        impl<S: StoreMut> GStoreMut for S {}
-    }
-}
-
+mod alter_table;
 mod data_row;
-pub use data_row::DataRow;
+mod index;
+mod transaction;
+
+pub trait GStore: Store + Index {}
+impl<S: Store + Index> GStore for S {}
+
+pub trait GStoreMut: StoreMut + IndexMut + AlterTable + Transaction {}
+impl<S: StoreMut + IndexMut + AlterTable + Transaction> GStoreMut for S {}
+
+pub use {
+    alter_table::{AlterTable, AlterTableError},
+    data_row::DataRow,
+    index::{Index, IndexError, IndexMut},
+    transaction::Transaction,
+};
 
 use {
     crate::{

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -1,22 +1,17 @@
 use {
-    super::{data_type::translate_data_type, expr::translate_expr, TranslateError},
+    super::{
+        data_type::translate_data_type, expr::translate_expr, translate_object_name, TranslateError,
+    },
     crate::{
-        ast::{ColumnDef, ColumnUniqueOption},
+        ast::{AlterTableOperation, ColumnDef, ColumnUniqueOption},
         result::Result,
     },
     sqlparser::ast::{
-        ColumnDef as SqlColumnDef, ColumnOption as SqlColumnOption,
-        ColumnOptionDef as SqlColumnOptionDef,
+        AlterTableOperation as SqlAlterTableOperation, ColumnDef as SqlColumnDef,
+        ColumnOption as SqlColumnOption, ColumnOptionDef as SqlColumnOptionDef,
     },
 };
 
-#[cfg(feature = "alter-table")]
-use {
-    super::translate_object_name, crate::ast::AlterTableOperation,
-    sqlparser::ast::AlterTableOperation as SqlAlterTableOperation,
-};
-
-#[cfg(feature = "alter-table")]
 pub fn translate_alter_table_operation(
     sql_alter_table_operation: &SqlAlterTableOperation,
 ) -> Result<AlterTableOperation> {

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -33,24 +33,9 @@ futures = "0.3"
 [features]
 # DB User
 default = [
-	"gluesql-core/alter-table",
-	"gluesql-core/index",
-	"gluesql-core/transaction",
 	"cli",
 	"test-suite",
 	"memory-storage",
 	"shared-memory-storage",
 	"sled-storage",
 ]
-
-# Storage Maker
-
-# optional: ALTER TABLE
-# you can include whether ALTER TABLE support or not for your custom database implementation.
-alter-table = ["gluesql-core/alter-table", "test-suite/alter-table"]
-
-# optional: INDEX
-index = ["gluesql-core/index", "test-suite/index"]
-
-# optional: TRANSACTION
-transaction = ["gluesql-core/transaction", "test-suite/transaction"]

--- a/storages/composite-storage/Cargo.toml
+++ b/storages/composite-storage/Cargo.toml
@@ -16,13 +16,6 @@ futures = "0.3"
 
 [dev-dependencies]
 test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
-gluesql_memory_storage = { path = "../memory-storage", version = "0.13.0", default-features = false }
+gluesql_memory_storage = { path = "../memory-storage", version = "0.13.0" }
 gluesql_sled_storage = { path = "../sled-storage", version = "0.13.0" }
 tokio = { version = "1", features = ["rt", "macros"] }
-
-[features]
-default = ["alter-table", "index", "transaction"]
-
-alter-table = ["gluesql-core/alter-table", "test-suite/alter-table", "gluesql_memory_storage/alter-table"]
-index = ["gluesql-core/index", "test-suite/index", "gluesql_memory_storage/index"]
-transaction = ["gluesql-core/transaction", "test-suite/transaction", "gluesql_memory_storage/transaction"]

--- a/storages/composite-storage/src/lib.rs
+++ b/storages/composite-storage/src/lib.rs
@@ -86,9 +86,6 @@ impl CompositeStorage {
     }
 }
 
-#[cfg(feature = "alter-table")]
 impl gluesql_core::store::AlterTable for CompositeStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::Index for CompositeStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::IndexMut for CompositeStorage {}

--- a/storages/composite-storage/src/transaction.rs
+++ b/storages/composite-storage/src/transaction.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "transaction")]
-
 use {
     super::CompositeStorage,
     async_trait::async_trait,

--- a/storages/composite-storage/tests/error.rs
+++ b/storages/composite-storage/tests/error.rs
@@ -57,21 +57,18 @@ fn error() {
     );
 }
 
-#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! exec {
     ($glue: ident $sql: literal) => {
         $glue.execute($sql).unwrap();
     };
 }
 
-#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! test {
     ($glue: ident $sql: literal, $result: expr) => {
         assert_eq!($glue.execute($sql), $result);
     };
 }
 
-#[cfg(feature = "index")]
 #[test]
 fn composite_storage_index() {
     use {

--- a/storages/composite-storage/tests/memory_and_sled.rs
+++ b/storages/composite-storage/tests/memory_and_sled.rs
@@ -1,5 +1,3 @@
-#![cfg(all(feature = "alter-table", feature = "index", feature = "transaction"))]
-
 use {
     gluesql_composite_storage::CompositeStorage,
     gluesql_core::{

--- a/storages/idb-storage/Cargo.toml
+++ b/storages/idb-storage/Cargo.toml
@@ -22,14 +22,3 @@ gloo-utils = { version = "0.1.6", features = ["serde"] }
 [dev-dependencies]
 test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
 wasm-bindgen-test = "0.3.33"
-
-[features]
-default = [
-	"alter-table",
-	"index",
-	"transaction",
-]
-
-alter-table = ["gluesql-core/alter-table"]
-index = ["gluesql-core/index"]
-transaction = ["gluesql-core/transaction"]

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -424,11 +424,7 @@ impl StoreMut for IdbStorage {
     }
 }
 
-#[cfg(feature = "alter-table")]
 impl gluesql_core::store::AlterTable for IdbStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::Index for IdbStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::IndexMut for IdbStorage {}
-#[cfg(feature = "transaction")]
 impl gluesql_core::store::Transaction for IdbStorage {}

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -18,14 +18,3 @@ indexmap = { version = "1.8", features = ["serde"] }
 test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
 tokio = { version = "1", features = ["rt", "macros"] }
 futures = "0.3"
-
-[features]
-default = [
-	"alter-table",
-	"index",
-	"transaction",
-]
-
-alter-table = ["gluesql-core/alter-table", "test-suite/alter-table"]
-index = ["gluesql-core/index", "test-suite/index"]
-transaction = ["gluesql-core/transaction", "test-suite/transaction"]

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "alter-table")]
-
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/src/index.rs
+++ b/storages/memory-storage/src/index.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "index")]
-
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/src/transaction.rs
+++ b/storages/memory-storage/src/transaction.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "transaction")]
-
 use {
     super::MemoryStorage,
     async_trait::async_trait,

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -23,24 +23,20 @@ impl Tester<MemoryStorage> for MemoryTester {
 
 generate_store_tests!(tokio::test, MemoryTester);
 
-#[cfg(feature = "alter-table")]
 generate_alter_table_tests!(tokio::test, MemoryTester);
 
-#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! exec {
     ($glue: ident $sql: literal) => {
         $glue.execute($sql).unwrap();
     };
 }
 
-#[cfg(any(feature = "alter-table", feature = "index"))]
 macro_rules! test {
     ($glue: ident $sql: literal, $result: expr) => {
         assert_eq!($glue.execute($sql), $result);
     };
 }
 
-#[cfg(feature = "index")]
 #[test]
 fn memory_storage_index() {
     use {
@@ -83,7 +79,6 @@ fn memory_storage_index() {
     );
 }
 
-#[cfg(feature = "transaction")]
 #[test]
 fn memory_storage_transaction() {
     use gluesql_core::{

--- a/storages/shared-memory-storage/Cargo.toml
+++ b/storages/shared-memory-storage/Cargo.toml
@@ -13,20 +13,12 @@ documentation.workspace = true
 
 [dependencies]
 memory-storage = { package = "gluesql_memory_storage", version = "0.13.0", path = "../memory-storage" }
-gluesql-core = { path = "../../core", version = "0.13.0", features = [
-	"alter-table",
-	"index",
-	"transaction",
-] }
+gluesql-core = { path = "../../core", version = "0.13.0" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
-	"alter-table",
-	"index",
-	"transaction",
-] }
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/storages/sled-storage/Cargo.toml
+++ b/storages/sled-storage/Cargo.toml
@@ -9,11 +9,7 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-gluesql-core = { path = "../../core", version = "0.13.0", features = [
-	"index",
-	"transaction",
-	"alter-table",
-] }
+gluesql-core = { path = "../../core", version = "0.13.0" }
 utils = { package = "gluesql-utils", path = "../../utils", version = "0.13.0" }
 async-trait = "0.1"
 iter-enum = "1"
@@ -23,11 +19,7 @@ bincode = "1"
 sled = "0.34"
 
 [dev-dependencies]
-test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0", features = [
-	"index",
-	"transaction",
-	"alter-table",
-] }
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
 criterion = "0.3"
 tokio = { version = "1", features = ["rt", "macros"] }
 

--- a/storages/web-storage/Cargo.toml
+++ b/storages/web-storage/Cargo.toml
@@ -19,14 +19,3 @@ web-sys = { version = "0.3.60" }
 [dev-dependencies]
 test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }
 wasm-bindgen-test = "0.3.33"
-
-[features]
-default = [
-	"alter-table",
-	"index",
-	"transaction",
-]
-
-alter-table = ["gluesql-core/alter-table"]
-index = ["gluesql-core/index"]
-transaction = ["gluesql-core/transaction"]

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -189,11 +189,7 @@ impl StoreMut for WebStorage {
     }
 }
 
-#[cfg(feature = "alter-table")]
 impl gluesql_core::store::AlterTable for WebStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::Index for WebStorage {}
-#[cfg(feature = "index")]
 impl gluesql_core::store::IndexMut for WebStorage {}
-#[cfg(feature = "transaction")]
 impl gluesql_core::store::Transaction for WebStorage {}

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -23,8 +23,3 @@ features = ["v4", "js"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1"
 features = ["v4"]
-
-[features]
-alter-table = ["gluesql-core/alter-table"]
-index = ["gluesql-core/index"]
-transaction = ["gluesql-core/transaction"]

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "alter-table")]
-
 use {
     crate::*,
     gluesql_core::{

--- a/test-suite/src/alter/drop_indexed.rs
+++ b/test-suite/src/alter/drop_indexed.rs
@@ -1,5 +1,3 @@
-#![cfg(all(feature = "alter-table", feature = "index"))]
-
 use {
     crate::*,
     gluesql_core::{

--- a/test-suite/src/alter/mod.rs
+++ b/test-suite/src/alter/mod.rs
@@ -3,9 +3,7 @@ mod create_table;
 mod drop_indexed;
 mod drop_table;
 
-#[cfg(feature = "alter-table")]
 pub use alter_table::{alter_table_add_drop, alter_table_rename};
 pub use create_table::create_table;
-#[cfg(all(feature = "alter-table", feature = "index"))]
 pub use drop_indexed::{drop_indexed_column, drop_indexed_table};
 pub use drop_table::drop_table;

--- a/test-suite/src/index/mod.rs
+++ b/test-suite/src/index/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "index")]
-
 mod and;
 mod basic;
 mod expr;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -190,7 +190,6 @@ macro_rules! generate_store_tests {
     };
 }
 
-#[cfg(feature = "alter-table")]
 #[macro_export]
 macro_rules! generate_alter_table_tests {
     ($test: meta, $storage: ident) => {
@@ -205,7 +204,6 @@ macro_rules! generate_alter_table_tests {
     };
 }
 
-#[cfg(feature = "index")]
 #[macro_export]
 macro_rules! generate_index_tests {
     ($test: meta, $storage: ident) => {
@@ -228,7 +226,6 @@ macro_rules! generate_index_tests {
     };
 }
 
-#[cfg(feature = "transaction")]
 #[macro_export]
 macro_rules! generate_transaction_tests {
     ($test: meta, $storage: ident) => {
@@ -246,7 +243,6 @@ macro_rules! generate_transaction_tests {
     };
 }
 
-#[cfg(all(feature = "alter-table", feature = "index"))]
 #[macro_export]
 macro_rules! generate_alter_table_index_tests {
     ($test: meta, $storage: ident) => {
@@ -261,7 +257,6 @@ macro_rules! generate_alter_table_index_tests {
     };
 }
 
-#[cfg(all(feature = "transaction", feature = "alter-table"))]
 #[macro_export]
 macro_rules! generate_transaction_alter_table_tests {
     ($test: meta, $storage: ident) => {
@@ -290,7 +285,6 @@ macro_rules! generate_transaction_alter_table_tests {
     };
 }
 
-#[cfg(all(feature = "transaction", feature = "index"))]
 #[macro_export]
 macro_rules! generate_transaction_index_tests {
     ($test: meta, $storage: ident) => {
@@ -305,7 +299,6 @@ macro_rules! generate_transaction_index_tests {
     };
 }
 
-#[cfg(all(feature = "transaction"))]
 #[macro_export]
 macro_rules! generate_transaction_dictionary_tests {
     ($test: meta, $storage: ident) => {

--- a/test-suite/src/transaction/alter_table.rs
+++ b/test-suite/src/transaction/alter_table.rs
@@ -1,5 +1,3 @@
-#![cfg(all(feature = "transaction", feature = "alter-table"))]
-
 use {
     crate::*,
     gluesql_core::{executor::FetchError, prelude::Value::*},

--- a/test-suite/src/transaction/basic.rs
+++ b/test-suite/src/transaction/basic.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "transaction")]
-
 use {crate::*, gluesql_core::prelude::*, Value::*};
 
 test_case!(basic, async move {

--- a/test-suite/src/transaction/dictionary.rs
+++ b/test-suite/src/transaction/dictionary.rs
@@ -1,5 +1,3 @@
-#![cfg(all(feature = "transaction"))]
-
 use {crate::*, gluesql_core::prelude::*};
 
 test_case!(dictionary, async move {

--- a/test-suite/src/transaction/index.rs
+++ b/test-suite/src/transaction/index.rs
@@ -1,5 +1,3 @@
-#![cfg(all(feature = "transaction", feature = "index"))]
-
 use {
     crate::*,
     gluesql_core::{ast::IndexOperator::*, prelude::Value::*},

--- a/test-suite/src/transaction/mod.rs
+++ b/test-suite/src/transaction/mod.rs
@@ -1,15 +1,11 @@
-#![cfg(feature = "transaction")]
-
 mod alter_table;
 mod basic;
 mod dictionary;
 mod index;
 mod table;
 
-#[cfg(feature = "alter-table")]
 pub use alter_table::*;
 pub use basic::basic;
 pub use dictionary::dictionary;
-#[cfg(feature = "index")]
 pub use index::*;
 pub use table::*;


### PR DESCRIPTION
Enable all by default.

Compile time feature control causes too much management cost.
We already have test cases in `test-suite` splitted based on store trait features.