### PR TITLE
Refactor GCD and LCM functions

### DIFF
--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -81,6 +81,15 @@ pub enum ValueError {
     #[error("unary factorial operation overflow")]
     FactorialOverflow,
 
+    #[error("GCD calculation overflowed on trying to get the absolute value of {0}")]
+    GcdOverflowError(i64),
+
+    #[error("LCM calculation overflowed on trying to get the absolute value of {0}")]
+    LcmOverflowError(i64),
+
+    #[error("LCM calculation resulted in a value out of the i64 range")]
+    LcmResultOutOfRange,
+
     #[error("unary bit_not operation for non numeric value")]
     UnaryBitwiseNotOnNonNumeric,
 

--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -81,11 +81,8 @@ pub enum ValueError {
     #[error("unary factorial operation overflow")]
     FactorialOverflow,
 
-    #[error("GCD calculation overflowed on trying to get the absolute value of {0}")]
-    GcdOverflowError(i64),
-
-    #[error("LCM calculation overflowed on trying to get the absolute value of {0}")]
-    LcmOverflowError(i64),
+    #[error("GCD or LCM calculation overflowed on trying to get the absolute value of {0}")]
+    GcdLcmOverflow(i64),
 
     #[error("LCM calculation resulted in a value out of the i64 range")]
     LcmResultOutOfRange,

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         ast::{DataType, DateTimeField},
         data::{Key, Point, Value, ValueError},
-        result::Result,
+        result::{Error, Result},
     },
     md5::{Digest, Md5},
     rand::{rngs::StdRng, Rng, SeedableRng},
@@ -452,26 +452,48 @@ pub fn gcd<'a>(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Resul
     let left = eval_to_int!(name, left);
     let right = eval_to_int!(name, right);
 
-    Ok(Evaluated::from(Value::I64(gcd_i64(left, right))))
+    Ok(Evaluated::from(Value::I64(gcd_i64(left, right)?)))
 }
 
 pub fn lcm<'a>(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Result<Evaluated<'a>> {
     let left = eval_to_int!(name, left);
     let right = eval_to_int!(name, right);
 
-    fn lcm(a: i64, b: i64) -> i64 {
-        a * b / gcd_i64(a, b)
+    fn lcm(a: i64, b: i64) -> Result<i64> {
+        let gcd_val = gcd_i64(a, b).map_err(|err| {
+            if let Error::Value(ValueError::GcdOverflowError(x)) = err {
+                ValueError::LcmOverflowError(x).into()
+            } else {
+                err
+            }
+        })?;
+
+        let a: i128 = a.into();
+        let b: i128 = b.into();
+
+        // lcm(a, b) = abs(a * b) / gcd(a, b)   if gcd(a, b) != 0
+        // lcm(a, b) = 0                        if gcd(a, b) == 0
+        let result = (a * b).abs().checked_div(gcd_val.into()).unwrap_or(0);
+
+        TryInto::<i64>::try_into(result).map_err(|_| Error::Value(ValueError::LcmResultOutOfRange))
     }
 
-    Ok(Evaluated::from(Value::I64(lcm(left, right))))
+    Ok(Evaluated::from(Value::I64(lcm(left, right)?)))
 }
 
-fn gcd_i64(a: i64, b: i64) -> i64 {
-    if b == 0 {
-        a
-    } else {
-        gcd_i64(b, a % b)
+fn gcd_i64(a: i64, b: i64) -> Result<i64> {
+    let mut a = a
+        .checked_abs()
+        .ok_or(Error::Value(ValueError::GcdOverflowError(a)))?;
+    let mut b = b
+        .checked_abs()
+        .ok_or(Error::Value(ValueError::GcdOverflowError(b)))?;
+
+    while b > 0 {
+        (a, b) = (b, a % b);
     }
+
+    Ok(a)
 }
 
 // --- list ---

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -460,20 +460,14 @@ pub fn lcm<'a>(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Resul
     let right = eval_to_int!(name, right);
 
     fn lcm(a: i64, b: i64) -> Result<i64> {
-        let gcd_val = gcd_i64(a, b).map_err(|err| {
-            if let Error::Value(ValueError::GcdOverflowError(x)) = err {
-                ValueError::LcmOverflowError(x).into()
-            } else {
-                err
-            }
-        })?;
+        let gcd_val: i128 = gcd_i64(a, b)?.into();
 
         let a: i128 = a.into();
         let b: i128 = b.into();
 
         // lcm(a, b) = abs(a * b) / gcd(a, b)   if gcd(a, b) != 0
         // lcm(a, b) = 0                        if gcd(a, b) == 0
-        let result = (a * b).abs().checked_div(gcd_val.into()).unwrap_or(0);
+        let result = (a * b).abs().checked_div(gcd_val).unwrap_or(0);
 
         TryInto::<i64>::try_into(result).map_err(|_| Error::Value(ValueError::LcmResultOutOfRange))
     }
@@ -484,10 +478,10 @@ pub fn lcm<'a>(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Resul
 fn gcd_i64(a: i64, b: i64) -> Result<i64> {
     let mut a = a
         .checked_abs()
-        .ok_or(Error::Value(ValueError::GcdOverflowError(a)))?;
+        .ok_or(Error::Value(ValueError::GcdLcmOverflow(a)))?;
     let mut b = b
         .checked_abs()
-        .ok_or(Error::Value(ValueError::GcdOverflowError(b)))?;
+        .ok_or(Error::Value(ValueError::GcdLcmOverflow(b)))?;
 
     while b > 0 {
         (a, b) = (b, a % b);

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -469,7 +469,7 @@ pub fn lcm<'a>(name: String, left: Evaluated<'_>, right: Evaluated<'_>) -> Resul
         // lcm(a, b) = 0                        if gcd(a, b) == 0
         let result = (a * b).abs().checked_div(gcd_val).unwrap_or(0);
 
-        TryInto::<i64>::try_into(result).map_err(|_| Error::Value(ValueError::LcmResultOutOfRange))
+        i64::try_from(result).map_err(|_| Error::Value(ValueError::LcmResultOutOfRange))
     }
 
     Ok(Evaluated::from(Value::I64(lcm(left, right)?)))

--- a/docs/docs/sql-syntax/functions/math/gcd.md
+++ b/docs/docs/sql-syntax/functions/math/gcd.md
@@ -31,3 +31,4 @@ NULL
 ## Errors
 1. If either of the arguments is not of INTEGER type, a `FunctionRequiresIntegerValue` error will be raised.
 2. If the number of arguments provided to the function is not equal to 2, a `FunctionArgsLengthNotMatching` error will be raised.
+3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to take the absolute value. In this case, a `GcdOverflowError` is raised.

--- a/docs/docs/sql-syntax/functions/math/gcd.md
+++ b/docs/docs/sql-syntax/functions/math/gcd.md
@@ -31,4 +31,4 @@ NULL
 ## Errors
 1. If either of the arguments is not of INTEGER type, a `FunctionRequiresIntegerValue` error will be raised.
 2. If the number of arguments provided to the function is not equal to 2, a `FunctionArgsLengthNotMatching` error will be raised.
-3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to take the absolute value. In this case, a `GcdOverflowError` is raised.
+3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to take the absolute value. In this case, a `GcdLcmOverflowError` is raised.

--- a/docs/docs/sql-syntax/functions/math/lcm.md
+++ b/docs/docs/sql-syntax/functions/math/lcm.md
@@ -31,5 +31,5 @@ NULL
 ## Errors
 1. If either of the arguments is not of INTEGER type, a `FunctionRequiresIntegerValue` error will be raised.
 2. If the number of arguments provided to the function is not equal to 2, a `FunctionArgsLengthNotMatching` error will be raised.
-3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to calculate the gcd, which is then used in the lcm calculation. In this case, an `LcmOverflowError` is raised.
+3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to calculate the gcd, which is then used in the lcm calculation. In this case, an `GcdLcmOverflowError` is raised.
 4. If the calculated result of lcm is outside the valid range of i64 (`-9223372036854775808` to `9223372036854775807`), a `LcmResultOutOfRange` error is raised. This may occur with large prime numbers.

--- a/docs/docs/sql-syntax/functions/math/lcm.md
+++ b/docs/docs/sql-syntax/functions/math/lcm.md
@@ -31,3 +31,5 @@ NULL
 ## Errors
 1. If either of the arguments is not of INTEGER type, a `FunctionRequiresIntegerValue` error will be raised.
 2. If the number of arguments provided to the function is not equal to 2, a `FunctionArgsLengthNotMatching` error will be raised.
+3. If either of the arguments is the minimum i64 value (`-9223372036854775808`), an overflow occurs when attempting to calculate the gcd, which is then used in the lcm calculation. In this case, an `LcmOverflowError` is raised.
+4. If the calculated result of lcm is outside the valid range of i64 (`-9223372036854775808` to `9223372036854775807`), a `LcmResultOutOfRange` error is raised. This may occur with large prime numbers.

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -115,7 +115,7 @@ test_case!(gcd_lcm, async move {
         (
             // check i64::MIN overflow error
             "SELECT GCD(-9223372036854775808, -9223372036854775808)",
-            Err(ValueError::GcdOverflowError(i64::MIN).into()),
+            Err(ValueError::GcdLcmOverflow(i64::MIN).into()),
         ),
         (
             "SELECT LCM(0, 0) as test",
@@ -136,7 +136,7 @@ test_case!(gcd_lcm, async move {
         (
             // check i64::MIN overflow error
             "SELECT LCM(-9223372036854775808, -9223372036854775808)",
-            Err(ValueError::LcmOverflowError(i64::MIN).into()),
+            Err(ValueError::GcdLcmOverflow(i64::MIN).into()),
         ),
         (
             // 10^10 + 19 and 10^10 + 33 are prime numbers


### PR DESCRIPTION
Resolves #1310

Hi! I have refactored the GCD and LCM functions for improved safety and error handling.

With these changes:
### GCD
- The GCD function is now implemented using iteration not recursive function.
- An overflow error is prevented when one of the arguments is `i64::MIN`

### LCM
- An overflow error is prevented when one of the arguments is `i64::MIN`.
- An overflow error is prevented when dealing with large prime numbers, i.e) `LCM(large prime, large prime)`.
- The case where both arguments are zero, ex) `LCM(0, 0)` is now properly handled.
