### PR TITLE
Upgrading from SqlParser 0.47 to 0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,9 +3320,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
+checksum = "749780d15ad1ee15fd74f5f84b0665560b6abb913de744c2b69155770f9601da"
 dependencies = [
  "bigdecimal",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,9 +3320,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a81a8cad9befe4cf1b9d2d4b9c6841c76f0882a3fec00d95133953c13b3d3d"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "bigdecimal",
  "log",

--- a/cli/tests/dump.rs
+++ b/cli/tests/dump.rs
@@ -32,7 +32,7 @@ async fn dump_and_import() {
             interval INTERVAL,
             uuid UUID,
             map MAP,
-            list LIST,
+            list LIST
          );",
         r#"INSERT INTO Foo
          VALUES (

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.47", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.48", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.25"
 bigdecimal = { version = "0.4.1", features = ["serde", "string-only"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.46", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.47", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.25"
 bigdecimal = { version = "0.4.1", features = ["serde", "string-only"] }

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -380,11 +380,11 @@ mod tests {
         let storage = run("
             CREATE TABLE Player (
                 id INTEGER PRIMARY KEY,
-                name TEXT,
+                name TEXT
             );
             CREATE TABLE Badge (
                 title TEXT PRIMARY KEY,
-                user_id INTEGER,
+                user_id INTEGER
             );
         ");
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -14,6 +14,17 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
             Ok(DataType::Int)
         }
         SqlDataType::Int8(None) => Ok(DataType::Int8),
+        SqlDataType::Int16 => Ok(DataType::Int16),
+        SqlDataType::Int32 => Ok(DataType::Int32),
+        SqlDataType::Int128 => Ok(DataType::Int128),
+        SqlDataType::UInt8 => Ok(DataType::Uint8),
+        SqlDataType::UInt16 => Ok(DataType::Uint16),
+        SqlDataType::UInt32 => Ok(DataType::Uint32),
+        SqlDataType::UInt64 => Ok(DataType::Uint64),
+        SqlDataType::UInt128 => Ok(DataType::Uint128),
+
+        SqlDataType::Float32 => Ok(DataType::Float32),
+        SqlDataType::Float64 => Ok(DataType::Float),
 
         SqlDataType::UnsignedInt(None) | SqlDataType::UnsignedInteger(None) => Ok(DataType::Uint64),
         SqlDataType::UnsignedInt8(None) => Ok(DataType::Uint8),

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -72,10 +72,6 @@ mod tests {
 
         test!("INT" => SqlDataType::Int(None) => Ok(DataType::Int));
         test!("INTEGER" => SqlDataType::Integer(None) => Ok(DataType::Int));
-        test!("INT64" => SqlDataType::Int64 => Ok(DataType::Int));
-
-        test!("INT8" => SqlDataType::Int8(None) => Ok(DataType::Int8));
-
         test!("INT UNSIGNED" => SqlDataType::UnsignedInt(None) => Ok(DataType::Uint64));
         test!("INTEGER UNSIGNED" => SqlDataType::UnsignedInteger(None) => Ok(DataType::Uint64));
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -72,6 +72,10 @@ mod tests {
 
         test!("INT" => SqlDataType::Int(None) => Ok(DataType::Int));
         test!("INTEGER" => SqlDataType::Integer(None) => Ok(DataType::Int));
+        test!("INT64" => SqlDataType::Int64 => Ok(DataType::Int));
+
+        test!("INT8" => SqlDataType::Int8(None) => Ok(DataType::Int8));
+
         test!("INT UNSIGNED" => SqlDataType::UnsignedInt(None) => Ok(DataType::Uint64));
         test!("INTEGER UNSIGNED" => SqlDataType::UnsignedInteger(None) => Ok(DataType::Uint64));
 

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -45,18 +45,8 @@ pub fn translate_data_type(sql_data_type: &SqlDataType) -> Result<DataType> {
             match name.as_deref() {
                 Some("MAP") => Ok(DataType::Map),
                 Some("LIST") => Ok(DataType::List),
-                Some("INT8") => Ok(DataType::Int8),
-                Some("INT16") => Ok(DataType::Int16),
-                Some("INT32") => Ok(DataType::Int32),
-                Some("INT128") => Ok(DataType::Int128),
-                Some("UINT8") => Ok(DataType::Uint8),
-                Some("UINT16") => Ok(DataType::Uint16),
-                Some("UINT32") => Ok(DataType::Uint32),
-                Some("UINT64") => Ok(DataType::Uint64),
-                Some("UINT128") => Ok(DataType::Uint128),
                 Some("POINT") => Ok(DataType::Point),
                 Some("INET") => Ok(DataType::Inet),
-                Some("FLOAT32") => Ok(DataType::Float32),
 
                 _ => Err(TranslateError::UnsupportedDataType(sql_data_type.to_string()).into()),
             }
@@ -122,21 +112,7 @@ mod tests {
 
         test!("MAP" => Ok(DataType::Map));
         test!("LIST" => Ok(DataType::List));
-
-        test!("INT8" => Ok(DataType::Int8));
-        test!("INT16" => Ok(DataType::Int16));
-        test!("INT32" => Ok(DataType::Int32));
-        test!("INT128" => Ok(DataType::Int128));
-
-        test!("UINT8" => Ok(DataType::Uint8));
-        test!("UINT16" => Ok(DataType::Uint16));
-        test!("UINT32" => Ok(DataType::Uint32));
-        test!("UINT64" => Ok(DataType::Uint64));
-        test!("UINT128" => Ok(DataType::Uint128));
-
         test!("POINT" => Ok(DataType::Point));
         test!("INET" => Ok(DataType::Inet));
-
-        test!("FLOAT32" => Ok(DataType::Float32));
     }
 }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -17,6 +17,9 @@ pub enum TranslateError {
     #[error("unimplemented - compound identifier on update not supported: {0}")]
     CompoundIdentOnUpdateNotSupported(String),
 
+    #[error("unimplemented - tuple assigment on update is not supported: {0}")]
+    TupleAssignmentOnUpdateNotSupported(String),
+
     #[error("too many params in drop index")]
     TooManyParamsInDropIndex,
 

--- a/core/src/translate/mod.rs
+++ b/core/src/translate/mod.rs
@@ -121,7 +121,9 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
                     Some(v) => Some(translate_query(v).map(Box::new)?),
                     None => None,
                 },
-                engine: engine.as_ref().map(|table_engine| table_engine.name.to_owned()),
+                engine: engine
+                    .as_ref()
+                    .map(|table_engine| table_engine.name.to_owned()),
                 foreign_keys,
                 comment: comment.as_ref().map(|comment| match comment {
                     SqlCommentDef::WithEq(comment) => comment.to_owned(),

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -95,8 +95,8 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
     };
 
     let group_by = match group_by {
-        SqlGroupByExpr::Expressions(group_by) => group_by,
-        SqlGroupByExpr::All => return Err(TranslateError::UnsupportedGroupByAll.into()),
+        SqlGroupByExpr::Expressions(group_by, _group_by_with_modifiers) => group_by,
+        SqlGroupByExpr::All(_group_by_with_modifiers) => return Err(TranslateError::UnsupportedGroupByAll.into()),
     };
 
     Ok(Select {

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -96,7 +96,9 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
 
     let group_by = match group_by {
         SqlGroupByExpr::Expressions(group_by, _group_by_with_modifiers) => group_by,
-        SqlGroupByExpr::All(_group_by_with_modifiers) => return Err(TranslateError::UnsupportedGroupByAll.into()),
+        SqlGroupByExpr::All(_group_by_with_modifiers) => {
+            return Err(TranslateError::UnsupportedGroupByAll.into())
+        }
     };
 
     Ok(Select {

--- a/docs/blog/2023-05-30-test-driven-documentation.md
+++ b/docs/blog/2023-05-30-test-driven-documentation.md
@@ -37,7 +37,7 @@ test_case!(insert, async move {
 CREATE TABLE Test (
     id INTEGER DEFAULT 1,
     num INTEGER NULL,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL
 );"
     );
 

--- a/docs/docs/sql-syntax/functions/text/initcap.md
+++ b/docs/docs/sql-syntax/functions/text/initcap.md
@@ -22,7 +22,7 @@ Create a table named `Item` with a column `name`:
 
 ```sql
 CREATE TABLE Item (
-    name TEXT DEFAULT 'abcd',
+    name TEXT DEFAULT 'abcd'
 );
 ```
 

--- a/docs/docs/sql-syntax/statements/data-manipulation/insert.md
+++ b/docs/docs/sql-syntax/statements/data-manipulation/insert.md
@@ -35,7 +35,7 @@ Consider the following `Test` table:
 CREATE TABLE Test (
     id INTEGER DEFAULT 1,
     num INTEGER NULL,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL
 );
 ```
 

--- a/storages/json-storage/tests/samples/Schema.sql
+++ b/storages/json-storage/tests/samples/Schema.sql
@@ -14,5 +14,5 @@ CREATE TABLE Schema (
   interval INTERVAL,
   uuid UUID,
   map MAP,
-  list LIST,
+  list LIST
 );

--- a/test-suite/src/aggregate/avg.rs
+++ b/test-suite/src/aggregate/avg.rs
@@ -9,7 +9,7 @@ test_case!(avg, {
             id INTEGER,
             quantity INTEGER,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/count.rs
+++ b/test-suite/src/aggregate/count.rs
@@ -9,7 +9,7 @@ test_case!(count, {
             id INTEGER,
             quantity INTEGER NULL,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/error.rs
+++ b/test-suite/src/aggregate/error.rs
@@ -12,7 +12,7 @@ test_case!(error, {
             id INTEGER,
             quantity INTEGER,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/group_by.rs
+++ b/test-suite/src/aggregate/group_by.rs
@@ -9,7 +9,7 @@ test_case!(group_by, {
             id INTEGER,
             quantity INTEGER NULL,
             city TEXT,
-            ratio FLOAT,
+            ratio FLOAT
         );
     ",
     )

--- a/test-suite/src/aggregate/max.rs
+++ b/test-suite/src/aggregate/max.rs
@@ -9,7 +9,7 @@ test_case!(max, {
             id INTEGER,
             quantity INTEGER,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/min.rs
+++ b/test-suite/src/aggregate/min.rs
@@ -9,7 +9,7 @@ test_case!(min, {
             id INTEGER,
             quantity INTEGER,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/stdev.rs
+++ b/test-suite/src/aggregate/stdev.rs
@@ -9,7 +9,7 @@ test_case!(stdev, {
         id INTEGER,
         quantity INTEGER,
         age INTEGER NULL,
-        total INTEGER,
+        total INTEGER
     );
     ",
     )

--- a/test-suite/src/aggregate/sum.rs
+++ b/test-suite/src/aggregate/sum.rs
@@ -9,7 +9,7 @@ test_case!(sum, {
             id INTEGER,
             quantity INTEGER,
             age INTEGER NULL,
-            total INTEGER,
+            total INTEGER
         );
     ",
     )

--- a/test-suite/src/aggregate/variance.rs
+++ b/test-suite/src/aggregate/variance.rs
@@ -9,7 +9,7 @@ test_case!(variance, {
         id INTEGER,
         quantity INTEGER,
         age INTEGER NULL,
-        total INTEGER,
+        total INTEGER
     );
     ",
     )

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -41,7 +41,7 @@ test_case!(create_table, {
         (
             "
         CREATE TABLE IF NOT EXISTS CreateTable2 (
-            id2 INTEGER NULL,
+            id2 INTEGER NULL
         )",
             Ok(Payload::Create),
         ),

--- a/test-suite/src/arithmetic/error.rs
+++ b/test-suite/src/arithmetic/error.rs
@@ -17,7 +17,7 @@ test_case!(error, {
         CREATE TABLE Arith (
             id INTEGER,
             num INTEGER,
-            name TEXT,
+            name TEXT
         );
     ",
     )

--- a/test-suite/src/arithmetic/on_where.rs
+++ b/test-suite/src/arithmetic/on_where.rs
@@ -8,7 +8,7 @@ test_case!(on_where, {
         CREATE TABLE Arith (
             id INTEGER,
             num INTEGER,
-            name TEXT,
+            name TEXT
         );
     ",
     )

--- a/test-suite/src/arithmetic/project.rs
+++ b/test-suite/src/arithmetic/project.rs
@@ -10,7 +10,7 @@ test_case!(project, {
         "
         CREATE TABLE Arith (
             id INTEGER,
-            num INTEGER,
+            num INTEGER
         );
     ",
     )

--- a/test-suite/src/bitwise_shift_left.rs
+++ b/test-suite/src/bitwise_shift_left.rs
@@ -10,7 +10,7 @@ test_case!(bitwise_shift_left, {
         r#"
 CREATE TABLE Test (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;
@@ -19,7 +19,7 @@ CREATE TABLE Test (
         r#"
 CREATE TABLE OverflowTest (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;
@@ -28,7 +28,7 @@ CREATE TABLE OverflowTest (
         r#"
 CREATE TABLE NullTest (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;

--- a/test-suite/src/bitwise_shift_right.rs
+++ b/test-suite/src/bitwise_shift_right.rs
@@ -10,7 +10,7 @@ test_case!(bitwise_shift_right, {
         r#"
 CREATE TABLE Test (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;
@@ -19,7 +19,7 @@ CREATE TABLE Test (
         r#"
 CREATE TABLE OverflowTest (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;
@@ -28,7 +28,7 @@ CREATE TABLE OverflowTest (
         r#"
 CREATE TABLE NullTest (
     id INTEGER,
-    num INTEGER,
+    num INTEGER
 )"#,
     )
     .await;

--- a/test-suite/src/concat.rs
+++ b/test-suite/src/concat.rs
@@ -10,7 +10,7 @@ test_case!(concat, {
             rate FLOAT,
             flag BOOLEAN,
             text TEXT,
-            null_value TEXT NULL,
+            null_value TEXT NULL
         );
     ",
     )

--- a/test-suite/src/data_type/date.rs
+++ b/test-suite/src/data_type/date.rs
@@ -11,7 +11,7 @@ test_case!(date, {
 CREATE TABLE DateLog (
     id INTEGER,
     date1 DATE,
-    date2 DATE,
+    date2 DATE
 )",
     )
     .await;

--- a/test-suite/src/data_type/int128.rs
+++ b/test-suite/src/data_type/int128.rs
@@ -12,7 +12,7 @@ test_case!(int128, {
     g.run(
         "CREATE TABLE Item (
         field_one INT128,
-        field_two INT128,
+        field_two INT128
     );",
     )
     .await;

--- a/test-suite/src/data_type/int16.rs
+++ b/test-suite/src/data_type/int16.rs
@@ -9,7 +9,7 @@ test_case!(int16, {
     g.run(
         "CREATE TABLE Item (
         field_one INT16,
-        field_two INT16,
+        field_two INT16
     );",
     )
     .await;

--- a/test-suite/src/data_type/int32.rs
+++ b/test-suite/src/data_type/int32.rs
@@ -12,7 +12,7 @@ test_case!(int32, {
     g.run(
         "CREATE TABLE Item (
         field_one INT32,
-        field_two INT32,
+        field_two INT32
     );",
     )
     .await;

--- a/test-suite/src/data_type/int64.rs
+++ b/test-suite/src/data_type/int64.rs
@@ -15,7 +15,7 @@ test_case!(int64, {
     g.run(
         "CREATE TABLE Item (
         field_one INT,
-        field_two INT,
+        field_two INT
     );",
     )
     .await;

--- a/test-suite/src/data_type/int8.rs
+++ b/test-suite/src/data_type/int8.rs
@@ -9,7 +9,7 @@ test_case!(int8, {
     g.run(
         "CREATE TABLE Item (
         field_one INT8,
-        field_two INT8,
+        field_two INT8
     );",
     )
     .await;

--- a/test-suite/src/data_type/interval.rs
+++ b/test-suite/src/data_type/interval.rs
@@ -11,7 +11,7 @@ test_case!(interval, {
 CREATE TABLE IntervalLog (
     id INTEGER,
     interval1 INTERVAL,
-    interval2 INTERVAL,
+    interval2 INTERVAL
 )",
     )
     .await;

--- a/test-suite/src/data_type/time.rs
+++ b/test-suite/src/data_type/time.rs
@@ -15,7 +15,7 @@ test_case!(time, {
 CREATE TABLE TimeLog (
     id INTEGER,
     time1 TIME,
-    time2 TIME,
+    time2 TIME
 )"#,
     )
     .await;

--- a/test-suite/src/data_type/timestamp.rs
+++ b/test-suite/src/data_type/timestamp.rs
@@ -11,7 +11,7 @@ test_case!(timestamp, {
 CREATE TABLE TimestampLog (
     id INTEGER,
     t1 TIMESTAMP,
-    t2 TIMESTAMP,
+    t2 TIMESTAMP
 )",
     )
     .await;

--- a/test-suite/src/data_type/uint128.rs
+++ b/test-suite/src/data_type/uint128.rs
@@ -9,7 +9,7 @@ test_case!(uint128, {
     g.run(
         "CREATE TABLE Item (
             field_one UINT128,
-            field_two UINT128,
+            field_two UINT128
         );",
     )
     .await;

--- a/test-suite/src/data_type/uint16.rs
+++ b/test-suite/src/data_type/uint16.rs
@@ -9,7 +9,7 @@ test_case!(uint16, {
     g.run(
         "CREATE TABLE Item (
             field_one UINT16,
-            field_two UINT16,
+            field_two UINT16
         );",
     )
     .await;

--- a/test-suite/src/data_type/uint32.rs
+++ b/test-suite/src/data_type/uint32.rs
@@ -9,7 +9,7 @@ test_case!(uint32, {
     g.run(
         "CREATE TABLE Item (
             field_one UINT32,
-            field_two UINT32,
+            field_two UINT32
         );",
     )
     .await;

--- a/test-suite/src/data_type/uint64.rs
+++ b/test-suite/src/data_type/uint64.rs
@@ -9,7 +9,7 @@ test_case!(uint64, {
     g.run(
         "CREATE TABLE Item (
             field_one UINT64,
-            field_two UINT64,
+            field_two UINT64
         );",
     )
     .await;

--- a/test-suite/src/data_type/uint8.rs
+++ b/test-suite/src/data_type/uint8.rs
@@ -9,7 +9,7 @@ test_case!(uint8, {
     g.run(
         "CREATE TABLE Item (
             field_one UINT8,
-            field_two UINT8,
+            field_two UINT8
         );",
     )
     .await;

--- a/test-suite/src/foreign_key.rs
+++ b/test-suite/src/foreign_key.rs
@@ -17,7 +17,7 @@ test_case!(foreign_key, {
     g.run(
         "CREATE TABLE ReferencedTableWithoutPK (
             id INTEGER,
-            name TEXT,
+            name TEXT
         );",
     )
     .await;
@@ -40,7 +40,7 @@ test_case!(foreign_key, {
     g.run(
         "CREATE TABLE ReferencedTableWithUnique (
             id INTEGER UNIQUE,
-            name TEXT,
+            name TEXT
         );",
     )
     .await;
@@ -64,7 +64,7 @@ test_case!(foreign_key, {
     g.run(
         "CREATE TABLE ReferencedTableWithPK (
             id INTEGER PRIMARY KEY,
-            name TEXT,
+            name TEXT
         );",
     )
     .await;
@@ -232,7 +232,7 @@ test_case!(foreign_key, {
         "
         CREATE TABLE ReferencedTableWithPK_2 (
             id INTEGER PRIMARY KEY,
-            name TEXT,
+            name TEXT
         );",
     )
     .await;

--- a/test-suite/src/function/cast.rs
+++ b/test-suite/src/function/cast.rs
@@ -398,7 +398,7 @@ test_case!(cast_value, {
         CREATE TABLE IntervalLog (
         id INTEGER,
         interval_str_1 TEXT,
-        interval_str_2 TEXT,
+        interval_str_2 TEXT
     )",
             Ok(Payload::Create),
         ),

--- a/test-suite/src/function/concat.rs
+++ b/test-suite/src/function/concat.rs
@@ -13,7 +13,7 @@ test_case!(concat, {
             rate FLOAT,
             flag BOOLEAN,
             text TEXT,
-            null_value TEXT NULL,
+            null_value TEXT NULL
         );
     ",
     )

--- a/test-suite/src/function/concat_ws.rs
+++ b/test-suite/src/function/concat_ws.rs
@@ -22,7 +22,7 @@ test_case!(concat_ws, {
             id INTEGER,
             flag BOOLEAN,
             text TEXT,
-            null_value TEXT NULL,
+            null_value TEXT NULL
         );
     ",
     )

--- a/test-suite/src/function/initcap.rs
+++ b/test-suite/src/function/initcap.rs
@@ -12,7 +12,7 @@ test_case!(initcap, {
     let test_cases = [
         (
             "CREATE TABLE Item (
-                name TEXT DEFAULT 'abcd',
+                name TEXT DEFAULT 'abcd'
             )",
             Ok(Payload::Create),
         ),

--- a/test-suite/src/function/last_day.rs
+++ b/test-suite/src/function/last_day.rs
@@ -11,7 +11,7 @@ test_case!(last_day, {
         "CREATE TABLE LastDay (
             id INTEGER,
             date DATE,
-            timestamp TIMESTAMP,
+            timestamp TIMESTAMP
         );",
     )
     .await;

--- a/test-suite/src/index/order_by.rs
+++ b/test-suite/src/index/order_by.rs
@@ -8,7 +8,7 @@ test_case!(order_by, {
 CREATE TABLE Test (
     id INTEGER,
     num INTEGER NULL,
-    name TEXT,
+    name TEXT
 )",
     )
     .await;

--- a/test-suite/src/insert.rs
+++ b/test-suite/src/insert.rs
@@ -14,7 +14,7 @@ test_case!(insert, {
 CREATE TABLE Test (
     id INTEGER DEFAULT 1,
     num INTEGER NULL,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL
 );",
     )
     .await;

--- a/test-suite/src/join.rs
+++ b/test-suite/src/join.rs
@@ -21,7 +21,7 @@ test_case!(join, {
         CREATE TABLE Item (
             id INTEGER,
             quantity INTEGER,
-            player_id INTEGER,
+            player_id INTEGER
         );
     ",
     ];
@@ -164,7 +164,7 @@ test_case!(project, {
         CREATE TABLE Item (
             id INTEGER,
             quantity INTEGER,
-            player_id INTEGER,
+            player_id INTEGER
         );
     ",
     ];

--- a/test-suite/src/nested_select.rs
+++ b/test-suite/src/nested_select.rs
@@ -17,7 +17,7 @@ test_case!(nested_select, {
         CREATE TABLE Request (
             id INTEGER,
             quantity INTEGER,
-            user_id INTEGER,
+            user_id INTEGER
         );
     ",
     ];

--- a/test-suite/src/ordering.rs
+++ b/test-suite/src/ordering.rs
@@ -7,7 +7,7 @@ test_case!(ordering, {
         "
         CREATE TABLE Operator (
             id INTEGER,
-            name TEXT,
+            name TEXT
         );
     ",
     )

--- a/test-suite/src/primary_key.rs
+++ b/test-suite/src/primary_key.rs
@@ -14,7 +14,7 @@ test_case!(primary_key, {
         "
         CREATE TABLE Allegro (
             id INTEGER PRIMARY KEY,
-            name TEXT,
+            name TEXT
         );
     ",
     )

--- a/test-suite/src/project.rs
+++ b/test-suite/src/project.rs
@@ -20,7 +20,7 @@ test_case!(project, {
         CREATE TABLE ProjectItem (
             id INTEGER,
             player_id INTEGER,
-            quantity INTEGER,
+            quantity INTEGER
         );
     ",
     ];

--- a/test-suite/src/show_columns.rs
+++ b/test-suite/src/show_columns.rs
@@ -21,7 +21,7 @@ test_case!(show_columns, {
             tstamp Timestamp,
             uid    Uuid,
             hash   Map,
-            glist  List,
+            glist  List
         );
     ",
     )

--- a/test-suite/src/synthesize.rs
+++ b/test-suite/src/synthesize.rs
@@ -7,7 +7,7 @@ test_case!(synthesize, {
         CREATE TABLE TableA (
             id INTEGER,
             test INTEGER,
-            target_id INTEGER,
+            target_id INTEGER
         );
     ";
 

--- a/test-suite/src/update.rs
+++ b/test-suite/src/update.rs
@@ -16,7 +16,7 @@ test_case!(update, {
             id INTEGER,
             num INTEGER,
             num2 INTEGER,
-            name TEXT,
+            name TEXT
         )",
     )
     .await;
@@ -38,7 +38,7 @@ test_case!(update, {
         CREATE TABLE TableB (
             id INTEGER,
             num INTEGER,
-            rank INTEGER,
+            rank INTEGER
         )",
     )
     .await;
@@ -109,17 +109,17 @@ test_case!(update, {
     g.run("INSERT INTO ErrTestTable (id) VALUES (1),(9);").await;
 
     let error_cases = [
-        (
-            "UPDATE TableA INNER JOIN ErrTestTable ON 1 = 1 SET 1 = 1",
-            Err(TranslateError::JoinOnUpdateNotSupported.into()),
-        ),
-        (
-            "UPDATE (SELECT * FROM ErrTestTable) SET 1 = 1",
-            Err(
-                TranslateError::UnsupportedTableFactor("(SELECT * FROM ErrTestTable)".to_owned())
-                    .into(),
-            ),
-        ),
+        // (
+        //     "UPDATE TableA INNER JOIN ErrTestTable ON 1 = 1 SET 1 = 1",
+        //     Err(TranslateError::JoinOnUpdateNotSupported.into()),
+        // ),
+        // (
+        //     "UPDATE (SELECT * FROM ErrTestTable) SET 1 = 1",
+        //     Err(
+        //         TranslateError::UnsupportedTableFactor("(SELECT * FROM ErrTestTable)".to_owned())
+        //             .into(),
+        //     ),
+        // ),
         (
             "UPDATE ErrTestTable SET ErrTestTable.id = 1 WHERE id = 1",
             Err(TranslateError::CompoundIdentOnUpdateNotSupported(

--- a/test-suite/src/update.rs
+++ b/test-suite/src/update.rs
@@ -109,17 +109,17 @@ test_case!(update, {
     g.run("INSERT INTO ErrTestTable (id) VALUES (1),(9);").await;
 
     let error_cases = [
-        // (
-        //     "UPDATE TableA INNER JOIN ErrTestTable ON 1 = 1 SET 1 = 1",
-        //     Err(TranslateError::JoinOnUpdateNotSupported.into()),
-        // ),
-        // (
-        //     "UPDATE (SELECT * FROM ErrTestTable) SET 1 = 1",
-        //     Err(
-        //         TranslateError::UnsupportedTableFactor("(SELECT * FROM ErrTestTable)".to_owned())
-        //             .into(),
-        //     ),
-        // ),
+        (
+            "UPDATE TableA INNER JOIN ErrTestTable ON 1 = 1 SET id = 1",
+            Err(TranslateError::JoinOnUpdateNotSupported.into()),
+        ),
+        (
+            "UPDATE (SELECT * FROM ErrTestTable) SET id = 1",
+            Err(
+                TranslateError::UnsupportedTableFactor("(SELECT * FROM ErrTestTable)".to_owned())
+                    .into(),
+            ),
+        ),
         (
             "UPDATE ErrTestTable SET ErrTestTable.id = 1 WHERE id = 1",
             Err(TranslateError::CompoundIdentOnUpdateNotSupported(


### PR DESCRIPTION
Most of the files updated are solely relative to the trailing commas present in many tests, which are not valid SQL syntax and as such, the SQL parser was not failing to process those.