### PR TITLE
Implement bitwise-not operator (~) in ast builder

### DIFF
--- a/core/src/ast_builder/expr/mod.rs
+++ b/core/src/ast_builder/expr/mod.rs
@@ -17,7 +17,7 @@ pub use {
     case::case,
     exists::{exists, not_exists},
     nested::nested,
-    unary_op::{factorial, minus, not, plus},
+    unary_op::{bitwise_not, factorial, minus, not, plus},
 };
 
 use {

--- a/core/src/ast_builder/expr/unary_op.rs
+++ b/core/src/ast_builder/expr/unary_op.rs
@@ -14,6 +14,9 @@ impl<'a> ExprNode<'a> {
     pub fn factorial(self) -> Self {
         factorial(self)
     }
+    pub fn bitwise_not(self) -> Self {
+        bitwise_not(self)
+    }
 }
 
 pub fn plus<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
@@ -44,6 +47,13 @@ pub fn factorial<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
     }
 }
 
+pub fn bitwise_not<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
+    ExprNode::UnaryOp {
+        op: UnaryOperator::BitwiseNot,
+        expr: Box::new(expr.into()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ast_builder::{col, num, test_expr};
@@ -64,6 +74,10 @@ mod tests {
 
         let actual = num(10).factorial();
         let expected = "10!";
+        test_expr(actual, expected);
+
+        let actual = num(10).bitwise_not();
+        let expected = "~10";
         test_expr(actual, expected);
     }
 }

--- a/core/src/ast_builder/mod.rs
+++ b/core/src/ast_builder/mod.rs
@@ -59,8 +59,8 @@ pub use {
 
 /// Available expression builder functions
 pub use expr::{
-    case, col, date, exists, expr, factorial, minus, nested, not, not_exists, null, num,
-    numeric::NumericNode, plus, subquery, text, time, timestamp, ExprNode,
+    bitwise_not, case, col, date, exists, expr, factorial, minus, nested, not, not_exists, null,
+    num, numeric::NumericNode, plus, subquery, text, time, timestamp, ExprNode,
 };
 
 pub use alter_table::{


### PR DESCRIPTION
resolved #1350 

Implement ExprNode for ~ operator.
And add a test case.