### PR TITLE
Feature/operator bit not

### DIFF
--- a/core/src/ast/operator.rs
+++ b/core/src/ast/operator.rs
@@ -19,7 +19,7 @@ impl ToSql for UnaryOperator {
             UnaryOperator::Minus => "-".to_owned(),
             UnaryOperator::Not => "NOT ".to_owned(),
             UnaryOperator::Factorial => "!".to_owned(),
-            &UnaryOperator::BitwiseNot => "~".to_owned(),
+            UnaryOperator::BitwiseNot => "~".to_owned(),
         }
     }
 }

--- a/core/src/ast/operator.rs
+++ b/core/src/ast/operator.rs
@@ -9,7 +9,7 @@ pub enum UnaryOperator {
     Minus,
     Not,
     Factorial,
-    BitNot,
+    BitwiseNot,
 }
 
 impl ToSql for UnaryOperator {
@@ -19,7 +19,7 @@ impl ToSql for UnaryOperator {
             UnaryOperator::Minus => "-".to_owned(),
             UnaryOperator::Not => "NOT ".to_owned(),
             UnaryOperator::Factorial => "!".to_owned(),
-            &UnaryOperator::BitNot => "~".to_owned(),
+            &UnaryOperator::BitwiseNot => "~".to_owned(),
         }
     }
 }
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(
             "~1",
             Expr::UnaryOp {
-                op: UnaryOperator::BitNot,
+                op: UnaryOperator::BitwiseNot,
                 expr: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1)))),
             }
             .to_sql(),

--- a/core/src/ast/operator.rs
+++ b/core/src/ast/operator.rs
@@ -9,6 +9,7 @@ pub enum UnaryOperator {
     Minus,
     Not,
     Factorial,
+    BitNot,
 }
 
 impl ToSql for UnaryOperator {
@@ -18,6 +19,7 @@ impl ToSql for UnaryOperator {
             UnaryOperator::Minus => "-".to_owned(),
             UnaryOperator::Not => "NOT ".to_owned(),
             UnaryOperator::Factorial => "!".to_owned(),
+            &UnaryOperator::BitNot => "~".to_owned(),
         }
     }
 }
@@ -304,5 +306,14 @@ mod tests {
             }
             .to_sql()
         );
