### PR TITLE
Add column comment support on CREATE TABLE,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,8 +1393,9 @@ dependencies = [
  "gluesql-core",
  "gluesql-test-suite",
  "mongodb",
- "regex",
  "rust_decimal",
+ "serde",
+ "serde_json",
  "strum",
  "strum_macros 0.24.3",
  "thiserror",
@@ -3069,9 +3070,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -3108,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3119,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "indexmap 2.2.2",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ dependencies = [
  "gluesql-core",
  "gluesql-test-suite",
  "mongodb",
+ "regex",
  "rust_decimal",
  "strum",
  "strum_macros 0.24.3",
@@ -2749,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -443,6 +443,7 @@ mod tests {
                     nullable: false,
                     default: None,
                     unique: None,
+                    comment: None,
                 },]),
                 source: None,
                 engine: None,
@@ -462,6 +463,7 @@ mod tests {
                         nullable: false,
                         default: None,
                         unique: None,
+                        comment: None,
                     },
                     ColumnDef {
                         name: "num".to_owned(),
@@ -469,6 +471,7 @@ mod tests {
                         nullable: true,
                         default: None,
                         unique: None,
+                        comment: None,
                     },
                     ColumnDef {
                         name: "name".to_owned(),
@@ -476,6 +479,7 @@ mod tests {
                         nullable: false,
                         default: None,
                         unique: None,
+                        comment: None,
                     }
                 ]),
                 source: None,
@@ -571,6 +575,7 @@ mod tests {
                     nullable: false,
                     default: None,
                     unique: None,
+                    comment: None,
                 },]),
                 source: None,
                 engine: Some("SLED".to_owned()),
@@ -624,6 +629,7 @@ mod tests {
                             BigDecimal::from_str("10").unwrap()
                         ))),
                         unique: None,
+                        comment: None,
                     }
                 }
             }

--- a/core/src/data/schema.rs
+++ b/core/src/data/schema.rs
@@ -190,6 +190,7 @@ mod tests {
                     nullable: false,
                     default: None,
                     unique: None,
+                    comment: None,
                 },
                 ColumnDef {
                     name: "name".to_owned(),
@@ -197,6 +198,7 @@ mod tests {
                     nullable: true,
                     default: Some(Expr::Literal(AstLiteral::QuotedString("glue".to_owned()))),
                     unique: None,
+                    comment: None,
                 },
             ]),
             indexes: Vec::new(),
@@ -232,6 +234,7 @@ mod tests {
                 nullable: false,
                 default: None,
                 unique: Some(ColumnUniqueOption { is_primary: true }),
+                comment: None,
             }]),
             indexes: Vec::new(),
             engine: None,
@@ -263,6 +266,7 @@ mod tests {
                     nullable: false,
                     default: None,
                     unique: None,
+                    comment: None,
                 },
                 ColumnDef {
                     name: "name".to_owned(),
@@ -270,6 +274,7 @@ mod tests {
                     nullable: false,
                     default: None,
                     unique: None,
+                    comment: None,
                 },
             ]),
             indexes: vec![
@@ -313,6 +318,7 @@ CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
                     nullable: true,
                     default: None,
                     unique: None,
+                    comment: None,
                 },
                 ColumnDef {
                     name: ";".to_owned(),
@@ -320,6 +326,7 @@ CREATE TABLE "User" ("id" INT NOT NULL, "name" TEXT NOT NULL);"#;
                     nullable: true,
                     default: None,
                     unique: None,
+                    comment: None,
                 },
             ]),
             indexes: vec![SchemaIndex {

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -40,6 +40,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                         nullable: false,
                         default: None,
                         unique: None,
+                        comment: None,
                     };
 
                     Some(vec![column_def])
@@ -82,6 +83,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                         nullable: true,
                         default: None,
                         unique: None,
+                        comment: None,
                     })
                     .collect::<Vec<_>>();
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -295,6 +295,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                                 .map(|expr| expr.to_sql())
                                                 .unwrap_or_default(),
                                         ),
+                                        Value::Str(column_def.comment.unwrap_or_default()),
                                     ];
 
                                     Ok(Row::Vec {
@@ -429,6 +430,7 @@ pub async fn fetch_relation_columns<T: GStore>(
                 "NULLABLE".to_owned(),
                 "KEY".to_owned(),
                 "DEFAULT".to_owned(),
+                "COMMENT".to_owned(),
             ],
             Dictionary::GlueIndexes => vec![
                 "TABLE_NAME".to_owned(),

--- a/core/src/mock.rs
+++ b/core/src/mock.rs
@@ -128,6 +128,7 @@ mod tests {
                 nullable: false,
                 default: None,
                 unique: None,
+                comment: None,
             },
         ))
         .is_err());

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -57,16 +57,16 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
         ..
     } = sql_column_def;
 
