### PR TITLE
Upgraded from 0.46 to 0.47 sql parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,9 +3320,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a81a8cad9befe4cf1b9d2d4b9c6841c76f0882a3fec00d95133953c13b3d3d"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "bigdecimal",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.46", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.47", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.25"
 bigdecimal = { version = "0.4.1", features = ["serde", "string-only"] }

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -314,7 +314,7 @@ mod tests {
     use {
         crate::ast::{
             AstLiteral, BinaryOperator, DataType, DateTimeField, Expr, Query, Select, SelectItem,
-            SetExpr, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted, UnaryOperator, Subscript,
+            SetExpr, Subscript, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted, UnaryOperator,
         },
         bigdecimal::BigDecimal,
         regex::Regex,

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -711,6 +711,20 @@ mod tests {
             .to_sql()
         );
 
+        // Next, we test the Slice variant of Subscript
+        assert_eq!(
+            r#""choco"[1:2:3]"#,
+            Expr::Subscript {
+                expr: Box::new(Expr::Identifier("choco".to_owned())),
+                subscript: Box::new(Subscript::Slice {
+                    lower_bound: Some(Expr::Literal(AstLiteral::Number(BigDecimal::from(1)))),
+                    upper_bound: Some(Expr::Literal(AstLiteral::Number(BigDecimal::from(2)))),
+                    stride: Some(Expr::Literal(AstLiteral::Number(BigDecimal::from(3)))),
+                })
+            }
+            .to_sql()
+        );
+
         assert_eq!(
             r#"['GlueSQL', 'Rust']"#,
             Expr::Array {

--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -68,9 +68,9 @@ pub enum Expr {
         when_then: Vec<(Expr, Expr)>,
         else_result: Option<Box<Expr>>,
     },
-    ArrayIndex {
-        obj: Box<Expr>,
-        indexes: Vec<Expr>,
+    Subscript {
+        expr: Box<Expr>,
+        subscript: Box<Subscript>,
     },
     Interval {
         expr: Box<Expr>,
@@ -80,6 +80,46 @@ pub enum Expr {
     Array {
         elem: Vec<Expr>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Subscript {
+    Index {
+        index: Expr,
+    },
+    Slice {
+        lower_bound: Option<Expr>,
+        upper_bound: Option<Expr>,
+        stride: Option<Expr>,
+    },
+}
+
+impl Subscript {
+    fn to_sql_with(&self, quoted: bool) -> String {
+        match self {
+            Subscript::Index { index } => index.to_sql_with(quoted),
+            Subscript::Slice {
+                lower_bound,
+                upper_bound,
+                stride,
+            } => {
+                let lower_bound = lower_bound
+                    .as_ref()
+                    .map(|expr| expr.to_sql_with(quoted))
+                    .unwrap_or_else(|| "".to_owned());
+                let upper_bound = upper_bound
+                    .as_ref()
+                    .map(|expr| expr.to_sql_with(quoted))
+                    .unwrap_or_else(|| "".to_owned());
+                let stride = stride
+                    .as_ref()
+                    .map(|expr| expr.to_sql_with(quoted))
+                    .unwrap_or_else(|| "".to_owned());
+
+                format!("{}:{}:{}", lower_bound, upper_bound, stride)
+            }
+        }
+    }
 }
 
 impl ToSql for Expr {
@@ -233,14 +273,11 @@ impl Expr {
                 true => format!("NOT EXISTS({})", subquery.to_sql()),
                 false => format!("EXISTS({})", subquery.to_sql()),
             },
-            Expr::ArrayIndex { obj, indexes } => {
-                let obj = obj.to_sql_with(quoted);
-                let indexes = indexes
-                    .iter()
-                    .map(|index| format!("[{}]", index.to_sql_with(quoted)))
-                    .collect::<Vec<_>>()
-                    .join("");
-                format!("{obj}{indexes}")
+            Expr::Subscript { expr, subscript } => {
+                let expr = expr.to_sql_with(quoted);
+                let subscript = subscript.to_sql_with(quoted);
+
+                format!("{}[{}]", expr, subscript)
             }
             Expr::Array { elem } => {
                 let elem = elem
@@ -277,7 +314,7 @@ mod tests {
     use {
         crate::ast::{
             AstLiteral, BinaryOperator, DataType, DateTimeField, Expr, Query, Select, SelectItem,
-            SetExpr, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted, UnaryOperator,
+            SetExpr, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted, UnaryOperator, Subscript,
         },
         bigdecimal::BigDecimal,
         regex::Regex,
@@ -660,12 +697,16 @@ mod tests {
 
         assert_eq!(
             r#""choco"[1][2]"#,
-            Expr::ArrayIndex {
-                obj: Box::new(Expr::Identifier("choco".to_owned())),
-                indexes: vec![
-                    Expr::Literal(AstLiteral::Number(BigDecimal::from_str("1").unwrap())),
-                    Expr::Literal(AstLiteral::Number(BigDecimal::from_str("2").unwrap()))
-                ]
+            Expr::Subscript {
+                expr: Box::new(Expr::Subscript {
+                    expr: Box::new(Expr::Identifier("choco".to_owned())),
+                    subscript: Box::new(Subscript::Index {
+                        index: Expr::Literal(AstLiteral::Number(BigDecimal::from(1)))
+                    })
+                }),
+                subscript: Box::new(Subscript::Index {
+                    index: Expr::Literal(AstLiteral::Number(BigDecimal::from(2)))
+                })
             }
             .to_sql()
         );

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -10,7 +10,7 @@ pub use {
     ast_literal::{AstLiteral, DateTimeField, TrimWhereField},
     data_type::DataType,
     ddl::*,
-    expr::Expr,
+    expr::{Expr, Subscript},
     function::{Aggregate, CountArgExpr, Function},
     operator::*,
     query::*,

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -1,7 +1,10 @@
 use {
     super::context::Context,
     crate::{
-        ast::{ColumnDef, ColumnUniqueOption, Expr, Function, Query, TableAlias, TableFactor, Subscript},
+        ast::{
+            ColumnDef, ColumnUniqueOption, Expr, Function, Query, Subscript, TableAlias,
+            TableFactor,
+        },
         data::Schema,
     },
     std::rc::Rc,

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -22,11 +22,11 @@ use {
     },
     ddl::translate_alter_table_operation,
     sqlparser::ast::{
-        Assignment as SqlAssignment, Delete as SqlDelete, FromTable as SqlFromTable,
-        Ident as SqlIdent, Insert as SqlInsert, ObjectName as SqlObjectName,
-        ObjectType as SqlObjectType, ReferentialAction as SqlReferentialAction,
-        Statement as SqlStatement, TableConstraint as SqlTableConstraint, TableFactor,
-        TableWithJoins, CreateFunctionBody as SqlCreateFunctionBody,
+        Assignment as SqlAssignment, CreateFunctionBody as SqlCreateFunctionBody,
+        Delete as SqlDelete, FromTable as SqlFromTable, Ident as SqlIdent, Insert as SqlInsert,
+        ObjectName as SqlObjectName, ObjectType as SqlObjectType,
+        ReferentialAction as SqlReferentialAction, Statement as SqlStatement,
+        TableConstraint as SqlTableConstraint, TableFactor, TableWithJoins,
     },
 };
 


### PR DESCRIPTION
As per request, I am breaking down the PR #1521 since it was deemed too large. This one solely tackles the bare minimum necessary for supporting version 0.47. 

It primarily focuses on replacing `ArrayIndex` with `Subscript` where needed. 