+
+        assert_eq!(
+            "~1",
+            Expr::UnaryOp {
+                op: UnaryOperator::BitNot,
+                expr: Box::new(Expr::Literal(AstLiteral::Number(BigDecimal::from(1)))),
+            }
+            .to_sql(),
+        )
     }
 }

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -82,10 +82,10 @@ pub enum ValueError {
     FactorialOverflow,
 
     #[error("unary bit_not operation for non numeric value")]
-    UnaryBitNotOnNonNumeric,
+    UnaryBitwiseNotOnNonNumeric,
 
     #[error("unary bit_not operation for non integer value")]
-    UnaryBitNotOnNonInteger,
+    UnaryBitwiseNotOnNonInteger,
 
     #[error("unreachable failure on parsing number")]
     UnreachableNumberParsing,

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -81,6 +81,12 @@ pub enum ValueError {
     #[error("unary factorial operation overflow")]
     FactorialOverflow,
 
+    #[error("unary bit_not operation for non numeric value")]
+    UnaryBitNotOnNonNumeric,
+
+    #[error("unary bit_not operation for non integer value")]
+    UnaryBitNotOnNonInteger,
+
     #[error("unreachable failure on parsing number")]
     UnreachableNumberParsing,
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -703,7 +703,7 @@ impl Value {
         }
     }
 
-    pub fn unary_bit_not(&self) -> Result<Value> {
+    pub fn unary_bitwise_not(&self) -> Result<Value> {
         use Value::*;
 
         match self {
@@ -717,10 +717,10 @@ impl Value {
             U32(v) => Ok(Value::U32(!v)),
             U64(v) => Ok(Value::U64(!v)),
             U128(v) => Ok(Value::U128(!v)),
-            F32(_) => Err(ValueError::UnaryBitNotOnNonInteger.into()),
-            F64(_) => Err(ValueError::UnaryBitNotOnNonInteger.into()),
+            F32(_) => Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
+            F64(_) => Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
             Null => Ok(Null),
-            _ => Err(ValueError::UnaryBitNotOnNonNumeric.into()),
+            _ => Err(ValueError::UnaryBitwiseNotOnNonNumeric.into()),
         }
     }
 

--- a/core/src/data/value/mod.rs
+++ b/core/src/data/value/mod.rs
@@ -703,6 +703,27 @@ impl Value {
         }
     }
 
+    pub fn unary_bit_not(&self) -> Result<Value> {
+        use Value::*;
+
+        match self {
+            I8(v) => Ok(Value::I8(!v)),
+            I16(v) => Ok(Value::I16(!v)),
+            I32(v) => Ok(Value::I32(!v)),
+            I64(v) => Ok(Value::I64(!v)),
+            I128(v) => Ok(Value::I128(!v)),
+            U8(v) => Ok(Value::U8(!v)),
+            U16(v) => Ok(Value::U16(!v)),
+            U32(v) => Ok(Value::U32(!v)),
+            U64(v) => Ok(Value::U64(!v)),
+            U128(v) => Ok(Value::U128(!v)),
+            F32(_) => Err(ValueError::UnaryBitNotOnNonInteger.into()),
+            F64(_) => Err(ValueError::UnaryBitNotOnNonInteger.into()),
+            Null => Ok(Null),
+            _ => Err(ValueError::UnaryBitNotOnNonNumeric.into()),
+        }
+    }
+
     pub fn like(&self, other: &Value, case_sensitive: bool) -> Result<Value> {
         use Value::*;
 

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -126,6 +126,9 @@ pub enum EvaluateError {
     #[error("unsupported evaluate string unary factorial: {0}")]
     UnsupportedUnaryFactorial(String),
 
+    #[error("unsupported evaluate string unary bit_not: {0}")]
+    UnsupportedUnaryBitNot(String),
+
     #[error("unsupported custom function in subqueries")]
     UnsupportedCustomFunction,
 

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -126,8 +126,8 @@ pub enum EvaluateError {
     #[error("unsupported evaluate string unary factorial: {0}")]
     UnsupportedUnaryFactorial(String),
 
-    #[error("unsupported evaluate string unary bit_not: {0}")]
-    UnsupportedUnaryBitNot(String),
+    #[error("incompatible bit operation ~{0}")]
+    IncompatibleUnaryBitwiseNotOperation(String),
 
     #[error("unsupported custom function in subqueries")]
     UnsupportedCustomFunction,

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -304,6 +304,17 @@ impl<'a> Evaluated<'a> {
         .map(Evaluated::from)
     }
 
+    pub fn unary_bit_not(&self) -> Result<Evaluated<'a>> {
+        match self {
+            Evaluated::Literal(v) => Value::try_from(v).and_then(|v| v.unary_bit_not()),
+            Evaluated::Value(v) => v.unary_bit_not(),
+            Evaluated::StrSlice { source, range } => {
+                Err(EvaluateError::UnsupportedUnaryBitNot(source[range.clone()].to_owned()).into())
+            }
+        }
+        .map(Evaluated::from)
+    }
+
     pub fn cast(self, data_type: &DataType) -> Result<Evaluated<'a>> {
         match self {
             Evaluated::Literal(literal) => Value::try_cast_from_literal(data_type, &literal),

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -304,12 +304,15 @@ impl<'a> Evaluated<'a> {
         .map(Evaluated::from)
     }
 
-    pub fn unary_bit_not(&self) -> Result<Evaluated<'a>> {
+    pub fn unary_bitwise_not(&self) -> Result<Evaluated<'a>> {
         match self {
-            Evaluated::Literal(v) => Value::try_from(v).and_then(|v| v.unary_bit_not()),
-            Evaluated::Value(v) => v.unary_bit_not(),
+            Evaluated::Literal(v) => Value::try_from(v).and_then(|v| v.unary_bitwise_not()),
+            Evaluated::Value(v) => v.unary_bitwise_not(),
             Evaluated::StrSlice { source, range } => {
-                Err(EvaluateError::UnsupportedUnaryBitNot(source[range.clone()].to_owned()).into())
+                Err(EvaluateError::IncompatibleUnaryBitwiseNotOperation(
+                    source[range.clone()].to_owned(),
+                )
+                .into())
             }
         }
         .map(Evaluated::from)

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -66,6 +66,7 @@ pub fn unary_op<'a>(op: &UnaryOperator, v: Evaluated<'a>) -> Result<Evaluated<'a
         UnaryOperator::Minus => v.unary_minus(),
         UnaryOperator::Not => v.try_into().map(|v: bool| Evaluated::from(Value::Bool(!v))),
         UnaryOperator::Factorial => v.unary_factorial(),
+        &UnaryOperator::BitNot => v.unary_bit_not(),
     }
 }
 

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -66,7 +66,7 @@ pub fn unary_op<'a>(op: &UnaryOperator, v: Evaluated<'a>) -> Result<Evaluated<'a
         UnaryOperator::Minus => v.unary_minus(),
         UnaryOperator::Not => v.try_into().map(|v: bool| Evaluated::from(Value::Bool(!v))),
         UnaryOperator::Factorial => v.unary_factorial(),
-        &UnaryOperator::BitNot => v.unary_bit_not(),
+        &UnaryOperator::BitwiseNot => v.unary_bitwise_not(),
     }
 }
 

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -66,7 +66,7 @@ pub fn unary_op<'a>(op: &UnaryOperator, v: Evaluated<'a>) -> Result<Evaluated<'a
         UnaryOperator::Minus => v.unary_minus(),
         UnaryOperator::Not => v.try_into().map(|v: bool| Evaluated::from(Value::Bool(!v))),
         UnaryOperator::Factorial => v.unary_factorial(),