-    let (nullable, default, unique) = options.iter().try_fold(
-        (true, None, None),
-        |(nullable, default, unique), SqlColumnOptionDef { option, .. }| -> Result<_> {
+    let (nullable, default, unique, comment) = options.iter().try_fold(
+        (true, None, None, None),
+        |(nullable, default, unique, comment), SqlColumnOptionDef { option, .. }| -> Result<_> {
             match option {
-                SqlColumnOption::Null => Ok((nullable, default, unique)),
-                SqlColumnOption::NotNull => Ok((false, default, unique)),
+                SqlColumnOption::Null => Ok((nullable, default, unique, comment)),
+                SqlColumnOption::NotNull => Ok((false, default, unique, comment)),
                 SqlColumnOption::Default(default) => {
                     let default = translate_expr(default).map(Some)?;
 
-                    Ok((nullable, default, unique))
+                    Ok((nullable, default, unique, comment))
                 }
                 SqlColumnOption::Unique { is_primary } => {
                     let nullable = if *is_primary { false } else { nullable };
@@ -74,7 +74,10 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
                         is_primary: *is_primary,
                     });
 
-                    Ok((nullable, default, unique))
+                    Ok((nullable, default, unique, comment))
+                }
+                SqlColumnOption::Comment(comment) => {
+                    Ok((nullable, default, unique, Some(comment.to_string())))
                 }
                 _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
             }
@@ -87,6 +90,7 @@ pub fn translate_column_def(sql_column_def: &SqlColumnDef) -> Result<ColumnDef> 
         nullable,
         default,
         unique,
+        comment,
     })
 }
 

--- a/storages/csv-storage/src/lib.rs
+++ b/storages/csv-storage/src/lib.rs
@@ -57,6 +57,7 @@ impl CsvStorage {
                             unique: None,
                             default: None,
                             nullable: true,
+                            comment: None,
                         })
                         .collect::<Vec<_>>(),
                 ),

