### PR TITLE
Update auto-assign-action to be triggered on PR open from fork repos

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,8 +1,8 @@
 name: auto-author-assign
 
 on:
-  pull_request:
-    types: [ opened, ready_for_review ]
+  pull_request_target:
+    types: [opened]
 
 permissions:
   pull-requests: write
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.6.2
+      - uses: kentaro-m/auto-assign-action@v1.2.5
         with:
           configuration-path: '.github/auto-author-assign-config.yml'

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.5
+      - uses: kentaro-m/auto-assign-action@v1.6.2
         with:
           configuration-path: '.github/auto-author-assign-config.yml'


### PR DESCRIPTION
> Change event that triggers a workflow to the pull_request_target if you want to enable the auto-assign action when opening pull requests from fork repositories or bots like Dependabot.

ref. https://github.com/kentaro-m/auto-assign-action