### PR TITLE
Setup blog based on docusaurus,

### DIFF
--- a/docs/blog/2023-05-18-test.md
+++ b/docs/blog/2023-05-18-test.md
@@ -1,0 +1,15 @@
+---
+title: Test - Greetings!
+description: Blog test test test
+slug: greetings
+authors:
+  - name: Taehoon Moon
+    title: Creator of GlueSQL
+    url: https://github.com/panarch
+    image_url: https://github.com/panarch.png
+tags: [temp, greetings]
+---
+
+# Greetings - Test
+
+Hello World

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -71,7 +71,18 @@ const config = {
     navbar: {
       title: 'GlueSQL',
       items: [
-        ...(!isBlog ? [
+        ...(isBlog ? [
+          {
+            to: '/',
+            label: 'Blog',
+            position: 'left',
+          },
+          {
+            href: 'https://gluesql.org/docs',
+            label: 'Docs',
+            position: 'right',
+          },
+        ] : [
           {
             type: 'doc',
             docId: 'getting-started/rust',
@@ -99,17 +110,6 @@ const config = {
           {
             href: 'https://gluesql.org/blog',
             label: 'Blog',
-            position: 'right',
-          },
-        ] : [
-          {
-            to: '/',
-            label: 'Blog',
-            position: 'left',
-          },
-          {
-            href: 'https://gluesql.org/docs',
-            label: 'Docs',
             position: 'right',
           },
         ]),

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -96,6 +96,11 @@ const config = {
             position: 'left',
             label: 'Storages',
           },
+          {
+            href: 'https://gluesql.org/blog',
+            label: 'Blog',
+            position: 'right',
+          },
         ] : [
           {
             to: '/',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -4,6 +4,9 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+const { env } = require('node:process');
+const isBlog = env.GLUESQL_DOC_TYPE === 'blog';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'GlueSQL',
@@ -14,12 +17,7 @@ const config = {
   url: 'https://gluesql.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs/dev/',
-
-  // GitHub pages deployment config.
-  // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  baseUrl: isBlog ? '/blog/' : '/docs/dev/',
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -37,13 +35,29 @@ const config = {
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-        },
-        blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        ...(
+          isBlog ? {
+            docs: false,
+            pages: false,
+            blog: {
+              routeBasePath: '/',
+              blogTitle: 'GlueSQL Blog',
+              blogDescription: 'GlueSQL Blog',
+              postsPerPage: 'ALL',
+              blogSidebarTitle: 'All posts',
+              blogSidebarCount: 'ALL',
+              showReadingTime: true,
+            },
+          } : {
+            docs: {
+              sidebarPath: require.resolve('./sidebars.js'),
+              routeBasePath: '/',
+            },
+          }
+        )
       }),
     ],
   ],
@@ -57,30 +71,43 @@ const config = {
     navbar: {
       title: 'GlueSQL',
       items: [
-        {
-          type: 'doc',
-          docId: 'getting-started/rust',
-          position: 'left',
-          label: 'Getting Started',
-        },
-        {
-          type: 'doc',
-          docId: 'sql-syntax/intro',
-          position: 'left',
-          label: 'SQL Syntax',
-        },
-        {
-          type: 'doc',
-          docId: 'ast-builder/intro',
-          position: 'left',
-          label: 'AST Builder',
-        },
-        {
-          type: 'doc',
-          docId: 'storages/intro',
-          position: 'left',
-          label: 'Storages',
-        },
+        ...(!isBlog ? [
+          {
+            type: 'doc',
+            docId: 'getting-started/rust',
+            position: 'left',
+            label: 'Getting Started',
+          },
+          {
+            type: 'doc',
+            docId: 'sql-syntax/intro',
+            position: 'left',
+            label: 'SQL Syntax',
+          },
+          {
+            type: 'doc',
+            docId: 'ast-builder/intro',
+            position: 'left',
+            label: 'AST Builder',
+          },
+          {
+            type: 'doc',
+            docId: 'storages/intro',
+            position: 'left',
+            label: 'Storages',
+          },
+        ] : [
+          {
+            to: '/',
+            label: 'Blog',
+            position: 'left',
+          },
+          {
+            href: 'https://gluesql.org/docs',
+            label: 'Docs',
+            position: 'right',
+          },
+        ]),
         {
           href: 'https://github.com/gluesql/gluesql',
           label: 'GitHub',
@@ -93,28 +120,37 @@ const config = {
       links: [
         {
           title: 'Docs',
-          items: [
+          items: isBlog ? [
+            {
+              label: 'Go to docs',
+              href: 'https://gluesql.org/docs',
+            },
+          ] : [
             {
               label: 'Getting Started',
-              to: '/docs/getting-started/rust',
+              to: '/getting-started/rust',
             },
             {
               label: 'SQL Syntax',
-              to: '/docs/sql-syntax/intro',
+              to: '/sql-syntax/intro',
             },
             {
               label: 'AST Builder',
-              to: '/docs/ast-builder/intro',
+              to: '/ast-builder/intro',
             },
             {
               label: 'Storages',
-              to: '/docs/storages/intro',
+              to: '/storages/intro',
             },
           ],
         },
         {
-          title: 'Community',
+          title: 'Resources',
           items: [
+            {
+              label: 'Blog',
+              href: 'https://gluesql.org/blog',
+            },
             {
               label: 'GitHub',
               href: 'https://github.com/gluesql/gluesql',

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "start:blog": "GLUESQL_DOC_TYPE=blog docusaurus start",
     "build": "docusaurus build",
+    "build:blog": "GLUESQL_DOC_TYPE=blog docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
Update docusaurus.config.js to handle both docs/ and blog/ by using GLUESQL_DOC_TYPE env variable.
Add test blog article.

blog/
<img width="933" alt="image" src="https://github.com/gluesql/gluesql/assets/2025065/3f7c76fd-19a6-4910-8ec0-2806a1f8d03a">


docs/ - blog link on the top-right side
<img width="943" alt="image" src="https://github.com/gluesql/gluesql/assets/2025065/23fbd47f-dbeb-47a6-aa84-44c73589f0b6">
