### PR TITLE
fix: allow interval cast-related functions to accept only literals instead of evaluations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,6 @@ dependencies = [
 name = "gluesql-json-storage"
 version = "0.14.0"
 dependencies = [
- "async-io",
  "async-trait",
  "futures",
  "gluesql-core",

--- a/core/src/data/interval/error.rs
+++ b/core/src/data/interval/error.rs
@@ -1,4 +1,11 @@
-use {serde::Serialize, std::fmt::Debug, thiserror::Error};
+use {
+    super::Interval,
+    crate::ast::{Expr, ToSql},
+    chrono::NaiveTime,
+    serde::Serialize,
+    std::fmt::Debug,
+    thiserror::Error,
+};
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
 pub enum IntervalError {
@@ -11,11 +18,11 @@ pub enum IntervalError {
     #[error("cannot subtract between YEAR TO MONTH and HOUR TO SECOND")]
     SubtractBetweenYearToMonthAndHourToSecond,
 
-    #[error("cannot add year or month to TIME: {time} + {interval}")]
-    AddYearOrMonthToTime { time: String, interval: String },
+    #[error("cannot add year or month to TIME: {time} + {interval}", time = time.to_string(), interval = interval.to_sql_str())]
+    AddYearOrMonthToTime { time: NaiveTime, interval: Interval },
 
-    #[error("cannot subtract year or month to TIME: {time} - {interval}")]
-    SubtractYearOrMonthToTime { time: String, interval: String },
+    #[error("cannot subtract year or month to TIME: {time} - {interval}", time = time.to_string(), interval = interval.to_sql_str())]
+    SubtractYearOrMonthToTime { time: NaiveTime, interval: Interval },
 
     #[error("failed to parse integer: {0}")]
     FailedToParseInteger(String),
@@ -43,6 +50,9 @@ pub enum IntervalError {
 
     #[error("failed to get extract from interval")]
     FailedToExtract,
+
+    #[error("parse supported only literal, expected: \"'1 1' DAY TO HOUR\", but got: {expr}", expr = expr.to_sql())]
+    ParseSupportedOnlyLiteral { expr: Expr },
 
     #[error("unreachable")]
     Unreachable,

--- a/core/src/data/interval/string.rs
+++ b/core/src/data/interval/string.rs
@@ -1,13 +1,15 @@
 use {
     super::{Interval, IntervalError, DAY, HOUR, MINUTE, SECOND},
     crate::{
-        ast::Expr, data::Value, executor::evaluate_stateless, parse_sql::parse_interval,
-        result::Result, translate::translate_expr,
+        ast::{Expr, ToSql},
+        parse_sql::parse_interval,
+        result::Result,
+        translate::translate_expr,
     },
 };
 
 impl Interval {
-    pub async fn parse(s: &str) -> Result<Self> {
+    pub fn parse(s: &str) -> Result<Self> {
         let parsed = parse_interval(s)?;
 
         match translate_expr(&parsed)? {
@@ -16,21 +18,21 @@ impl Interval {
                 leading_field,
                 last_field,
             } => {
-                let value = evaluate_stateless(None, &expr)
-                    .await
-                    .and_then(Value::try_from)
-                    .map(String::from)?;
+                let literal = match &*expr {
+                    Expr::Literal(literal) => literal.to_sql(),
+                    _ => {
+                        return Err(IntervalError::ParseSupportedOnlyLiteral { expr: *expr }.into())
+                    }
+                };
 
-                Interval::try_from_literal(&value, leading_field, last_field)
+                Interval::try_from_str(&literal, leading_field, last_field)
             }
             _ => Err(IntervalError::Unreachable.into()),
         }
     }
-}
 
-impl From<&Interval> for String {
-    fn from(interval: &Interval) -> Self {
-        match interval {
+    pub fn to_sql_str(&self) -> String {
+        match self {
             Interval::Month(v) => {
                 let v = *v;
                 let (sign, v) = if v < 0 { ("-", -v) } else { ("", v) };
@@ -142,26 +144,20 @@ impl From<&Interval> for String {
     }
 }
 
-impl From<Interval> for String {
-    fn from(interval: Interval) -> Self {
-        (&interval).into()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use {super::Interval, futures::executor::block_on};
+    use super::Interval;
 
     #[test]
-    fn into_owned() {
+    fn parse() {
         macro_rules! test {
             ($( $value: literal $duration: ident ),* => $result: literal $from_to: tt) => {
                 let interval = interval!($( $value $duration ),*);
                 let interval_str = format!("'{}' {}", $result, stringify!($from_to));
 
-                let expected = block_on(Interval::parse(interval_str.as_str()));
+                let expected = Interval::parse(interval_str.as_str());
                 assert_eq!(Ok(interval), expected);
-                assert_eq!(String::from(interval), interval_str);
+                assert_eq!(interval.to_sql_str(), interval_str);
             };
             ($( $value: literal $duration: ident ),* => $result: literal $from: tt TO $to: tt) => {
                 let interval = interval!($( $value $duration ),*);
@@ -172,9 +168,9 @@ mod tests {
                     stringify!($to),
                 );
 
-                let expected = block_on(Interval::parse(interval_str.as_str()));
+                let expected = Interval::parse(interval_str.as_str());
                 assert_eq!(Ok(interval), expected);
-                assert_eq!(String::from(interval), interval_str);
+                assert_eq!(interval.to_sql_str(), interval_str);
             };
         }
 

--- a/core/src/data/interval/string.rs
+++ b/core/src/data/interval/string.rs
@@ -18,7 +18,7 @@ impl Interval {
                 leading_field,
                 last_field,
             } => {
-                let literal = match &*expr {
+                let literal = match expr.as_ref() {
                     Expr::Literal(literal) => literal.to_sql(),
                     _ => {
                         return Err(IntervalError::ParseSupportedOnlyLiteral { expr: *expr }.into())

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -81,7 +81,7 @@ impl TryFrom<Value> for JsonValue {
             Value::Date(v) => Ok(v.to_string().into()),
             Value::Timestamp(v) => Ok(DateTime::<Utc>::from_utc(v, Utc).to_string().into()),
             Value::Time(v) => Ok(v.to_string().into()),
-            Value::Interval(v) => Ok(String::from(&v).into()),
+            Value::Interval(v) => Ok(v.to_sql_str().into()),
             Value::Uuid(v) => Ok(Uuid::from_u128(v).hyphenated().to_string().into()),
             Value::Map(v) => v
                 .into_iter()

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -267,10 +267,7 @@ impl Value {
         }
     }
 
-    pub async fn try_cast_from_literal(
-        data_type: &DataType,
-        literal: &Literal<'_>,
-    ) -> Result<Value> {
+    pub fn try_cast_from_literal(data_type: &DataType, literal: &Literal<'_>) -> Result<Value> {
         match (data_type, literal) {
             (DataType::Boolean, Literal::Boolean(v)) => Ok(Value::Bool(*v)),
             (DataType::Boolean, Literal::Text(v)) => match v.to_uppercase().as_str() {
@@ -474,7 +471,7 @@ impl Value {
                 Ok(Value::Str(v.to_owned()))
             }
             (DataType::Interval, Literal::Text(v)) => {
-                Interval::parse(v.as_ref()).await.map(Value::Interval)
+                Interval::parse(v.as_ref()).map(Value::Interval)
             }
             (DataType::Uuid, Literal::Text(v)) => parse_uuid(v).map(Value::Uuid),
             (DataType::Boolean, Literal::Null)
@@ -850,7 +847,6 @@ mod tests {
         use {
             crate::{ast::DataType, data::Interval as I},
             chrono::NaiveDate,
-            futures::executor::block_on,
             std::{borrow::Cow, str::FromStr},
         };
 
@@ -868,7 +864,7 @@ mod tests {
 
         macro_rules! test {
             ($to: expr, $from: expr, $expected: expr) => {
-                let actual = block_on(Value::try_cast_from_literal(&$to, &$from));
+                let actual = Value::try_cast_from_literal(&$to, &$from);
 
                 assert_eq!(actual, Ok($expected))
             };
@@ -877,7 +873,7 @@ mod tests {
         macro_rules! test_null {
             ($to: expr, $from: expr) => {
                 assert!(matches!(
-                    block_on(Value::try_cast_from_literal(&$to, &$from)),
+                    Value::try_cast_from_literal(&$to, &$from),
                     Ok(Value::Null)
                 ))
             };

--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -127,10 +127,7 @@ impl AggrValue {
             let count = Value::I64(count);
             let sum_expr1 = sum_square.multiply(&count)?;
             let sum_expr2 = sum.multiply(&sum)?;
-            let expr_sub = sum_expr1
-                .cast(&DataType::Float)
-                .await?
-                .subtract(&sum_expr2)?;
+            let expr_sub = sum_expr1.cast(&DataType::Float)?.subtract(&sum_expr2)?;
             let cnt_square = count.multiply(&count)?;
             expr_sub.divide(&cnt_square)
         };
@@ -139,7 +136,7 @@ impl AggrValue {
             Self::Count { count, .. } => Ok(Value::I64(count)),
             Self::Sum(value) | Self::Min(value) | Self::Max(value) => Ok(value),
             Self::Avg { sum, count } => {
-                let sum = sum.cast(&DataType::Float).await?;
+                let sum = sum.cast(&DataType::Float)?;
 
                 sum.divide(&Value::I64(count))
             }

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -252,12 +252,12 @@ impl<'a> Evaluated<'a> {
         .map(Evaluated::from)
     }
 
-    pub async fn cast(self, data_type: &DataType) -> Result<Evaluated<'a>> {
+    pub fn cast(self, data_type: &DataType) -> Result<Evaluated<'a>> {
         match self {
-            Evaluated::Literal(literal) => Value::try_cast_from_literal(data_type, &literal).await,
-            Evaluated::Value(value) => value.cast(data_type).await,
+            Evaluated::Literal(literal) => Value::try_cast_from_literal(data_type, &literal),
+            Evaluated::Value(value) => value.cast(data_type),
             Evaluated::StrSlice { source, range } => {
-                Value::Str(source[range].to_owned()).cast(data_type).await
+                Value::Str(source[range].to_owned()).cast(data_type)
             }
         }
         .map(Evaluated::from)

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -625,8 +625,8 @@ pub fn find_idx<'a>(
     .map(Evaluated::from)
 }
 
-pub async fn cast<'a>(expr: Evaluated<'a>, data_type: &DataType) -> Result<Evaluated<'a>> {
-    expr.cast(data_type).await
+pub fn cast<'a>(expr: Evaluated<'a>, data_type: &DataType) -> Result<Evaluated<'a>> {
+    expr.cast(data_type)
 }
 
 pub fn extract<'a>(field: &DateTimeField, expr: Evaluated<'_>) -> Result<Evaluated<'a>> {

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -296,7 +296,7 @@ async fn evaluate_inner<'a, 'b: 'a, 'c: 'a, T: GStore>(
                 .and_then(Value::try_from)
                 .map(String::from)?;
 
-            Interval::try_from_literal(&value, *leading_field, *last_field)
+            Interval::try_from_str(&value, *leading_field, *last_field)
                 .map(Value::Interval)
                 .map(Evaluated::from)
         }
@@ -590,7 +590,7 @@ async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(
         }
         Function::Cast { expr, data_type } => {
             let expr = eval(expr).await?;
-            f::cast(expr, data_type).await
+            f::cast(expr, data_type)
         }
         Function::Extract { field, expr } => {
             let expr = eval(expr).await?;

--- a/storages/idb-storage/src/convert.rs
+++ b/storages/idb-storage/src/convert.rs
@@ -1,6 +1,5 @@
 use {
     super::ErrInto,
-    futures::stream::{self, StreamExt, TryStreamExt},
     gloo_utils::format::JsValueSerdeExt,
     gluesql_core::{
         ast::ColumnDef,
@@ -13,30 +12,27 @@ use {
     wasm_bindgen::JsValue,
 };
 
-pub async fn convert(value: JsValue, column_defs: Option<&[ColumnDef]>) -> Result<DataRow> {
+pub fn convert(value: JsValue, column_defs: Option<&[ColumnDef]>) -> Result<DataRow> {
     let value: JsonValue = value.into_serde().err_into()?;
 
     match (value, column_defs) {
         (JsonValue::Array(json_array), Some(column_defs))
             if json_array.len() == column_defs.len() =>
         {
-            stream::iter(
-                json_array
-                    .into_iter()
-                    .map(Value::try_from)
-                    .zip(column_defs.iter()),
-            )
-            .then(|(value, ColumnDef { data_type, .. })| async move {
-                let value = value?;
+            json_array
+                .into_iter()
+                .map(Value::try_from)
+                .zip(column_defs.iter())
+                .map(|(value, ColumnDef { data_type, .. })| {
+                    let value = value?;
 
-                match value.get_type() {
-                    Some(curr_type) if &curr_type != data_type => value.cast(data_type).await,
-                    _ => Ok(value),
-                }
-            })
-            .try_collect::<Vec<Value>>()
-            .await
-            .map(DataRow::Vec)
+                    match value.get_type() {
+                        Some(curr_type) if &curr_type != data_type => value.cast(data_type),
+                        _ => Ok(value),
+                    }
+                })
+                .collect::<Result<Vec<_>>>()
+                .map(DataRow::Vec)
         }
         (JsonValue::Object(json_map), None) => json_map
             .into_iter()

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -74,7 +74,6 @@ impl IdbStorage {
                     };
 
                     *error = Some(e);
-                    return;
                 }
             });
 
@@ -167,7 +166,7 @@ impl Store for IdbStorage {
         transaction.commit().await.err_into()?;
 
         match row {
-            Some(row) => convert(row, column_defs.as_deref()).await.map(Some),
+            Some(row) => convert(row, column_defs.as_deref()).map(Some),
             None => Ok(None),
         }
     }
@@ -203,7 +202,7 @@ impl Store for IdbStorage {
             let key: JsonValue = current_key.into_serde().err_into()?;
             let key: Key = Value::try_from(key)?.try_into()?;
 
-            let row = convert(current_row, column_defs.as_deref()).await?;
+            let row = convert(current_row, column_defs.as_deref())?;
 
             rows.push((key, row));
 

--- a/storages/idb-storage/tests/convert.rs
+++ b/storages/idb-storage/tests/convert.rs
@@ -48,7 +48,7 @@ async fn convert_schema() {
         Value::Bool(true),
     ]);
     assert_eq!(
-        convert(actual_data, Some(actual_defs.as_slice())).await,
+        convert(actual_data, Some(actual_defs.as_slice())),
         Ok(expected)
     );
 }
@@ -70,5 +70,5 @@ async fn convert_schemaless() {
         .into_iter()
         .collect(),
     );
-    assert_eq!(convert(actual, None).await, Ok(expected));
+    assert_eq!(convert(actual, None), Ok(expected));
 }

--- a/storages/json-storage/Cargo.toml
+++ b/storages/json-storage/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 hex = "0.4"
 thiserror = "1.0"
 iter-enum = "1"
-async-io = "1"
 
 [dev-dependencies]
 test-suite.workspace = true

--- a/storages/json-storage/src/lib.rs
+++ b/storages/json-storage/src/lib.rs
@@ -7,7 +7,6 @@ mod store_mut;
 mod transaction;
 
 use {
-    async_io::block_on,
     error::{JsonStorageError, OptionExt, ResultExt},
     gluesql_core::{
         ast::ColumnUniqueOption,
@@ -173,7 +172,7 @@ impl JsonStorage {
 
                 let value = match value.get_type() {
                     Some(data_type) if data_type != column_def.data_type => {
-                        block_on(value.cast(&column_def.data_type))?
+                        value.cast(&column_def.data_type)?
                     }
                     Some(_) | None => value.clone(),
                 };

--- a/test-suite/src/data_type/time.rs
+++ b/test-suite/src/data_type/time.rs
@@ -126,8 +126,8 @@ INSERT INTO TimeLog VALUES
     test!(
         "SELECT * FROM TimeLog WHERE time1 > time2 + INTERVAL '1' YEAR",
         Err(IntervalError::AddYearOrMonthToTime {
-            time: t(13, 31, 1, 123).to_string(),
-            interval: gluesql_core::data::Interval::years(1).into(),
+            time: t(13, 31, 1, 123),
+            interval: gluesql_core::data::Interval::years(1),
         }
         .into())
     );
@@ -135,8 +135,8 @@ INSERT INTO TimeLog VALUES
     test!(
         "SELECT * FROM TimeLog WHERE time1 > time2 - INTERVAL '1-2' YEAR TO MONTH",
         Err(IntervalError::SubtractYearOrMonthToTime {
-            time: t(13, 31, 1, 123).to_string(),
-            interval: gluesql_core::data::Interval::months(14).into(),
+            time: t(13, 31, 1, 123),
+            interval: gluesql_core::data::Interval::months(14),
         }
         .into())
     );

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -410,7 +410,7 @@ test_case!(cast_value, async move {
             6     I::hours(12)          I::seconds(-(12 * 3600 + 30 * 60 + 12));
             7     I::months(-12_011)    I::seconds(-(30 * 60 + 11))
             )),
-        ),
+        )
     ];
 
     for (sql, expected) in test_cases {


### PR DESCRIPTION
- remote async [Value::try_cast_from_literal, Interval::parse]
- remove `DataType::Interval` cast to Value
- remove `Value::try_into_interval`
- Rename `From<&Interval> for String` to `to_sql_str`