### PR TITLE
Update docs/ast-builder padding.md code block lang keyword,

### DIFF
--- a/docs/docs/ast-builder/functions/text/padding.md
+++ b/docs/docs/ast-builder/functions/text/padding.md
@@ -6,7 +6,7 @@ The AST Builder API in GlueSQL allows you to execute lpad and rpad functions for
 
 `lpad` returns the string with leading space if the length of the string is less than the specified length.
 
-```rs
+```rust
 lpad<'a, T: Into<ExprNode<'a>>>(expr: T, len: usize, fill: Option<String>) -> ExprNode<'a>
 ```
 
@@ -14,7 +14,7 @@ lpad<'a, T: Into<ExprNode<'a>>>(expr: T, len: usize, fill: Option<String>) -> Ex
 
 `rpad` returns the string with trailing space if the length of the string is less than the specified length.
 
-```rs
+```rust
 rpad<'a, T: Into<ExprNode<'a>>>(expr: T, len: usize, fill: Option<String>) -> ExprNode<'a>
 ```
 
@@ -22,7 +22,7 @@ rpad<'a, T: Into<ExprNode<'a>>>(expr: T, len: usize, fill: Option<String>) -> Ex
 
 In these examples, the LPAD and RPAD functions should return matching values.
 
-```rs
+```rust
 use {
     crate::*,
     gluesql_core::{


### PR DESCRIPTION
Rename "rs" to "rust".
"rs" is not supported by docusaurus.

<img width="917" alt="image" src="https://github.com/gluesql/gluesql/assets/2025065/cf630f8e-c78f-4d16-94a7-f529f77bddd4">
