### PR TITLE
ci: Automatically assign a PR to its author

### DIFF
--- a/.github/auto-author-assign-config.yml
+++ b/.github/auto-author-assign-config.yml
@@ -1,0 +1,10 @@
+addAssignees: author
+
+addReviewers: true
+reviewers:
+  - panarch
+  - ever0de
+  - devgony
+numberOfReviewers: 0
+
+runOnDraft: true

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,8 +1,8 @@
 name: auto-author-assign
 
 on:
-  pull_request_target:
-    types: [ opened, reopened ]
+  pull_request:
+    types: [ opened, ready_for_review ]
 
 permissions:
   pull-requests: write
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.6.2
+      - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/auto-author-assign-config.yml

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,16 @@
+name: auto-author-assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR resolves #667, using a well-known GitHub Actions workflow [toshimaru/auto-author-assign](https://github.com/toshimaru/auto-author-assign).

Please refer [this](https://github.com/rapsealk/github-actions-swing/pull/1) to see how it will work.
