### PR TITLE
Add datetime current date and time test case for ast builder

### DIFF
--- a/test-suite/src/ast_builder/function/datetime/current_date_and_time.rs
+++ b/test-suite/src/ast_builder/function/datetime/current_date_and_time.rs
@@ -1,0 +1,49 @@
+use {
+    crate::*,
+    gluesql_core::{ast_builder::*, prelude::{Payload, Value::*}},
+};
+
+test_case!(current_date_and_time, async move {
+    macro_rules! t {
+        ($timestamp: expr) => {
+            $timestamp.parse().unwrap()
+        };
+    }
+
+    let glue = get_glue!();
+
+    let actual = table("Record")
+        .create_table()
+        .add_column("id INTEGER PRIMARY KEY")
+        .add_column("time_stamp TIMESTAMP")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    test(actual, expected);
+
+    let actual = table("Record")
+        .insert()
+        .values(vec![
+            "1, '2022-12-23T05:30:11.164932863'",
+            "2, NOW()",
+            "3, '9999-12-31T23:59:40.364832862'",
+            ])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(3));
+    test(actual, expected);
+
+    // Now
+    let actual = table("Record")
+        .select()
+        .filter(col("time_stamp").gt(now()))
+        .project("id, time_stamp")
+        .execute(glue)
+        .await;
+    let expected = Ok(select!(
+        id  | time_stamp
+        I64 | Timestamp;
+        3     t!("9999-12-31T23:59:40.364832862")
+    ));
+    test(actual, expected);
+});

--- a/test-suite/src/ast_builder/function/datetime/current_date_and_time.rs
+++ b/test-suite/src/ast_builder/function/datetime/current_date_and_time.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{ast_builder::*, prelude::{Payload, Value::*}},
+    gluesql_core::{
+        ast_builder::*,
+        prelude::{Payload, Value::*},
+    },
 };
 
 test_case!(current_date_and_time, async move {
@@ -27,7 +30,7 @@ test_case!(current_date_and_time, async move {
             "1, '2022-12-23T05:30:11.164932863'",
             "2, NOW()",
             "3, '9999-12-31T23:59:40.364832862'",
-            ])
+        ])
         .execute(glue)
         .await;
     let expected = Ok(Payload::Insert(3));

--- a/test-suite/src/ast_builder/function/datetime/mod.rs
+++ b/test-suite/src/ast_builder/function/datetime/mod.rs
@@ -1,7 +1,7 @@
 mod conversion;
-mod formatting;
 mod current_date_and_time;
+mod formatting;
 
 pub use conversion::conversion;
-pub use formatting::formatting;
 pub use current_date_and_time::current_date_and_time;
+pub use formatting::formatting;

--- a/test-suite/src/ast_builder/function/datetime/mod.rs
+++ b/test-suite/src/ast_builder/function/datetime/mod.rs
@@ -1,3 +1,5 @@
 mod conversion;
+mod current_date_and_time;
 
 pub use conversion::conversion;
+pub use current_date_and_time::current_date_and_time;

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -222,6 +222,10 @@ macro_rules! generate_store_tests {
             ast_builder_function_text_trimming,
             ast_builder::function::text::trimming
         );
+        glue!(
+            ast_builder_function_datetime_current_date_and_time,
+            ast_builder::function::datetime::current_date_and_time
+        );
 
         // schemaless data support
         glue!(schemaless_basic, schemaless::basic);


### PR DESCRIPTION
### Goal
- Add datetime current date and time test case for ast builder

### Todo
- [x] Add datetime current date and time test case for ast builder (`now()`)