### PR TITLE
Introduced the Nullable enum and propagated Null evaluation

### DIFF
--- a/core/src/data/mod.rs
+++ b/core/src/data/mod.rs
@@ -3,6 +3,7 @@ mod function;
 mod interval;
 mod key;
 mod literal;
+mod nullable;
 mod point;
 mod row;
 mod string_ext;
@@ -17,6 +18,7 @@ pub use {
     interval::{Interval, IntervalError},
     key::{Key, KeyError},
     literal::{Literal, LiteralError},
+    nullable::Nullable,
     point::Point,
     row::{Row, RowError},
     schema::{Schema, SchemaIndex, SchemaIndexOrd, SchemaParseError},

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -67,15 +67,3 @@ impl<T: Not<Output = T>> Not for Nullable<T> {
         }
     }
 }
-
-impl<T: BitOr<Output = T>> BitOr for Nullable<T> {
-    type Output = Self;
-
-    /// Bitwise ORs two nullable values, returning NULL if either value is NULL.
-    fn bitor(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs | rhs),
-        }
-    }
-}

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -1,6 +1,9 @@
 //! Submodule providing the `Nullable` enum and associated traits.
 
 use core::ops::{Add, Div, Mul, Not, Sub};
+use std::ops::{
+    AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, DivAssign, MulAssign, SubAssign,
+};
 
 #[derive(Debug, Clone, Copy, Hash)]
 /// Enum representing a nullable value.
@@ -8,18 +11,18 @@ use core::ops::{Add, Div, Mul, Not, Sub};
 /// # Implementations details
 /// This enum differs from the `Option` enum in that it does not represent
 /// a `Option::None` value, but rather a `Nullable::Null` SQL `NULL` value.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use gluesql_core::data::Nullable;
-/// 
+///
 /// let null: Nullable<i32> = Nullable::Null;
-/// 
+///
 /// assert!(null.is_null());
 /// assert!(!null.is_entry());
 /// ```
