### PR TITLE
Simplify error conversion codes in IdbStorage,

### DIFF
--- a/storages/idb-storage/src/error.rs
+++ b/storages/idb-storage/src/error.rs
@@ -1,6 +1,8 @@
 use {
+    async_trait::async_trait,
     core::fmt::Display,
     gluesql_core::error::{Error, Result},
+    std::{future::IntoFuture, result::Result as StdResult},
 };
 
 pub trait ErrInto<T> {
@@ -10,5 +12,20 @@ pub trait ErrInto<T> {
 impl<T, E: Display> ErrInto<T> for Result<T, E> {
     fn err_into(self) -> Result<T> {
         self.map_err(|e| Error::StorageMsg(e.to_string()))
+    }
+}
+
+#[async_trait(?Send)]
+pub trait StoreReqIntoFuture<T> {
+    async fn into_future(self) -> Result<T>;
+}
+
+#[async_trait(?Send)]
+impl<F, T, E: Display> StoreReqIntoFuture<T> for Result<F, E>
+where
+    F: IntoFuture<Output = StdResult<T, E>>,
+{
+    async fn into_future(self) -> Result<T> {
+        self.err_into()?.await.err_into()
     }
 }

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 use {
     async_trait::async_trait,
     convert::convert,
-    error::ErrInto,
+    error::{ErrInto, StoreReqIntoFuture},
     futures::stream::{empty, iter},
     gloo_utils::format::JsValueSerdeExt,
     gluesql_core::{
@@ -103,11 +103,7 @@ impl IdbStorage {
     }
 
     pub async fn delete(&self) -> Result<()> {
-        self.factory
-            .delete(&self.namespace)
-            .err_into()?
-            .await
-            .err_into()
+        self.factory.delete(&self.namespace).into_future().await
     }
 
     async fn alter_object_store(
@@ -208,9 +204,9 @@ impl Store for IdbStorage {
             .err_into()?;
 
         let store = transaction.object_store(SCHEMA_STORE).err_into()?;
-        let schemas = store.get_all(None, None).err_into()?.await.err_into()?;
+        let schemas = store.get_all(None, None).into_future().await?;
 
-        transaction.commit().err_into()?.await.err_into()?;
+        transaction.commit().into_future().await?;
         schemas
             .into_iter()
             .map(|schema| {
@@ -234,14 +230,13 @@ impl Store for IdbStorage {
         let store = transaction.object_store(SCHEMA_STORE).err_into()?;
         let schema = store
             .get(JsValue::from_str(table_name))
-            .err_into()?
-            .await
-            .err_into()?
+            .into_future()
+            .await?
             .and_then(|schema| JsValue::as_string(&schema))
             .map(|schema| Schema::from_ddl(schema.as_str()))
             .transpose()?;
 
-        transaction.commit().err_into()?.await.err_into()?;
+        transaction.commit().into_future().await?;
         Ok(schema)
     }
 
@@ -260,9 +255,9 @@ impl Store for IdbStorage {
         let key: Value = target.clone().into();
         let key: JsonValue = key.try_into()?;
         let key = JsValue::from_serde(&key).err_into()?;
-        let row = store.get(key).err_into()?.await.err_into()?;
+        let row = store.get(key).into_future().await?;
 
-        transaction.commit().err_into()?.await.err_into()?;
+        transaction.commit().into_future().await?;
 
         match row {
             Some(row) => convert(row, column_defs.as_deref()).map(Some),
@@ -283,9 +278,8 @@ impl Store for IdbStorage {
         let store = transaction.object_store(table_name).err_into()?;
         let cursor = store
             .open_cursor(None, Some(CursorDirection::Next))
-            .err_into()?
-            .await
-            .err_into()?;
+            .into_future()
+            .await?;
 
         let mut cursor = match cursor {
             Some(cursor) => cursor.into_managed(),
@@ -311,7 +305,7 @@ impl Store for IdbStorage {
             current_row = cursor.value().err_into()?.unwrap_or(JsValue::NULL);
         }
 
-        transaction.commit().err_into()?.await.err_into()?;
+        transaction.commit().into_future().await?;
 
         let rows = rows.into_iter().map(Ok);
         Ok(Box::pin(iter(rows)))
@@ -342,25 +336,13 @@ impl StoreMut for IdbStorage {
         let key = JsValue::from_str(&schema.table_name);
         let schema = JsValue::from(schema.to_ddl());
 
-        match schema_exists {
-            true => store
-                .put(&schema, Some(&key))
-                .err_into()?
-                .await
-                .err_into()?,
-            false => store
-                .add(&schema, Some(&key))
-                .err_into()?
-                .await
-                .err_into()?,
+        if schema_exists {
+            store.put(&schema, Some(&key)).into_future().await?;
+        } else {
+            store.add(&schema, Some(&key)).into_future().await?;
         };
 
-        transaction
-            .commit()
-            .err_into()?
-            .await
-            .err_into()
-            .map(|_| ())
+        transaction.commit().into_future().await.map(|_| ())
     }
 
     async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
@@ -374,18 +356,9 @@ impl StoreMut for IdbStorage {
         let store = transaction.object_store(SCHEMA_STORE).err_into()?;
 
         let key = JsValue::from_str(table_name);
-        store
-            .delete(Query::from(key))
-            .err_into()?
-            .await
-            .err_into()?;
+        store.delete(Query::from(key)).into_future().await?;
 
-        transaction
-            .commit()
-            .err_into()?
-            .await
-            .err_into()
-            .map(|_| ())
+        transaction.commit().into_future().await.map(|_| ())
     }
 
     async fn append_data(&mut self, table_name: &str, new_rows: Vec<DataRow>) -> Result<()> {
@@ -404,15 +377,10 @@ impl StoreMut for IdbStorage {
             let row = JsonValue::try_from(row)?;
             let row = JsValue::from_serde(&row).err_into()?;
 
-            store.add(&row, None).err_into()?.await.err_into()?;
+            store.add(&row, None).into_future().await?;
         }
 
-        transaction
-            .commit()
-            .err_into()?
-            .await
-            .err_into()
-            .map(|_| ())
+        transaction.commit().into_future().await.map(|_| ())
     }
 
     async fn insert_data(&mut self, table_name: &str, new_rows: Vec<(Key, DataRow)>) -> Result<()> {
@@ -434,15 +402,10 @@ impl StoreMut for IdbStorage {
             let key: JsonValue = Value::from(key).try_into()?;
             let key = JsValue::from_serde(&key).err_into()?;
 
-            store.put(&row, Some(&key)).err_into()?.await.err_into()?;
+            store.put(&row, Some(&key)).into_future().await?;
         }
 
-        transaction
-            .commit()
-            .err_into()?
-            .await
-            .err_into()
-            .map(|_| ())
+        transaction.commit().into_future().await.map(|_| ())
     }
 
     async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
@@ -457,15 +420,10 @@ impl StoreMut for IdbStorage {
             let key = JsValue::from_serde(&key).err_into()?;
             let key = Query::from(key);
 
-            store.delete(key).err_into()?.await.err_into()?;
+            store.delete(key).into_future().await?;
         }
 
-        transaction
-            .commit()
-            .err_into()?
-            .await
-            .err_into()
-            .map(|_| ())
+        transaction.commit().into_future().await.map(|_| ())
     }
 }
 


### PR DESCRIPTION
Add StoreReqIntoFuture trait impl to flatten two err_into into a single into_future call.