### PR TITLE
Rename EvaluateError::ValueNotFound to IdentifierNotFound,

### DIFF
--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -44,8 +44,14 @@ pub enum EvaluateError {
     #[error("function requires one of string, list, map types: {0}")]
     FunctionRequiresStrOrListOrMapValue(String),
 
-    #[error("value not found: {0}")]
-    ValueNotFound(String),
+    #[error("identifier not found: {0}")]
+    IdentifierNotFound(String),
+
+    #[error("identifier not found: {table_alias}.{column_name}")]
+    CompoundIdentifierNotFound {
+        table_alias: String,
+        column_name: String,
+    },
 
     #[error("only boolean value is accepted: {0}")]
     BooleanTypeRequired(String),

--- a/test-suite/src/aggregate/error.rs
+++ b/test-suite/src/aggregate/error.rs
@@ -32,7 +32,7 @@ test_case!(error, {
     let test_cases = [
         (
             "SELECT SUM(num) FROM Item;",
-            EvaluateError::ValueNotFound("num".to_owned()).into(),
+            EvaluateError::IdentifierNotFound("num".to_owned()).into(),
         ),
         (
             "SELECT COUNT(Foo.*) FROM Item;",

--- a/test-suite/src/inline_view.rs
+++ b/test-suite/src/inline_view.rs
@@ -106,7 +106,11 @@ test_case!(inline_view, {
             FROM OuterTable JOIN (
                 SELECT name FROM InnerTable
             ) AS InlineView ON OuterTable.id = InlineView.id",
-            Err(EvaluateError::ValueNotFound("id".to_owned()).into()),
+            Err(EvaluateError::CompoundIdentifierNotFound {
+                table_alias: "InlineView".to_owned(),
+                column_name: "id".to_owned(),
+            }
+            .into()),
         ),
         (
             // join - Expr with WHERE clause

--- a/test-suite/src/migrate.rs
+++ b/test-suite/src/migrate.rs
@@ -64,7 +64,7 @@ test_case!(migrate, {
         ),
         (
             "SELECT * FROM Test WHERE noname = 1;",
-            EvaluateError::ValueNotFound("noname".to_owned()).into(),
+            EvaluateError::IdentifierNotFound("noname".to_owned()).into(),
         ),
         (
             "SELECT * FROM Nothing;",

--- a/test-suite/src/project.rs
+++ b/test-suite/src/project.rs
@@ -155,7 +155,7 @@ test_case!(project, {
         ),
         (
             "SELECT noname FROM ProjectUser",
-            EvaluateError::ValueNotFound("noname".to_owned()).into(),
+            EvaluateError::IdentifierNotFound("noname".to_owned()).into(),
         ),
         (
             "SELECT (SELECT id FROM ProjectItem) as id FROM ProjectItem",


### PR DESCRIPTION
Split ValueNotFound error into IdentifierNotFound and CompoundIdentifierNotFound errors.