### PR TITLE
Remove gen-_transaction_dictionary_tests! in test-suite,

### DIFF
--- a/storages/sled-storage/tests/sled_storage.rs
+++ b/storages/sled-storage/tests/sled_storage.rs
@@ -93,5 +93,4 @@ generate_alter_table_tests!(tokio::test, SledTester);
 generate_alter_table_index_tests!(tokio::test, SledTester);
 generate_transaction_alter_table_tests!(tokio::test, SledTester);
 generate_transaction_index_tests!(tokio::test, SledTester);
-generate_transaction_dictionary_tests!(tokio::test, SledTester);
 generate_metadata_index_tests!(tokio::test, SledTester);

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -270,6 +270,7 @@ macro_rules! generate_transaction_tests {
             transaction_create_drop_table,
             transaction::create_drop_table
         );
+        glue!(transaction_dictionary, transaction::dictionary);
     };
 }
 
@@ -326,19 +327,6 @@ macro_rules! generate_transaction_index_tests {
 
         glue!(transaction_index_create, transaction::index_create);
         glue!(transaction_index_drop, transaction::index_drop);
-    };
-}
-
-#[macro_export]
-macro_rules! generate_transaction_dictionary_tests {
-    ($test: meta, $storage: ident) => {
-        macro_rules! glue {
-            ($title: ident, $func: path) => {
-                declare_test_fn!($test, $storage, $title, $func);
-            };
-        }
-
-        glue!(transaction_dictionary, transaction::dictionary);
     };
 }
 


### PR DESCRIPTION
transaction_dictionary does not depend on any other store trait than transaction.
Move transaction::dictionary to generate_transaction_tests