-/// 
+///
 pub enum Nullable<T> {
     /// Represents an SQL `NULL` value.
     Null,
@@ -29,19 +32,19 @@ pub enum Nullable<T> {
 
 impl<T> Nullable<T> {
     /// Returns `true` if the value is `Nullable::Null`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// assert!(null.is_null());
     /// assert!(!null.is_entry());
-    /// 
+    ///
     /// let entry: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert!(!entry.is_null());
     /// assert!(entry.is_entry());
     /// ```
@@ -50,19 +53,19 @@ impl<T> Nullable<T> {
     }
 
     /// Returns `true` if the value is `Nullable::Entry`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// assert!(null.is_null());
     /// assert!(!null.is_entry());
-    /// 
+    ///
     /// let entry: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert!(!entry.is_null());
     /// assert!(entry.is_entry());
     /// ```
@@ -71,18 +74,18 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// assert_eq!(null.as_entry(), None);
-    /// 
+    ///
     /// let entry: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert_eq!(entry.as_entry(), Some(&10));
     /// ```
     pub fn as_entry(&self) -> Option<&T> {
@@ -93,18 +96,18 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
-    /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
+    /// let mut null: Nullable<i32> = Nullable::Null;
+    ///
     /// assert_eq!(null.as_entry_mut(), None);
-    /// 
+    ///
     /// let mut entry: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert_eq!(entry.as_entry_mut(), Some(&mut 10));
     /// ```
     pub fn as_entry_mut(&mut self) -> Option<&mut T> {
@@ -115,18 +118,18 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// assert_eq!(null.into_entry(), None);
-    /// 
+    ///
     /// let entry: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert_eq!(entry.into_entry(), Some(10));
     /// ```
     pub fn into_entry(self) -> Option<T> {
@@ -134,18 +137,18 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise returns `default`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// assert_eq!(null.unwrap_or(10), 10);
-    /// 
+    ///
     /// let entry: Nullable<i32> = 20.into();
-    /// 
+    ///
     /// assert_eq!(entry.unwrap_or(10), 20);
     /// ```
     pub fn unwrap_or(self, default: T) -> T {
@@ -156,25 +159,25 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise panics.
-    /// 
+    ///
     /// # Panics
     /// * If the value is `Nullable::Null`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let entry: Nullable<i32> = 20.into();
-    /// 
+    ///
     /// assert_eq!(entry.unwrap(), 20);
     /// ```
-    /// 
+    ///
     /// ```should_panic
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// null.unwrap();
     /// ```
     pub fn unwrap(self) -> T {
@@ -182,25 +185,25 @@ impl<T> Nullable<T> {
     }
 
     /// Returns the value if it is `Nullable::Entry`, otherwise panics with the provided message.
-    /// 
+    ///
     /// # Panics
     /// * If the value is `Nullable::Null`.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let entry: Nullable<i32> = 20.into();
-    /// 
+    ///
     /// assert_eq!(entry.expect("value is not null"), 20);
     /// ```
-    /// 
+    ///
     /// ```should_panic
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let null: Nullable<i32> = Nullable::Null;
-    /// 
+    ///
     /// null.expect("value is not null");
     /// ```
     pub fn expect(self, message: &str) -> T {
@@ -238,6 +241,23 @@ impl<T> From<Nullable<T>> for Option<T> {
 impl<T: Not<Output = T>> Not for Nullable<T> {
     type Output = Self;
 
+    /// Negates a nullable value, returning NULL if the value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let null: Nullable<bool> = Nullable::Null;
+    ///
+    /// assert!(null.is_null());
+    /// assert!((!null).is_null());
+    ///
+    /// let entry: Nullable<bool> = true.into();
+    ///
+    /// assert_eq!((entry).unwrap(), true);
+    /// assert_eq!((!entry).unwrap(), false);
+    /// ```
     fn not(self) -> Self::Output {
         match self {
             Nullable::Null => Nullable::Null,
@@ -250,20 +270,20 @@ impl<T: Add<Output = T>> Add for Nullable<T> {
     type Output = Self;
 
     /// Adds two nullable values, returning NULL if either value is NULL.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let lhs: Nullable<i32> = Nullable::Null;
     /// let rhs: Nullable<i32> = 10.into();
-    /// 
+    ///
     /// assert!((lhs + rhs).is_null());
     /// assert!((rhs + lhs).is_null());
-    /// 
+    ///
     /// let lhs: Nullable<i32> = 20.into();
-    /// 
+    ///
     /// assert_eq!((lhs + rhs).unwrap(), 30);
     /// ```
     fn add(self, rhs: Self) -> Self::Output {
@@ -274,28 +294,54 @@ impl<T: Add<Output = T>> Add for Nullable<T> {
     }
 }
 
+impl<T: Add<Output = T> + Copy> AddAssign for Nullable<T> {
+    /// Adds two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// lhs += rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<i32> = 20.into();
+    ///
+    /// lhs += rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), 30);
+    /// ```
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
 impl<T: Sub<Output = T>> Sub for Nullable<T> {
     type Output = Self;
 
     /// Subtracts two nullable values, returning NULL if either value is NULL.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let lhs: Nullable<i32> = Nullable::Null;
     /// let rhs: Nullable<i32> = 10.into();
-    /// 
-    /// assert_eq!((lhs - rhs).is_null());
-    /// assert_eq!((rhs - lhs).is_null());
-    /// 
+    ///
+    /// assert!((lhs - rhs).is_null());
+    /// assert!((rhs - lhs).is_null());
+    ///
     /// let lhs: Nullable<i32> = 20.into();
-    /// 
-    /// assert!((lhs - rhs).unwrap(), 10);
-    /// assert!((rhs - lhs).unwrap(), -10);
+    ///
+    /// assert_eq!((lhs - rhs).unwrap(), 10);
+    /// assert_eq!((rhs - lhs).unwrap(), -10);
     /// ```
-    /// 
+    ///
     fn sub(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
@@ -304,27 +350,53 @@ impl<T: Sub<Output = T>> Sub for Nullable<T> {
     }
 }
 
+impl<T: Sub<Output = T> + Copy> SubAssign for Nullable<T> {
+    /// Subtracts two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// lhs -= rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<i32> = 20.into();
+    ///
+    /// lhs -= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), 10);
+    /// ```
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
 impl<T: Mul<Output = T>> Mul for Nullable<T> {
     type Output = Self;
 
     /// Multiplies two nullable values, returning NULL if either value is NULL.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let lhs: Nullable<i32> = Nullable::Null;
     /// let rhs: Nullable<i32> = 10.into();
-    /// 
-    /// assert_eq!((lhs * rhs).is_null());
-    /// assert_eq!((rhs * lhs).is_null());
-    /// 
+    ///
+    /// assert!((lhs * rhs).is_null());
+    /// assert!((rhs * lhs).is_null());
+    ///
     /// let lhs: Nullable<i32> = 20.into();
-    /// 
-    /// assert!((lhs * rhs).unwrap(), 200);
+    ///
+    /// assert_eq!((lhs * rhs).unwrap(), 200);
     /// ```
-    /// 
+    ///
     fn mul(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
@@ -333,31 +405,218 @@ impl<T: Mul<Output = T>> Mul for Nullable<T> {
     }
 }
 
+impl<T: Mul<Output = T> + Copy> MulAssign for Nullable<T> {
+    /// Multiplies two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// lhs *= rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<i32> = 20.into();
+    ///
+    /// lhs *= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), 200);
+    /// ```
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
 impl<T: Div<Output = T>> Div for Nullable<T> {
     type Output = Self;
 
     /// Divides two nullable values, returning NULL if either value is NULL.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use gluesql_core::data::Nullable;
-    /// 
+    ///
     /// let lhs: Nullable<i32> = Nullable::Null;
     /// let rhs: Nullable<i32> = 10.into();
-    /// 
-    /// assert_eq!((lhs / rhs).is_null());
-    /// assert_eq!((rhs / lhs).is_null());
-    /// 
+    ///
+    /// assert!((lhs / rhs).is_null());
+    /// assert!((rhs / lhs).is_null());
+    ///
     /// let lhs: Nullable<i32> = 20.into();
-    /// 
-    /// assert!((lhs / rhs).unwrap(), 2);
+    ///
+    /// assert_eq!((lhs / rhs).unwrap(), 2);
     /// ```
-    /// 
+    ///
     fn div(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
             (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs / rhs),
         }
+    }
+}
+
+impl<T: Div<Output = T> + Copy> DivAssign for Nullable<T> {
+    /// Divides two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// lhs /= rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<i32> = 20.into();
+    ///
+    /// lhs /= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), 2);
+    /// ```
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl<T: BitOr<Output = T>> BitOr for Nullable<T> {
+    type Output = Self;
+
+    /// Bitwise ORs two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// assert!((lhs | rhs).is_null());
+    /// assert!((rhs | lhs).is_null());
+    ///
+    /// let lhs: Nullable<i32> = 20.into();
+    ///
+    /// assert_eq!((lhs | rhs).unwrap(), 30);
+    /// ```
+    ///
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs | rhs),
+        }
+    }
+}
+
+impl<T: BitOr<Output = T> + Copy> BitOrAssign for Nullable<T> {
+    /// Bitwise ORs two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<bool> = Nullable::Null;
+    ///
+    /// let rhs: Nullable<bool> = true.into();
+    ///
+    /// lhs |= rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<bool> = true.into();
+    ///
+    /// lhs |= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), true);
+    ///
+    /// let mut lhs: Nullable<bool> = false.into();
+    ///
+    /// assert_eq!(lhs.unwrap(), false);
+    ///
+    /// lhs |= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), true);
+    /// ```
+    ///
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
+    }
+}
+
+impl<T: BitAnd<Output = T>> BitAnd for Nullable<T> {
+    type Output = Self;
+
+    /// Bitwise ANDs two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    ///
+    /// assert!((lhs & rhs).is_null());
+    /// assert!((rhs & lhs).is_null());
+    ///
+    /// let lhs: Nullable<i32> = 20.into();
+    ///
+    /// assert_eq!((lhs & rhs).unwrap(), 0);
+    /// ```
+    ///
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs & rhs),
+        }
+    }
+}
+
+impl<T: BitAnd<Output = T> + Copy> BitAndAssign for Nullable<T> {
+    /// Bitwise ANDs two nullable values, returning NULL if either value is NULL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    ///
+    /// let mut lhs: Nullable<bool> = Nullable::Null;
+    ///
+    /// let rhs: Nullable<bool> = true.into();
+    ///
+    /// lhs &= rhs;
+    ///
+    /// assert!(lhs.is_null());
+    ///
+    /// let mut lhs: Nullable<bool> = true.into();
+    ///
+    /// lhs &= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), true);
+    ///
+    /// let mut lhs: Nullable<bool> = false.into();
+    ///
+    /// assert_eq!(lhs.unwrap(), false);
+    ///
+    /// lhs &= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), false);
+    ///
+    /// let mut lhs: Nullable<bool> = false.into();
+    ///
+    /// lhs &= rhs;
+    ///
+    /// assert_eq!(lhs.unwrap(), false);
+    /// ```
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = *self & rhs;
     }
 }

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -1,12 +1,363 @@
 //! Submodule providing the `Nullable` enum and associated traits.
 
+use core::ops::{Add, Div, Mul, Not, Sub};
+
 #[derive(Debug, Clone, Copy, Hash)]
 /// Enum representing a nullable value.
 ///
 /// # Implementations details
 /// This enum differs from the `Option` enum in that it does not represent
 /// a `Option::None` value, but rather a `Nullable::Null` SQL `NULL` value.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use gluesql_core::data::Nullable;
+/// 
+/// let null: Nullable<i32> = Nullable::Null;
+/// 
+/// assert!(null.is_null());
+/// assert!(!null.is_entry());
+/// ```
+/// 
 pub enum Nullable<T> {
+    /// Represents an SQL `NULL` value.
     Null,
+    /// Represents a non-`NULL` value.
     Entry(T),
+}
+
+impl<T> Nullable<T> {
+    /// Returns `true` if the value is `Nullable::Null`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert!(null.is_null());
+    /// assert!(!null.is_entry());
+    /// 
+    /// let entry: Nullable<i32> = 10.into();
+    /// 
+    /// assert!(!entry.is_null());
+    /// assert!(entry.is_entry());
+    /// ```
+    pub fn is_null(&self) -> bool {
+        matches!(self, Nullable::Null)
+    }
+
+    /// Returns `true` if the value is `Nullable::Entry`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert!(null.is_null());
+    /// assert!(!null.is_entry());
+    /// 
+    /// let entry: Nullable<i32> = 10.into();
+    /// 
+    /// assert!(!entry.is_null());
+    /// assert!(entry.is_entry());
+    /// ```
+    pub fn is_entry(&self) -> bool {
+        matches!(self, Nullable::Entry(_))
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert_eq!(null.as_entry(), None);
+    /// 
+    /// let entry: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!(entry.as_entry(), Some(&10));
+    /// ```
+    pub fn as_entry(&self) -> Option<&T> {
+        match self {
+            Nullable::Null => None,
+            Nullable::Entry(value) => Some(value),
+        }
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert_eq!(null.as_entry_mut(), None);
+    /// 
+    /// let mut entry: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!(entry.as_entry_mut(), Some(&mut 10));
+    /// ```
+    pub fn as_entry_mut(&mut self) -> Option<&mut T> {
+        match self {
+            Nullable::Null => None,
+            Nullable::Entry(value) => Some(value),
+        }
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert_eq!(null.into_entry(), None);
+    /// 
+    /// let entry: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!(entry.into_entry(), Some(10));
+    /// ```
+    pub fn into_entry(self) -> Option<T> {
+        self.into()
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise returns `default`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// assert_eq!(null.unwrap_or(10), 10);
+    /// 
+    /// let entry: Nullable<i32> = 20.into();
+    /// 
+    /// assert_eq!(entry.unwrap_or(10), 20);
+    /// ```
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Nullable::Null => default,
+            Nullable::Entry(value) => value,
+        }
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise panics.
+    /// 
+    /// # Panics
+    /// * If the value is `Nullable::Null`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let entry: Nullable<i32> = 20.into();
+    /// 
+    /// assert_eq!(entry.unwrap(), 20);
+    /// ```
+    /// 
+    /// ```should_panic
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// null.unwrap();
+    /// ```
+    pub fn unwrap(self) -> T {
+        self.expect("called `Nullable::unwrap()` on a `Nullable::Null` value")
+    }
+
+    /// Returns the value if it is `Nullable::Entry`, otherwise panics with the provided message.
+    /// 
+    /// # Panics
+    /// * If the value is `Nullable::Null`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let entry: Nullable<i32> = 20.into();
+    /// 
+    /// assert_eq!(entry.expect("value is not null"), 20);
+    /// ```
+    /// 
+    /// ```should_panic
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let null: Nullable<i32> = Nullable::Null;
+    /// 
+    /// null.expect("value is not null");
+    /// ```
+    pub fn expect(self, message: &str) -> T {
+        match self {
+            Nullable::Null => panic!("{}", message),
+            Nullable::Entry(value) => value,
+        }
+    }
+}
+
+impl<T> From<T> for Nullable<T> {
+    fn from(value: T) -> Self {
+        Nullable::Entry(value)
+    }
+}
+
+impl<T> From<Option<T>> for Nullable<T> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(value) => Nullable::Entry(value),
+            None => Nullable::Null,
+        }
+    }
+}
+
+impl<T> From<Nullable<T>> for Option<T> {
+    fn from(value: Nullable<T>) -> Self {
+        match value {
+            Nullable::Null => None,
+            Nullable::Entry(value) => Some(value),
+        }
+    }
+}
+
+impl<T: Not<Output = T>> Not for Nullable<T> {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Nullable::Null => Nullable::Null,
+            Nullable::Entry(value) => Nullable::Entry(!value),
+        }
+    }
+}
+
+impl<T: Add<Output = T>> Add for Nullable<T> {
+    type Output = Self;
+
+    /// Adds two nullable values, returning NULL if either value is NULL.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    /// 
+    /// assert!((lhs + rhs).is_null());
+    /// assert!((rhs + lhs).is_null());
+    /// 
+    /// let lhs: Nullable<i32> = 20.into();
+    /// 
+    /// assert_eq!((lhs + rhs).unwrap(), 30);
+    /// ```
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs + rhs),
+        }
+    }
+}
+
+impl<T: Sub<Output = T>> Sub for Nullable<T> {
+    type Output = Self;
+
+    /// Subtracts two nullable values, returning NULL if either value is NULL.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!((lhs - rhs).is_null());
+    /// assert_eq!((rhs - lhs).is_null());
+    /// 
+    /// let lhs: Nullable<i32> = 20.into();
+    /// 
+    /// assert!((lhs - rhs).unwrap(), 10);
+    /// assert!((rhs - lhs).unwrap(), -10);
+    /// ```
+    /// 
+    fn sub(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs - rhs),
+        }
+    }
+}
+
+impl<T: Mul<Output = T>> Mul for Nullable<T> {
+    type Output = Self;
+
+    /// Multiplies two nullable values, returning NULL if either value is NULL.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!((lhs * rhs).is_null());
+    /// assert_eq!((rhs * lhs).is_null());
+    /// 
+    /// let lhs: Nullable<i32> = 20.into();
+    /// 
+    /// assert!((lhs * rhs).unwrap(), 200);
+    /// ```
+    /// 
+    fn mul(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs * rhs),
+        }
+    }
+}
+
+impl<T: Div<Output = T>> Div for Nullable<T> {
+    type Output = Self;
+
+    /// Divides two nullable values, returning NULL if either value is NULL.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use gluesql_core::data::Nullable;
+    /// 
+    /// let lhs: Nullable<i32> = Nullable::Null;
+    /// let rhs: Nullable<i32> = 10.into();
+    /// 
+    /// assert_eq!((lhs / rhs).is_null());
+    /// assert_eq!((rhs / lhs).is_null());
+    /// 
+    /// let lhs: Nullable<i32> = 20.into();
+    /// 
+    /// assert!((lhs / rhs).unwrap(), 2);
+    /// ```
+    /// 
+    fn div(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
+            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs / rhs),
+        }
+    }
 }

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -1,7 +1,6 @@
 //! Submodule providing the `Nullable` enum and associated traits.
 
 use core::ops::Not;
