### PR TITLE
Update core to bundle all errors using error module,

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@ pub use {chrono, sqlparser};
 
 mod glue;
 mod mock;
+mod result;
 
 pub mod ast;
 pub mod ast_builder;
@@ -12,7 +13,6 @@ pub mod data;
 pub mod executor;
 pub mod parse_sql;
 pub mod plan;
-pub mod result;
 pub mod store;
 pub mod translate;
 
@@ -24,7 +24,11 @@ pub mod prelude {
         glue::Glue,
         parse_sql::parse,
         plan::plan,
-        result::Error,
+        result::{Error, Result},
         translate::translate,
     };
+}
+
+pub mod error {
+    pub use crate::result::*;
 }

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -1,21 +1,18 @@
-use {
-    crate::{
-        ast_builder::AstBuilderError,
-        data::{
-            IntervalError, KeyError, LiteralError, RowError, SchemaParseError, StringExtError,
-            TableError, ValueError,
-        },
-        executor::{
-            AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, InsertError,
-            SelectError, SortError, UpdateError, ValidateError,
-        },
-        plan::PlanError,
-        store::{AlterTableError, IndexError},
-        translate::TranslateError,
+use {serde::Serialize, std::fmt::Debug, thiserror::Error as ThisError};
+
+pub use crate::{
+    ast_builder::AstBuilderError,
+    data::{
+        IntervalError, KeyError, LiteralError, RowError, SchemaParseError, StringExtError,
+        TableError, ValueError,
     },
-    serde::Serialize,
-    std::fmt::Debug,
-    thiserror::Error as ThisError,
+    executor::{
+        AggregateError, AlterError, EvaluateError, ExecuteError, FetchError, InsertError,
+        SelectError, SortError, UpdateError, ValidateError,
+    },
+    plan::PlanError,
+    store::{AlterTableError, IndexError},
+    translate::TranslateError,
 };
 
 #[derive(ThisError, Serialize, Debug, PartialEq)]

--- a/storages/composite-storage/src/lib.rs
+++ b/storages/composite-storage/src/lib.rs
@@ -7,7 +7,7 @@ mod transaction;
 use {
     gluesql_core::{
         data::Schema,
-        result::{Error, Result},
+        error::{Error, Result},
         store::{GStore, GStoreMut, Metadata, Store},
     },
     std::collections::HashMap,

--- a/storages/composite-storage/src/store.rs
+++ b/storages/composite-storage/src/store.rs
@@ -4,7 +4,7 @@ use {
     futures::stream::{self, StreamExt, TryStreamExt},
     gluesql_core::{
         data::{Key, Schema},
-        result::Result,
+        error::Result,
         store::{DataRow, RowIter, Store},
     },
 };

--- a/storages/composite-storage/src/store_mut.rs
+++ b/storages/composite-storage/src/store_mut.rs
@@ -3,7 +3,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         data::{Key, Schema},
-        result::{Error, Result},
+        error::{Error, Result},
         store::{DataRow, StoreMut},
     },
 };

--- a/storages/composite-storage/src/transaction.rs
+++ b/storages/composite-storage/src/transaction.rs
@@ -2,7 +2,7 @@ use {
     super::CompositeStorage,
     async_trait::async_trait,
     gluesql_core::{
-        result::{Error, Result},
+        error::{Error, Result},
         store::Transaction,
     },
 };

--- a/storages/composite-storage/tests/basic.rs
+++ b/storages/composite-storage/tests/basic.rs
@@ -1,9 +1,8 @@
 use {
     gluesql_composite_storage::CompositeStorage,
     gluesql_core::{
-        executor::FetchError,
-        prelude::{Glue, Value::I64},
-        result::Error,
+        error::FetchError,
+        prelude::{Error, Glue, Value::I64},
     },
     gluesql_memory_storage::MemoryStorage,
     test_suite::*,

--- a/storages/composite-storage/tests/error.rs
+++ b/storages/composite-storage/tests/error.rs
@@ -2,8 +2,7 @@ use {
     futures::executor::block_on,
     gluesql_composite_storage::CompositeStorage,
     gluesql_core::{
-        prelude::Glue,
-        result::Error,
+        prelude::{Error, Glue, Result},
         store::{Store, StoreMut},
     },
     gluesql_memory_storage::MemoryStorage,
@@ -71,10 +70,7 @@ macro_rules! test {
 
 #[test]
 fn composite_storage_index() {
-    use {
-        gluesql_core::{result::Result, store::Index},
-        gluesql_memory_storage::MemoryStorage,
-    };
+    use {gluesql_core::store::Index, gluesql_memory_storage::MemoryStorage};
 
     let mut storage = CompositeStorage::default();
     storage.push("mem", MemoryStorage::default());

--- a/storages/composite-storage/tests/memory_and_sled.rs
+++ b/storages/composite-storage/tests/memory_and_sled.rs
@@ -1,9 +1,6 @@
 use {
     gluesql_composite_storage::CompositeStorage,
-    gluesql_core::{
-        prelude::{Glue, Value::I64},
-        result::Error,
-    },
+    gluesql_core::prelude::{Error, Glue, Value::I64},
     gluesql_memory_storage::MemoryStorage,
     gluesql_sled_storage::SledStorage,
     std::fs,

--- a/storages/idb-storage/src/convert.rs
+++ b/storages/idb-storage/src/convert.rs
@@ -5,7 +5,7 @@ use {
     gluesql_core::{
         ast::ColumnDef,
         data::Value,
-        result::{Error, Result},
+        error::{Error, Result},
         store::DataRow,
     },
     serde_json::Value as JsonValue,

--- a/storages/idb-storage/src/error.rs
+++ b/storages/idb-storage/src/error.rs
@@ -1,6 +1,6 @@
 use {
     core::fmt::Display,
-    gluesql_core::result::{Error, Result},
+    gluesql_core::error::{Error, Result},
 };
 
 pub trait ErrInto<T> {

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -11,7 +11,7 @@ use {
     gloo_utils::format::JsValueSerdeExt,
     gluesql_core::{
         data::{Key, Schema, Value},
-        result::{Error, Result},
+        error::{Error, Result},
         store::{DataRow, Metadata, RowIter, Store, StoreMut},
     },
     idb::{CursorDirection, Database, Factory, ObjectStoreParams, Query, TransactionMode},

--- a/storages/json-storage/src/error.rs
+++ b/storages/json-storage/src/error.rs
@@ -1,4 +1,4 @@
-use {gluesql_core::result::Error, thiserror::Error};
+use {gluesql_core::error::Error, thiserror::Error};
 
 pub trait ResultExt<T, E: ToString> {
     fn map_storage_err(self) -> Result<T, Error>;

--- a/storages/json-storage/src/lib.rs
+++ b/storages/json-storage/src/lib.rs
@@ -11,10 +11,8 @@ use {
     error::{JsonStorageError, OptionExt, ResultExt},
     gluesql_core::{
         ast::ColumnUniqueOption,
-        data::{value::HashMapJsonExt, Schema},
-        prelude::Key,
-        result::Error,
-        result::Result,
+        data::{value::HashMapJsonExt, Key, Schema},
+        error::{Error, Result},
         store::{DataRow, Metadata, RowIter},
     },
     iter_enum::Iterator,

--- a/storages/json-storage/src/store.rs
+++ b/storages/json-storage/src/store.rs
@@ -5,9 +5,8 @@ use {
     },
     async_trait::async_trait,
     gluesql_core::{
-        data::Schema,
-        prelude::Key,
-        result::Result,
+        data::{Key, Schema},
+        error::Result,
         store::{DataRow, RowIter, Store},
     },
     std::{ffi::OsStr, fs},

--- a/storages/json-storage/src/store_mut.rs
+++ b/storages/json-storage/src/store_mut.rs
@@ -5,9 +5,8 @@ use {
     },
     async_trait::async_trait,
     gluesql_core::{
-        data::Schema,
-        prelude::Key,
-        result::Result,
+        data::{Key, Schema},
+        error::Result,
         store::{DataRow, StoreMut},
     },
     serde_json::{to_string_pretty, Map, Value as JsonValue},

--- a/storages/json-storage/tests/error.rs
+++ b/storages/json-storage/tests/error.rs
@@ -1,8 +1,7 @@
 use {
     gluesql_core::{
-        data::{SchemaParseError, ValueError},
-        prelude::Glue,
-        result::Error,
+        error::{SchemaParseError, ValueError},
+        prelude::{Error, Glue},
     },
     gluesql_json_storage::{error::JsonStorageError, JsonStorage},
     test_suite::test,

--- a/storages/memory-storage/src/alter_table.rs
+++ b/storages/memory-storage/src/alter_table.rs
@@ -4,8 +4,8 @@ use {
     gluesql_core::{
         ast::ColumnDef,
         data::Value,
-        result::{Error, Result},
-        store::{AlterTable, AlterTableError, DataRow},
+        error::{AlterTableError, Error, Result},
+        store::{AlterTable, DataRow},
     },
 };
 

--- a/storages/memory-storage/src/index.rs
+++ b/storages/memory-storage/src/index.rs
@@ -4,7 +4,7 @@ use {
     gluesql_core::{
         ast::{IndexOperator, OrderByExpr},
         data::Value,
-        result::{Error, Result},
+        error::{Error, Result},
         store::{Index, IndexMut, RowIter},
     },
 };

--- a/storages/memory-storage/src/lib.rs
+++ b/storages/memory-storage/src/lib.rs
@@ -9,9 +9,8 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         chrono::Utc,
-        data::{CustomFunction as StructCustomFunction, Key, Schema},
-        prelude::Value,
-        result::Result,
+        data::{CustomFunction as StructCustomFunction, Key, Schema, Value},
+        error::Result,
         store::{CustomFunction, CustomFunctionMut, DataRow, RowIter, Store, StoreMut},
     },
     serde::{Deserialize, Serialize},

--- a/storages/memory-storage/src/metadata.rs
+++ b/storages/memory-storage/src/metadata.rs
@@ -2,7 +2,7 @@ use {
     crate::MemoryStorage,
     async_trait::async_trait,
     gluesql_core::{
-        result::Result,
+        error::Result,
         store::{MetaIter, Metadata},
     },
 };

--- a/storages/memory-storage/src/transaction.rs
+++ b/storages/memory-storage/src/transaction.rs
@@ -2,7 +2,7 @@ use {
     super::MemoryStorage,
     async_trait::async_trait,
     gluesql_core::{
-        result::{Error, Result},
+        error::{Error, Result},
         store::Transaction,
     },
 };

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -46,8 +46,7 @@ fn memory_storage_index() {
     use {
         futures::executor::block_on,
         gluesql_core::{
-            prelude::Glue,
-            result::{Error, Result},
+            prelude::{Error, Glue, Result},
             store::{Index, Store},
         },
     };
@@ -85,10 +84,7 @@ fn memory_storage_index() {
 
 #[test]
 fn memory_storage_transaction() {
-    use gluesql_core::{
-        prelude::{Glue, Payload},
-        result::Error,
-    };
+    use gluesql_core::prelude::{Error, Glue, Payload};
 
     let storage = MemoryStorage::default();
     let mut glue = Glue::new(storage);

--- a/storages/shared-memory-storage/src/alter_table.rs
+++ b/storages/shared-memory-storage/src/alter_table.rs
@@ -1,7 +1,7 @@
 use {
     super::SharedMemoryStorage,
     async_trait::async_trait,
-    gluesql_core::{ast::ColumnDef, result::Result, store::AlterTable},
+    gluesql_core::{ast::ColumnDef, error::Result, store::AlterTable},
     std::sync::Arc,
 };
 

--- a/storages/shared-memory-storage/src/index.rs
+++ b/storages/shared-memory-storage/src/index.rs
@@ -4,7 +4,7 @@ use {
     gluesql_core::{
         ast::{IndexOperator, OrderByExpr},
         data::Value,
-        result::{Error, Result},
+        error::{Error, Result},
         store::{Index, IndexMut, RowIter},
     },
 };

--- a/storages/shared-memory-storage/src/lib.rs
+++ b/storages/shared-memory-storage/src/lib.rs
@@ -8,7 +8,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         data::{Key, Schema},
-        result::Result,
+        error::Result,
         store::{DataRow, Metadata, RowIter, Store, StoreMut},
     },
     memory_storage::MemoryStorage,

--- a/storages/shared-memory-storage/src/transaction.rs
+++ b/storages/shared-memory-storage/src/transaction.rs
@@ -2,7 +2,7 @@ use {
     super::SharedMemoryStorage,
     async_trait::async_trait,
     gluesql_core::{
-        result::{Error, Result},
+        error::{Error, Result},
         store::Transaction,
     },
 };

--- a/storages/shared-memory-storage/tests/shared_memory_storage.rs
+++ b/storages/shared-memory-storage/tests/shared_memory_storage.rs
@@ -42,8 +42,8 @@ fn shared_memory_storage_index() {
     use {
         futures::executor::block_on,
         gluesql_core::{
+            error::{Error, Result},
             prelude::Glue,
-            result::{Error, Result},
             store::{Index, Store},
         },
     };
@@ -81,7 +81,7 @@ fn shared_memory_storage_index() {
 
 #[test]
 fn shared_memory_storage_transaction() {
-    use gluesql_core::{prelude::Glue, result::Error};
+    use gluesql_core::{error::Error, prelude::Glue};
 
     let storage = SharedMemoryStorage::new();
     let mut glue = Glue::new(storage);
@@ -94,7 +94,7 @@ fn shared_memory_storage_transaction() {
 
 #[test]
 fn shared_memory_storage_function() {
-    use gluesql_core::result::Error;
+    use gluesql_core::error::Error;
 
     let storage = SharedMemoryStorage::new();
     let mut glue = Glue::new(storage);

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -11,9 +11,9 @@ use {
     gluesql_core::{
         ast::ColumnDef,
         data::{schema::Schema, Value},
+        error::{AlterTableError, Error, Result},
         executor::evaluate_stateless,
-        result::{Error, Result},
-        store::{AlterTable, AlterTableError, DataRow},
+        store::{AlterTable, DataRow},
     },
     sled::transaction::ConflictableTransactionError,
     std::{iter::once, str},

--- a/storages/sled-storage/src/error.rs
+++ b/storages/sled-storage/src/error.rs
@@ -1,8 +1,5 @@
 use {
-    gluesql_core::{
-        result::Error,
-        store::{AlterTableError, IndexError},
-    },
+    gluesql_core::error::{AlterTableError, Error, IndexError},
     sled::transaction::TransactionError as SledTransactionError,
     std::{str, time},
     thiserror::Error as ThisError,

--- a/storages/sled-storage/src/gc.rs
+++ b/storages/sled-storage/src/gc.rs
@@ -4,7 +4,7 @@ use {
         lock::{get_txdata_key, Lock, TxData},
         SledStorage, Snapshot,
     },
-    gluesql_core::{data::Schema, result::Result, store::DataRow},
+    gluesql_core::{data::Schema, error::Result, store::DataRow},
     std::time::{SystemTime, UNIX_EPOCH},
 };
 

--- a/storages/sled-storage/src/index.rs
+++ b/storages/sled-storage/src/index.rs
@@ -7,10 +7,9 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         ast::IndexOperator,
-        data::Key,
-        prelude::Value,
-        result::{Error, Result},
-        store::{DataRow, Index, IndexError, RowIter},
+        data::{Key, Value},
+        error::{Error, IndexError, Result},
+        store::{DataRow, Index, RowIter},
     },
     iter_enum::{DoubleEndedIterator, Iterator},
     sled::IVec,

--- a/storages/sled-storage/src/index_mut.rs
+++ b/storages/sled-storage/src/index_mut.rs
@@ -13,8 +13,8 @@ use {
         ast::OrderByExpr,
         chrono::Utc,
         data::{Schema, SchemaIndex, SchemaIndexOrd},
-        result::{Error, Result},
-        store::{IndexError, IndexMut, Store},
+        error::{Error, IndexError, Result},
+        store::{IndexMut, Store},
     },
     sled::transaction::{
         ConflictableTransactionError, ConflictableTransactionResult, TransactionalTree,

--- a/storages/sled-storage/src/index_sync.rs
+++ b/storages/sled-storage/src/index_sync.rs
@@ -3,10 +3,10 @@ use {
     gluesql_core::{
         ast::Expr,
         data::schema::{Schema, SchemaIndex},
+        error::{Error, IndexError, Result},
         executor::evaluate_stateless,
         prelude::Value,
-        result::{Error, Result},
-        store::{DataRow, IndexError},
+        store::DataRow,
     },
     sled::{
         transaction::{

--- a/storages/sled-storage/src/lib.rs
+++ b/storages/sled-storage/src/lib.rs
@@ -21,7 +21,7 @@ use {
     error::{err_into, tx_err_into},
     gluesql_core::{
         data::Schema,
-        result::{Error, Result},
+        error::{Error, Result},
         store::Metadata,
     },
     sled::{

--- a/storages/sled-storage/src/lock.rs
+++ b/storages/sled-storage/src/lock.rs
@@ -1,6 +1,6 @@
 use {
     super::{err_into, State},
-    gluesql_core::result::{Error, Result},
+    gluesql_core::error::{Error, Result},
     serde::{Deserialize, Serialize},
     sled::{
         transaction::{

--- a/storages/sled-storage/src/store.rs
+++ b/storages/sled-storage/src/store.rs
@@ -3,7 +3,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         data::{Key, Schema},
-        result::{Error, Result},
+        error::{Error, Result},
         store::{DataRow, RowIter, Store},
     },
     std::str,

--- a/storages/sled-storage/src/store_mut.rs
+++ b/storages/sled-storage/src/store_mut.rs
@@ -11,8 +11,8 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         data::{Key, Schema},
-        result::{Error, Result},
-        store::{DataRow, IndexError, StoreMut},
+        error::{Error, IndexError, Result},
+        store::{DataRow, StoreMut},
     },
     sled::transaction::{ConflictableTransactionError, ConflictableTransactionResult},
 };

--- a/storages/sled-storage/src/transaction.rs
+++ b/storages/sled-storage/src/transaction.rs
@@ -7,7 +7,7 @@ use {
     async_trait::async_trait,
     gluesql_core::{
         data::Schema,
-        result::{Error, Result},
+        error::{Error, Result},
         store::{DataRow, Transaction},
     },
     serde::{de::DeserializeOwned, Serialize},

--- a/storages/sled-storage/tests/export_and_import.rs
+++ b/storages/sled-storage/tests/export_and_import.rs
@@ -1,8 +1,4 @@
-use {
-    gluesql_core::{prelude::*, result::Error},
-    gluesql_sled_storage::SledStorage,
-    sled::Config,
-};
+use {gluesql_core::prelude::*, gluesql_sled_storage::SledStorage, sled::Config};
 
 #[test]
 fn export_and_import() {

--- a/storages/sled-storage/tests/sled_transaction.rs
+++ b/storages/sled-storage/tests/sled_transaction.rs
@@ -8,7 +8,6 @@ use {
     gluesql_core::{
         executor::FetchError,
         prelude::{Value::*, *},
-        result::Error,
         store::StoreMut,
         *,
     },

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -7,7 +7,7 @@ use {
     gluesql_core::{
         ast::ColumnUniqueOption,
         data::{Key, Schema},
-        result::{Error, Result},
+        error::{Error, Result},
         store::{DataRow, Metadata, RowIter, Store, StoreMut},
     },
     serde::{Deserialize, Serialize},

--- a/test-suite/src/aggregate/error.rs
+++ b/test-suite/src/aggregate/error.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, translate::TranslateError},
+    gluesql_core::error::{EvaluateError, TranslateError},
 };
 
 test_case!(error, async move {

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -3,10 +3,8 @@ use {
     gluesql_core::{
         ast::*,
         data::Value::*,
-        executor::{AlterError, EvaluateError},
+        error::{AlterError, AlterTableError, EvaluateError, TranslateError},
         prelude::Payload,
-        store::AlterTableError,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -2,9 +2,8 @@ use {
     crate::*,
     gluesql_core::{
         data::value::Value::{Null, Str, I64},
-        executor::{AlterError, EvaluateError},
+        error::{AlterError, EvaluateError, TranslateError},
         prelude::Payload,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/alter/drop_indexed.rs
+++ b/test-suite/src/alter/drop_indexed.rs
@@ -2,9 +2,8 @@ use {
     crate::*,
     gluesql_core::{
         ast::IndexOperator::*,
-        executor::{AlterError, FetchError},
+        error::{AlterError, FetchError, TranslateError},
         prelude::Value::*,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/alter/drop_table.rs
+++ b/test-suite/src/alter/drop_table.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{AlterError, FetchError, Payload},
-        prelude::Value::*,
-        translate::TranslateError,
+        error::{AlterError, FetchError, TranslateError},
+        prelude::{Payload, Value::*},
     },
 };
 

--- a/test-suite/src/arithmetic/error.rs
+++ b/test-suite/src/arithmetic/error.rs
@@ -2,8 +2,8 @@ use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
-        data::{Literal, LiteralError, NumericBinaryOperator, ValueError},
-        executor::{EvaluateError, UpdateError},
+        data::{Literal, NumericBinaryOperator},
+        error::{EvaluateError, LiteralError, UpdateError, ValueError},
         prelude::Value,
     },
     std::borrow::Cow,

--- a/test-suite/src/basic.rs
+++ b/test-suite/src/basic.rs
@@ -1,8 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
+        error::TranslateError,
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/case.rs
+++ b/test-suite/src/case.rs
@@ -1,8 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
+        error::TranslateError,
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/column_alias.rs
+++ b/test-suite/src/column_alias.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::FetchError,
+        error::FetchError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/custom_function.rs
+++ b/test-suite/src/custom_function.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{AlterError, EvaluateError},
+        error::{AlterError, EvaluateError, TranslateError},
         prelude::{Payload, PayloadVariable, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/data_type/bytea.rs
+++ b/test-suite/src/data_type/bytea.rs
@@ -3,9 +3,9 @@ use {
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType,
-        data::{Literal, LiteralError, ValueError},
-        executor::Payload,
-        prelude::Value::Bytea,
+        data::Literal,
+        error::{LiteralError, ValueError},
+        prelude::{Payload, Value::Bytea},
     },
     std::borrow::Cow,
 };

--- a/test-suite/src/data_type/date.rs
+++ b/test-suite/src/data_type/date.rs
@@ -1,4 +1,7 @@
-use {crate::*, gluesql_core::prelude::Value::*};
+use {
+    crate::*,
+    gluesql_core::{error::ValueError, prelude::Value::*},
+};
 
 test_case!(date, async move {
     run!(
@@ -110,6 +113,6 @@ INSERT INTO DateLog VALUES
 
     test!(
         "INSERT INTO DateLog VALUES (1, '12345-678', '2021-05-01')",
-        Err(gluesql_core::data::ValueError::FailedToParseDate("12345-678".to_owned()).into())
+        Err(ValueError::FailedToParseDate("12345-678".to_owned()).into())
     );
 });

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::Payload, prelude::Value::*},
+    gluesql_core::prelude::{Payload, Value::*},
     rust_decimal::prelude::Decimal,
 };
 

--- a/test-suite/src/data_type/float32.rs
+++ b/test-suite/src/data_type/float32.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::Payload, prelude::Value::*},
+    gluesql_core::prelude::{Payload, Value::*},
 };
 
 test_case!(float32, async move {

--- a/test-suite/src/data_type/inet.rs
+++ b/test-suite/src/data_type/inet.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, executor::Payload, prelude::Value::Inet},
+    gluesql_core::{
+        error::ValueError,
+        prelude::{Payload, Value::Inet},
+    },
     std::{net::IpAddr, str::FromStr},
 };
 

--- a/test-suite/src/data_type/int128.rs
+++ b/test-suite/src/data_type/int128.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::ValueError,
+        error::ValueError,
         prelude::{DataType, Value::*},
     },
 };

--- a/test-suite/src/data_type/int16.rs
+++ b/test-suite/src/data_type/int16.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(int16, async move {

--- a/test-suite/src/data_type/int32.rs
+++ b/test-suite/src/data_type/int32.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::ValueError,
+        error::ValueError,
         prelude::{DataType, Payload, Value::*},
     },
 };

--- a/test-suite/src/data_type/int64.rs
+++ b/test-suite/src/data_type/int64.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::ValueError,
+        error::ValueError,
         prelude::{DataType, Value::*},
     },
 };

--- a/test-suite/src/data_type/int8.rs
+++ b/test-suite/src/data_type/int8.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(int8, async move {

--- a/test-suite/src/data_type/interval.rs
+++ b/test-suite/src/data_type/interval.rs
@@ -1,9 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{
-        data::{Interval as I, IntervalError},
-        prelude::Value::*,
-    },
+    gluesql_core::{data::Interval as I, error::IntervalError, prelude::Value::*},
 };
 
 test_case!(interval, async move {

--- a/test-suite/src/data_type/list.rs
+++ b/test-suite/src/data_type/list.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::{KeyError, ValueError},
+        error::{KeyError, ValueError},
         prelude::Value::{self, *},
     },
 };

--- a/test-suite/src/data_type/map.rs
+++ b/test-suite/src/data_type/map.rs
@@ -1,8 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::{KeyError, ValueError},
-        executor::EvaluateError,
+        error::{EvaluateError, KeyError, ValueError},
         prelude::Value::{self, *},
     },
 };

--- a/test-suite/src/data_type/point.rs
+++ b/test-suite/src/data_type/point.rs
@@ -3,10 +3,9 @@ use {
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType,
-        data::{Literal, ValueError},
-        executor::Payload,
-        prelude::Value::*,
-        translate::TranslateError,
+        data::Literal,
+        error::{TranslateError, ValueError},
+        prelude::{Payload, Value::*},
     },
     std::borrow::Cow,
 };

--- a/test-suite/src/data_type/time.rs
+++ b/test-suite/src/data_type/time.rs
@@ -2,7 +2,7 @@ use {
     crate::*,
     chrono::{NaiveDate, NaiveTime},
     gluesql_core::{
-        data::{IntervalError, ValueError},
+        error::{IntervalError, ValueError},
         prelude::Value::*,
     },
 };

--- a/test-suite/src/data_type/timestamp.rs
+++ b/test-suite/src/data_type/timestamp.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(timestamp, async move {

--- a/test-suite/src/data_type/uint128.rs
+++ b/test-suite/src/data_type/uint128.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(uint128, async move {

--- a/test-suite/src/data_type/uint16.rs
+++ b/test-suite/src/data_type/uint16.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(uint16, async move {

--- a/test-suite/src/data_type/uint32.rs
+++ b/test-suite/src/data_type/uint32.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(uint32, async move {

--- a/test-suite/src/data_type/uint64.rs
+++ b/test-suite/src/data_type/uint64.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(uint64, async move {

--- a/test-suite/src/data_type/uint8.rs
+++ b/test-suite/src/data_type/uint8.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(uint8, async move {

--- a/test-suite/src/data_type/uuid.rs
+++ b/test-suite/src/data_type/uuid.rs
@@ -3,9 +3,9 @@ use {
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType,
-        data::{Literal, ValueError},
-        executor::Payload,
-        prelude::Value::*,
+        data::Literal,
+        error::ValueError,
+        prelude::{Payload, Value::*},
     },
     std::borrow::Cow,
     uuid::Uuid as UUID,

--- a/test-suite/src/default.rs
+++ b/test-suite/src/default.rs
@@ -2,7 +2,7 @@ use {
     crate::*,
     chrono::NaiveDate,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/dictionary.rs
+++ b/test-suite/src/dictionary.rs
@@ -1,8 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
+        error::TranslateError,
         prelude::{Payload::ShowVariable, PayloadVariable, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/dictionary_index.rs
+++ b/test-suite/src/dictionary_index.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{prelude::Value::*, translate::TranslateError},
+    gluesql_core::{error::TranslateError, prelude::Value::*},
 };
 
 test_case!(ditionary_index, async move {

--- a/test-suite/src/function/abs.rs
+++ b/test-suite/src/function/abs.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{EvaluateError, Payload},
-        prelude::Value::*,
-        translate::TranslateError,
+        error::{EvaluateError, TranslateError},
+        prelude::{Payload, Value::*},
     },
 };
 

--- a/test-suite/src/function/append.rs
+++ b/test-suite/src/function/append.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Payload, prelude::Value::*},
+    gluesql_core::{
+        error::EvaluateError,
+        prelude::{Payload, Value::*},
+    },
 };
 test_case!(append, async move {
     run!(

--- a/test-suite/src/function/ascii.rs
+++ b/test-suite/src/function/ascii.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(ascii, async move {

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -2,10 +2,10 @@ use {
     crate::*,
     chrono::{NaiveDate, NaiveTime},
     gluesql_core::{
-        data::{Interval as I, ValueError},
-        executor::Payload,
+        data::Interval as I,
+        error::ValueError,
         prelude::{
-            DataType,
+            DataType, Payload,
             Value::{self, *},
         },
     },

--- a/test-suite/src/function/ceil.rs
+++ b/test-suite/src/function/ceil.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(ceil, async move {

--- a/test-suite/src/function/chr.rs
+++ b/test-suite/src/function/chr.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*},
+    gluesql_core::{error::EvaluateError, prelude::Value::*},
 };
 
 test_case!(chr, async move {

--- a/test-suite/src/function/concat.rs
+++ b/test-suite/src/function/concat.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(concat, async move {

--- a/test-suite/src/function/concat_ws.rs
+++ b/test-suite/src/function/concat_ws.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{prelude::Value::*, translate::TranslateError},
+    gluesql_core::{error::TranslateError, prelude::Value::*},
 };
 
 test_case!(concat_ws, async move {

--- a/test-suite/src/function/degrees.rs
+++ b/test-suite/src/function/degrees.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(degrees, async move {

--- a/test-suite/src/function/div_mod.rs
+++ b/test-suite/src/function/div_mod.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/exp_log.rs
+++ b/test-suite/src/function/exp_log.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*},
+    gluesql_core::{error::EvaluateError, prelude::Value::*},
 };
 
 test_case!(log2, async move {

--- a/test-suite/src/function/extract.rs
+++ b/test-suite/src/function/extract.rs
@@ -2,15 +2,9 @@ use {
     crate::*,
     gluesql_core::{
         ast::DateTimeField,
-        data::{
-            value::{
-                Value::{self, *},
-                ValueError,
-            },
-            IntervalError,
-        },
+        data::value::Value::{self, *},
+        error::{IntervalError, TranslateError, ValueError},
         prelude::Payload,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/find_idx.rs
+++ b/test-suite/src/function/find_idx.rs
@@ -1,8 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::ValueError,
-        executor::EvaluateError,
+        error::{EvaluateError, ValueError},
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/function/floor.rs
+++ b/test-suite/src/function/floor.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(floor, async move {

--- a/test-suite/src/function/format.rs
+++ b/test-suite/src/function/format.rs
@@ -1,8 +1,9 @@
-use crate::*;
+use {
+    crate::*,
+    gluesql_core::{error::EvaluateError, prelude::Value::*},
+};
 
 test_case!(format, async move {
-    use gluesql_core::{executor::EvaluateError, prelude::Value::*};
-
     let test_cases = vec![
         (
             "VALUES(FORMAT(DATE '2017-06-15', '%Y-%m'))",

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/function/generate_uuid.rs
+++ b/test-suite/src/function/generate_uuid.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{ast::DataType, prelude::Payload, translate::TranslateError},
+    gluesql_core::{ast::DataType, error::TranslateError, prelude::Payload},
 };
 
 test_case!(generate_uuid, async move {

--- a/test-suite/src/function/geometry/calc_distance.rs
+++ b/test-suite/src/function/geometry/calc_distance.rs
@@ -1,7 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError, executor::Payload, prelude::Value::*, translate::TranslateError,
+        error::{EvaluateError, TranslateError},
+        prelude::{Payload, Value::*},
     },
 };
 

--- a/test-suite/src/function/geometry/get_x.rs
+++ b/test-suite/src/function/geometry/get_x.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, executor::Payload, prelude::Value::*},
+    gluesql_core::{
+        error::EvaluateError,
+        prelude::{Payload, Value::*},
+    },
 };
 
 test_case!(get_x, async move {

--- a/test-suite/src/function/geometry/get_y.rs
+++ b/test-suite/src/function/geometry/get_y.rs
@@ -1,8 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{EvaluateError, Payload},
-        prelude::Value::*,
+        error::EvaluateError,
+        prelude::{Payload, Value::*},
     },
 };
 

--- a/test-suite/src/function/ifnull.rs
+++ b/test-suite/src/function/ifnull.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
-    gluesql_core::{executor::Payload, prelude::Value::*},
+    gluesql_core::prelude::{Payload, Value::*},
     rust_decimal::Decimal,
 };
 

--- a/test-suite/src/function/initcap.rs
+++ b/test-suite/src/function/initcap.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/left_right.rs
+++ b/test-suite/src/function/left_right.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/lpad_rpad.rs
+++ b/test-suite/src/function/lpad_rpad.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/ltrim_rtrim.rs
+++ b/test-suite/src/function/ltrim_rtrim.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{
             Payload,
             Value::{self, *},

--- a/test-suite/src/function/math_function.rs
+++ b/test-suite/src/function/math_function.rs
@@ -1,12 +1,11 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{
             Payload,
             Value::{self, *},
         },
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/pi.rs
+++ b/test-suite/src/function/pi.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{prelude::Value::*, translate::TranslateError},
+    gluesql_core::{error::TranslateError, prelude::Value::*},
 };
 
 test_case!(pi, async move {

--- a/test-suite/src/function/position.rs
+++ b/test-suite/src/function/position.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::ValueError,
+        error::ValueError,
         prelude::{
             Payload,
             Value::{self, *},

--- a/test-suite/src/function/prepend.rs
+++ b/test-suite/src/function/prepend.rs
@@ -1,7 +1,11 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Payload, prelude::Value::*},
+    gluesql_core::{
+        error::EvaluateError,
+        prelude::{Payload, Value::*},
+    },
 };
+
 test_case!(prepend, async move {
     run!(
         "

--- a/test-suite/src/function/radians.rs
+++ b/test-suite/src/function/radians.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(radians, async move {

--- a/test-suite/src/function/rand.rs
+++ b/test-suite/src/function/rand.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/repeat.rs
+++ b/test-suite/src/function/repeat.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/function/reverse.rs
+++ b/test-suite/src/function/reverse.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{Payload, Value},
     },
 };

--- a/test-suite/src/function/round.rs
+++ b/test-suite/src/function/round.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(round, async move {

--- a/test-suite/src/function/sign.rs
+++ b/test-suite/src/function/sign.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::EvaluateError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(sign, async move {

--- a/test-suite/src/function/sqrt_power.rs
+++ b/test-suite/src/function/sqrt_power.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, executor::EvaluateError, prelude::Value::*},
+    gluesql_core::{
+        error::{EvaluateError, ValueError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(sqrt, async move {

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/function/to_date.rs
+++ b/test-suite/src/function/to_date.rs
@@ -1,17 +1,16 @@
-use crate::*;
+use {
+    crate::*,
+    chrono::{format::ParseErrorKind, NaiveDate, NaiveTime},
+    gluesql_core::{
+        error::EvaluateError,
+        prelude::{Error, Value::*},
+    },
+};
 
 test_case!(to_date, async move {
-    use {
-        chrono::{NaiveDate, NaiveTime},
-        gluesql_core::{executor::EvaluateError, prelude::Value::*},
-    };
-
-    fn assert_chrono_error_kind_eq(
-        error: gluesql_core::result::Error,
-        kind: chrono::format::ParseErrorKind,
-    ) {
+    fn assert_chrono_error_kind_eq(error: Error, kind: ParseErrorKind) {
         match error {
-            gluesql_core::result::Error::Evaluate(EvaluateError::FormatParseError(err)) => {
+            Error::Evaluate(EvaluateError::FormatParseError(err)) => {
                 assert_eq!(err.kind(), kind)
             }
             _ => panic!("invalid error: {error}"),

--- a/test-suite/src/function/trim.rs
+++ b/test-suite/src/function/trim.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::EvaluateError,
         prelude::{Payload, Value},
     },
 };

--- a/test-suite/src/function/upper_lower.rs
+++ b/test-suite/src/function/upper_lower.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/index/basic.rs
+++ b/test-suite/src/index/basic.rs
@@ -2,10 +2,8 @@ use {
     crate::*,
     gluesql_core::{
         ast::IndexOperator::*,
-        executor::AlterError,
+        error::{AlterError, IndexError, TranslateError},
         prelude::{Payload, Value::*},
-        store::IndexError,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/index/expr.rs
+++ b/test-suite/src/index/expr.rs
@@ -2,7 +2,7 @@ use {
     crate::*,
     gluesql_core::{
         ast::IndexOperator::*,
-        executor::AlterError,
+        error::AlterError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/index/showindexes.rs
+++ b/test-suite/src/index/showindexes.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::ExecuteError,
+        error::ExecuteError,
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/inline_view.rs
+++ b/test-suite/src/inline_view.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::EvaluateError,
+        error::{EvaluateError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{plan::PlanError, prelude::*, translate::TranslateError},
+    gluesql_core::{
+        error::{PlanError, TranslateError},
+        prelude::*,
+    },
     Value::*,
 };
 

--- a/test-suite/src/like_ilike.rs
+++ b/test-suite/src/like_ilike.rs
@@ -2,7 +2,8 @@ use {
     crate::*,
     bigdecimal::BigDecimal,
     gluesql_core::{
-        data::{Literal, LiteralError, ValueError},
+        data::Literal,
+        error::{LiteralError, ValueError},
         prelude::Value::{self, Bool},
     },
     std::{borrow::Cow, str::FromStr},

--- a/test-suite/src/migrate.rs
+++ b/test-suite/src/migrate.rs
@@ -2,10 +2,8 @@ use {
     crate::*,
     gluesql_core::{
         ast::Expr,
-        data::ValueError,
-        executor::{EvaluateError, FetchError},
+        error::{EvaluateError, FetchError, TranslateError, ValueError},
         prelude::Value::*,
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/nullable.rs
+++ b/test-suite/src/nullable.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{data::ValueError, prelude::Value::*},
+    gluesql_core::{error::ValueError, prelude::Value::*},
 };
 
 test_case!(nullable, async move {

--- a/test-suite/src/order_by.rs
+++ b/test-suite/src/order_by.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::SortError, prelude::Value::*, translate::TranslateError},
+    gluesql_core::{
+        error::{SortError, TranslateError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(order_by, async move {

--- a/test-suite/src/primary_key.rs
+++ b/test-suite/src/primary_key.rs
@@ -1,8 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        data::{Value::*, ValueError},
-        executor::{UpdateError, ValidateError},
+        data::Value::*,
+        error::{UpdateError, ValidateError, ValueError},
         prelude::{Key, Payload},
     },
 };

--- a/test-suite/src/project.rs
+++ b/test-suite/src/project.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{EvaluateError, FetchError},
+        error::{EvaluateError, FetchError},
         prelude::Value::*,
     },
 };

--- a/test-suite/src/schemaless/error.rs
+++ b/test-suite/src/schemaless/error.rs
@@ -1,9 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{
-        data::ValueError,
-        executor::{EvaluateError, InsertError},
-    },
+    gluesql_core::error::{EvaluateError, InsertError, ValueError},
     serde_json::json,
 };
 

--- a/test-suite/src/series.rs
+++ b/test-suite/src/series.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::FetchError,
+        error::{FetchError, TranslateError},
         prelude::{Payload, Value::*},
-        translate::TranslateError,
     },
 };
 

--- a/test-suite/src/show_columns.rs
+++ b/test-suite/src/show_columns.rs
@@ -1,9 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{
-        ast::DataType,
-        executor::{ExecuteError, Payload},
-    },
+    gluesql_core::{ast::DataType, error::ExecuteError, executor::Payload},
 };
 
 test_case!(show_columns, async move {

--- a/test-suite/src/tester/mod.rs
+++ b/test-suite/src/tester/mod.rs
@@ -4,7 +4,6 @@ use {
         ast::*,
         parse_sql::parse_expr,
         prelude::*,
-        result::Result,
         store::{GStore, GStoreMut},
         translate::translate_expr,
     },

--- a/test-suite/src/transaction/alter_table.rs
+++ b/test-suite/src/transaction/alter_table.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::FetchError, prelude::Value::*},
+    gluesql_core::{error::FetchError, prelude::Value::*},
 };
 
 test_case!(alter_table_rename_table, async move {

--- a/test-suite/src/transaction/table.rs
+++ b/test-suite/src/transaction/table.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::FetchError, prelude::Value::*},
+    gluesql_core::{error::FetchError, prelude::Value::*},
 };
 
 test_case!(create_drop_table, async move {

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        data::{LiteralError, ValueError},
+        error::{LiteralError, ValueError},
         prelude::{Payload, Value::*},
     },
 };

--- a/test-suite/src/update.rs
+++ b/test-suite/src/update.rs
@@ -1,9 +1,8 @@
 use {
     crate::*,
     gluesql_core::{
-        executor::{ExecuteError, UpdateError},
+        error::{ExecuteError, TranslateError, UpdateError},
         prelude::*,
-        translate::TranslateError,
     },
     Value::*,
 };

--- a/test-suite/src/validate/types.rs
+++ b/test-suite/src/validate/types.rs
@@ -1,10 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{
-        ast::DataType,
-        data::{Literal, ValueError},
-        prelude::Value,
-    },
+    gluesql_core::{ast::DataType, data::Literal, error::ValueError, prelude::Value},
     std::borrow::Cow,
 };
 

--- a/test-suite/src/validate/unique.rs
+++ b/test-suite/src/validate/unique.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{executor::ValidateError, prelude::Value},
+    gluesql_core::{error::ValidateError, prelude::Value},
 };
 
 test_case!(unique, async move {

--- a/test-suite/src/values.rs
+++ b/test-suite/src/values.rs
@@ -3,8 +3,8 @@ use {
     bigdecimal::BigDecimal,
     gluesql_core::{
         ast::DataType::{Boolean, Int, Text},
-        data::{Literal, ValueError},
-        executor::{InsertError, SelectError},
+        data::Literal,
+        error::{InsertError, SelectError, ValueError},
         prelude::{DataType, Payload, Value::*},
     },
     std::borrow::Cow,


### PR DESCRIPTION
* Bundle and export all errors using error module.
* Rename result module to "error" for out-of-core-workspace users.
* Update storages/ and test-suite/ codes to use global error module.