### PR TITLE
Fix MemoryStorage & WebStorage primary key support

### DIFF
--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -12,7 +12,6 @@ documentation.workspace = true
 gluesql-core = { path = "../../core", version = "0.13.0" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
-indexmap = { version = "1.8", features = ["serde"] }
 
 [dev-dependencies]
 test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.13.0" }

--- a/storages/memory-storage/src/lib.rs
+++ b/storages/memory-storage/src/lib.rs
@@ -11,15 +11,17 @@ use {
         result::Result,
         store::{DataRow, RowIter, Store, StoreMut},
     },
-    indexmap::IndexMap,
     serde::{Deserialize, Serialize},
-    std::{collections::HashMap, iter::empty},
+    std::{
+        collections::{BTreeMap, HashMap},
+        iter::empty,
+    },
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Item {
     pub schema: Schema,
-    pub rows: IndexMap<Key, DataRow>,
+    pub rows: BTreeMap<Key, DataRow>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -72,7 +74,7 @@ impl StoreMut for MemoryStorage {
         let table_name = schema.table_name.clone();
         let item = Item {
             schema: schema.clone(),
-            rows: IndexMap::new(),
+            rows: BTreeMap::new(),
         };
 
         self.items.insert(table_name, item);

--- a/test-suite/src/primary_key.rs
+++ b/test-suite/src/primary_key.rs
@@ -17,7 +17,7 @@ test_case!(primary_key, async move {
     "
     );
     test!(
-        "INSERT INTO Allegro VALUES (1, 'hello'), (2, 'world');",
+        "INSERT INTO Allegro VALUES (1, 'hello'), (3, 'world');",
         Ok(Payload::Insert(2))
     );
 
@@ -27,7 +27,7 @@ test_case!(primary_key, async move {
             id  | name
             I64 | Str;
             1     "hello".to_owned();
-            2     "world".to_owned()
+            3     "world".to_owned()
         ))
     );
     test!(
@@ -53,7 +53,7 @@ test_case!(primary_key, async move {
             JOIN Allegro a2
             WHERE a.id = a2.id;
         ",
-        Ok(select!(id I64; 1; 2))
+        Ok(select!(id I64; 1; 3))
     );
     test!(
         "
@@ -61,10 +61,10 @@ test_case!(primary_key, async move {
                 SELECT id FROM Allegro WHERE id = id
             );
         ",
-        Ok(select!(id I64; 1; 2))
+        Ok(select!(id I64; 1; 3))
     );
 
-    run!("INSERT INTO Allegro VALUES (3, 'foo'), (4, 'bar'), (5, 'neon');");
+    run!("INSERT INTO Allegro VALUES (5, 'neon'), (2, 'foo'), (4, 'bar');");
 
     test!(
         "SELECT id, name FROM Allegro",
@@ -72,8 +72,8 @@ test_case!(primary_key, async move {
             id  | name
             I64 | Str;
             1     "hello".to_owned();
-            2     "world".to_owned();
-            3     "foo".to_owned();
+            2     "foo".to_owned();
+            3     "world".to_owned();
             4     "bar".to_owned();
             5     "neon".to_owned()
         ))
@@ -83,7 +83,7 @@ test_case!(primary_key, async move {
         Ok(select!(
             id  | name
             I64 | Str;
-            2     "world".to_owned();
+            2     "foo".to_owned();
             4     "bar".to_owned()
         ))
     );
@@ -103,8 +103,8 @@ test_case!(primary_key, async move {
             id  | name
             I64 | Str;
             1     "hello".to_owned();
-            2     "world".to_owned();
-            3     "foo".to_owned()
+            2     "foo".to_owned();
+            3     "world".to_owned()
         ))
     );
     run!(


### PR DESCRIPTION
depends on #1114 

Fix MemoryStorage primary key support - replace IndexMap to BTreeMap for storing rows.
Fix WebStorage primary key support - sort on scan_data if primary key exists in the schema.
Update test-suite/ primary_key to test edge cases.