--- a/storages/idb-storage/tests/convert.rs
+++ b/storages/idb-storage/tests/convert.rs
@@ -26,6 +26,7 @@ async fn convert_schema() {
             nullable: false,
             default: None,
             unique: None,
+            comment: None,
         },
         ColumnDef {
             name: "name".to_owned(),
@@ -33,6 +34,7 @@ async fn convert_schema() {
             nullable: false,
             default: None,
             unique: None,
+            comment: None,
         },
         ColumnDef {
             name: "flag".to_owned(),
@@ -40,6 +42,7 @@ async fn convert_schema() {
             nullable: true,
             default: None,
             unique: None,
+            comment: None,
         },
     ];
     let expected = DataRow::Vec(vec![

--- a/storages/mongo-storage/Cargo.toml
+++ b/storages/mongo-storage/Cargo.toml
@@ -23,7 +23,8 @@ chrono = { version = "0.4.26", features = ["serde", "wasmbind"] }
 strum_macros = "0.24"
 strum = "0.24"
 rust_decimal = { version = "1", features = ["serde-str"] }
-regex = "1"
+serde_json = "1.0.115"
+serde = "1.0.197"
 
 [dev-dependencies]
 test-suite.workspace = true

--- a/storages/mongo-storage/Cargo.toml
+++ b/storages/mongo-storage/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0.4.26", features = ["serde", "wasmbind"] }
 strum_macros = "0.24"
 strum = "0.24"
 rust_decimal = { version = "1", features = ["serde-str"] }
+regex = "1"
 
 [dev-dependencies]
 test-suite.workspace = true

--- a/storages/mongo-storage/src/column_description.rs
+++ b/storages/mongo-storage/src/column_description.rs
@@ -1,0 +1,8 @@
+use gluesql_core::ast::Expr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ColumnDescription {
+    pub default: Option<Expr>,
+    pub comment: Option<String>,
+}

--- a/storages/mongo-storage/src/lib.rs
+++ b/storages/mongo-storage/src/lib.rs
@@ -1,3 +1,4 @@
+mod column_description;
 pub mod error;
 pub mod row;
 mod store;

--- a/storages/mongo-storage/src/store_mut.rs
+++ b/storages/mongo-storage/src/store_mut.rs
@@ -93,10 +93,27 @@ impl StoreMut for MongoStorage {
                             });
                         }
 
-                        if let Some(default) = &column_def.default {
-                            property.extend(doc! {
-                                "description": default.to_sql()
-                            });
+                        match (&column_def.default, &column_def.comment) {
+                            (Some(default), Some(comment)) => {
+                                property.extend(doc! {
+                                    "description": format!(
+                                        "DEFAULT {} COMMENT '{}'",
+                                        default.to_sql(),
+                                        comment
+                                    ),
+                                });
+                            }
+                            (Some(default), None) => {
+                                property.extend(doc! {
+                                    "description": format!("DEFAULT {}", default.to_sql()),
+                                });
+                            }
+                            (None, Some(comment)) => {
+                                property.extend(doc! {
+                                    "description": format!("COMMENT '{}'", comment)
+                                });
+                            }
+                            _ => {}
                         }
 
                         let type_str = column_def.data_type.to_string();

--- a/storages/parquet-storage/src/column_def.rs
+++ b/storages/parquet-storage/src/column_def.rs
@@ -76,6 +76,7 @@ impl<'a> TryFrom<ParquetSchemaType<'a>> for ColumnDef {
         let nullable = inner.is_optional();
         let mut unique = None;
         let mut default = None;
+        let mut comment = None;
 
         if let Some(metadata) = parquet_col_def.get_metadata().as_deref() {
             for kv in metadata.iter() {
@@ -101,6 +102,11 @@ impl<'a> TryFrom<ParquetSchemaType<'a>> for ColumnDef {
                             default = Some(tran);
                         }
                     }
+                    k if k == format!("comment_{}", name) => {
+                        if let Some(value) = &kv.value {
+                            comment = Some(value.clone());
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -111,6 +117,7 @@ impl<'a> TryFrom<ParquetSchemaType<'a>> for ColumnDef {
             nullable,
             default,
             unique,
+            comment,
         })
     }
 }

--- a/storages/parquet-storage/src/lib.rs
+++ b/storages/parquet-storage/src/lib.rs
@@ -169,6 +169,7 @@ impl ParquetStorage {
                 nullable: true,
                 default: None,
                 unique: None,
+                comment: None,
             }]),
             indexes: vec![],
             engine: None,

--- a/storages/parquet-storage/src/store_mut.rs
+++ b/storages/parquet-storage/src/store_mut.rs
@@ -445,6 +445,7 @@ impl ParquetStorage {
                     nullable: true,
                     default: None,
                     unique: None,
+                    comment: None,
                 }]
             }
         };
@@ -501,6 +502,13 @@ impl ParquetStorage {
                     metadata.push(KeyValue {
                         key: format!("default_{}", column_def.name),
                         value: Some(ToSql::to_sql(default_value)),
+                    });
+                }
+
+                if let Some(comment) = &column_def.comment {
+                    metadata.push(KeyValue {
+                        key: format!("comment_{}", column_def.name),
+                        value: Some(comment.to_string()),
                     });
                 }
 

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -190,6 +190,7 @@ impl AlterTable for SledStorage {
                 nullable,
                 default,
                 unique,
+                comment,
                 ..
             } = column_defs[i].clone();
 
@@ -199,6 +200,7 @@ impl AlterTable for SledStorage {
                 nullable,
                 default,
                 unique,
+                comment,
             };
             let column_defs = Vector::from(column_defs).update(i, column_def).into();
 

