### PR TITLE
Apply word-wrap to docs/ article h1

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -30,13 +30,8 @@ h1 {
 
 article h1 {
   padding: 25px 30px 0 5px;
-  width: max-content;
-  line-height: 0.15;
-
-  border-style: solid;
-  border-color: var(--docusaurus-highlighted-code-line-bg);
-
-  border-width: 0 0 20px 0;
+  width: 100%;
+  word-wrap: break-word;
 }
 
 h2 {


### PR DESCRIPTION
before:
<img width="733" alt="image" src="https://github.com/gluesql/gluesql/assets/2025065/0a0d6930-c2c6-4701-a35e-51e58db72443">

after:
<img width="722" alt="image" src="https://github.com/gluesql/gluesql/assets/2025065/a1e3cffd-2136-49df-8870-8bd04e6a4404">
