### PR TITLE
Upgrade sqlparser-rs version to v0.46,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,9 +3279,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+checksum = "11a81a8cad9befe4cf1b9d2d4b9c6841c76f0882a3fec00d95133953c13b3d3d"
 dependencies = [
  "bigdecimal",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.45", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.46", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.25"
 bigdecimal = { version = "0.4.1", features = ["serde", "string-only"] }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -51,6 +51,9 @@ pub enum TranslateError {
     #[error("unnamed function arg is not supported")]
     UnNamedFunctionArgNotSupported,
 
+    #[error("subquery function arg is not supported")]
+    UnreachableSubqueryFunctionArgNotSupported,
+
     #[error("INSERT INTO {0} DEFAULT VALUES is not supported")]
     DefaultValuesOnInsertNotSupported(String),
 
@@ -65,6 +68,12 @@ pub enum TranslateError {
 
     #[error("unsupported CAST format: {0}")]
     UnsupportedCastFormat(String),
+
+    #[error("TRY_CAST(..) is not supported")]
+    TryCastNotSupported,
+
+    #[error("SAFE_CAST(..) is not supported")]
+    SafeCastNotSupported,
 
     #[error("unsupported multiple alter table operations, expected: `ALTER TABLE <table> <operation>`, got: `ALTER TABLE <table> <operation>, <operation>, ..`")]
     UnsupportedMultipleAlterTableOperations,

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -191,13 +191,8 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             expr,
             data_type,
             format,
-        } => {
-            if let Some(format) = format {
-                return Err(TranslateError::UnsupportedCastFormat(format.to_string()).into());
-            }
-
-            translate_cast(expr, data_type)
-        }
+            kind,
+        } => translate_cast(kind, expr, data_type, format.as_ref()),
 
         _ => Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into()),
     }

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -22,21 +22,21 @@ use {
     },
     ddl::translate_alter_table_operation,
     sqlparser::ast::{
-        Assignment as SqlAssignment, FromTable as SqlFromTable, Ident as SqlIdent,
-        ObjectName as SqlObjectName, ObjectType as SqlObjectType, Statement as SqlStatement,
-        TableFactor, TableWithJoins,
+        Assignment as SqlAssignment, Delete as SqlDelete, FromTable as SqlFromTable,
+        Ident as SqlIdent, Insert as SqlInsert, ObjectName as SqlObjectName,
+        ObjectType as SqlObjectType, Statement as SqlStatement, TableFactor, TableWithJoins,
     },
 };
 
 pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
     match sql_statement {
         SqlStatement::Query(query) => translate_query(query).map(Statement::Query),
-        SqlStatement::Insert {
+        SqlStatement::Insert(SqlInsert {
             table_name,
             columns,
             source,
             ..
-        } => {
+        }) => {
             let table_name = translate_object_name(table_name)?;
             let columns = translate_idents(columns);
             let source = source
@@ -65,9 +65,9 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
                 .collect::<Result<_>>()?,
             selection: selection.as_ref().map(translate_expr).transpose()?,
         }),
-        SqlStatement::Delete {
+        SqlStatement::Delete(SqlDelete {
             from, selection, ..
-        } => {
+        }) => {
             let from = match from {
                 SqlFromTable::WithFromKeyword(from) => from,
                 SqlFromTable::WithoutKeyword(_) => {

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -41,6 +41,10 @@ test_case!(cast_literal, {
             Ok(select!(cast Bool; true)),
         ),
         (
+            "SELECT 1::BOOLEAN AS cast",
+            Ok(select!(cast Bool; true)),
+        ),
+        (
             "SELECT CAST(1 AS BOOLEAN) AS cast FROM Item",
             Ok(select!(cast Bool; true)),
         ),


### PR DESCRIPTION
Upgrade sqlparser-rs version to v0.46.
Add 'id::TEXT' cast expression support which is equal to 'CAST(id AS TEXT)'.

fyi. @MRGRAVITY817 with this PR, now we can specify length to array type :D