### PR TITLE
Add prepare-release gh action that bump versions and create PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,42 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number or step to bump'
+        required: true
+        default: 'minor'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bump_version:
+    name: Bump versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Bump versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo release version ${{ github.event.inputs.version }} --workspace --execute --no-confirm
+          cd pkg/javascript 
+          NEW_VERSION=$(npm version ${{ github.event.inputs.version }}>&1)
+          cd ../../
+          NEW_BRANCH="prepare-release-$NEW_VERSION"
+          git checkout -b $NEW_BRANCH
+          git config --local user.email "taehoon.moon@outlook.com"
+          git config --local user.name "Taehoon Moon"
+          git add .
+          git commit -m "Bump version to $NEW_VERSION"
+          git push origin $NEW_BRANCH
+          gh pr create --draft --title "Prepare release $NEW_VERSION" --body "Prepare release $NEW_VERSION" --repo $GITHUB_REPOSITORY


### PR DESCRIPTION
This is a starting action to prepare the new release. It’s all about keeping things simple: manually triggered, bumps versions, and creates a PR ready for the next steps.

Here’s the Plan:
1. Kickoff - I trigger prepare-release gh action.
2. Writing release note - This Action bumps our version and creates a PR automatically. I'll dive in to add release notes right there, updating our docs in the process.
3. Merge to main - After tweaking the docs and ensuring everything’s on point, we merge into the main branch.
4. Deployment Automation - I’m setting up four more Actions to automate our deployment process:
release-rust.yml
release-javascript.yml
release-python.yml
release-docs.yml
These Actions will kick in when commits are pushed to the release branch, taking care of both package and documentation deployment.


May be we can try release note writing automation in the future. for now, I'll do it by myself. With this automation, I expect that we can release the new version quite more often than now :D
