### PR TITLE
Add nullable, key, default to `GLUE_TABLE_COLUMNS`

### DIFF
--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -1,11 +1,13 @@
-use crate::ast::ToSql;
-
 use {
     super::{context::RowContext, evaluate::evaluate_stateless, filter::check_expr},
     crate::{
         ast::{
-            ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
-            SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSqlUnquoted, Values,
+            ToSql,
+            {
+                ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
+                SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSqlUnquoted,
+                Values,
+            },
         },
         data::{get_alias, get_index, Key, Row, Value},
         executor::{evaluate::evaluate, select::select},

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -1,3 +1,5 @@
+use crate::ast::ToSql;
+
 use {
     super::{context::RowContext, evaluate::evaluate_stateless, filter::check_expr},
     crate::{
@@ -276,6 +278,19 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                         Value::Str(table_name.clone()),
                                         Value::Str(column_def.name),
                                         Value::I64(index as i64 + 1),
+                                        Value::Bool(column_def.nullable),
+                                        Value::Str(
+                                            column_def
+                                                .unique
+                                                .map(|unique| unique.to_sql())
+                                                .unwrap_or_default(),
+                                        ),
+                                        Value::Str(
+                                            column_def
+                                                .default
+                                                .map(|expr| expr.to_sql())
+                                                .unwrap_or_default(),
+                                        ),
                                     ];
 
                                     Ok(Row::Vec {
@@ -407,6 +422,9 @@ pub async fn fetch_relation_columns<T: GStore>(
                 "TABLE_NAME".to_owned(),
                 "COLUMN_NAME".to_owned(),
                 "COLUMN_ID".to_owned(),
+                "NULLABLE".to_owned(),
+                "KEY".to_owned(),
+                "DEFAULT".to_owned(),
             ],
             Dictionary::GlueIndexes => vec![
                 "TABLE_NAME".to_owned(),

--- a/test-suite/src/dictionary.rs
+++ b/test-suite/src/dictionary.rs
@@ -23,8 +23,8 @@ test_case!(dictionary, async move {
     run!("CREATE TABLE Foo (id INTEGER, name TEXT NULL, type TEXT NULL);");
     test!("SHOW TABLES", tables(vec!["Foo"]));
 
-    run!("CREATE TABLE Zoo (id INTEGER);");
-    run!("CREATE TABLE Bar (id INTEGER, name TEXT NULL);");
+    run!("CREATE TABLE Zoo (id INTEGER PRIMARY KEY);");
+    run!("CREATE TABLE Bar (id INTEGER UNIQUE, name TEXT NOT NULL DEFAULT 'NONE');");
 
     test!("SHOW TABLES", tables(vec!["Bar", "Foo", "Zoo"]));
 
@@ -55,14 +55,14 @@ test_case!(dictionary, async move {
     test!(
         "SELECT * FROM GLUE_TABLE_COLUMNS",
         Ok(select!(
-            TABLE_NAME       | COLUMN_NAME      | COLUMN_ID;
-            Str              | Str              | I64;
-            "Bar".to_owned()   "id".to_owned()    1;
-            "Bar".to_owned()   "name".to_owned()  2;
-            "Foo".to_owned()   "id".to_owned()    1;
-            "Foo".to_owned()   "name".to_owned()  2;
-            "Foo".to_owned()   "type".to_owned()  3;
-            "Zoo".to_owned()   "id".to_owned()    1
+            TABLE_NAME       | COLUMN_NAME      | COLUMN_ID | NULLABLE | KEY                      | DEFAULT;
+            Str              | Str              | I64       | Bool     | Str                      | Str;
+            "Bar".to_owned()   "id".to_owned()    1           true       "UNIQUE".to_owned()        "".to_owned();
+            "Bar".to_owned()   "name".to_owned()  2           false      "".to_owned()              "'NONE'".to_owned();
+            "Foo".to_owned()   "id".to_owned()    1           true       "".to_owned()              "".to_owned();
+            "Foo".to_owned()   "name".to_owned()  2           true       "".to_owned()              "".to_owned();
+            "Foo".to_owned()   "type".to_owned()  3           true       "".to_owned()              "".to_owned();
+            "Zoo".to_owned()   "id".to_owned()    1           false      "PRIMARY KEY".to_owned()   "".to_owned()
         ))
     );
 });


### PR DESCRIPTION
## Goal
```sql
gluesql> CREATE TABLE T1 (id INT PRIMARY KEY, name TEXT NULL);
Table created

gluesql> CREATE TABLE T2 (id INT UNIQUE DEFAULT 0 NULL);
Table created

gluesql> SELECT * FROM GLUE_TABLE_COLUMNS;
```
gluesql> SELECT * FROM GLUE_TABLE_COLUMNS;
| TABLE_NAME | COLUMN_NAME | COLUMN_ID | NULLABLE | KEY         | DEFAULT |
|------------|-------------|-----------|----------|-------------|---------|
| T1         | id          | 1         | FALSE    | PRIMARY KEY |         |
| T1         | name        | 2         | TRUE     |             |         |
| T2         | id          | 1         | TRUE     | UNIQUE      | 0       |

## Todo
- [x] add nullable, key, default to `GLUE_TABLE_COLUMNS`