### PR TITLE
Fix Value::evaluate_cmp_with_literal between Decimal and Literal::Num…

### DIFF
--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -9,6 +9,7 @@ use {
         data::{value::uuid::parse_uuid, BigDecimalExt, Interval, Literal, Point},
         result::{Error, Result},
     },
+    bigdecimal::BigDecimal,
     chrono::NaiveDate,
     rust_decimal::Decimal,
     std::{
@@ -134,6 +135,9 @@ impl Value {
             }
             (Value::F64(l), Literal::Number(r)) => {
                 r.to_f64().map(|r| l.partial_cmp(&r)).unwrap_or(None)
+            }
+            (Value::Decimal(l), Literal::Number(r)) => {
+                BigDecimal::new(l.mantissa().into(), l.scale() as i64).partial_cmp(r)
             }
             (Value::Str(l), Literal::Text(r)) => {
                 let l: &str = l.as_ref();

--- a/test-suite/src/data_type/decimal.rs
+++ b/test-suite/src/data_type/decimal.rs
@@ -1,110 +1,53 @@
-use {
-    crate::*,
-    gluesql_core::prelude::{Payload, Value::*},
-    rust_decimal::prelude::Decimal,
-};
+use {crate::*, gluesql_core::prelude::Value::*, rust_decimal::prelude::Decimal as D};
 
 test_case!(decimal, async move {
-    let test_cases = [
-        (
-            "CREATE TABLE DECIMAL_ITEM (decimal_field DECIMAL)",
-            Ok(Payload::Create),
-        ),
-        (
-            r#"INSERT INTO DECIMAL_ITEM VALUES (1)"#,
-            Ok(Payload::Insert(1)),
-        ),
-        (
-            r#"SELECT decimal_field AS decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::ONE
-            )),
-        ),
-        (
-            r#"SELECT decimal_field +1 as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::TWO
-            )),
-        ),
-        (
-            r#"SELECT 1+ decimal_field  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                I64;
-                2
-            )),
-        ),
-        (
-            r#"SELECT decimal_field -1 as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::ZERO
-            )),
-        ),
-        (
-            r#"SELECT 1- decimal_field  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                I64;
-                0
-            )),
-        ),
-        (
-            r#"SELECT decimal_field * 2 as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::TWO
-            )),
-        ),
-        (
-            r#"SELECT 2* decimal_field  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                I64;
-                2
-            )),
-        ),
-        (
-            r#"SELECT decimal_field/2 as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::from_f64_retain(0.5f64).unwrap()
-            )),
-        ),
-        (
-            r#"SELECT 2/decimal_field  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                I64;
-                2
-            )),
-        ),
-        (
-            r#"SELECT 2%decimal_field  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                I64;
-                0
-            )),
-        ),
-        (
-            r#"SELECT decimal_field % 2  as decimal_field FROM DECIMAL_ITEM"#,
-            Ok(select!(
-                decimal_field
-                Decimal;
-                Decimal::ONE
-            )),
-        ),
-    ];
+    run!("CREATE TABLE DECIMAL_ITEM (v DECIMAL)");
+    run!("INSERT INTO DECIMAL_ITEM VALUES (1)");
 
-    for (sql, expected) in test_cases {
-        test!(sql, expected);
+    test! {
+        sql: "
+            SELECT
+                v AS a,
+                v + 1 AS b,
+                1 + v AS c,
+                v - 1 AS d,
+                1 - v AS e,
+                v * 2 AS f,
+                2 * v AS g
+            FROM DECIMAL_ITEM
+                ",
+        expected: Ok(select!(
+            a       | b       | c   | d       | e   | f       | g;
+            Decimal | Decimal | I64 | Decimal | I64 | Decimal | I64;
+            D::ONE    D::TWO    2     D::ZERO   0     D::TWO    2
+        ))
+    };
+
+    test! {
+        sql: "
+            SELECT
+                v / 2 AS h,
+                2 / v AS i,
+                2 % v AS j,
+                v % 2 AS k
+            FROM DECIMAL_ITEM
+                ",
+        expected: Ok(select!(
+            h            | i   | j   | k;
+            Decimal      | I64 | I64 | Decimal;
+            D::new(5, 1)   2     0     D::ONE
+        ))
+    };
+
+    run!("INSERT INTO DECIMAL_ITEM VALUES (1.5), (2.0), (25.12)");
+
+    test! {
+        sql: "SELECT v FROM DECIMAL_ITEM WHERE v > 1.5 AND v <= 25.12",
+        expected: Ok(select!(
+            v;
+            Decimal;
+            D::new(2, 0);
+            D::new(2512, 2)
+        ))
     }
 });


### PR DESCRIPTION
…ber,

Handle Value::Decimal & Literal::Number branch - convert value to bigdecimal and run cmp.
Rewrite test-suite/ data-type/decimal tests, add a comparison test case.


e.g.
```sql
CREATE TABLE Foo (v DECIMAL);
INSERT INTO Foo VALUES (1), (2);

SELECT v FROM Foo WHERE v > 0;
```
`WHERE v > 0` was not working.