-use std::ops::BitOr;
 
 #[derive(Debug, Clone, Copy, Hash)]
 /// Enum representing a nullable value.

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -1,9 +1,7 @@
 //! Submodule providing the `Nullable` enum and associated traits.
 
-use core::ops::{Add, Div, Mul, Not, Sub};
-use std::ops::{
-    AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, DivAssign, MulAssign, SubAssign,
-};
+use core::ops::Not;
+use std::ops::BitOr;
 
 #[derive(Debug, Clone, Copy, Hash)]
 /// Enum representing a nullable value.
@@ -20,7 +18,10 @@ use std::ops::{
 /// let null: Nullable<i32> = Nullable::Null;
 ///
 /// assert!(null.is_null());
-/// assert!(!null.is_entry());
+///
+/// let entry: Nullable<i32> = 10.into();
+///
+/// assert!(!entry.is_null());
 /// ```
 ///
 pub enum Nullable<T> {
@@ -41,174 +42,20 @@ impl<T> Nullable<T> {
     /// let null: Nullable<i32> = Nullable::Null;
     ///
     /// assert!(null.is_null());
-    /// assert!(!null.is_entry());
     ///
     /// let entry: Nullable<i32> = 10.into();
     ///
     /// assert!(!entry.is_null());
-    /// assert!(entry.is_entry());
     /// ```
     pub fn is_null(&self) -> bool {
         matches!(self, Nullable::Null)
     }
 
-    /// Returns `true` if the value is `Nullable::Entry`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert!(null.is_null());
-    /// assert!(!null.is_entry());
-    ///
-    /// let entry: Nullable<i32> = 10.into();
-    ///
-    /// assert!(!entry.is_null());
-    /// assert!(entry.is_entry());
-    /// ```
-    pub fn is_entry(&self) -> bool {
-        matches!(self, Nullable::Entry(_))
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert_eq!(null.as_entry(), None);
-    ///
-    /// let entry: Nullable<i32> = 10.into();
-    ///
-    /// assert_eq!(entry.as_entry(), Some(&10));
-    /// ```
-    pub fn as_entry(&self) -> Option<&T> {
-        match self {
-            Nullable::Null => None,
-            Nullable::Entry(value) => Some(value),
-        }
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert_eq!(null.as_entry_mut(), None);
-    ///
-    /// let mut entry: Nullable<i32> = 10.into();
-    ///
-    /// assert_eq!(entry.as_entry_mut(), Some(&mut 10));
-    /// ```
-    pub fn as_entry_mut(&mut self) -> Option<&mut T> {
-        match self {
-            Nullable::Null => None,
-            Nullable::Entry(value) => Some(value),
-        }
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise returns `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert_eq!(null.into_entry(), None);
-    ///
-    /// let entry: Nullable<i32> = 10.into();
-    ///
-    /// assert_eq!(entry.into_entry(), Some(10));
-    /// ```
-    pub fn into_entry(self) -> Option<T> {
-        self.into()
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise returns `default`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert_eq!(null.unwrap_or(10), 10);
-    ///
-    /// let entry: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!(entry.unwrap_or(10), 20);
-    /// ```
-    pub fn unwrap_or(self, default: T) -> T {
-        match self {
-            Nullable::Null => default,
-            Nullable::Entry(value) => value,
-        }
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise panics.
-    ///
-    /// # Panics
-    /// * If the value is `Nullable::Null`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let entry: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!(entry.unwrap(), 20);
-    /// ```
-    ///
-    /// ```should_panic
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// null.unwrap();
-    /// ```
+    #[cfg(test)]
+    /// Returns the value if it is an `Entry`, otherwise panics.
     pub fn unwrap(self) -> T {
-        self.expect("called `Nullable::unwrap()` on a `Nullable::Null` value")
-    }
-
-    /// Returns the value if it is `Nullable::Entry`, otherwise panics with the provided message.
-    ///
-    /// # Panics
-    /// * If the value is `Nullable::Null`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let entry: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!(entry.expect("value is not null"), 20);
-    /// ```
-    ///
-    /// ```should_panic
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// null.expect("value is not null");
-    /// ```
-    pub fn expect(self, message: &str) -> T {
         match self {
-            Nullable::Null => panic!("{}", message),
+            Nullable::Null => panic!("called `Nullable::unwrap()` on a `Null` value"),
             Nullable::Entry(value) => value,
         }
     }
@@ -220,269 +67,15 @@ impl<T> From<T> for Nullable<T> {
     }
 }
 
-impl<T> From<Option<T>> for Nullable<T> {
-    fn from(value: Option<T>) -> Self {
-        match value {
-            Some(value) => Nullable::Entry(value),
-            None => Nullable::Null,
-        }
-    }
-}
-
-impl<T> From<Nullable<T>> for Option<T> {
-    fn from(value: Nullable<T>) -> Self {
-        match value {
-            Nullable::Null => None,
-            Nullable::Entry(value) => Some(value),
-        }
-    }
-}
-
 impl<T: Not<Output = T>> Not for Nullable<T> {
     type Output = Self;
 
     /// Negates a nullable value, returning NULL if the value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<bool> = Nullable::Null;
-    ///
-    /// assert!(null.is_null());
-    /// assert!((!null).is_null());
-    ///
-    /// let entry: Nullable<bool> = true.into();
-    ///
-    /// assert_eq!((entry).unwrap(), true);
-    /// assert_eq!((!entry).unwrap(), false);
-    /// ```
     fn not(self) -> Self::Output {
         match self {
             Nullable::Null => Nullable::Null,
             Nullable::Entry(value) => Nullable::Entry(!value),
         }
-    }
-}
-
-impl<T: Add<Output = T>> Add for Nullable<T> {
-    type Output = Self;
-
-    /// Adds two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs + rhs).is_null());
-    /// assert!((rhs + lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!((lhs + rhs).unwrap(), 30);
-    /// ```
-    fn add(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs + rhs),
-        }
-    }
-}
-
-impl<T: Add<Output = T> + Copy> AddAssign for Nullable<T> {
-    /// Adds two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// lhs += rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<i32> = 20.into();
-    ///
-    /// lhs += rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), 30);
-    /// ```
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-impl<T: Sub<Output = T>> Sub for Nullable<T> {
-    type Output = Self;
-
-    /// Subtracts two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs - rhs).is_null());
-    /// assert!((rhs - lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!((lhs - rhs).unwrap(), 10);
-    /// assert_eq!((rhs - lhs).unwrap(), -10);
-    /// ```
-    ///
-    fn sub(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs - rhs),
-        }
-    }
-}
-
-impl<T: Sub<Output = T> + Copy> SubAssign for Nullable<T> {
-    /// Subtracts two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// lhs -= rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<i32> = 20.into();
-    ///
-    /// lhs -= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), 10);
-    /// ```
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-impl<T: Mul<Output = T>> Mul for Nullable<T> {
-    type Output = Self;
-
-    /// Multiplies two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs * rhs).is_null());
-    /// assert!((rhs * lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!((lhs * rhs).unwrap(), 200);
-    /// ```
-    ///
-    fn mul(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs * rhs),
-        }
-    }
-}
-
-impl<T: Mul<Output = T> + Copy> MulAssign for Nullable<T> {
-    /// Multiplies two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// lhs *= rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<i32> = 20.into();
-    ///
-    /// lhs *= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), 200);
-    /// ```
-    fn mul_assign(&mut self, rhs: Self) {
-        *self = *self * rhs;
-    }
-}
-
-impl<T: Div<Output = T>> Div for Nullable<T> {
-    type Output = Self;
-
-    /// Divides two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs / rhs).is_null());
-    /// assert!((rhs / lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!((lhs / rhs).unwrap(), 2);
-    /// ```
-    ///
-    fn div(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs / rhs),
-        }
-    }
-}
-
-impl<T: Div<Output = T> + Copy> DivAssign for Nullable<T> {
-    /// Divides two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// lhs /= rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<i32> = 20.into();
-    ///
-    /// lhs /= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), 2);
-    /// ```
-    fn div_assign(&mut self, rhs: Self) {
-        *self = *self / rhs;
     }
 }
 
@@ -504,7 +97,7 @@ impl<T: BitOr<Output = T>> BitOr for Nullable<T> {
     ///
     /// let lhs: Nullable<i32> = 20.into();
     ///
-    /// assert_eq!((lhs | rhs).unwrap(), 30);
+    /// assert!(!(lhs | rhs).is_null());
     /// ```
     ///
     fn bitor(self, rhs: Self) -> Self::Output {
@@ -512,111 +105,5 @@ impl<T: BitOr<Output = T>> BitOr for Nullable<T> {
             (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
             (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs | rhs),
         }
-    }
-}
-
-impl<T: BitOr<Output = T> + Copy> BitOrAssign for Nullable<T> {
-    /// Bitwise ORs two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<bool> = Nullable::Null;
-    ///
-    /// let rhs: Nullable<bool> = true.into();
-    ///
-    /// lhs |= rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<bool> = true.into();
-    ///
-    /// lhs |= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), true);
-    ///
-    /// let mut lhs: Nullable<bool> = false.into();
-    ///
-    /// assert_eq!(lhs.unwrap(), false);
-    ///
-    /// lhs |= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), true);
-    /// ```
-    ///
-    fn bitor_assign(&mut self, rhs: Self) {
-        *self = *self | rhs;
-    }
-}
-
-impl<T: BitAnd<Output = T>> BitAnd for Nullable<T> {
-    type Output = Self;
-
-    /// Bitwise ANDs two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs & rhs).is_null());
-    /// assert!((rhs & lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert_eq!((lhs & rhs).unwrap(), 0);
-    /// ```
-    ///
-    fn bitand(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,
-            (Nullable::Entry(lhs), Nullable::Entry(rhs)) => Nullable::Entry(lhs & rhs),
-        }
-    }
-}
-
-impl<T: BitAnd<Output = T> + Copy> BitAndAssign for Nullable<T> {
-    /// Bitwise ANDs two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let mut lhs: Nullable<bool> = Nullable::Null;
-    ///
-    /// let rhs: Nullable<bool> = true.into();
-    ///
-    /// lhs &= rhs;
-    ///
-    /// assert!(lhs.is_null());
-    ///
-    /// let mut lhs: Nullable<bool> = true.into();
-    ///
-    /// lhs &= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), true);
-    ///
-    /// let mut lhs: Nullable<bool> = false.into();
-    ///
-    /// assert_eq!(lhs.unwrap(), false);
-    ///
-    /// lhs &= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), false);
-    ///
-    /// let mut lhs: Nullable<bool> = false.into();
-    ///
-    /// lhs &= rhs;
-    ///
-    /// assert_eq!(lhs.unwrap(), false);
-    /// ```
-    fn bitand_assign(&mut self, rhs: Self) {
-        *self = *self & rhs;
     }
 }

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -1,0 +1,12 @@
+//! Submodule providing the `Nullable` enum and associated traits.
+
+#[derive(Debug, Clone, Copy, Hash)]
+/// Enum representing a nullable value.
+///
+/// # Implementations details
+/// This enum differs from the `Option` enum in that it does not represent
+/// a `Option::None` value, but rather a `Nullable::Null` SQL `NULL` value.
+pub enum Nullable<T> {
+    Null,
+    Entry(T),
+}

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -16,6 +16,24 @@ pub enum Nullable<T> {
     Entry(T),
 }
 
+impl<T> Nullable<T> {
+    /// When the value is non-null, maps it to another nullable value.
+    pub(crate) fn then<U, F: FnOnce(T) -> Nullable<U>>(self, f: F) -> Nullable<U> {
+        match self {
+            Nullable::Null => Nullable::Null,
+            Nullable::Entry(value) => f(value),
+        }
+    }
+
+    /// Maps a nullable value to another nullable value, providing a default value if the value is `NULL`.
+    pub(crate) fn map_or<U, F: FnOnce(T) -> U>(self, default: U, f: F) -> U {
+        match self {
+            Nullable::Null => default,
+            Nullable::Entry(value) => f(value),
+        }
+    }
+}
+
 #[cfg(test)]
 impl<T> Nullable<T> {
     /// Returns `true` if the value is `Nullable::Null`.

--- a/core/src/data/nullable.rs
+++ b/core/src/data/nullable.rs
@@ -9,21 +9,6 @@ use std::ops::BitOr;
 /// # Implementations details
 /// This enum differs from the `Option` enum in that it does not represent
 /// a `Option::None` value, but rather a `Nullable::Null` SQL `NULL` value.
-///
-/// # Examples
-///
-/// ```
-/// use gluesql_core::data::Nullable;
-///
-/// let null: Nullable<i32> = Nullable::Null;
-///
-/// assert!(null.is_null());
-///
-/// let entry: Nullable<i32> = 10.into();
-///
-/// assert!(!entry.is_null());
-/// ```
-///
 pub enum Nullable<T> {
     /// Represents an SQL `NULL` value.
     Null,
@@ -31,29 +16,15 @@ pub enum Nullable<T> {
     Entry(T),
 }
 
+#[cfg(test)]
 impl<T> Nullable<T> {
     /// Returns `true` if the value is `Nullable::Null`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let null: Nullable<i32> = Nullable::Null;
-    ///
-    /// assert!(null.is_null());
-    ///
-    /// let entry: Nullable<i32> = 10.into();
-    ///
-    /// assert!(!entry.is_null());
-    /// ```
-    pub fn is_null(&self) -> bool {
+    pub(crate) fn is_null(&self) -> bool {
         matches!(self, Nullable::Null)
     }
 
-    #[cfg(test)]
     /// Returns the value if it is an `Entry`, otherwise panics.
-    pub fn unwrap(self) -> T {
+    pub(crate) fn unwrap(self) -> T {
         match self {
             Nullable::Null => panic!("called `Nullable::unwrap()` on a `Null` value"),
             Nullable::Entry(value) => value,
@@ -83,23 +54,6 @@ impl<T: BitOr<Output = T>> BitOr for Nullable<T> {
     type Output = Self;
 
     /// Bitwise ORs two nullable values, returning NULL if either value is NULL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gluesql_core::data::Nullable;
-    ///
-    /// let lhs: Nullable<i32> = Nullable::Null;
-    /// let rhs: Nullable<i32> = 10.into();
-    ///
-    /// assert!((lhs | rhs).is_null());
-    /// assert!((rhs | lhs).is_null());
-    ///
-    /// let lhs: Nullable<i32> = 20.into();
-    ///
-    /// assert!(!(lhs | rhs).is_null());
-    /// ```
-    ///
     fn bitor(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             (Nullable::Null, _) | (_, Nullable::Null) => Nullable::Null,

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -276,33 +276,41 @@ mod tests {
         assert!(Value::try_from(JsonValue::Null).unwrap().is_null());
         assert!(Value::try_from(JsonValue::Bool(false))
             .unwrap()
-            .evaluate_eq(&Value::Bool(false)));
+            .evaluate_eq(&Value::Bool(false))
+            .unwrap());
         assert!(Value::try_from(JsonValue::Number(54321.into()))
             .unwrap()
-            .evaluate_eq(&Value::I32(54321)));
+            .evaluate_eq(&Value::I32(54321))
+            .unwrap());
         assert!(Value::try_from(JsonValue::Number(54321.into()))
             .unwrap()
-            .evaluate_eq(&Value::I64(54321)));
+            .evaluate_eq(&Value::I64(54321))
+            .unwrap());
         assert!(Value::try_from(JsonValue::Number(54321.into()))
             .unwrap()
-            .evaluate_eq(&Value::I128(54321)));
+            .evaluate_eq(&Value::I128(54321))
+            .unwrap());
         assert!(
             Value::try_from(JsonValue::Number(JsonNumber::from_f64(3.21).unwrap()))
                 .unwrap()
                 .evaluate_eq(&Value::F64(3.21))
+                .unwrap()
         );
         assert!(Value::try_from(JsonValue::String("world".to_owned()))
             .unwrap()
-            .evaluate_eq(&Value::Str("world".to_owned())));
+            .evaluate_eq(&Value::Str("world".to_owned()))
+            .unwrap());
         assert!(
             Value::try_from(JsonValue::Array(vec![JsonValue::Bool(true)]))
                 .unwrap()
                 .evaluate_eq(&Value::List(vec![Value::Bool(true)]))
+                .unwrap()
         );
         assert!(Value::try_from(json!({ "a": true }))
             .unwrap()
             .evaluate_eq(&Value::Map(
                 [("a".to_owned(), Value::Bool(true))].into_iter().collect()
-            )));
+            ))
+            .unwrap());
     }
 }

--- a/core/src/executor/aggregate/mod.rs
+++ b/core/src/executor/aggregate/mod.rs
@@ -10,7 +10,7 @@ use {
     },
     crate::{
         ast::{Expr, SelectItem},
-        data::Key,
+        data::{Key, Nullable},
         result::Result,
         store::GStore,
     },
@@ -155,7 +155,10 @@ impl<'a, T: GStore> Aggregator<'a, T> {
                                 having,
                             )
                             .await
-                            .map(|pass| pass.then_some((aggregated, next)))
+                            .map(|pass| match pass {
+                                Nullable::Entry(true) => Some((aggregated, next)),
+                                Nullable::Entry(false) | Nullable::Null => None,
+                            })
                             .transpose()
                         }
                     }

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -23,6 +23,10 @@ pub fn binary_op<'a>(
     l: Evaluated<'a>,
     r: Evaluated<'a>,
 ) -> Result<Evaluated<'a>> {
