### PR TITLE
Wrap identifiers with double qoute (`"`) at `to_sql`

### DIFF
--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -48,15 +48,15 @@ impl ToSql for AlterTableOperation {
                 column_name,
                 if_exists,
             } => match if_exists {
-                true => format!("DROP COLUMN IF EXISTS {column_name}"),
-                false => format!("DROP COLUMN {column_name}"),
+                true => format!(r#"DROP COLUMN IF EXISTS "{column_name}""#),
+                false => format!(r#"DROP COLUMN "{column_name}""#),
             },
             AlterTableOperation::RenameColumn {
                 old_column_name,
                 new_column_name,
-            } => format!("RENAME COLUMN {old_column_name} TO {new_column_name}"),
+            } => format!(r#"RENAME COLUMN "{old_column_name}" TO "{new_column_name}""#),
             AlterTableOperation::RenameTable { table_name } => {
-                format!("RENAME TO {table_name}")
+                format!(r#"RENAME TO "{table_name}""#)
             }
         }
     }

--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn to_sql_column_def() {
         assert_eq!(
-            "name TEXT NOT NULL UNIQUE",
+            r#""name" TEXT NOT NULL UNIQUE"#,
             ColumnDef {
                 name: "name".to_owned(),
                 data_type: DataType::Text,
@@ -121,7 +121,7 @@ mod tests {
         );
 
         assert_eq!(
-            "accepted BOOLEAN NULL",
+            r#""accepted" BOOLEAN NULL"#,
             ColumnDef {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
@@ -133,7 +133,7 @@ mod tests {
         );
 
         assert_eq!(
-            "id INT NOT NULL PRIMARY KEY",
+            r#""id" INT NOT NULL PRIMARY KEY"#,
             ColumnDef {
                 name: "id".to_owned(),
                 data_type: DataType::Int,
@@ -145,7 +145,7 @@ mod tests {
         );
 
         assert_eq!(
-            "accepted BOOLEAN NOT NULL DEFAULT FALSE",
+            r#""accepted" BOOLEAN NOT NULL DEFAULT FALSE"#,
             ColumnDef {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,
@@ -157,7 +157,7 @@ mod tests {
         );
 
         assert_eq!(
-            "accepted BOOLEAN NOT NULL DEFAULT FALSE UNIQUE",
+            r#""accepted" BOOLEAN NOT NULL DEFAULT FALSE UNIQUE"#,
             ColumnDef {
                 name: "accepted".to_owned(),
                 data_type: DataType::Boolean,

--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -76,7 +76,7 @@ impl ToSql for ColumnDef {
                 true => "NULL",
                 false => "NOT NULL",
             };
-            let column_def = format!("{name} {data_type} {nullable}");
+            let column_def = format!(r#""{name}" {data_type} {nullable}"#);
             let default = default
                 .as_ref()
                 .map(|expr| format!("DEFAULT {}", expr.to_sql()));

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -262,10 +262,11 @@ impl Expr {
 
 #[cfg(test)]
 mod tests {
+
     use {
         crate::ast::{
             AstLiteral, BinaryOperator, DataType, DateTimeField, Expr, Query, Select, SelectItem,
-            SetExpr, TableFactor, TableWithJoins, ToSql, UnaryOperator,
+            SetExpr, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted, UnaryOperator,
         },
         bigdecimal::BigDecimal,
         regex::Regex,
@@ -304,6 +305,15 @@ mod tests {
                 ident: "column".into()
             }
             .to_sql()
+        );
+
+        assert_eq!(
+            "alias.column",
+            Expr::CompoundIdentifier {
+                alias: "alias".into(),
+                ident: "column".into()
+            }
+            .to_sql_unquoted()
         );
 
         let id_expr: Box<Expr> = Box::new(Expr::Identifier("id".to_owned()));

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         Aggregate, AstLiteral, BinaryOperator, DataType, DateTimeField, Function, Query, ToSql,
-        UnaryOperator,
+        ToSqlUnquoted, UnaryOperator,
     },
     serde::{Deserialize, Serialize},
 };
@@ -83,13 +83,13 @@ impl ToSql for Expr {
     fn to_sql(&self) -> String {
         self.to_sql_with(true)
     }
+}
 
+impl ToSqlUnquoted for Expr {
     fn to_sql_unquoted(&self) -> String {
         self.to_sql_with(false)
     }
-}
 
-impl Expr {
     fn to_sql_with(&self, qouted: bool) -> String {
         match self {
             Expr::Identifier(s) => match qouted {

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -226,7 +226,26 @@ impl ToSql for Expr {
 //     DDL,
 // }
 impl Expr {
-    // fn to_string_with(&self, usage: Usage) {}
+    fn to_string_with(&self, qouted: bool) -> String {
+        match self {
+            Expr::Identifier(s) => match qouted {
+                true => format! {r#""{s}""#},
+                false => s.to_string(),
+            },
+            Expr::BinaryOp { left, op, right } => format!(
+                "{} {} {}",
+                left.to_string_with(qouted),
+                op.to_sql(),
+                right.to_string_with(qouted)
+            ),
+            Expr::CompoundIdentifier { alias, ident } => match qouted {
+                true => format!(r#""{alias}"."{ident}""#),
+                false => self.to_sql(),
+            },
+            Expr::IsNull(s) => format!("{} IS NULL", s.to_string_with(qouted)),
+            _ => todo!(),
+        }
+    }
     pub fn to_ddl(&self) -> String {
         match self {
             Expr::Identifier(s) => format! {r#""{s}""#},

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -89,7 +89,9 @@ impl ToSqlUnquoted for Expr {
     fn to_sql_unquoted(&self) -> String {
         self.to_sql_with(false)
     }
+}
 
+impl Expr {
     fn to_sql_with(&self, qouted: bool) -> String {
         match self {
             Expr::Identifier(s) => match qouted {

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -579,6 +579,42 @@ mod tests {
 
         assert_eq!(
             trim(
+                r#"CASE
+                  WHEN "id" = 1 THEN 'a'
+                  WHEN "id" = 2 THEN 'b'
+                END"#,
+            ),
+            Expr::Case {
+                operand: None,
+                when_then: vec![
+                    (
+                        Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier("id".to_owned())),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(Expr::Literal(AstLiteral::Number(
+                                BigDecimal::from_str("1").unwrap()
+                            )))
+                        },
+                        Expr::Literal(AstLiteral::QuotedString("a".to_owned()))
+                    ),
+                    (
+                        Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier("id".to_owned())),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(Expr::Literal(AstLiteral::Number(
+                                BigDecimal::from_str("2").unwrap()
+                            )))
+                        },
+                        Expr::Literal(AstLiteral::QuotedString("b".to_owned()))
+                    )
+                ],
+                else_result: None,
+            }
+            .to_sql()
+        );
+
+        assert_eq!(
+            trim(
                 r#"CASE "id"
                   WHEN 1 THEN 'a'
                   WHEN 2 THEN 'b'

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -82,7 +82,7 @@ pub enum Expr {
 impl ToSql for Expr {
     fn to_sql(&self) -> String {
         match self {
-            Expr::Identifier(s) => s.to_owned(),
+            Expr::Identifier(s) => format! {r#""{s}""#},
             Expr::BinaryOp { left, op, right } => {
                 format!("{} {} {}", left.to_sql(), op.to_sql(), right.to_sql())
             }

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -509,9 +509,9 @@ mod tests {
         );
 
         assert_eq!(
-            r#"CONCAT_WS(-, "Tic", "tac", "toe")"#,
+            r#"CONCAT_WS('-', "Tic", "tac", "toe")"#,
             &Expr::Function(Box::new(Function::ConcatWs {
-                separator: Expr::Identifier("-".to_owned()),
+                separator: Expr::Literal(AstLiteral::QuotedString("-".to_owned())),
                 exprs: vec![
                     Expr::Identifier("Tic".to_owned()),
                     Expr::Identifier("tac".to_owned()),

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn to_sql_function() {
         assert_eq!(
-            "ABS(num)",
+            r#"ABS("num")"#,
             &Expr::Function(Box::new(Function::Abs(Expr::Identifier("num".to_owned())))).to_sql()
         );
 
@@ -421,7 +421,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"ASIN(2)"#,
+            "ASIN(2)",
             &Expr::Function(Box::new(Function::Asin(Expr::Literal(AstLiteral::Number(
                 BigDecimal::from_str("2").unwrap()
             )))))
@@ -429,7 +429,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"ACOS(2)"#,
+            "ACOS(2)",
             &Expr::Function(Box::new(Function::Acos(Expr::Literal(AstLiteral::Number(
                 BigDecimal::from_str("2").unwrap()
             )))))
@@ -437,7 +437,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"ATAN(2)"#,
+            "ATAN(2)",
             &Expr::Function(Box::new(Function::Atan(Expr::Literal(AstLiteral::Number(
                 BigDecimal::from_str("2").unwrap()
             )))))
@@ -494,12 +494,12 @@ mod tests {
         );
 
         assert_eq!(
-            "CEIL(num)",
+            r#"CEIL("num")"#,
             &Expr::Function(Box::new(Function::Ceil(Expr::Identifier("num".to_owned())))).to_sql()
         );
 
         assert_eq!(
-            "CONCAT(Tic, tac, toe)",
+            r#"CONCAT("Tic", "tac", "toe")"#,
             &Expr::Function(Box::new(Function::Concat(vec![
                 Expr::Identifier("Tic".to_owned()),
                 Expr::Identifier("tac".to_owned()),
@@ -509,7 +509,7 @@ mod tests {
         );
 
         assert_eq!(
-            "CONCAT_WS(-, Tic, tac, toe)",
+            r#"CONCAT_WS(-, "Tic", "tac", "toe")"#,
             &Expr::Function(Box::new(Function::ConcatWs {
                 separator: Expr::Identifier("-".to_owned()),
                 exprs: vec![
@@ -522,7 +522,7 @@ mod tests {
         );
 
         assert_eq!(
-            "IFNULL(updated_at, created_at)",
+            r#"IFNULL("updated_at", "created_at")"#,
             &Expr::Function(Box::new(Function::IfNull {
                 expr: Expr::Identifier("updated_at".to_owned()),
                 then: Expr::Identifier("created_at".to_owned())
@@ -536,7 +536,7 @@ mod tests {
         );
 
         assert_eq!(
-            "RAND(num)",
+            r#"RAND("num")"#,
             &Expr::Function(Box::new(Function::Rand(Some(Expr::Identifier(
                 "num".to_owned()
             )))))
@@ -544,7 +544,7 @@ mod tests {
         );
 
         assert_eq!(
-            "ROUND(num)",
+            r#"ROUND("num")"#,
             &Expr::Function(Box::new(Function::Round(Expr::Identifier(
                 "num".to_owned()
             ))))
@@ -552,7 +552,7 @@ mod tests {
         );
 
         assert_eq!(
-            "FLOOR(num)",
+            r#"FLOOR("num")"#,
             &Expr::Function(Box::new(Function::Floor(Expr::Identifier(
                 "num".to_owned()
             ))))
@@ -560,7 +560,7 @@ mod tests {
         );
 
         assert_eq!(
-            "TRIM(name)",
+            r#"TRIM("name")"#,
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: None,
@@ -570,7 +570,7 @@ mod tests {
         );
 
         assert_eq!(
-            "TRIM('*' FROM name)",
+            r#"TRIM('*' FROM "name")"#,
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -580,7 +580,7 @@ mod tests {
         );
 
         assert_eq!(
-            "TRIM(BOTH '*' FROM name)",
+            r#"TRIM(BOTH '*' FROM "name")"#,
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -590,7 +590,7 @@ mod tests {
         );
 
         assert_eq!(
-            "TRIM(LEADING '*' FROM name)",
+            r#"TRIM(LEADING '*' FROM "name")"#,
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: Some(Expr::Literal(AstLiteral::QuotedString("*".to_owned()))),
@@ -600,7 +600,7 @@ mod tests {
         );
 
         assert_eq!(
-            r#"TRIM(LEADING name)"#,
+            r#"TRIM(LEADING "name")"#,
             &Expr::Function(Box::new(Function::Trim {
                 expr: Expr::Identifier("name".to_owned()),
                 filter_chars: None,
@@ -635,12 +635,12 @@ mod tests {
         );
 
         assert_eq!(
-            "LOG2(num)",
+            r#"LOG2("num")"#,
             &Expr::Function(Box::new(Function::Log2(Expr::Identifier("num".to_owned())))).to_sql()
         );
 
         assert_eq!(
-            "LOG10(num)",
+            r#"LOG10("num")"#,
             &Expr::Function(Box::new(Function::Log10(Expr::Identifier(
                 "num".to_owned()
             ))))
@@ -781,7 +781,7 @@ mod tests {
         );
 
         assert_eq!(
-            "REVERSE(name)",
+            r#"REVERSE("name")"#,
             &Expr::Function(Box::new(Function::Reverse(Expr::Identifier(
                 "name".to_owned()
             ))))
@@ -828,7 +828,7 @@ mod tests {
         );
 
         assert_eq!(
-            "UNWRAP(nested, 'a.foo')",
+            r#"UNWRAP("nested", 'a.foo')"#,
             &Expr::Function(Box::new(Function::Unwrap {
                 expr: Expr::Identifier("nested".to_owned()),
                 selector: Expr::Literal(AstLiteral::QuotedString("a.foo".to_owned()))
@@ -928,7 +928,7 @@ mod tests {
         );
 
         assert_eq!(
-            "EXTRACT(MINUTE FROM '2022-05-05 01:02:03')",
+            r#"EXTRACT("MINUTE" FROM '2022-05-05 01:02:03')"#,
             &Expr::Function(Box::new(Function::Extract {
                 field: DateTimeField::Minute,
                 expr: Expr::Identifier("2022-05-05 01:02:03".to_owned())
@@ -937,7 +937,7 @@ mod tests {
         );
 
         assert_eq!(
-            "APPEND(list, value)",
+            r#"APPEND("list", "value")"#,
             &Expr::Function(Box::new(Function::Append {
                 expr: Expr::Identifier("list".to_owned()),
                 value: Expr::Identifier("value".to_owned())
@@ -949,7 +949,7 @@ mod tests {
     #[test]
     fn to_sql_aggregate() {
         assert_eq!(
-            "MAX(id)",
+            r#"MAX("id")"#,
             Expr::Aggregate(Box::new(Aggregate::Max(Expr::Identifier("id".to_owned())))).to_sql()
         );
 
@@ -959,12 +959,12 @@ mod tests {
         );
 
         assert_eq!(
-            "MIN(id)",
+            r#"MIN("id")"#,
             Expr::Aggregate(Box::new(Aggregate::Min(Expr::Identifier("id".to_owned())))).to_sql()
         );
 
         assert_eq!(
-            "SUM(price)",
+            r#"SUM("price")"#,
             &Expr::Aggregate(Box::new(Aggregate::Sum(Expr::Identifier(
                 "price".to_owned()
             ))))
@@ -972,18 +972,18 @@ mod tests {
         );
 
         assert_eq!(
-            "AVG(pay)",
+            r#"AVG("pay")"#,
             &Expr::Aggregate(Box::new(Aggregate::Avg(Expr::Identifier("pay".to_owned())))).to_sql()
         );
         assert_eq!(
-            "VARIANCE(pay)",
+            r#"VARIANCE("pay")"#,
             &Expr::Aggregate(Box::new(Aggregate::Variance(Expr::Identifier(
                 "pay".to_owned()
             ))))
             .to_sql()
         );
         assert_eq!(
-            "STDEV(total)",
+            r#"STDEV("total")"#,
             &Expr::Aggregate(Box::new(Aggregate::Stdev(Expr::Identifier(
                 "total".to_owned()
             ))))

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -313,7 +313,7 @@ impl ToSql for Function {
                 ),
             },
             Function::Extract { field, expr } => {
-                format!("EXTRACT({field} FROM '{}')", expr.to_sql())
+                format!("EXTRACT({field} FROM {})", expr.to_sql())
             }
             Function::Ascii(e) => format!("ASCII({})", e.to_sql()),
             Function::Chr(e) => format!("CHR({})", e.to_sql()),
@@ -928,10 +928,10 @@ mod tests {
         );
 
         assert_eq!(
-            r#"EXTRACT("MINUTE" FROM '2022-05-05 01:02:03')"#,
+            r#"EXTRACT(MINUTE FROM '2022-05-05 01:02:03')"#,
             &Expr::Function(Box::new(Function::Extract {
                 field: DateTimeField::Minute,
-                expr: Expr::Identifier("2022-05-05 01:02:03".to_owned())
+                expr: Expr::Literal(AstLiteral::QuotedString("2022-05-05 01:02:03".to_owned()))
             }))
             .to_sql()
         );

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -198,10 +198,14 @@ impl ToSql for Statement {
                 format!("{sql};")
             }
             Statement::AlterTable { name, operation } => {
-                format!("ALTER TABLE {name} {};", operation.to_sql())
+                format!(r#"ALTER TABLE "{name}" {};"#, operation.to_sql())
             }
             Statement::DropTable { if_exists, names } => {
-                let names = names.join(", ");
+                let names = names
+                    .iter()
+                    .map(|name| format!(r#""{name}""#))
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 match if_exists {
                     true => format!("DROP TABLE IF EXISTS {};", names),
                     false => format!("DROP TABLE {};", names),

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -24,8 +24,6 @@ pub trait ToSql {
 
 pub trait ToSqlUnquoted {
     fn to_sql_unquoted(&self) -> String;
-
-    fn to_sql_with(&self, qouted: bool) -> String;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -22,7 +22,7 @@ pub trait ToSql {
     fn to_sql(&self) -> String;
 
     fn to_sql_unquoted(&self) -> String {
-        panic!("to_sql_unquoted is not implemented");
+        unimplemented!("to_sql_unquoted is not implemented");
     }
 }
 

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -228,7 +228,7 @@ impl ToSql for Statement {
                 Variable::Version => "SHOW VERSIONS;".to_owned(),
             },
             Statement::ShowIndexes(object_name) => {
-                format!("SHOW INDEXES FROM {object_name};")
+                format!(r#"SHOW INDEXES FROM "{object_name}";"#)
             }
             _ => "(..statement..)".to_owned(),
         }
@@ -674,7 +674,7 @@ mod tests {
     #[test]
     fn to_sql_show_indexes() {
         assert_eq!(
-            "SHOW INDEXES FROM Test;",
+            r#"SHOW INDEXES FROM "Test";"#,
             Statement::ShowIndexes("Test".into()).to_sql()
         );
     }
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn to_sql_assignment() {
         assert_eq!(
-            "count = 5",
+            r#""count" = 5"#,
             Assignment {
                 id: "count".to_owned(),
                 value: Expr::Literal(AstLiteral::Number(BigDecimal::from_str("5").unwrap()))

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -20,6 +20,10 @@ use serde::{Deserialize, Serialize};
 
 pub trait ToSql {
     fn to_sql(&self) -> String;
+
+    fn to_sql_unquoted(&self) -> String {
+        panic!("to_sql_unquoted is not implemented");
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -142,19 +142,19 @@ impl ToSql for Statement {
                 match selection {
                     Some(expr) => {
                         format!(
-                            "UPDATE {table_name} SET {assignments} WHERE {};",
+                            r#"UPDATE "{table_name}" SET {assignments} WHERE {};"#,
                             expr.to_sql()
                         )
                     }
-                    None => format!("UPDATE {table_name} SET {assignments};"),
+                    None => format!(r#"UPDATE "{table_name}" SET {assignments};"#),
                 }
             }
             Statement::Delete {
                 table_name,
                 selection,
             } => match selection {
-                Some(expr) => format!("DELETE FROM {table_name} WHERE {};", expr.to_sql()),
-                None => format!("DELETE FROM {table_name};"),
+                Some(expr) => format!(r#"DELETE FROM "{table_name}" WHERE {};"#, expr.to_sql()),
+                None => format!(r#"DELETE FROM "{table_name}";"#),
             },
             Statement::CreateTable {
                 if_not_exists,
@@ -237,7 +237,7 @@ impl ToSql for Statement {
 
 impl ToSql for Assignment {
     fn to_sql(&self) -> String {
-        format!("{} = {}", self.id, self.value.to_sql())
+        format!(r#""{}" = {}"#, self.id, self.value.to_sql())
     }
 }
 
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn to_sql_update() {
         assert_eq!(
-            "UPDATE Foo SET id = 4, color = 'blue';",
+            r#"UPDATE "Foo" SET "id" = 4, "color" = 'blue';"#,
             Statement::Update {
                 table_name: "Foo".into(),
                 assignments: vec![
@@ -310,7 +310,7 @@ mod tests {
         );
 
         assert_eq!(
-            "UPDATE Foo SET name = 'first' WHERE a > b;",
+            r#"UPDATE "Foo" SET "name" = 'first' WHERE "a" > "b";"#,
             Statement::Update {
                 table_name: "Foo".into(),
                 assignments: vec![Assignment {

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -20,10 +20,12 @@ use serde::{Deserialize, Serialize};
 
 pub trait ToSql {
     fn to_sql(&self) -> String;
+}
 
-    fn to_sql_unquoted(&self) -> String {
-        unimplemented!("to_sql_unquoted is not implemented");
-    }
+pub trait ToSqlUnquoted {
+    fn to_sql_unquoted(&self) -> String;
+
+    fn to_sql_with(&self, qouted: bool) -> String;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -186,7 +186,7 @@ impl ToSql for Statement {
                 let sql = vec![
                     Some("CREATE TABLE"),
                     if_not_exists,
-                    Some(name),
+                    Some(&format! {r#""{name}""#}),
                     body.as_deref(),
                     engine.as_deref(),
                 ]

--- a/core/src/ast/operator.rs
+++ b/core/src/ast/operator.rs
@@ -100,15 +100,18 @@ impl From<IndexOperator> for BinaryOperator {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{BinaryOperator, Expr, ToSql, UnaryOperator};
+    use {
+        crate::ast::{AstLiteral, BinaryOperator, Expr, ToSql, UnaryOperator},
+        bigdecimal::BigDecimal,
+    };
     #[test]
     fn to_sql() {
         assert_eq!(
             "1 + 2",
             Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1)))),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Identifier(2.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(2))))
             }
             .to_sql()
         );
@@ -116,9 +119,9 @@ mod tests {
         assert_eq!(
             "100 - 10",
             Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(100.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(100)))),
                 op: BinaryOperator::Minus,
-                right: Box::new(Expr::Identifier(10.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(10))))
             }
             .to_sql()
         );
@@ -126,9 +129,9 @@ mod tests {
         assert_eq!(
             "1024 * 1024",
             Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::Multiply,
-                right: Box::new(Expr::Identifier(1024.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024))))
             }
             .to_sql()
         );
@@ -136,9 +139,9 @@ mod tests {
         assert_eq!(
             "1024 / 8",
             Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::Divide,
-                right: Box::new(Expr::Identifier(8.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8))))
             }
             .to_sql()
         );
@@ -146,78 +149,78 @@ mod tests {
         assert_eq!(
             "1024 % 4",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::Modulo,
-                right: Box::new(Expr::Identifier(4.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(4))))
             }
             .to_sql()
         );
 
         assert_eq!(
-            "Glue + SQL",
+            "'Glue' + 'SQL'",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier("Glue".to_owned())),
+                left: Box::new(Expr::Literal(AstLiteral::QuotedString("Glue".to_owned()))),
                 op: BinaryOperator::StringConcat,
-                right: Box::new(Expr::Identifier("SQL".to_owned()))
+                right: Box::new(Expr::Literal(AstLiteral::QuotedString("SQL".to_owned())))
             }
             .to_sql()
         );
         assert_eq!(
             "1024 > 4",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Identifier(4.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(4))))
             }
             .to_sql()
         );
         assert_eq!(
             "8 < 1024",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(8.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8)))),
                 op: BinaryOperator::Lt,
-                right: Box::new(Expr::Identifier(1024.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024))))
             }
             .to_sql()
         );
         assert_eq!(
             "1024 >= 1024",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::GtEq,
-                right: Box::new(Expr::Identifier(1024.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024))))
             }
             .to_sql()
         );
         assert_eq!(
             "8 <= 8",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(8.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8)))),
                 op: BinaryOperator::LtEq,
-                right: Box::new(Expr::Identifier(8.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8))))
             }
             .to_sql()
         );
         assert_eq!(
             "1024 = 1024",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Identifier(1024.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024))))
             }
             .to_sql()
         );
         assert_eq!(
             "1024 <> 1024",
             &Expr::BinaryOp {
-                left: Box::new(Expr::Identifier(1024.to_string())),
+                left: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024)))),
                 op: BinaryOperator::NotEq,
-                right: Box::new(Expr::Identifier(1024.to_string()))
+                right: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1024))))
             }
             .to_sql()
         );
         assert_eq!(
-            "condition_0 AND condition_1",
+            r#""condition_0" AND "condition_1""#,
             &Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("condition_0".to_owned())),
                 op: BinaryOperator::And,
@@ -226,7 +229,7 @@ mod tests {
             .to_sql()
         );
         assert_eq!(
-            "condition_0 OR condition_1",
+            r#""condition_0" OR "condition_1""#,
             &Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("condition_0".to_owned())),
                 op: BinaryOperator::Or,
@@ -235,7 +238,7 @@ mod tests {
             .to_sql()
         );
         assert_eq!(
-            "condition_0 XOR condition_1",
+            r#""condition_0" XOR "condition_1""#,
             &Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("condition_0".to_owned())),
                 op: BinaryOperator::Xor,
@@ -248,7 +251,7 @@ mod tests {
             "+8",
             Expr::UnaryOp {
                 op: UnaryOperator::Plus,
-                expr: Box::new(Expr::Identifier("8".to_owned())),
+                expr: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8)))),
             }
             .to_sql(),
         );
@@ -257,13 +260,13 @@ mod tests {
             "-8",
             Expr::UnaryOp {
                 op: UnaryOperator::Minus,
-                expr: Box::new(Expr::Identifier("8".to_owned())),
+                expr: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(8)))),
             }
             .to_sql(),
         );
 
         assert_eq!(
-            "NOT id",
+            r#"NOT "id""#,
             Expr::UnaryOp {
                 op: UnaryOperator::Not,
                 expr: Box::new(Expr::Identifier("id".to_owned())),
@@ -275,7 +278,7 @@ mod tests {
             "5!",
             Expr::UnaryOp {
                 op: UnaryOperator::Factorial,
-                expr: Box::new(Expr::Identifier("5".to_owned())),
+                expr: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(5)))),
             }
             .to_sql(),
         )

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -727,7 +727,7 @@ mod tests {
 
     #[test]
     fn to_sql_order_by_expr() {
-        let actual = "foo ASC".to_owned();
+        let actual = r#""foo" ASC"#;
         let expected = OrderByExpr {
             expr: Expr::Identifier("foo".to_owned()),
             asc: Some(true),
@@ -735,7 +735,7 @@ mod tests {
         .to_sql();
         assert_eq!(actual, expected);
 
-        let actual = "foo DESC".to_owned();
+        let actual = r#""foo" DESC"#;
         let expected = OrderByExpr {
             expr: Expr::Identifier("foo".to_owned()),
             asc: Some(false),
@@ -743,7 +743,7 @@ mod tests {
         .to_sql();
         assert_eq!(actual, expected);
 
-        let actual = "foo".to_owned();
+        let actual = r#""foo""#;
         let expected = OrderByExpr {
             expr: Expr::Identifier("foo".to_owned()),
             asc: None,

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -216,12 +216,11 @@ impl ToSql for Select {
             .filter(|sql| !sql.is_empty())
             .join(" ");
 
-        let condition = match condition.is_empty() {
-            true => "".to_owned(),
-            false => format!(" {}", condition),
-        };
-
-        format!(r#"SELECT {projection} FROM {}{condition}"#, from.to_sql())
+        if condition.is_empty() {
+            format!("SELECT {projection} FROM {}", from.to_sql())
+        } else {
+            format!("SELECT {projection} FROM {} {condition}", from.to_sql())
+        }
     }
 }
 

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -216,11 +216,12 @@ impl ToSql for Select {
             .filter(|sql| !sql.is_empty())
             .join(" ");
 
-        if condition.is_empty() {
-            format!("SELECT {projection} FROM {}", from.to_sql())
-        } else {
-            format!("SELECT {projection} FROM {} {condition}", from.to_sql())
-        }
+        let condition = match condition.is_empty() {
+            true => "".to_owned(),
+            false => format!(" {}", condition),
+        };
+
+        format!(r#"SELECT {projection} FROM "{}"{condition}"#, from.to_sql())
     }
 }
 

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -1,7 +1,7 @@
 use {
     super::ExprNode,
     crate::{
-        ast::{Expr, SelectItem, ToSql},
+        ast::{Expr, SelectItem, ToSqlUnquoted},
         parse_sql::parse_select_item,
         result::{Error, Result},
         translate::translate_select_item,

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -1,7 +1,7 @@
 use {
     super::ExprNode,
     crate::{
-        ast::{Expr, SelectItem},
+        ast::{Expr, SelectItem, ToSql},
         parse_sql::parse_select_item,
         result::{Error, Result},
         translate::translate_select_item,
@@ -44,7 +44,7 @@ impl<'a> TryFrom<SelectItemNode<'a>> for SelectItem {
             }
             SelectItemNode::Expr(expr_node) => {
                 let expr = Expr::try_from(expr_node)?;
-                let label = expr.to_ddl();
+                let label = expr.to_sql_unquoted();
 
                 Ok(SelectItem::Expr { expr, label })
             }

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -44,7 +44,7 @@ impl<'a> TryFrom<SelectItemNode<'a>> for SelectItem {
             }
             SelectItemNode::Expr(expr_node) => {
                 let expr = Expr::try_from(expr_node)?;
-                let label = expr.clone().into();
+                let label = expr.to_ddl();
 
                 Ok(SelectItem::Expr { expr, label })
             }

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -44,7 +44,7 @@ impl<'a> TryFrom<SelectItemNode<'a>> for SelectItem {
             }
             SelectItemNode::Expr(expr_node) => {
                 let expr = Expr::try_from(expr_node)?;
-                let label = expr.to_sql().replace("\"", ""); // TODO: should replace to_sql to into()
+                let label = expr.clone().into();
 
                 Ok(SelectItem::Expr { expr, label })
             }

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -1,7 +1,7 @@
 use {
     super::ExprNode,
     crate::{
-        ast::{Expr, SelectItem, ToSql},
+        ast::{Expr, SelectItem},
         parse_sql::parse_select_item,
         result::{Error, Result},
         translate::translate_select_item,

--- a/core/src/ast_builder/select_item.rs
+++ b/core/src/ast_builder/select_item.rs
@@ -44,7 +44,7 @@ impl<'a> TryFrom<SelectItemNode<'a>> for SelectItem {
             }
             SelectItemNode::Expr(expr_node) => {
                 let expr = Expr::try_from(expr_node)?;
-                let label = expr.to_sql();
+                let label = expr.to_sql().replace("\"", ""); // TODO: should replace to_sql to into()
 
                 Ok(SelectItem::Expr { expr, label })
             }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -321,7 +321,7 @@ CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
                     unique: None,
                 },
                 ColumnDef {
-                    name: ";".to_string(),
+                    name: ";".to_owned(),
                     data_type: DataType::Int,
                     nullable: true,
                     default: None,
@@ -329,8 +329,8 @@ CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
                 },
             ]),
             indexes: vec![SchemaIndex {
-                name: ".".to_string(),
-                expr: Expr::Identifier(";".to_string()),
+                name: ".".to_owned(),
+                expr: Expr::Identifier(";".to_owned()),
                 order: SchemaIndexOrd::Both,
                 created: Utc::now().naive_utc(),
             }],

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -206,7 +206,7 @@ mod tests {
             created: Utc::now().naive_utc(),
         };
 
-        let ddl = "CREATE TABLE User (id INT NOT NULL, name TEXT NULL DEFAULT 'glue');";
+        let ddl = r#"CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NULL DEFAULT 'glue');"#;
         assert_eq!(schema.to_ddl(), ddl);
 
         let actual = Schema::from_ddl(ddl).unwrap();
@@ -219,7 +219,7 @@ mod tests {
             engine: None,
             created: Utc::now().naive_utc(),
         };
-        let ddl = "CREATE TABLE Test;";
+        let ddl = r#"CREATE TABLE "Test";"#;
         assert_eq!(schema.to_ddl(), ddl);
 
         let actual = Schema::from_ddl(ddl).unwrap();
@@ -242,7 +242,7 @@ mod tests {
             created: Utc::now().naive_utc(),
         };
 
-        let ddl = "CREATE TABLE User (id INT NOT NULL PRIMARY KEY);";
+        let ddl = r#"CREATE TABLE "User" ("id" INT NOT NULL PRIMARY KEY);"#;
         assert_eq!(schema.to_ddl(), ddl);
 
         let actual = Schema::from_ddl(ddl).unwrap();
@@ -251,7 +251,8 @@ mod tests {
 
     #[test]
     fn invalid_ddl() {
-        let invalid_ddl = "DROP TABLE Users";
+        // Only Statement::CreateTable is supported
+        let invalid_ddl = r#"DROP TABLE "Users";"#;
         let actual = Schema::from_ddl(invalid_ddl);
         assert_eq!(actual, Err(SchemaParseError::CannotParseDDL.into()));
     }
@@ -293,16 +294,16 @@ mod tests {
             engine: None,
             created: Utc::now().naive_utc(),
         };
-        let ddl = "CREATE TABLE User (id INT NOT NULL, name TEXT NOT NULL);
-CREATE INDEX User_id ON User (id);
-CREATE INDEX User_name ON User (name);";
+        let ddl = r#"CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);
+CREATE INDEX "User_id" ON "User" ("id");
+CREATE INDEX "User_name" ON "User" ("name");"#;
         assert_eq!(schema.to_ddl(), ddl);
 
         let actual = Schema::from_ddl(ddl).unwrap();
         assert_schema(actual, schema);
 
-        let index_should_not_be_first = "CREATE INDEX User_id ON User (id);
-CREATE TABLE User (id INT NOT NULL, name TEXT NOT NULL);";
+        let index_should_not_be_first = r#"CREATE INDEX "User_id" ON "User" ("id");
+CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
         let actual = Schema::from_ddl(index_should_not_be_first);
         assert_eq!(actual, Err(SchemaParseError::CannotParseDDL.into()));
     }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -329,7 +329,6 @@ CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
                 created: Utc::now().naive_utc(),
             }],
             engine: None,
-            created: Utc::now().naive_utc(),
         };
         let ddl = r#"CREATE TABLE "1" ("2" INT NULL, ";" INT NULL);
 CREATE INDEX "." ON "1" (";");"#;

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -319,7 +319,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                     Value::Str(schema.table_name.clone()),
                                     Value::Str(index.name),
                                     Value::Str(index.order.to_string()),
-                                    Value::Str(index.expr.to_sql()),
+                                    Value::Str(index.expr.into()),
                                     Value::Bool(false),
                                 ];
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         ast::{
             ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
-            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSql, Values,
+            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSqlUnquoted, Values,
         },
         data::{get_alias, get_index, Key, Row, Value},
         executor::{evaluate::evaluate, select::select},

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         ast::{
             ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
-            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, Values,
+            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSql, Values,
         },
         data::{get_alias, get_index, Key, Row, Value},
         executor::{evaluate::evaluate, select::select},
@@ -319,7 +319,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                     Value::Str(schema.table_name.clone()),
                                     Value::Str(index.name),
                                     Value::Str(index.order.to_string()),
-                                    Value::Str(index.expr.to_ddl()),
+                                    Value::Str(index.expr.to_sql_unquoted()),
                                     Value::Bool(false),
                                 ];
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -319,7 +319,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                     Value::Str(schema.table_name.clone()),
                                     Value::Str(index.name),
                                     Value::Str(index.order.to_string()),
-                                    Value::Str(index.expr.into()),
+                                    Value::Str(index.expr.to_ddl()),
                                     Value::Bool(false),
                                 ];
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         ast::{
             ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
-            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSql, Values,
+            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, Values,
         },
         data::{get_alias, get_index, Key, Row, Value},
         executor::{evaluate::evaluate, select::select},


### PR DESCRIPTION
## Goal
```sql
gluesql> CREATE TABLE "1" (";" INT);
Table created
gluesql> SHOW TABLES;
```
| tables |
|--------|
| 1      |
```sql
gluesql> SHOW COLUMNS FROM "1";
```
| Field | Type |
|-------|------|
| ;     | INT  |

- Currently Table with non-word identifier (like above `Table 1`) can be created but will get `parse error`  at `dump_database` and `from_ddl`(especially at `json_storage`)
- To fix it, this PR will wrap all identifiers(TABLE_NAME, COLUMN_NAME, ALIAS..) with double qoute (`"`) at `to_sql`
## Todo
- [x] wrap all kind of identifiers with `"` at `to_sql`
- [x] correct test cases (QuotedStrings were confused with Identifiers)
- [x] implement  `impl From<Expr> for String` to solve below cases
  - [x] correct SelectItemNode and GLUE_INDEXES to use `expr.into()`
## Next
- fix CTAS to infer types from not only VALUES but also SELECT clause