### PR TITLE
Pass data even when `deleted_by` is not present

### DIFF
--- a/storages/sled-storage/src/snapshot.rs
+++ b/storages/sled-storage/src/snapshot.rs
@@ -23,13 +23,13 @@ impl<T: Clone> Snapshot<T> {
     }
 
     pub fn update(mut self, txid: u64, data: T) -> (Self, Option<T>) {
-        let old_data = if !self.0.is_empty() && self.0[0].deleted_by.is_none() {
-            self.0[0].deleted_by = Some(txid);
+        let old_data = (!self.0.is_empty()).then(|| {
+            if self.0[0].deleted_by.is_none() {
+                self.0[0].deleted_by = Some(txid);
+            }
 
-            Some(self.0[0].data.clone())
-        } else {
-            None
-        };
+            self.0[0].data.clone()
+        });
 
         let new_item = SnapshotItem {
             data,


### PR DESCRIPTION
## sled storage bug(reported by @devgony, fixed by @panarch)


### Before

```sql
gluesql> create table foo(id int primary key);
Table created

gluesql> insert into foo values(1),(2);
2 rows inserted

gluesql> delete from foo where id =1 ;
1 row deleted

gluesql> insert into foo values(1);
data: SnapshotItem { data: Vec([I64(1)]), created_by: 3, deleted_by: Some(4) }
1 row inserted

gluesql> select * from foo;
| id |
|----|
| 2  |

gluesql> insert into foo values(1);
data: SnapshotItem { data: Vec([I64(1)]), created_by: 3, deleted_by: Some(4) }
1 row inserted

gluesql> select * from foo;
| id |
|----|
| 2  |
```