### PR TITLE
Add AlterTable store trait default implementation,

### DIFF
--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -87,7 +87,6 @@ pub trait AlterTable: Store + StoreMut {
             .try_collect::<Vec<_>>()
             .await?;
 
-        self.delete_schema(table_name).await?;
         self.insert_schema(&schema).await?;
         self.insert_data(table_name, rows).await
     }

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -1,9 +1,8 @@
 use {
-    crate::{
-        ast::ColumnDef,
-        result::{Error, Result},
-    },
+    super::{DataRow, Store, StoreMut},
+    crate::{ast::ColumnDef, data::Value, executor::evaluate_stateless, result::Result},
     async_trait::async_trait,
+    futures::TryStreamExt,
     serde::Serialize,
     std::fmt::Debug,
     thiserror::Error,
@@ -28,41 +27,168 @@ pub enum AlterTableError {
 
     #[error("Schemaless table does not support ALTER TABLE: {0}")]
     SchemalessTableFound(String),
+
+    #[error("conflict - Vec expected but Map row found")]
+    ConflictOnUnexpectedMapRowFound,
 }
 
 #[async_trait(?Send)]
-pub trait AlterTable {
-    async fn rename_schema(&mut self, _table_name: &str, _new_table_name: &str) -> Result<()> {
-        let msg = "[Storage] AlterTable::rename_schema is not supported".to_owned();
+pub trait AlterTable: Store + StoreMut {
+    async fn rename_schema(&mut self, table_name: &str, new_table_name: &str) -> Result<()> {
+        let mut schema = self
+            .fetch_schema(table_name)
+            .await?
+            .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()))?;
+        schema.table_name = new_table_name.to_owned();
+        self.insert_schema(&schema).await?;
 
-        Err(Error::StorageMsg(msg))
+        let rows = self
+            .scan_data(table_name)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        self.insert_data(new_table_name, rows).await?;
+        self.delete_schema(table_name).await
     }
 
     async fn rename_column(
         &mut self,
-        _table_name: &str,
-        _old_column_name: &str,
-        _new_column_name: &str,
+        table_name: &str,
+        old_column_name: &str,
+        new_column_name: &str,
     ) -> Result<()> {
-        let msg = "[Storage] AlterTable::rename_column is not supported".to_owned();
+        let mut schema = self
+            .fetch_schema(table_name)
+            .await?
+            .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()))?;
 
-        Err(Error::StorageMsg(msg))
+        let column_defs = schema
+            .column_defs
+            .as_mut()
+            .ok_or_else(|| AlterTableError::SchemalessTableFound(table_name.to_owned()))?;
+
+        if column_defs
+            .iter()
+            .any(|column_def| column_def.name == new_column_name)
+        {
+            return Err(AlterTableError::AlreadyExistingColumn(new_column_name.to_owned()).into());
+        }
+
+        column_defs
+            .iter_mut()
+            .find(|column_def| column_def.name == old_column_name)
+            .ok_or_else(|| AlterTableError::RenamingColumnNotFound)?
+            .name = new_column_name.to_owned();
+
+        let rows = self
+            .scan_data(table_name)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        self.delete_schema(table_name).await?;
+        self.insert_schema(&schema).await?;
+        self.insert_data(table_name, rows).await
     }
 
-    async fn add_column(&mut self, _table_name: &str, _column_def: &ColumnDef) -> Result<()> {
-        let msg = "[Storage] AlterTable::add_column is not supported".to_owned();
+    async fn add_column(&mut self, table_name: &str, column_def: &ColumnDef) -> Result<()> {
+        let mut schema = self
+            .fetch_schema(table_name)
+            .await?
+            .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()))?;
 