-        &UnaryOperator::BitwiseNot => v.unary_bitwise_not(),
+        UnaryOperator::BitwiseNot => v.unary_bitwise_not(),
     }
 }
 

--- a/core/src/translate/operator.rs
+++ b/core/src/translate/operator.rs
@@ -13,6 +13,7 @@ pub fn translate_unary_operator(sql_unary_operator: &SqlUnaryOperator) -> Result
         SqlUnaryOperator::Minus => Ok(UnaryOperator::Minus),
         SqlUnaryOperator::Not => Ok(UnaryOperator::Not),
         SqlUnaryOperator::PGPostfixFactorial => Ok(UnaryOperator::Factorial),
+        &SqlUnaryOperator::PGBitwiseNot => Ok(UnaryOperator::BitNot),
         _ => Err(TranslateError::UnreachableUnaryOperator(sql_unary_operator.to_string()).into()),
     }
 }

--- a/core/src/translate/operator.rs
+++ b/core/src/translate/operator.rs
@@ -13,7 +13,7 @@ pub fn translate_unary_operator(sql_unary_operator: &SqlUnaryOperator) -> Result
         SqlUnaryOperator::Minus => Ok(UnaryOperator::Minus),
         SqlUnaryOperator::Not => Ok(UnaryOperator::Not),
         SqlUnaryOperator::PGPostfixFactorial => Ok(UnaryOperator::Factorial),
-        &SqlUnaryOperator::PGBitwiseNot => Ok(UnaryOperator::BitwiseNot),
+        SqlUnaryOperator::PGBitwiseNot => Ok(UnaryOperator::BitwiseNot),
         _ => Err(TranslateError::UnreachableUnaryOperator(sql_unary_operator.to_string()).into()),
     }
 }

--- a/core/src/translate/operator.rs
+++ b/core/src/translate/operator.rs
@@ -13,7 +13,7 @@ pub fn translate_unary_operator(sql_unary_operator: &SqlUnaryOperator) -> Result
         SqlUnaryOperator::Minus => Ok(UnaryOperator::Minus),
         SqlUnaryOperator::Not => Ok(UnaryOperator::Not),
         SqlUnaryOperator::PGPostfixFactorial => Ok(UnaryOperator::Factorial),
