### PR TITLE
fix: unable to query UUID primary key by literal value in evaluated

### DIFF
--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -229,6 +229,7 @@ impl Value {
         }
     }
 
+    // sql like "CAST"
     pub fn try_cast_from_literal(data_type: &DataType, literal: &Literal<'_>) -> Result<Value> {
         match (data_type, literal) {
             (DataType::Boolean, Literal::Boolean(v)) => Ok(Value::Bool(*v)),

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -229,7 +229,6 @@ impl Value {
         }
     }
 
-    // sql like "CAST"
     pub fn try_cast_from_literal(data_type: &DataType, literal: &Literal<'_>) -> Result<Value> {
         match (data_type, literal) {
             (DataType::Boolean, Literal::Boolean(v)) => Ok(Value::Bool(*v)),

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -48,8 +48,6 @@ pub async fn fetch<'a, T: GStore>(
     columns: Option<Rc<[String]>>,
     where_clause: Option<&'a Expr>,
 ) -> Result<impl Stream<Item = Result<(Key, Row)>> + 'a> {
-    println!("fetch, were_clause: {:?}", where_clause);
-
     let columns = columns.unwrap_or_else(|| Rc::from([]));
     let rows = storage
         .scan_data(table_name)
@@ -175,7 +173,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                                         })
                                     })
                                     .map(|column_def| &column_def.data_type)
-                                    .unwrap();
+                                    .ok_or(FetchError::Unreachable)?;
 
                                 Value::try_from_literal(data_type, &literal)
                             }

--- a/storages/json-storage/src/lib.rs
+++ b/storages/json-storage/src/lib.rs
@@ -172,7 +172,8 @@ impl JsonStorage {
                 )?;
 
                 if column_def.unique == Some(ColumnUniqueOption { is_primary: true }) {
-                    key = Some(value.clone().try_into().map_storage_err()?);
+                    let value = value.cast(&column_def.data_type)?;
+                    key = Some(value.try_into().map_storage_err()?);
                 }
 
                 let value = match value.get_type() {

--- a/storages/web-storage/Cargo.toml
+++ b/storages/web-storage/Cargo.toml
@@ -13,7 +13,7 @@ gluesql-core.workspace = true
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 gloo-storage = "0.2.2"
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { version = "1.2.2", features = ["v4", "v7"] }
 web-sys = { version = "0.3.60" }
 futures = "0.3"
 

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -20,7 +20,7 @@ pretty_assertions = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
 version = "1"
-features = ["v4", "js"]
+features = ["v4", "v7", "js"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1"
 features = ["v4", "v7"]

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -16,11 +16,11 @@ chrono = "0.4.31"
 rust_decimal = "1"
 hex = "0.4"
 serde_json = "1.0.91"
-pretty_assertions= "1"
+pretty_assertions = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
 version = "1"
 features = ["v4", "js"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1"
-features = ["v4"]
+features = ["v4", "v7"]


### PR DESCRIPTION
fixed #1579

This commit addresses the issue where select queries with a primary key of type UUID fail when using literal values in the SQL AST. The solution involves modifying the SQL AST evaluation to use `try_from_literal` instead of `Value::try_from` when the evaluated type is `literal`.

Steps to fix:
- Check if the evaluated type is `literal` in SQL AST.
- Use `try_from_literal` with `data_type` parsing to handle UUID values correctly.

- [ ] Currently, the implementation calls `fetch_schema` multiple times, leading to inefficiencies. This should be improved through refactoring.