### PR TITLE
Apply workspace inheritance to remaining Cargo.toml in storages/,

### DIFF
--- a/storages/idb-storage/Cargo.toml
+++ b/storages/idb-storage/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "gluesql-idb-storage"
 version = "0.13.0"
-edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
-description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
-license = "Apache-2.0"
-repository = "https://github.com/gluesql/gluesql"
-documentation = "https://docs.rs/gluesql/"
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
 
 [dependencies]
 gluesql-core = { path = "../../core", version = "0.13.0" }

--- a/storages/json-storage/Cargo.toml
+++ b/storages/json-storage/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "gluesql-json-storage"
 version = "0.13.0"
-edition = "2021"
 authors = [
   "Hyoungkwan Cho <devgony@gmail.com>",
   "Taehoon Moon <taehoon.moon@outlook.com>",
 ]
-description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
-license = "Apache-2.0"
-repository = "https://github.com/gluesql/gluesql"
-documentation = "https://docs.rs/gluesql/"
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
 
 [dependencies]
 gluesql-core = { path = "../../core", version = "0.13.0" }

--- a/storages/web-storage/Cargo.toml
+++ b/storages/web-storage/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "gluesql-web-storage"
 version = "0.13.0"
-edition = "2021"
 authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
-description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
-license = "Apache-2.0"
-repository = "https://github.com/gluesql/gluesql"
-documentation = "https://docs.rs/gluesql/"
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
 
 [dependencies]
 gluesql-core = { path = "../../core", version = "0.13.0" }


### PR DESCRIPTION
update - idb-storage, json-storage and web-storage


fyi.
Now only remaining Cargo.toml where the workspace inheritance is not applied yet is `pkg/javascript/web/`.
though `wasm-pack` v0.11 supports workspace inheritance but `wasm-plugin-rollup` is not yet updated so it is still required not to use workspace inheritance for `pkg/javascript/web/Cargo.toml`