--- a/test-suite/src/alter/alter_table.rs
+++ b/test-suite/src/alter/alter_table.rs
@@ -63,6 +63,7 @@ test_case!(alter_table_add_drop, {
                 nullable: false,
                 default: None,
                 unique: None,
+                comment: None,
             })
             .into()),
         ),

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -25,7 +25,7 @@ test_case!(create_table, {
         CREATE TABLE CreateTable1 (
             id INTEGER NULL,
             num INTEGER,
-            name TEXT
+            name TEXT COMMENT 'this is comment for name column'
         )",
             Err(AlterError::TableAlreadyExists("CreateTable1".to_owned()).into()),
         ),

--- a/test-suite/src/dictionary.rs
+++ b/test-suite/src/dictionary.rs
@@ -26,7 +26,7 @@ test_case!(dictionary, {
         .await;
     g.test("SHOW TABLES", tables(vec!["Foo"])).await;
 
-    g.run("CREATE TABLE Zoo (id INTEGER PRIMARY KEY);").await;
+    g.run("CREATE TABLE Zoo (id INTEGER PRIMARY KEY COMMENT 'hello');").await;
     g.run("CREATE TABLE Bar (id INTEGER UNIQUE, name TEXT NOT NULL DEFAULT 'NONE');")
         .await;
 
@@ -63,14 +63,14 @@ test_case!(dictionary, {
     g.test(
         "SELECT * FROM GLUE_TABLE_COLUMNS",
         Ok(select!(
-            TABLE_NAME       | COLUMN_NAME      | COLUMN_ID | NULLABLE | KEY                      | DEFAULT;
-            Str              | Str              | I64       | Bool     | Str                      | Str;
-            "Bar".to_owned()   "id".to_owned()    1           true       "UNIQUE".to_owned()        "".to_owned();
-            "Bar".to_owned()   "name".to_owned()  2           false      "".to_owned()              "'NONE'".to_owned();
-            "Foo".to_owned()   "id".to_owned()    1           true       "".to_owned()              "".to_owned();
-            "Foo".to_owned()   "name".to_owned()  2           true       "".to_owned()              "".to_owned();
-            "Foo".to_owned()   "type".to_owned()  3           true       "".to_owned()              "".to_owned();
-            "Zoo".to_owned()   "id".to_owned()    1           false      "PRIMARY KEY".to_owned()   "".to_owned()
+            TABLE_NAME       | COLUMN_NAME      | COLUMN_ID | NULLABLE | KEY                      | DEFAULT              | COMMENT;
+            Str              | Str              | I64       | Bool     | Str                      | Str                  | Str;
+            "Bar".to_owned()   "id".to_owned()    1           true       "UNIQUE".to_owned()        "".to_owned()          "".to_owned();
+            "Bar".to_owned()   "name".to_owned()  2           false      "".to_owned()              "'NONE'".to_owned()    "".to_owned();
+            "Foo".to_owned()   "id".to_owned()    1           true       "".to_owned()              "".to_owned()          "".to_owned();
+            "Foo".to_owned()   "name".to_owned()  2           true       "".to_owned()              "".to_owned()          "".to_owned();
+            "Foo".to_owned()   "type".to_owned()  3           true       "".to_owned()              "".to_owned()          "".to_owned();
+            "Zoo".to_owned()   "id".to_owned()    1           false      "PRIMARY KEY".to_owned()   "".to_owned()          "hello".to_owned() 
         ))
     ).await;
 });

--- a/test-suite/src/dictionary.rs
+++ b/test-suite/src/dictionary.rs
@@ -26,7 +26,8 @@ test_case!(dictionary, {
         .await;
     g.test("SHOW TABLES", tables(vec!["Foo"])).await;
 
-    g.run("CREATE TABLE Zoo (id INTEGER PRIMARY KEY COMMENT 'hello');").await;
+    g.run("CREATE TABLE Zoo (id INTEGER PRIMARY KEY COMMENT 'hello');")
+        .await;
     g.run("CREATE TABLE Bar (id INTEGER UNIQUE, name TEXT NOT NULL DEFAULT 'NONE');")
         .await;
 

--- a/test-suite/src/store/insert_schema.rs
+++ b/test-suite/src/store/insert_schema.rs
@@ -14,6 +14,7 @@ test_case!(insert_schema, {
         nullable: false,
         default: None,
         unique: None,
+        comment: None,
     }]);
 
     let mut schema = Schema {
@@ -33,6 +34,7 @@ test_case!(insert_schema, {
             nullable: false,
             default: None,
             unique: None,
+            comment: Some("this is comment for name column".to_owned()),
         });
 
         column_defs

--- a/test-suite/src/store/insert_schema.rs
+++ b/test-suite/src/store/insert_schema.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        ast::{ColumnDef, DataType},
+        ast::{AstLiteral, ColumnDef, DataType, Expr},
         data::Schema,
     },
 };
@@ -12,9 +12,9 @@ test_case!(insert_schema, {
         name: "id".to_owned(),
         data_type: DataType::Int,
         nullable: false,
-        default: None,
+        default: Some(Expr::Literal(AstLiteral::Number(11.into()))),
         unique: None,
-        comment: None,
+        comment: Some("default value is lucky eleven".to_owned()),
     }]);
 
     let mut schema = Schema {


### PR DESCRIPTION
Add comment to ast::ColumnDef.
Update translate_column_def to handle comment ColumnOption.
Update MongoStorage validator description field to support both DEFAULT and COMMENT.
Update ParquetStorage to support column comment.
Modify test-suite store/insert_schema test case to use comment field.

e.g.
```sql
CREATE TABLE Foo (
  id TEXT NULL COMMENT 'comment something'
);
```