+    if l.is_null() || r.is_null() {
+        return Ok(Evaluated::null());
+    }
+
     macro_rules! cmp {
         ($expr: expr) => {
             Ok(Evaluated::Value(Value::Bool($expr)))
@@ -46,8 +50,8 @@ pub fn binary_op<'a>(
         BinaryOperator::Divide => l.divide(&r),
         BinaryOperator::Modulo => l.modulo(&r),
         BinaryOperator::StringConcat => l.concat(r),
-        BinaryOperator::Eq => cmp!(l.evaluate_eq(&r)),
-        BinaryOperator::NotEq => cmp!(!l.evaluate_eq(&r)),
+        BinaryOperator::Eq => Ok(l.evaluate_eq(&r).into()),
+        BinaryOperator::NotEq => Ok((!l.evaluate_eq(&r)).into()),
         BinaryOperator::Lt => cmp!(l.evaluate_cmp(&r) == Some(Ordering::Less)),
         BinaryOperator::LtEq => cmp!(matches!(
             l.evaluate_cmp(&r),
@@ -68,6 +72,10 @@ pub fn binary_op<'a>(
 }
 
 pub fn unary_op<'a>(op: &UnaryOperator, v: Evaluated<'a>) -> Result<Evaluated<'a>> {
+    if v.is_null() {
+        return Ok(Evaluated::null());
+    }
+
     match op {
         UnaryOperator::Plus => v.unary_plus(),
         UnaryOperator::Minus => v.unary_minus(),

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -23,10 +23,6 @@ pub fn binary_op<'a>(
     l: Evaluated<'a>,
     r: Evaluated<'a>,
 ) -> Result<Evaluated<'a>> {
-    if l.is_null() || r.is_null() {
-        return Ok(Evaluated::null());
-    }
-
     macro_rules! cmp {
         ($expr: expr) => {
             Ok(Evaluated::Value(Value::Bool($expr)))
@@ -72,16 +68,17 @@ pub fn binary_op<'a>(
 }
 
 pub fn unary_op<'a>(op: &UnaryOperator, v: Evaluated<'a>) -> Result<Evaluated<'a>> {
-    if v.is_null() {
-        return Ok(Evaluated::null());
-    }
-
     match op {
         UnaryOperator::Plus => v.unary_plus(),
         UnaryOperator::Minus => v.unary_minus(),
-        UnaryOperator::Not => v
-            .try_into()
-            .map(|v: bool| Evaluated::Value(Value::Bool(!v))),
+        UnaryOperator::Not => {
+            if v.is_null() {
+                Ok(Evaluated::null())
+            } else {
+                let v: bool = v.try_into()?;
+                Ok(Evaluated::Value(Value::Bool(!v)))
+            }
+        }
         UnaryOperator::Factorial => v.unary_factorial(),
         UnaryOperator::BitwiseNot => v.unary_bitwise_not(),
     }

--- a/core/src/executor/evaluate/mod.rs
+++ b/core/src/executor/evaluate/mod.rs
@@ -61,7 +61,7 @@ async fn stream_contains_target<'life, 'stream, 'item>(
     stream
         .try_fold(Nullable::Entry(negated), |acc, evaluated| {
             ready(Ok(
-                // If we have already found a non-match, we don't need to check the rest of
+                // If we have already found a match/non-match, we don't need to check the rest of
                 // the list.
                 if acc.map_or(false, |v| v != negated) {
                     Nullable::Entry(!negated)

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -6,7 +6,7 @@ use {
             SelectItem, SetExpr, TableAlias, TableFactor, TableWithJoins, ToSql, ToSqlUnquoted,
             Values,
         },
-        data::{get_alias, get_index, Key, Row, Value},
+        data::{get_alias, get_index, Key, Nullable, Row, Value},
         executor::{evaluate::evaluate, select::select},
         result::Result,
         store::{DataRow, GStore},
@@ -67,7 +67,10 @@ pub async fn fetch<'a, T: GStore>(
 
                 check_expr(storage, Some(Rc::new(context)), None, expr)
                     .await
-                    .map(|pass| pass.then_some((key, row)))
+                    .map(|pass| match pass {
+                        Nullable::Entry(true) => Some((key, row)),
+                        Nullable::Null | Nullable::Entry(false) => None,
+                    })
             }
         });
 


### PR DESCRIPTION
As per title, this PR introduces the propagation of Null evaluations up to the root. In order to make the Null case semantically different from the None object, a new enum `Nullable` has been introduced.