### PR TITLE
Update AST builder UpdateNode to enforce .filter(..) before .set(..),

### DIFF
--- a/core/src/ast_builder/table_name.rs
+++ b/core/src/ast_builder/table_name.rs
@@ -24,7 +24,7 @@ impl<'a> TableNameNode {
         DeleteNode::new(self.table_name)
     }
 
-    pub fn update(self) -> UpdateNode<'static> {
+    pub fn update(self) -> UpdateNode {
         UpdateNode::new(self.table_name)
     }
 

--- a/core/src/ast_builder/update.rs
+++ b/core/src/ast_builder/update.rs
@@ -98,7 +98,7 @@ impl<'a> Build for UpdateSetNode<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast_builder::{table, col, num, text, test, Build};
+    use crate::ast_builder::{table, test, Build};
 
     #[test]
     fn update() {
@@ -121,18 +121,6 @@ mod tests {
             .set("name", "americano")
             .build();
         let expected = "UPDATE Foo SET id = 2, name = americano WHERE Bar = 1";
-        test(actual, expected);
-
-        let actual = table("Foo")
-            .update()
-            .filter(col("id").gt(num(1)))
-            .filter("name = 'americano'")
-            .set("name", text("espresso"))
-            .build();
-        let expected = "
-            UPDATE Foo
-            SET name = 'espresso'
-            WHERE id > 1 AND name = 'americano'";
         test(actual, expected);
 
         let actual = table("Foo")

--- a/test-suite/src/ast_builder/basic.rs
+++ b/test-suite/src/ast_builder/basic.rs
@@ -42,8 +42,8 @@ test_case!(basic, {
 
     let actual = table("Foo")
         .update()
-        .set("id", col("id").mul(2))
         .filter(col("id").eq(200))
+        .set("id", col("id").mul(2))
         .execute(glue)
         .await;
     let expected = Ok(Payload::Update(1));

--- a/test-suite/src/ast_builder/update.rs
+++ b/test-suite/src/ast_builder/update.rs
@@ -60,9 +60,9 @@ test_case!(update, {
     // update set multiple and use filter
     let actual = table("Foo")
         .update()
+        .filter(col("score").lte(30))
         .set("score", "score * 2 + 5")
         .set("flag", col("flag").negate())
-        .filter(col("score").lte(30))
         .execute(glue)
         .await;
     let expected = Ok(Payload::Update(2));

--- a/test-suite/src/transaction/ast_builder.rs
+++ b/test-suite/src/transaction/ast_builder.rs
@@ -196,8 +196,8 @@ test_case!(ast_builder, {
 
     let actual = table("TxTest")
         .update()
-        .set("name", "'Sunday'")
         .filter("id = 1")
+        .set("name", "'Sunday'")
         .execute(glue)
         .await;
     let expected = Ok(Payload::Update(1));
@@ -239,8 +239,8 @@ test_case!(ast_builder, {
 
     let actual = table("TxTest")
         .update()
-        .set("name", "'Sunday'")
         .filter("id = 1")
+        .set("name", "'Sunday'")
         .execute(glue)
         .await;
     let expected = Ok(Payload::Update(1));


### PR DESCRIPTION
Add UpdateFilterNode and UpdateSetNode.
UpdateNode -> (UpdateFilterNode) -> UpdateSetNode chains are only supported.
As we provide in select nodes, filter must appear before set method.