### PR TITLE
Replace `actions-rs/toolchain` with `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,9 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Read rust-toolchain file
+        id: rust-toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add llvm-tools-preview
       - name: Install grcov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,11 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Read rust-toolchain file
+        id: rust-toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
       - name: Add clippy
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          default: true
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
@@ -33,11 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Read rust-toolchain file
+        id: rust-toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
       - name: Add rustfmt
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          default: true
+          toolchain: ${{ steps.rust-toolchain.outputs.toolchain }}
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: |


### PR DESCRIPTION
## Description

Resolve #1249 

The [actions-rs/toolchain](https://github.com/actions-rs/toolchain/issues/216) project is not currently maintained, so I replaced `actions-rs/toolchain` with `dtolnay/rust-toolchain`.

**AS-IS**

```yaml
- uses: actions-rs/toolchain@v1
  with:
    toolchain: stable
```

> `actions-rs/toolchain` can set up a profile. (e.g. default, minimal)

```yaml
- uses: actions-rs/toolchain@v1.0.6
  with:
    profile: minimal
    default: true
    components: clippy
```

**TO-BE**

```yaml
- uses: dtolnay/rust-toolchain@stable
```

> `dtolnay/rust-toolchain` ONLY install "minimal"

```yaml
- uses: dtolnay/rust-toolchain@master
  with:
    toolchain: 1.68
    components: clippy
```

