### PR TITLE
Js pkg wasm pack build not to generate readme and packagejson

### DIFF
--- a/pkg/javascript/Cargo.toml
+++ b/pkg/javascript/Cargo.toml
@@ -7,6 +7,7 @@ description.workspace = true
 license.workspace = true
 repository.workspace = true
 documentation.workspace = true
+readme = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/pkg/javascript/DEVELOPMENT.md
+++ b/pkg/javascript/DEVELOPMENT.md
@@ -12,10 +12,10 @@ opt-level = "s"
 ### Build
 ```
 # browser module, webpack and rollup
-wasm-pack build --target web --no-typescript --release --out-dir ./dist_web
+wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web
 
 # nodejs
-wasm-pack build --target nodejs --no-typescript --release --out-dir ./dist_nodejs -- --no-default-features --features nodejs
+wasm-pack build --no-pack --target nodejs --no-typescript --release --out-dir ./dist_nodejs -- --no-default-features --features nodejs
 ```
 
 ### 🔬 Test in Headless Browsers with `wasm-pack test`


### PR DESCRIPTION
prior pr #1326 

update wasm-pack build not to generate unused package.json and README.md files in dist-* directory.