### PR TITLE
Update coverage.yml gh-action to ignore await only lines,

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,7 +53,7 @@ jobs:
             --ignore "/*" \
             --ignore "pkg/rust/examples/*.rs" \
             --ignore "cli/src/{cli,helper,lib,main}.rs" \
-            --excl-line "#\\[derive\\(" \
+            --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)" \
             -o ./coverage/lcov.info
       - name: Coveralls
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Currently there is no way to cover await only lines using grcov.
The main purpose of running code coverage is to check the uncovered line easily but this missing await lines make hard to find uncovered ones.
So update coverage.yml grcov --excl-line option to ignore await only lines.