-        &SqlUnaryOperator::PGBitwiseNot => Ok(UnaryOperator::BitNot),
+        &SqlUnaryOperator::PGBitwiseNot => Ok(UnaryOperator::BitwiseNot),
         _ => Err(TranslateError::UnreachableUnaryOperator(sql_unary_operator.to_string()).into()),
     }
 }

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -268,6 +268,10 @@ test_case!(substr, async move {
             r#"SELECT SUBSTR('123', 2, 3)! AS test FROM SingleItem"#,
             Err(EvaluateError::UnsupportedUnaryFactorial("23".to_owned()).into()),
         ),
+        (
+            r#"SELECT ~SUBSTR('123', 2, 3) AS test FROM SingleItem"#,
+            Err(EvaluateError::UnsupportedUnaryBitNot("23".to_owned()).into()),
+        ),
     ];
     for (sql, expected) in test_cases {
         test!(sql, expected);

--- a/test-suite/src/function/substr.rs
+++ b/test-suite/src/function/substr.rs
@@ -270,7 +270,7 @@ test_case!(substr, async move {
         ),
         (
             r#"SELECT ~SUBSTR('123', 2, 3) AS test FROM SingleItem"#,
-            Err(EvaluateError::UnsupportedUnaryBitNot("23".to_owned()).into()),
+            Err(EvaluateError::IncompatibleUnaryBitwiseNotOperation("23".to_owned()).into()),
         ),
     ];
     for (sql, expected) in test_cases {

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -200,15 +200,15 @@ test_case!(unary_operator, async move {
         ),
         (
             "SELECT ~(5.5) as v4 FROM Test",
-            Err(ValueError::UnaryBitNotOnNonInteger.into()),
+            Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
         ),
         (
             "SELECT ~(CAST(5.5 AS FLOAT32)) as v4 FROM Test",
-            Err(ValueError::UnaryBitNotOnNonInteger.into()),
+            Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
         ),
         (
             "SELECT ~'error' as v1 FROM Test",
-            Err(ValueError::UnaryBitNotOnNonNumeric.into()),
+            Err(ValueError::UnaryBitwiseNotOnNonNumeric.into()),
         ),
     ];
 

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -111,108 +111,123 @@ test_case!(unary_operator, async move {
             "SELECT 1000! as v4 FROM Test",
             Err(ValueError::FactorialOverflow.into()),
         ),
-        (
-            "SELECT ~(CAST(1 AS UINT8)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                U8;
-                254
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS UINT16)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                U16;
-                65534
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS UINT32)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                U32;
-                4294967294
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS UINT64)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                U64;
-                18446744073709551614
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS UINT128)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                U128;
-                340282366920938463463374607431768211454
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS INT8)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                I8;
-                -2
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS INT16)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                I16;
-                -2
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS INT32)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                I32;
-                -2
-            )),
-        ),
-        (
-            "SELECT ~1 as v1 FROM Test",
-            Ok(select!(
-                v1
-                I64;
-                -2
-            )),
-        ),
-        (
-            "SELECT ~(CAST(1 AS INT128)) as v1 FROM Test",
-            Ok(select!(
-                v1
-                I128;
-                -2
-            )),
-        ),
-        (
-            "SELECT ~Null as v1 FROM Test",
-            Ok(select_with_null!(
-                v1;
-                Null
-            )),
-        ),
-        (
-            "SELECT ~(5.5) as v4 FROM Test",
-            Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
-        ),
-        (
-            "SELECT ~(CAST(5.5 AS FLOAT32)) as v4 FROM Test",
-            Err(ValueError::UnaryBitwiseNotOnNonInteger.into()),
-        ),
-        (
-            "SELECT ~'error' as v1 FROM Test",
-            Err(ValueError::UnaryBitwiseNotOnNonNumeric.into()),
-        ),
     ];
 
     for (sql, expected) in test_cases {
         test!(sql, expected);
     }
