### PR TITLE
Replace `TryStream` to `Stream`

### DIFF
--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -11,7 +11,7 @@ use {
         store::{DataRow, GStore},
     },
     async_recursion::async_recursion,
-    futures::stream::{self, StreamExt, TryStream, TryStreamExt},
+    futures::stream::{self, Stream, StreamExt, TryStreamExt},
     iter_enum::Iterator,
     itertools::Itertools,
     serde::Serialize,
@@ -39,7 +39,7 @@ pub async fn fetch<'a, T: GStore>(
     table_name: &'a str,
     columns: Option<Rc<[String]>>,
     where_clause: Option<&'a Expr>,
-) -> Result<impl TryStream<Ok = (Key, Row), Error = Error> + 'a> {
+) -> Result<impl Stream<Item = Result<(Key, Row)>> + 'a> {
     let columns = columns.unwrap_or_else(|| Rc::from([]));
     let rows = storage
         .scan_data(table_name)
@@ -85,7 +85,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
     storage: &'a T,
     table_factor: &'a TableFactor,
     filter_context: &Option<Rc<RowContext<'a>>>,
-) -> Result<impl TryStream<Ok = Row, Error = Error, Item = Result<Row>> + 'a> {
+) -> Result<impl Stream<Item = Result<Row>> + 'a> {
     let columns = Rc::from(
         fetch_relation_columns(storage, table_factor)
             .await?

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -7,12 +7,12 @@ use {
         },
         data::{get_alias, Key, Row, Value},
         executor::{context::RowContext, evaluate::evaluate, filter::check_expr},
-        result::{Error, Result},
+        result::Result,
         store::GStore,
     },
     futures::{
         future,
-        stream::{self, empty, once, Stream, StreamExt, TryStream, TryStreamExt},
+        stream::{self, empty, once, Stream, StreamExt, TryStreamExt},
     },
     itertools::Itertools,
     std::{borrow::Cow, collections::HashMap, pin::Pin, rc::Rc},
@@ -26,8 +26,7 @@ pub struct Join<'a, T: GStore> {
 }
 
 type JoinItem<'a> = Rc<RowContext<'a>>;
-type Joined<'a> =
-    Pin<Box<dyn TryStream<Ok = JoinItem<'a>, Error = Error, Item = Result<JoinItem<'a>>> + 'a>>;
+type Joined<'a> = Pin<Box<dyn Stream<Item = Result<JoinItem<'a>>> + 'a>>;
 
 impl<'a, T: GStore> Join<'a, T> {
     pub fn new(
@@ -63,7 +62,7 @@ async fn join<'a, T: GStore>(
     storage: &'a T,
     filter_context: Option<Rc<RowContext<'a>>>,
     ast_join: &'a AstJoin,
-    left_rows: impl TryStream<Ok = JoinItem<'a>, Error = Error, Item = Result<JoinItem<'a>>> + 'a,
+    left_rows: impl Stream<Item = Result<JoinItem<'a>>> + 'a,
 ) -> Result<Joined<'a>> {
     let AstJoin {
         relation,

--- a/core/src/executor/select/mod.rs
+++ b/core/src/executor/select/mod.rs
@@ -19,11 +19,11 @@ use {
         ast::{Expr, OrderByExpr, Query, Select, SetExpr, TableWithJoins, Values},
         data::{get_alias, Row},
         prelude::{DataType, Value},
-        result::{Error, Result},
+        result::Result,
         store::GStore,
     },
     async_recursion::async_recursion,
-    futures::stream::{self, StreamExt, TryStream, TryStreamExt},
+    futures::stream::{self, Stream, StreamExt, TryStreamExt},
     std::{borrow::Cow, iter, rc::Rc},
     utils::Vector,
 };
@@ -110,10 +110,7 @@ pub async fn select_with_labels<'a, T: GStore>(
     storage: &'a T,
     query: &'a Query,
     filter_context: Option<Rc<RowContext<'a>>>,
-) -> Result<(
-    Option<Vec<String>>,
-    impl TryStream<Ok = Row, Error = Error, Item = Result<Row>> + 'a,
-)> {
+) -> Result<(Option<Vec<String>>, impl Stream<Item = Result<Row>> + 'a)> {
     let Select {
         from: table_with_joins,
         selection: where_clause,
@@ -210,7 +207,7 @@ pub async fn select<'a, T: GStore>(
     storage: &'a T,
     query: &'a Query,
     filter_context: Option<Rc<RowContext<'a>>>,
-) -> Result<impl TryStream<Ok = Row, Error = Error, Item = Result<Row>> + 'a> {
+) -> Result<impl Stream<Item = Result<Row>> + 'a> {
     select_with_labels(storage, query, filter_context)
         .await
         .map(|(_, rows)| rows)


### PR DESCRIPTION
While `Stream<Item = Result<T, E>>` implements `TryStream<Ok = T, Error = E>`,
https://docs.rs/futures/latest/futures/prelude/trait.TryStream.html#impl-TryStream-for-S

`TryStream<Ok = T, Error = E>` does not implement `Stream<Item = Result<T, E>>`.
That's why we were sometimes writing `TryStream<Ok=T, Error = E, Item = Result<T, E>>`.
Replace this with.