-        Err(Error::StorageMsg(msg))
+        let default_value = match (column_def.default.as_ref(), column_def.nullable) {
+            (Some(default), _) => evaluate_stateless(None, default).await?.try_into()?,
+            (None, true) => Value::Null,
+            (None, false) => {
+                return Err(AlterTableError::DefaultValueRequired(column_def.clone()).into())
+            }
+        };
+
+        let column_defs = schema
+            .column_defs
+            .as_mut()
+            .ok_or_else(|| AlterTableError::SchemalessTableFound(table_name.to_owned()))?;
+
+        if column_defs.iter().any(|def| def.name == column_def.name) {
+            return Err(AlterTableError::AlreadyExistingColumn(column_def.name.clone()).into());
+        }
+
+        column_defs.push(column_def.clone());
+
+        let rows = self
+            .scan_data(table_name)
+            .await?
+            .and_then(|(key, mut data_row)| {
+                let default_value = default_value.clone();
+
+                async move {
+                    match &mut data_row {
+                        DataRow::Map(_) => {
+                            Err(AlterTableError::ConflictOnUnexpectedMapRowFound.into())
+                        }
+                        DataRow::Vec(ref mut rows) => {
+                            rows.push(default_value);
+
+                            Ok((key, data_row))
+                        }
+                    }
+                }
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        self.insert_schema(&schema).await?;
+        self.insert_data(table_name, rows).await
     }
 
     async fn drop_column(
         &mut self,
-        _table_name: &str,
-        _column_name: &str,
-        _if_exists: bool,
+        table_name: &str,
+        column_name: &str,
+        if_exists: bool,
     ) -> Result<()> {
-        let msg = "[Storage] AlterTable::drop_column is not supported".to_owned();
+        let mut schema = self
+            .fetch_schema(table_name)
+            .await?
+            .ok_or_else(|| AlterTableError::TableNotFound(table_name.to_owned()))?;
 
-        Err(Error::StorageMsg(msg))
+        let column_defs = schema
+            .column_defs
+            .as_mut()
+            .ok_or_else(|| AlterTableError::SchemalessTableFound(table_name.to_owned()))?;
+
+        let i = match column_defs
+            .iter()
+            .position(|column_def| column_def.name == column_name)
+        {
+            Some(i) => i,
+            None if if_exists => return Ok(()),
+            None => {
+                return Err(AlterTableError::DroppingColumnNotFound(column_name.to_owned()).into())
+            }
+        };
+
+        column_defs.retain(|column_def| column_def.name != column_name);
+
+        let rows = self
+            .scan_data(table_name)
+            .await?
+            .and_then(|(key, mut data_row)| async move {
+                match &mut data_row {
+                    DataRow::Map(_) => Err(AlterTableError::ConflictOnUnexpectedMapRowFound.into()),
+                    DataRow::Vec(ref mut rows) => {
+                        rows.remove(i);
+
+                        Ok((key, data_row))
+                    }
+                }
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        self.insert_schema(&schema).await?;
+        self.insert_data(table_name, rows).await
     }
 }

--- a/storages/composite-storage/tests/composite_storage.rs
+++ b/storages/composite-storage/tests/composite_storage.rs
@@ -25,3 +25,4 @@ impl Tester<CompositeStorage> for CompositeTester {
 }
 
 generate_store_tests!(tokio::test, CompositeTester);
+generate_alter_table_tests!(tokio::test, CompositeTester);

--- a/storages/csv-storage/tests/csv_storage.rs
+++ b/storages/csv-storage/tests/csv_storage.rs
@@ -27,3 +27,4 @@ impl Tester<CsvStorage> for CsvTester {
 }
 
 generate_store_tests!(tokio::test, CsvTester);
+generate_alter_table_tests!(tokio::test, CsvTester);

--- a/storages/file-storage/tests/file_storage.rs
+++ b/storages/file-storage/tests/file_storage.rs
@@ -30,6 +30,7 @@ impl Tester<FileStorage> for FileStorageTester {
 }
 
 generate_store_tests!(tokio::test, FileStorageTester);
+generate_alter_table_tests!(tokio::test, FileStorageTester);
 
 #[tokio::test]
 async fn scan_data_to_ignore_directory_items() {

--- a/storages/git-storage/src/lib.rs
+++ b/storages/git-storage/src/lib.rs
@@ -104,6 +104,7 @@ impl GitStorage {
         Command::new("git")
             .current_dir(&self.path)
             .arg("commit")
+            .arg("--allow-empty")
             .arg("-m")
             .arg(message)
             .execute()

--- a/storages/git-storage/tests/git_storage_csv.rs
+++ b/storages/git-storage/tests/git_storage_csv.rs
@@ -30,3 +30,4 @@ impl Tester<GitStorage> for GitStorageTester {
 }
 
 generate_store_tests!(tokio::test, GitStorageTester);
+generate_alter_table_tests!(tokio::test, GitStorageTester);

--- a/storages/git-storage/tests/git_storage_file.rs
+++ b/storages/git-storage/tests/git_storage_file.rs
@@ -30,3 +30,4 @@ impl Tester<GitStorage> for GitStorageTester {
 }
 
 generate_store_tests!(tokio::test, GitStorageTester);
+generate_alter_table_tests!(tokio::test, GitStorageTester);

--- a/storages/git-storage/tests/git_storage_json.rs
+++ b/storages/git-storage/tests/git_storage_json.rs
@@ -30,3 +30,4 @@ impl Tester<GitStorage> for GitStorageTester {
 }
 
 generate_store_tests!(tokio::test, GitStorageTester);
+generate_alter_table_tests!(tokio::test, GitStorageTester);

--- a/storages/idb-storage/tests/idb_storage.rs
+++ b/storages/idb-storage/tests/idb_storage.rs
@@ -29,3 +29,4 @@ impl Tester<IdbStorage> for IdbStorageTester {
 }
 
 generate_store_tests!(wasm_bindgen_test, IdbStorageTester);
+generate_alter_table_tests!(wasm_bindgen_test, IdbStorageTester);

--- a/storages/json-storage/tests/json_storage.rs
+++ b/storages/json-storage/tests/json_storage.rs
@@ -27,3 +27,4 @@ impl Tester<JsonStorage> for JsonTester {
 }
 
 generate_store_tests!(tokio::test, JsonTester);
+generate_alter_table_tests!(tokio::test, JsonTester);

--- a/storages/mongo-storage/tests/mongo_storage.rs
+++ b/storages/mongo-storage/tests/mongo_storage.rs
@@ -28,3 +28,4 @@ impl Tester<MongoStorage> for MongoTester {
 }
 
 generate_store_tests!(tokio::test, MongoTester);
+generate_alter_table_tests!(tokio::test, MongoTester);

--- a/storages/parquet-storage/tests/parquet_storage.rs
+++ b/storages/parquet-storage/tests/parquet_storage.rs
@@ -27,3 +27,4 @@ impl Tester<ParquetStorage> for ParquetTester {
 }
 
 generate_store_tests!(tokio::test, ParquetTester);
+generate_alter_table_tests!(tokio::test, ParquetTester);

--- a/storages/web-storage/tests/local_storage.rs
+++ b/storages/web-storage/tests/local_storage.rs
@@ -31,3 +31,4 @@ impl Tester<WebStorage> for LocalStorageTester {
 }
 
 generate_store_tests!(wasm_bindgen_test, LocalStorageTester);
+generate_alter_table_tests!(wasm_bindgen_test, LocalStorageTester);

--- a/storages/web-storage/tests/session_storage.rs
+++ b/storages/web-storage/tests/session_storage.rs
@@ -31,3 +31,4 @@ impl Tester<WebStorage> for SessionStorageTester {
 }
 
 generate_store_tests!(wasm_bindgen_test, SessionStorageTester);
+generate_alter_table_tests!(wasm_bindgen_test, SessionStorageTester);


### PR DESCRIPTION
Now all the storages that has Store & StoreMut impl support AlterTable trait automatically.
It is default impl that all the alter table operations rewrite the entire table including schema & data.
Therefore, it is still recommended for custom storage makers to impl manual AlterTable trait for better performance.