### PR TITLE
docs(javascript): update examples link

### DIFF
--- a/pkg/javascript/README.md
+++ b/pkg/javascript/README.md
@@ -43,10 +43,9 @@ console.log(rows);
 ```
 
 ## Examples
-* [JavaScript modules](https://github.com/gluesql/gluesql/tree/main/gluesql-js/examples/web/module)
-* [Rollup](https://github.com/gluesql/gluesql/tree/main/gluesql-js/examples/web/rollup)
-* [Webpack](https://github.com/gluesql/gluesql/tree/main/gluesql-js/examples/web/webpack)
-* [Node.js](https://github.com/gluesql/gluesql/tree/main/gluesql-js/examples/nodejs)
+* [JavaScript modules](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/module)
+* [Rollup](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/rollup)
+* [Webpack](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/webpack)
 
 ## 🚧 Documentation- WIP
 * [General examples](https://github.com/gluesql/gluesql/tree/main/test-suite/src)

--- a/pkg/javascript/README.md
+++ b/pkg/javascript/README.md
@@ -46,6 +46,7 @@ console.log(rows);
 * [JavaScript modules](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/module)
 * [Rollup](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/rollup)
 * [Webpack](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/web/webpack)
+* [Node.js](https://github.com/gluesql/gluesql/tree/main/pkg/javascript/examples/nodejs)
 
 ## 🚧 Documentation- WIP
 * [General examples](https://github.com/gluesql/gluesql/tree/main/test-suite/src)


### PR DESCRIPTION
It was broken during the repository migration from gluesql-js to gluesql.