### PR TITLE
Fix spool on `tabular off` and `SelectMap`

### DIFF
--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -99,30 +99,30 @@ impl<'a, W: Write> Print<W> {
     pub fn payload(&mut self, payload: &Payload) -> IOResult<()> {
         let mut affected = |n: usize, msg: &str| -> IOResult<()> {
             let payload = format!("{} row{} {}", n, if n > 1 { "s" } else { "" }, msg);
-            self.write(payload)
+            self.writeln(payload)
         };
 
         match payload {
-            Payload::Create => self.write("Table created")?,
-            Payload::DropTable => self.write("Table dropped")?,
-            Payload::DropFunction => self.write("Function dropped")?,
-            Payload::AlterTable => self.write("Table altered")?,
-            Payload::CreateIndex => self.write("Index created")?,
-            Payload::DropIndex => self.write("Index dropped")?,
-            Payload::Commit => self.write("Commit completed")?,
-            Payload::Rollback => self.write("Rollback completed")?,
-            Payload::StartTransaction => self.write("Transaction started")?,
+            Payload::Create => self.writeln("Table created")?,
+            Payload::DropTable => self.writeln("Table dropped")?,
+            Payload::DropFunction => self.writeln("Function dropped")?,
+            Payload::AlterTable => self.writeln("Table altered")?,
+            Payload::CreateIndex => self.writeln("Index created")?,
+            Payload::DropIndex => self.writeln("Index dropped")?,
+            Payload::Commit => self.writeln("Commit completed")?,
+            Payload::Rollback => self.writeln("Rollback completed")?,
+            Payload::StartTransaction => self.writeln("Transaction started")?,
             Payload::Insert(n) => affected(*n, "inserted")?,
             Payload::Delete(n) => affected(*n, "deleted")?,
             Payload::Update(n) => affected(*n, "updated")?,
-            Payload::ShowVariable(PayloadVariable::Version(v)) => self.write(format!("v{v}"))?,
+            Payload::ShowVariable(PayloadVariable::Version(v)) => self.writeln(format!("v{v}"))?,
             Payload::ShowVariable(PayloadVariable::Tables(names)) => {
                 let mut table = self.get_table(["tables"]);
                 for name in names {
                     table.add_record([name]);
                 }
                 let table = self.build_table(table);
-                self.write(table)?;
+                self.writeln(table)?;
             }
             Payload::ShowVariable(PayloadVariable::Functions(names)) => {
                 let mut table = self.get_table(["functions"]);
@@ -130,7 +130,7 @@ impl<'a, W: Write> Print<W> {
                     table.add_record([name]);
                 }
                 let table = self.build_table(table);
-                self.write(table)?;
+                self.writeln(table)?;
             }
             Payload::ShowColumns(columns) => {
                 let mut table = self.get_table(vec!["Field", "Type"]);
@@ -138,7 +138,7 @@ impl<'a, W: Write> Print<W> {
                     table.add_record([field, &field_type.to_string()]);
                 }
                 let table = self.build_table(table);
-                self.write(table)?;
+                self.writeln(table)?;
             }
             Payload::Select { labels, rows } => match &self.option.tabular {
                 true => {
@@ -150,34 +150,20 @@ impl<'a, W: Write> Print<W> {
                         table.add_record(row);
                     }
                     let table = self.build_table(table);
-                    self.write(table)?;
+                    self.writeln(table)?;
                 }
                 false => {
-                    let PrintOption {
-                        colsep,
-                        colwrap,
-                        heading,
-                        ..
-                    } = &self.option;
-
-                    if *heading {
-                        let labels = labels
-                            .iter()
-                            .map(|v| format!("{colwrap}{v}{colwrap}"))
-                            .collect::<Vec<_>>()
-                            .join(colsep.as_str());
-
-                        writeln!(self.output, "{}", labels)?;
-                    }
+                    self.write_header(labels.iter().map(|s| s.as_str()))?;
 
                     for row in rows {
                         let row = row
                             .iter()
                             .map(Into::into)
-                            .map(|v: String| format!("{colwrap}{v}{colwrap}"))
+                            .map(|v: String| format!("{c}{v}{c}", c = self.option.colwrap))
                             .collect::<Vec<_>>()
-                            .join(colsep.as_str());
-                        writeln!(self.output, "{}", row)?
+                            .join(self.option.colsep.as_str());
+
+                        self.write(row)?;
                     }
                 }
             },