+
+    test! {
+        name: "test bitwise-not operator with UINT8 type",
+        sql: "SELECT ~(CAST(1 AS UINT8)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            U8;
+            254
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with UINT16 type",
+        sql: "SELECT ~(CAST(1 AS UINT16)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            U16;
+            65534
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with UINT32 type",
+        sql: "SELECT ~(CAST(1 AS UINT32)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            U32;
+            4294967294
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with UINT64 type",
+        sql: "SELECT ~(CAST(1 AS UINT64)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            U64;
+            18446744073709551614
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with UINT128 type",
+        sql: "SELECT ~(CAST(1 AS UINT128)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            U128;
+            340282366920938463463374607431768211454
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with INT8 type",
+        sql: "SELECT ~(CAST(1 AS INT8)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            I8;
+            -2
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with INT16 type",
+        sql: "SELECT ~(CAST(1 AS INT16)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            I16;
+            -2
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with INT32 type",
+        sql: "SELECT ~(CAST(1 AS INT32)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            I32;
+            -2
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with INT64 type",
+        sql: "SELECT ~1 as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            I64;
+            -2
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with INT128 type",
+        sql: "SELECT ~(CAST(1 AS INT128)) as v1 FROM Test",
+        expected: Ok(select!(
+            v1
+            I128;
+            -2
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with Null",
+        sql: "SELECT ~Null as v1 FROM Test",
+        expected: Ok(select_with_null!(
+            v1;
+            Null
+        ))
+    };
+    test! {
+        name: "test bitwise-not operator with FLOAT64 type",
+        sql: "SELECT ~(5.5) as v4 FROM Test",
+        expected: Err(ValueError::UnaryBitwiseNotOnNonInteger.into())
+    };
+    test! {
+        name: "test bitwise-not operator with FLOAT32 type",
+        sql: "SELECT ~(CAST(5.5 AS FLOAT32)) as v4 FROM Test",
+        expected: Err(ValueError::UnaryBitwiseNotOnNonInteger.into())
+    };
+    test! {
+        name: "test bitwise-not operator with string type",
+        sql: "SELECT ~'error' as v1 FROM Test",
+        expected: Err(ValueError::UnaryBitwiseNotOnNonNumeric.into())
+    };
 });

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -111,6 +111,30 @@ test_case!(unary_operator, async move {
             "SELECT 1000! as v4 FROM Test",
             Err(ValueError::FactorialOverflow.into()),
         ),
+        (
+            "SELECT ~1 as v1 FROM Test",
+            Ok(select!(
+                v1
+                I64;
+                -2
+            )),
+        ),
+        (
+            "SELECT ~(CAST(11936128518282651045 AS UINT64)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U64;
+                6510615555426900570
+            )),
+        ),
+        (
+            "SELECT ~(5.5) as v4 FROM Test",
+            Err(ValueError::UnaryBitNotOnNonInteger.into()),
+        ),
+        (
+            "SELECT ~'error' as v1 FROM Test",
+            Err(ValueError::UnaryBitNotOnNonNumeric.into()),
+        ),
     ];
 
     for (sql, expected) in test_cases {

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -192,7 +192,7 @@ test_case!(unary_operator, async move {
             )),
         ),
         (
-            "SELECT Null as v1 FROM Test",
+            "SELECT ~Null as v1 FROM Test",
             Ok(select_with_null!(
                 v1;
                 Null

--- a/test-suite/src/unary_operator.rs
+++ b/test-suite/src/unary_operator.rs
@@ -112,6 +112,70 @@ test_case!(unary_operator, async move {
             Err(ValueError::FactorialOverflow.into()),
         ),
         (
+            "SELECT ~(CAST(1 AS UINT8)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U8;
+                254
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS UINT16)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U16;
+                65534
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS UINT32)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U32;
+                4294967294
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS UINT64)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U64;
+                18446744073709551614
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS UINT128)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                U128;
+                340282366920938463463374607431768211454
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS INT8)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                I8;
+                -2
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS INT16)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                I16;
+                -2
+            )),
+        ),
+        (
+            "SELECT ~(CAST(1 AS INT32)) as v1 FROM Test",
+            Ok(select!(
+                v1
+                I32;
+                -2
+            )),
+        ),
+        (
             "SELECT ~1 as v1 FROM Test",
             Ok(select!(
                 v1
@@ -120,15 +184,26 @@ test_case!(unary_operator, async move {
             )),
         ),
         (
-            "SELECT ~(CAST(11936128518282651045 AS UINT64)) as v1 FROM Test",
+            "SELECT ~(CAST(1 AS INT128)) as v1 FROM Test",
             Ok(select!(
                 v1
-                U64;
-                6510615555426900570
+                I128;
+                -2
+            )),
+        ),
+        (
+            "SELECT Null as v1 FROM Test",
+            Ok(select_with_null!(
+                v1;
+                Null
             )),
         ),
         (
             "SELECT ~(5.5) as v4 FROM Test",
+            Err(ValueError::UnaryBitNotOnNonInteger.into()),
+        ),
+        (
+            "SELECT ~(CAST(5.5 AS FLOAT32)) as v4 FROM Test",
             Err(ValueError::UnaryBitNotOnNonInteger.into()),
         ),
         (


### PR DESCRIPTION
In the last PR, I pushed a implementation for bot of `BIT_NOT` function and ~ operator.
As review comment, I removed implementation of `BIT_NOT` function and pushed only ~ operator in this PR.
Please review.

I will add more test cases if the coverage test result is not good enough.