### PR TITLE
[DRAFT] Add PartialEq for Value::Null type

### DIFF
--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -95,6 +95,7 @@ impl PartialEq<Value> for Value {
             (Value::Map(l), Value::Map(r)) => l == r,
             (Value::List(l), Value::List(r)) => l == r,
             (Value::Point(l), Value::Point(r)) => l == r,
+            (&Value::Null, &Value::Null) => true,
             _ => false,
         }
     }

--- a/pkg/rust/examples/memory_storage_usage.rs
+++ b/pkg/rust/examples/memory_storage_usage.rs
@@ -52,8 +52,7 @@ mod api_usage {
         let mut row1 = rows[1].iter();
         assert_eq!(row1.next(), Some(&Value::I64(2)));
         assert_eq!(row1.next(), Some(&Value::Str("test2".to_string())));
-        // PartialEq for Null is not implemented.
-        row1.next();
+        assert_eq!(row1.next(), Some(&Value::Null));
         assert_eq!(row1.next(), Some(&Value::Bool(false)));
         assert_eq!(row1.next(), None);
     }

--- a/pkg/rust/examples/memory_storage_usage.rs
+++ b/pkg/rust/examples/memory_storage_usage.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "memory-storage")]
 mod api_usage {
-    use gluesql::{memory_storage::MemoryStorage, prelude::Glue};
+    use gluesql::{
+        memory_storage::MemoryStorage,
+        prelude::{Glue, Payload, Value},
+    };
 
     fn memory_basic() {
         let storage = MemoryStorage::default();
@@ -29,6 +32,30 @@ mod api_usage {
                 (2, 'test2', NULL, FALSE)",
         )
         .unwrap();
+
+        let queries = "SELECT * FROM api_test";
+        let result = glue
+            .execute(queries)
+            .expect(&format!("Failed to execute query: {}", queries));
+        assert_eq!(result.len(), 1);
+        let rows = match &result[0] {
+            Payload::Select { labels: _, rows } => rows,
+            _ => panic!("Unexpected result: {:?}", result),
+        };
+
+        let mut row0 = rows[0].iter();
+        assert_eq!(row0.next(), Some(&Value::I64(1)));
+        assert_eq!(row0.next(), Some(&Value::Str("test1".to_string())));
+        assert_eq!(row0.next(), Some(&Value::Str("not null".to_string())));
+        assert_eq!(row0.next(), Some(&Value::Bool(true)));
+        assert_eq!(row0.next(), None);
+        let mut row1 = rows[1].iter();
+        assert_eq!(row1.next(), Some(&Value::I64(2)));
+        assert_eq!(row1.next(), Some(&Value::Str("test2".to_string())));
+        // PartialEq for Null is not implemented.
+        row1.next();
+        assert_eq!(row1.next(), Some(&Value::Bool(false)));
+        assert_eq!(row1.next(), None);
     }
 
     fn memory_basic_async() {


### PR DESCRIPTION
Add PartialEq implementation for Value::Null type.
And add a test case accordingly.

Hi,
I am sorry to bother you if there is a historical reason.
In my opinion, Value::Null type also should be comparable.