@@ -207,25 +193,10 @@ impl<'a, W: Write> Print<W> {
                             table.add_record(row);
                         }
                         let table = self.build_table(table);
-                        self.write(table)?;
+                        self.writeln(table)?;
                     }
                     false => {
-                        let PrintOption {
-                            colsep,
-                            colwrap,
-                            heading,
-                            ..
-                        } = &self.option;
-
-                        if *heading {
-                            let labels = labels
-                                .iter()
-                                .map(|v| format!("{colwrap}{v}{colwrap}"))
-                                .collect::<Vec<_>>()
-                                .join(colsep.as_str());
-
-                            writeln!(self.output, "{}", labels)?;
-                        }
+                        self.write_header(labels.iter().map(AsRef::as_ref))?;
 
                         for row in rows {
                             let row = labels
@@ -236,12 +207,12 @@ impl<'a, W: Write> Print<W> {
                                         .map(Into::into)
                                         .unwrap_or_else(|| "".to_owned());
 
-                                    format!("{colwrap}{v}{colwrap}")
+                                    format!("{c}{v}{c}", c = self.option.colwrap)
                                 })
                                 .collect::<Vec<_>>()
-                                .join(colsep.as_str());
+                                .join(self.option.colsep.as_str());
 
-                            writeln!(self.output, "{}", row)?
+                            self.write(row)?;
                         }
                     }
                 }
@@ -251,12 +222,40 @@ impl<'a, W: Write> Print<W> {
         Ok(())
     }
 
-    fn write(&mut self, payload: impl Display) -> IOResult<()> {
+    fn write_lf(&mut self, payload: impl Display, lf: &str) -> IOResult<()> {
         if let Some(file) = &self.spool_file {
-            writeln!(file.to_owned(), "{}\n", payload)?;
+            writeln!(file.to_owned(), "{payload}{lf}")?;
         };
 
-        writeln!(self.output, "{}\n", payload)
+        writeln!(self.output, "{payload}{lf}")
+    }
+
+    fn write(&mut self, payload: impl Display) -> IOResult<()> {
+        self.write_lf(payload, "")
+    }
+
+    fn writeln(&mut self, payload: impl Display) -> IOResult<()> {
+        self.write_lf(payload, "\n")
+    }
+
+    fn write_header<'b>(&mut self, labels: impl Iterator<Item = &'b str>) -> IOResult<()> {
+        let PrintOption {
+            heading,
+            colsep,
+            colwrap,
+            ..
+        } = &self.option;
+
+        if !heading {
+            return Ok(());
+        }
+
+        let labels = labels
+            .map(|v| format!("{colwrap}{v}{colwrap}"))
+            .collect::<Vec<_>>()
+            .join(colsep.as_str());
+
+        self.write(labels)
     }
 
     pub fn help(&mut self) -> IOResult<()> {
@@ -318,7 +317,7 @@ impl<'a, W: Write> Print<W> {
 
     pub fn show_option(&mut self, option: ShowOption) -> IOResult<()> {
         let payload = self.option.format(option);
-        self.write(payload)?;
+        self.writeln(payload)?;
 
         Ok(())
     }
@@ -779,9 +778,9 @@ heading ON"
         // Spooling on file
         fs::create_dir_all("tmp").unwrap();
         assert!(print.spool_on(PathBuf::from("tmp/spool.txt")).is_ok());
-        assert!(print.write("Test").is_ok());
+        assert!(print.writeln("Test").is_ok());
         assert!(print.show_option(ShowOption::All).is_ok());
         print.spool_off();
-        assert!(print.write("Test").is_ok());
+        assert!(print.writeln("Test").is_ok());
     }
 }


### PR DESCRIPTION
## Issue
- Currently, CLI `.spool {path}` does not work on `tabular off` and `SelectMap`

## Goal
- `writeln!` should be replaced with `self.write` which perform spool

## Todo
- [x] fix: replace writeln to self.write
- [x] refactor: extract write_header
- [x] refactor: split self.write to self.{write_lf, write, writeln}