### PR TITLE
impl Send futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,24 @@
 [workspace]
 resolver = "2"
 members = [
-  "cli",
+  #"cli",
   "core",
-  "pkg/rust",
-  "pkg/javascript",
-  "pkg/python",
-  "storages/*",
+  #"pkg/rust",
+  #"pkg/javascript",
+  #"pkg/python",
+  #"storages/*",
+  "storages/memory-storage",
+  #"storages/shared-memory-storage",
   "test-suite",
   "utils",
 ]
 default-members = [
-  "cli",
+  #"cli",
   "core",
-  "pkg/rust",
-  "pkg/javascript",
-  "pkg/python",
-  "storages/*",
+  #"pkg/rust",
+  #"pkg/javascript",
+  #"pkg/python",
+  #"storages/*",
   "test-suite",
   "utils",
 ]
@@ -35,21 +37,21 @@ repository = "https://github.com/gluesql/gluesql"
 documentation = "https://docs.rs/gluesql/"
 
 [workspace.dependencies]
-gluesql-core = { path = "./core", version = "0.16.3" }
+#gluesql-core = { path = "./core", version = "0.16.3" }
 
-cli = { package = "gluesql-cli", path = "./cli", version = "0.16.3" }
-test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.16.3" }
-gluesql_memory_storage = { path = "./storages/memory-storage", version = "0.16.3" }
-gluesql-shared-memory-storage = { path = "./storages/shared-memory-storage", version = "0.16.3" }
-gluesql_sled_storage = { path = "./storages/sled-storage", version = "0.16.3" }
-gluesql-json-storage = { path = "./storages/json-storage", version = "0.16.3" }
-gluesql-csv-storage = { path = "./storages/csv-storage", version = "0.16.3" }
-gluesql-composite-storage = { path = "./storages/composite-storage", version = "0.16.3" }
-gluesql-web-storage = { path = "./storages/web-storage", version = "0.16.3" }
-gluesql-idb-storage = { path = "./storages/idb-storage", version = "0.16.3" }
-gluesql-redis-storage = { path = "./storages/redis-storage", version = "0.16.3" }
-gluesql-mongo-storage = { path = "./storages/mongo-storage", version = "0.16.3" }
-gluesql-parquet-storage = { path = "./storages/parquet-storage", version = "0.16.3" }
-gluesql-file-storage = { path = "./storages/file-storage", version = "0.16.3" }
-gluesql-git-storage = { path = "./storages/git-storage", version = "0.16.3" }
-utils = { package = "gluesql-utils", path = "./utils", version = "0.16.3" }
+#cli = { package = "gluesql-cli", path = "./cli", version = "0.16.3" }
+#test-suite = { package = "gluesql-test-suite", path = "./test-suite", version = "0.16.3" }
+#gluesql_memory_storage = { path = "./storages/memory-storage", version = "0.16.3" }
+#gluesql-shared-memory-storage = { path = "./storages/shared-memory-storage", version = "0.16.3" }
+#gluesql_sled_storage = { path = "./storages/sled-storage", version = "0.16.3" }
+#gluesql-json-storage = { path = "./storages/json-storage", version = "0.16.3" }
+#gluesql-csv-storage = { path = "./storages/csv-storage", version = "0.16.3" }
+#gluesql-composite-storage = { path = "./storages/composite-storage", version = "0.16.3" }
+#gluesql-web-storage = { path = "./storages/web-storage", version = "0.16.3" }
+#gluesql-idb-storage = { path = "./storages/idb-storage", version = "0.16.3" }
+#gluesql-redis-storage = { path = "./storages/redis-storage", version = "0.16.3" }
+#gluesql-mongo-storage = { path = "./storages/mongo-storage", version = "0.16.3" }
+#gluesql-parquet-storage = { path = "./storages/parquet-storage", version = "0.16.3" }
+#gluesql-file-storage = { path = "./storages/file-storage", version = "0.16.3" }
+#gluesql-git-storage = { path = "./storages/git-storage", version = "0.16.3" }
+#utils = { package = "gluesql-utils", path = "./utils", version = "0.16.3" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-utils.workspace = true
-
+#utils.workspace = true
+utils = { package = "gluesql-utils", path = "../utils", version = "0.16.3" }
 regex = "1"
 async-trait = "0.1"
 async-recursion = "1"
@@ -19,9 +19,11 @@ futures-enum = "0.1.17"
 futures = "0.3"
 chrono = { version = "0.4.38", features = ["serde", "wasmbind"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
+im = { version = "15", optional = true }
 im-rc = "15"
 iter-enum = "1"
 itertools = "0.12"
+iter-chunks = "=0.2.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlparser = { version = "0.50", features = ["serde", "bigdecimal"] }
@@ -39,6 +41,9 @@ features = ["v4", "js"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]
 version = "1"
 features = ["v4"]
+
+[features]
+send = ["im"]
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -1,7 +1,7 @@
 use {
-    crate::{data::Value, executor::RowContext, result::Result},
+    crate::{data::Value, executor::RowContext, result::Result, Grc},
     serde::Serialize,
-    std::{collections::HashMap, fmt::Debug, rc::Rc},
+    std::{collections::HashMap, fmt::Debug},
     thiserror::Error,
 };
 
@@ -17,7 +17,7 @@ pub enum RowError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Row {
     Vec {
-        columns: Rc<[String]>,
+        columns: Grc<[String]>,
         values: Vec<Value>,
     },
     Map(HashMap<String, Value>),

--- a/core/src/executor/aggregate/mod.rs
+++ b/core/src/executor/aggregate/mod.rs
@@ -13,20 +13,21 @@ use {
         data::Key,
         result::Result,
         store::GStore,
+        Grc,
     },
     async_recursion::async_recursion,
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
-    std::{convert::identity, rc::Rc},
+    std::convert::identity,
 };
 
 pub use error::AggregateError;
 
-pub struct Aggregator<'a, T: GStore> {
+pub struct Aggregator<'a, T> {
     storage: &'a T,
     fields: &'a [SelectItem],
     group_by: &'a [Expr],
     having: Option<&'a Expr>,
-    filter_context: Option<Rc<RowContext<'a>>>,
+    filter_context: Option<Grc<RowContext<'a>>>,
 }
 
 #[derive(futures_enum::Stream)]
@@ -35,13 +36,18 @@ enum S<T1, T2> {
     Aggregate(T2),
 }
 
-impl<'a, T: GStore> Aggregator<'a, T> {
+impl<
+        'a,
+        #[cfg(feature = "send")] T: GStore + Send + Sync,
+        #[cfg(not(feature = "send"))] T: GStore,
+    > Aggregator<'a, T>
+{
     pub fn new(
         storage: &'a T,
         fields: &'a [SelectItem],
         group_by: &'a [Expr],
         having: Option<&'a Expr>,
-        filter_context: Option<Rc<RowContext<'a>>>,
+        filter_context: Option<Grc<RowContext<'a>>>,
     ) -> Self {
         Self {
             storage,
@@ -52,9 +58,11 @@ impl<'a, T: GStore> Aggregator<'a, T> {
         }
     }
 
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(not(feature = "send"))]
     pub async fn apply(
         &self,
-        rows: impl Stream<Item = Result<Rc<RowContext<'a>>>>,
+        rows: impl Stream<Item = Result<Grc<RowContext<'a>>>>,
     ) -> Result<impl Stream<Item = Result<AggregateContext<'a>>>> {
         if !self.check_aggregate() {
             let rows = rows.map_ok(|project_context| AggregateContext {
@@ -72,17 +80,17 @@ impl<'a, T: GStore> Aggregator<'a, T> {
                 State::new(self.storage),
                 |state, (index, project_context)| async move {
                     let filter_context = match &self.filter_context {
-                        Some(filter_context) => Rc::new(RowContext::concat(
-                            Rc::clone(&project_context),
-                            Rc::clone(filter_context),
+                        Some(filter_context) => Grc::new(RowContext::concat(
+                            Grc::clone(&project_context),
+                            Grc::clone(filter_context),
                         )),
-                        None => Rc::clone(&project_context),
+                        None => Grc::clone(&project_context),
                     };
                     let filter_context = Some(filter_context);
 
                     let evaluated: Vec<Evaluated<'_>> = stream::iter(self.group_by.iter())
                         .then(|expr| {
-                            let filter_clone = filter_context.as_ref().map(Rc::clone);
+                            let filter_clone = filter_context.as_ref().map(Grc::clone);
                             async move { evaluate(self.storage, filter_clone, None, expr).await }
                         })
                         .try_collect::<Vec<_>>()
@@ -93,11 +101,11 @@ impl<'a, T: GStore> Aggregator<'a, T> {
                         .map(Key::try_from)
                         .collect::<Result<Vec<Key>>>()?;
 
-                    let state = state.apply(index, group, Rc::clone(&project_context));
+                    let state = state.apply(index, group, Grc::clone(&project_context));
                     let state = stream::iter(self.fields)
                         .map(Ok)
                         .try_fold(state, |state, field| {
-                            let filter_clone = filter_context.as_ref().map(Rc::clone);
+                            let filter_clone = filter_context.as_ref().map(Grc::clone);
 
                             async move {
                                 match field {
@@ -118,40 +126,111 @@ impl<'a, T: GStore> Aggregator<'a, T> {
         self.group_by_having(state).await.map(S::Aggregate)
     }
 
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(feature = "send")]
+    pub async fn apply(
+        &self,
+        rows: impl Stream<Item = Result<Grc<RowContext<'a>>>> + Send,
+    ) -> Result<impl Stream<Item = Result<AggregateContext<'a>>> + Send> {
+        if !self.check_aggregate() {
+            let rows = rows.map_ok(|project_context| AggregateContext {
+                aggregated: None,
+                next: project_context,
+            });
+            return Ok(S::NonAggregate(rows));
+        }
+
+        let state = rows
+            .into_stream()
+            .enumerate()
+            .map(|(i, row)| row.map(|row| (i, row)))
+            .try_fold(
+                State::new(self.storage),
+                |state, (index, project_context)| async move {
+                    let filter_context = match &self.filter_context {
+                        Some(filter_context) => Grc::new(RowContext::concat(
+                            Grc::clone(&project_context),
+                            Grc::clone(filter_context),
+                        )),
+                        None => Grc::clone(&project_context),
+                    };
+                    let filter_context = Some(filter_context);
+
+                    let evaluated: Vec<Evaluated<'_>> = stream::iter(self.group_by.iter())
+                        .then(|expr| {
+                            let filter_clone = filter_context.as_ref().map(Grc::clone);
+                            async move { evaluate(self.storage, filter_clone, None, expr).await }
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await?;
+
+                    let group = evaluated
+                        .iter()
+                        .map(Key::try_from)
+                        .collect::<Result<Vec<Key>>>()?;
+
+                    let state = state.apply(index, group, Grc::clone(&project_context));
+                    let state = stream::iter(self.fields)
+                        .map(Ok)
+                        .try_fold(state, |state, field| {
+                            let filter_clone = filter_context.as_ref().map(Grc::clone);
+
+                            async move {
+                                match field {
+                                    SelectItem::Expr { expr, .. } => {
+                                        aggregate(state, filter_clone, expr).await
+                                    }
+                                    _ => Ok(state),
+                                }
+                            }
+                        })
+                        .await?;
+
+                    Ok(state)
+                },
+            )
+            .await?;
+
+        self.group_by_having(state).await.map(S::Aggregate)
+    }
+
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(not(feature = "send"))]
     pub async fn group_by_having(
         &self,
         state: State<'a, T>,
     ) -> Result<impl Stream<Item = Result<AggregateContext<'a>>>> {
         let storage = self.storage;
-        let filter_context = self.filter_context.as_ref().map(Rc::clone);
+        let filter_context = self.filter_context.as_ref().map(Grc::clone);
         let having = self.having;
         let rows = state
             .export()
             .await?
             .into_iter()
             .filter_map(|(aggregated, next)| next.map(|next| (aggregated, next)));
+
         let rows = stream::iter(rows)
             .filter_map(move |(aggregated, next)| {
-                let filter_context = filter_context.as_ref().map(Rc::clone);
-                let aggregated = aggregated.map(Rc::new);
+                let filter_context = filter_context.as_ref().map(Grc::clone);
+                let aggregated = aggregated.map(Grc::new);
 
                 async move {
                     match having {
-                        None => Some(Ok((aggregated.as_ref().map(Rc::clone), next))),
+                        None => Some(Ok((aggregated.as_ref().map(Grc::clone), next))),
                         Some(having) => {
                             let filter_context = match filter_context {
                                 Some(filter_context) => {
-                                    Rc::new(RowContext::concat(Rc::clone(&next), filter_context))
+                                    Grc::new(RowContext::concat(Grc::clone(&next), filter_context))
                                 }
-                                None => Rc::clone(&next),
+                                None => Grc::clone(&next),
                             };
                             let filter_context = Some(filter_context);
-                            let aggregated = aggregated.as_ref().map(Rc::clone);
+                            let aggregated = aggregated.as_ref().map(Grc::clone);
 
                             check_expr(
                                 storage,
                                 filter_context,
-                                aggregated.as_ref().map(Rc::clone),
+                                aggregated.as_ref().map(Grc::clone),
                                 having,
                             )
                             .await
@@ -163,7 +242,64 @@ impl<'a, T: GStore> Aggregator<'a, T> {
             })
             .and_then(|(aggregated, next)| async move {
                 aggregated
-                    .map(Rc::try_unwrap)
+                    .map(Grc::try_unwrap)
+                    .transpose()
+                    .map_err(|_| AggregateError::UnreachableRcUnwrapFailure.into())
+                    .map(|aggregated| AggregateContext { aggregated, next })
+            });
+
+        Ok(rows)
+    }
+
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(feature = "send")]
+    pub async fn group_by_having(
+        &self,
+        state: State<'a, T>,
+    ) -> Result<impl Stream<Item = Result<AggregateContext<'a>>> + Send> {
+        let storage = self.storage;
+        let filter_context = self.filter_context.as_ref().map(Grc::clone);
+        let having = self.having;
+        let rows = state
+            .export()
+            .await?
+            .into_iter()
+            .filter_map(|(aggregated, next)| next.map(|next| (aggregated, next)));
+
+        let rows = stream::iter(rows)
+            .filter_map(move |(aggregated, next)| {
+                let filter_context = filter_context.as_ref().map(Grc::clone);
+                let aggregated = aggregated.map(Grc::new);
+
+                async move {
+                    match having {
+                        None => Some(Ok((aggregated.as_ref().map(Grc::clone), next))),
+                        Some(having) => {
+                            let filter_context = match filter_context {
+                                Some(filter_context) => {
+                                    Grc::new(RowContext::concat(Grc::clone(&next), filter_context))
+                                }
+                                None => Grc::clone(&next),
+                            };
+                            let filter_context = Some(filter_context);
+                            let aggregated = aggregated.as_ref().map(Grc::clone);
+
+                            check_expr(
+                                storage,
+                                filter_context,
+                                aggregated.as_ref().map(Grc::clone),
+                                having,
+                            )
+                            .await
+                            .map(|pass| pass.then_some((aggregated, next)))
+                            .transpose()
+                        }
+                    }
+                }
+            })
+            .and_then(|(aggregated, next)| async move {
+                aggregated
+                    .map(Grc::try_unwrap)
                     .transpose()
                     .map_err(|_| AggregateError::UnreachableRcUnwrapFailure.into())
                     .map(|aggregated| AggregateContext { aggregated, next })
@@ -187,51 +323,70 @@ impl<'a, T: GStore> Aggregator<'a, T> {
     }
 }
 
-#[async_recursion(?Send)]
-async fn aggregate<'a, T>(
+#[cfg_attr(not(feature = "send"), async_recursion(?Send))]
+#[cfg_attr(feature = "send", async_recursion)]
+async fn aggregate<
+    'a,
+    #[cfg(feature = "send")] T: GStore + Send + Sync,
+    #[cfg(not(feature = "send"))] T: GStore,
+>(
     state: State<'a, T>,
-    filter_context: Option<Rc<RowContext<'a>>>,
+    filter_context: Option<Grc<RowContext<'a>>>,
     expr: &'a Expr,
-) -> Result<State<'a, T>>
-where
-    T: GStore,
-{
-    let aggr = |state, expr| aggregate(state, filter_context.as_ref().map(Rc::clone), expr);
+) -> Result<State<'a, T>> {
+    let aggr =
+        |state: State<'a, T>, expr| aggregate(state, filter_context.as_ref().map(Grc::clone), expr);
 
     match expr {
-        Expr::Between {
-            expr, low, high, ..
-        } => {
-            stream::iter([expr, low, high])
-                .map(Ok)
-                .try_fold(state, |state, expr| async move { aggr(state, expr).await })
-                .await
-        }
-        Expr::BinaryOp { left, right, .. } => {
-            stream::iter([left, right])
-                .map(Ok)
-                .try_fold(state, |state, expr| async move { aggr(state, expr).await })
-                .await
-        }
-        Expr::UnaryOp { expr, .. } => aggr(state, expr).await,
-        Expr::Nested(expr) => aggr(state, expr).await,
         Expr::Case {
             operand,
             when_then,
             else_result,
         } => {
-            let operand = std::iter::once(operand.as_ref())
-                .filter_map(|operand| operand.map(|operand| &**operand));
-            let when_then = when_then
-                .iter()
-                .flat_map(|(when, then)| std::iter::once(when).chain(std::iter::once(then)));
-            let else_result = std::iter::once(else_result.as_ref())
-                .filter_map(|else_result| else_result.map(|else_result| &**else_result));
+            // not using iters and chaining due to cryptic lifetimes issues
+            let mut exprs = vec![];
 
-            stream::iter(operand.chain(when_then).chain(else_result).map(Ok))
-                .try_fold(state, aggr)
+            if let Some(e) = operand {
+                exprs.push(&**e)
+            }
+
+            let mut when_then_iter = when_then.into_iter();
+            while let Some((when, then)) = when_then_iter.next() {
+                exprs.push(when);
+                exprs.push(then);
+            }
+
+            if let Some(e) = else_result {
+                exprs.push(&**e)
+            }
+
+            stream::iter(exprs)
+                .fold(
+                    Ok(state),
+                    |state, expr| async move { aggr(state?, expr).await },
+                )
                 .await
         }
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            stream::iter([expr, low, high])
+                .fold(
+                    Ok(state),
+                    |state, expr| async move { aggr(state?, expr).await },
+                )
+                .await
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            stream::iter([left, right])
+                .fold(
+                    Ok(state),
+                    |state, expr| async move { aggr(state?, expr).await },
+                )
+                .await
+        }
+        Expr::UnaryOp { expr, .. } => aggr(state, expr).await,
+        Expr::Nested(expr) => aggr(state, expr).await,
         Expr::Aggregate(aggr) => state.accumulate(filter_context, aggr.as_ref()).await,
         _ => Ok(state),
     }

--- a/core/src/executor/alter/alter_table.rs
+++ b/core/src/executor/alter/alter_table.rs
@@ -8,8 +8,9 @@ use {
     },
 };
 
-pub async fn alter_table<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn alter_table(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     table_name: &str,
     operation: &AlterTableOperation,
 ) -> Result<()> {

--- a/core/src/executor/alter/function.rs
+++ b/core/src/executor/alter/function.rs
@@ -8,8 +8,9 @@ use {
     },
 };
 
-pub async fn insert_function<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn insert_function(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     func_name: &str,
     args: &Vec<OperateFunctionArg>,
     or_replace: bool,
@@ -33,8 +34,9 @@ pub async fn insert_function<T: GStore + GStoreMut>(
     }
 }
 
-pub async fn delete_function<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn delete_function(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     func_names: &[String],
     if_exists: bool,
 ) -> Result<()> {

--- a/core/src/executor/alter/index.rs
+++ b/core/src/executor/alter/index.rs
@@ -8,8 +8,9 @@ use {
     },
 };
 
-pub async fn create_index<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn create_index(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     table_name: &str,
     index_name: &str,
     column: &OrderByExpr,

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -25,8 +25,9 @@ pub struct CreateTableOptions<'a> {
     pub comment: &'a Option<String>,
 }
 
-pub async fn create_table<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn create_table(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     CreateTableOptions {
         target_table_name,
         column_defs,
@@ -211,8 +212,9 @@ pub async fn create_table<T: GStore + GStoreMut>(
     }
 }
 
-pub async fn drop_table<T: GStore + GStoreMut>(
-    storage: &mut T,
+pub async fn drop_table(
+    #[cfg(feature = "send")] storage: &mut (impl GStore + GStoreMut + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &mut (impl GStore + GStoreMut),
     table_names: &[String],
     if_exists: bool,
     cascade: bool,

--- a/core/src/executor/context/aggregate_context.rs
+++ b/core/src/executor/context/aggregate_context.rs
@@ -1,12 +1,11 @@
 use {
     super::RowContext,
-    crate::{ast::Aggregate, data::Value},
-    im_rc::HashMap,
-    std::{fmt::Debug, rc::Rc},
+    crate::{ast::Aggregate, data::Value, Grc, HashMap},
+    std::fmt::Debug,
 };
 
 #[derive(Debug)]
 pub struct AggregateContext<'a> {
     pub aggregated: Option<HashMap<&'a Aggregate, Value>>,
-    pub next: Rc<RowContext<'a>>,
+    pub next: Grc<RowContext<'a>>,
 }

--- a/core/src/executor/context/row_context.rs
+++ b/core/src/executor/context/row_context.rs
@@ -1,6 +1,9 @@
 use {
-    crate::data::{Row, Value},
-    std::{borrow::Cow, collections::HashMap, fmt::Debug, rc::Rc},
+    crate::{
+        data::{Row, Value},
+        Grc,
+    },
+    std::{borrow::Cow, collections::HashMap, fmt::Debug},
 };
 
 #[derive(Debug)]
@@ -8,7 +11,7 @@ pub enum RowContext<'a> {
     Data {
         table_alias: &'a str,
         row: Cow<'a, Row>,
-        next: Option<Rc<RowContext<'a>>>,
+        next: Option<Grc<RowContext<'a>>>,
     },
     RefVecData {
         columns: &'a [String],
@@ -16,13 +19,13 @@ pub enum RowContext<'a> {
     },
     RefMapData(&'a HashMap<String, Value>),
     Bridge {
-        left: Rc<RowContext<'a>>,
-        right: Rc<RowContext<'a>>,
+        left: Grc<RowContext<'a>>,
+        right: Grc<RowContext<'a>>,
     },
 }
 
 impl<'a> RowContext<'a> {
-    pub fn new(table_alias: &'a str, row: Cow<'a, Row>, next: Option<Rc<RowContext<'a>>>) -> Self {
+    pub fn new(table_alias: &'a str, row: Cow<'a, Row>, next: Option<Grc<RowContext<'a>>>) -> Self {
         Self::Data {
             table_alias,
             row,
@@ -30,7 +33,7 @@ impl<'a> RowContext<'a> {
         }
     }
 
-    pub fn concat(left: Rc<RowContext<'a>>, right: Rc<RowContext<'a>>) -> Self {
+    pub fn concat(left: Grc<RowContext<'a>>, right: Grc<RowContext<'a>>) -> Self {
         Self::Bridge { left, right }
     }
 

--- a/core/src/executor/filter.rs
+++ b/core/src/executor/filter.rs
@@ -5,24 +5,28 @@ use {
         data::Value,
         result::Result,
         store::GStore,
+        Grc, HashMap,
     },
-    im_rc::HashMap,
-    std::rc::Rc,
 };
 
-pub struct Filter<'a, T: GStore> {
+pub struct Filter<'a, T> {
     storage: &'a T,
     where_clause: Option<&'a Expr>,
-    context: Option<Rc<RowContext<'a>>>,
-    aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
+    context: Option<Grc<RowContext<'a>>>,
+    aggregated: Option<Grc<HashMap<&'a Aggregate, Value>>>,
 }
 
-impl<'a, T: GStore> Filter<'a, T> {
+impl<
+        'a,
+        #[cfg(feature = "send")] T: GStore + Send + Sync,
+        #[cfg(not(feature = "send"))] T: GStore,
+    > Filter<'a, T>
+{
     pub fn new(
         storage: &'a T,
         where_clause: Option<&'a Expr>,
-        context: Option<Rc<RowContext<'a>>>,
-        aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
+        context: Option<Grc<RowContext<'a>>>,
+        aggregated: Option<Grc<HashMap<&'a Aggregate, Value>>>,
     ) -> Self {
         Self {
             storage,
@@ -32,17 +36,17 @@ impl<'a, T: GStore> Filter<'a, T> {
         }
     }
 
-    pub async fn check(&self, project_context: Rc<RowContext<'a>>) -> Result<bool> {
+    pub async fn check(&self, project_context: Grc<RowContext<'a>>) -> Result<bool> {
         match self.where_clause {
             Some(expr) => {
                 let context = match &self.context {
                     Some(context) => {
-                        Rc::new(RowContext::concat(project_context, Rc::clone(context)))
+                        Grc::new(RowContext::concat(project_context, Grc::clone(context)))
                     }
                     None => project_context,
                 };
                 let context = Some(context);
-                let aggregated = self.aggregated.as_ref().map(Rc::clone);
+                let aggregated = self.aggregated.as_ref().map(Grc::clone);
 
                 check_expr(self.storage, context, aggregated, expr).await
             }
@@ -51,10 +55,11 @@ impl<'a, T: GStore> Filter<'a, T> {
     }
 }
 
-pub async fn check_expr<'a, T: GStore>(
-    storage: &'a T,
-    context: Option<Rc<RowContext<'a>>>,
-    aggregated: Option<Rc<HashMap<&'a Aggregate, Value>>>,
+pub async fn check_expr<'a>(
+    #[cfg(feature = "send")] storage: &'a (impl GStore + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &'a impl GStore,
+    context: Option<Grc<RowContext<'a>>>,
+    aggregated: Option<Grc<HashMap<&'a Aggregate, Value>>>,
     expr: &'a Expr,
 ) -> Result<bool> {
     evaluate(storage, context, aggregated, expr)

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -9,30 +9,39 @@ use {
         executor::{context::RowContext, evaluate::evaluate, filter::check_expr},
         result::Result,
         store::GStore,
+        Grc,
     },
     futures::{
         future,
         stream::{self, empty, once, Stream, StreamExt, TryStreamExt},
     },
     itertools::Itertools,
-    std::{borrow::Cow, collections::HashMap, pin::Pin, rc::Rc},
+    std::{borrow::Cow, collections::HashMap, pin::Pin},
     utils::OrStream,
 };
 
-pub struct Join<'a, T: GStore> {
+pub struct Join<'a, T> {
     storage: &'a T,
     join_clauses: &'a [AstJoin],
-    filter_context: Option<Rc<RowContext<'a>>>,
+    filter_context: Option<Grc<RowContext<'a>>>,
 }
 
-type JoinItem<'a> = Rc<RowContext<'a>>;
+type JoinItem<'a> = Grc<RowContext<'a>>;
+#[cfg(feature = "send")]
+type Joined<'a> = Pin<Box<dyn Stream<Item = Result<JoinItem<'a>>> + Send + 'a>>;
+#[cfg(not(feature = "send"))]
 type Joined<'a> = Pin<Box<dyn Stream<Item = Result<JoinItem<'a>>> + 'a>>;
 
-impl<'a, T: GStore> Join<'a, T> {
+impl<
+        'a,
+        #[cfg(feature = "send")] T: GStore + Send + Sync,
+        #[cfg(not(feature = "send"))] T: GStore,
+    > Join<'a, T>
+{
     pub fn new(
         storage: &'a T,
         join_clauses: &'a [AstJoin],
-        filter_context: Option<Rc<RowContext<'a>>>,
+        filter_context: Option<Grc<RowContext<'a>>>,
     ) -> Self {
         Self {
             storage,
@@ -41,16 +50,19 @@ impl<'a, T: GStore> Join<'a, T> {
         }
     }
 
-    pub async fn apply(
+    pub async fn apply<
+        #[cfg(feature = "send")] S: Stream<Item = Result<RowContext<'a>>> + Send + 'a,
+        #[cfg(not(feature = "send"))] S: Stream<Item = Result<RowContext<'a>>> + 'a,
+    >(
         self,
-        rows: impl Stream<Item = Result<RowContext<'a>>> + 'a,
+        rows: S,
     ) -> Result<Joined<'a>> {
-        let init_rows: Joined = Box::pin(rows.map(|row| row.map(Rc::new)));
+        let init_rows: Joined = Box::pin(rows.map(|row| row.map(Grc::new)));
 
         stream::iter(self.join_clauses)
             .map(Ok)
             .try_fold(init_rows, |rows, join_clause| {
-                let filter_context = self.filter_context.as_ref().map(Rc::clone);
+                let filter_context = self.filter_context.as_ref().map(Grc::clone);
 
                 async move { join(self.storage, filter_context, join_clause, rows).await }
             })
@@ -58,11 +70,16 @@ impl<'a, T: GStore> Join<'a, T> {
     }
 }
 
-async fn join<'a, T: GStore>(
-    storage: &'a T,
-    filter_context: Option<Rc<RowContext<'a>>>,
+async fn join<
+    'a,
+    #[cfg(feature = "send")] S: Stream<Item = Result<JoinItem<'a>>> + Send + 'a,
+    #[cfg(not(feature = "send"))] S: Stream<Item = Result<JoinItem<'a>>> + 'a,
+>(
+    #[cfg(feature = "send")] storage: &'a (impl GStore + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &'a impl GStore,
+    filter_context: Option<Grc<RowContext<'a>>>,
     ast_join: &'a AstJoin,
-    left_rows: impl Stream<Item = Result<JoinItem<'a>>> + 'a,
+    left_rows: S,
 ) -> Result<Joined<'a>> {
     let AstJoin {
         relation,
@@ -74,11 +91,11 @@ async fn join<'a, T: GStore>(
     let join_executor = JoinExecutor::new(
         storage,
         relation,
-        filter_context.as_ref().map(Rc::clone),
+        filter_context.as_ref().map(Grc::clone),
         join_executor,
     )
     .await
-    .map(Rc::new)?;
+    .map(Grc::new)?;
 
     let (join_operator, where_clause) = match join_operator {
         AstJoinOperator::Inner(JoinConstraint::None) => (JoinOperator::Inner, None),
@@ -93,33 +110,33 @@ async fn join<'a, T: GStore>(
 
     let columns = fetch_relation_columns(storage, relation)
         .await?
-        .map(Rc::from);
+        .map(Grc::from);
     let rows = left_rows.and_then(move |project_context| {
         let init_context = {
             let init_row = match columns.as_ref() {
                 Some(columns) => Row::Vec {
-                    columns: Rc::clone(columns),
+                    columns: Grc::clone(columns),
                     values: columns.iter().map(|_| Value::Null).collect(),
                 },
                 None => Row::Map(HashMap::new()),
             };
 
-            Rc::new(RowContext::new(
+            Grc::new(RowContext::new(
                 table_alias,
                 Cow::Owned(init_row),
-                Some(Rc::clone(&project_context)),
+                Some(Grc::clone(&project_context)),
             ))
         };
-        let filter_context = filter_context.as_ref().map(Rc::clone);
-        let join_executor = Rc::clone(&join_executor);
+        let filter_context = filter_context.as_ref().map(Grc::clone);
+        let join_executor = Grc::clone(&join_executor);
 
         async move {
             let filter_context = match filter_context {
-                Some(filter_context) => Rc::new(RowContext::concat(
-                    Rc::clone(&project_context),
-                    Rc::clone(&filter_context),
+                Some(filter_context) => Grc::new(RowContext::concat(
+                    Grc::clone(&project_context),
+                    Grc::clone(&filter_context),
                 )),
-                None => Rc::clone(&project_context),
+                None => Grc::clone(&project_context),
             };
             let filter_context = Some(filter_context);
 
@@ -138,8 +155,8 @@ async fn join<'a, T: GStore>(
                             check_where_clause(
                                 storage,
                                 table_alias,
-                                filter_context.as_ref().map(Rc::clone),
-                                Some(Rc::clone(&project_context)),
+                                filter_context.as_ref().map(Grc::clone),
+                                Some(Grc::clone(&project_context)),
                                 where_clause,
                                 row,
                             )
@@ -152,7 +169,7 @@ async fn join<'a, T: GStore>(
                 } => {
                     let rows = evaluate(
                         storage,
-                        filter_context.as_ref().map(Rc::clone),
+                        filter_context.as_ref().map(Grc::clone),
                         None,
                         value_expr,
                     )
@@ -165,8 +182,8 @@ async fn join<'a, T: GStore>(
                         Some(rows) => {
                             let rows = stream::iter(rows)
                                 .filter_map(|row| {
-                                    let filter_context = filter_context.as_ref().map(Rc::clone);
-                                    let project_context = Some(Rc::clone(&project_context));
+                                    let filter_context = filter_context.as_ref().map(Grc::clone);
+                                    let project_context = Some(Grc::clone(&project_context));
 
                                     async {
                                         check_where_clause(
@@ -221,10 +238,11 @@ enum JoinExecutor<'a> {
 }
 
 impl<'a> JoinExecutor<'a> {
-    async fn new<T: GStore>(
-        storage: &'a T,
+    async fn new(
+        #[cfg(feature = "send")] storage: &'a (impl GStore + Send + Sync),
+        #[cfg(not(feature = "send"))] storage: &'a impl GStore,
         relation: &TableFactor,
-        filter_context: Option<Rc<RowContext<'a>>>,
+        filter_context: Option<Grc<RowContext<'a>>>,
         ast_join_executor: &'a AstJoinExecutor,
     ) -> Result<JoinExecutor<'a>> {
         let (key_expr, value_expr, where_clause) = match ast_join_executor {
@@ -239,17 +257,17 @@ impl<'a> JoinExecutor<'a> {
         let rows_map = fetch_relation_rows(storage, relation, &filter_context)
             .await?
             .try_filter_map(|row| {
-                let filter_context = filter_context.as_ref().map(Rc::clone);
+                let filter_context = filter_context.as_ref().map(Grc::clone);
 
                 async move {
-                    let filter_context = Rc::new(RowContext::new(
+                    let filter_context = Grc::new(RowContext::new(
                         get_alias(relation),
                         Cow::Borrowed(&row),
                         filter_context,
                     ));
 
                     let hash_key: Key =
-                        evaluate(storage, Some(Rc::clone(&filter_context)), None, key_expr)
+                        evaluate(storage, Some(Grc::clone(&filter_context)), None, key_expr)
                             .await?
                             .try_into()?;
 
@@ -276,23 +294,24 @@ impl<'a> JoinExecutor<'a> {
     }
 }
 
-async fn check_where_clause<'a, 'b, T: GStore>(
-    storage: &'a T,
+async fn check_where_clause<'a, 'b>(
+    #[cfg(feature = "send")] storage: &'a (impl GStore + Send + Sync),
+    #[cfg(not(feature = "send"))] storage: &'a impl GStore,
     table_alias: &'a str,
-    filter_context: Option<Rc<RowContext<'a>>>,
-    project_context: Option<Rc<RowContext<'a>>>,
+    filter_context: Option<Grc<RowContext<'a>>>,
+    project_context: Option<Grc<RowContext<'a>>>,
     where_clause: Option<&'a Expr>,
     row: Cow<'b, Row>,
-) -> Result<Option<Rc<RowContext<'a>>>> {
+) -> Result<Option<Grc<RowContext<'a>>>> {
     let filter_context = RowContext::new(table_alias, Cow::Borrowed(&row), filter_context);
-    let filter_context = Some(Rc::new(filter_context));
+    let filter_context = Some(Grc::new(filter_context));
 
     match where_clause {
         Some(expr) => check_expr(storage, filter_context, None, expr).await?,
         None => true,
     }
     .then(|| RowContext::new(table_alias, Cow::Owned(row.into_owned()), project_context))
-    .map(Rc::new)
+    .map(Grc::new)
     .map(Ok)
     .transpose()
 }

--- a/core/src/executor/sort.rs
+++ b/core/src/executor/sort.rs
@@ -5,12 +5,12 @@ use {
         data::{Key, Row, Value},
         result::{Error, Result},
         store::GStore,
+        Grc, HashMap,
     },
     bigdecimal::ToPrimitive,
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
-    im_rc::HashMap,
     serde::Serialize,
-    std::{borrow::Cow, cmp::Ordering, fmt::Debug, rc::Rc},
+    std::{borrow::Cow, cmp::Ordering, fmt::Debug},
     thiserror::Error as ThisError,
     utils::Vector,
 };
@@ -23,16 +23,21 @@ pub enum SortError {
     Unreachable,
 }
 
-pub struct Sort<'a, T: GStore> {
+pub struct Sort<'a, T> {
     storage: &'a T,
-    context: Option<Rc<RowContext<'a>>>,
+    context: Option<Grc<RowContext<'a>>>,
     order_by: &'a [OrderByExpr],
 }
 
-impl<'a, T: GStore> Sort<'a, T> {
+impl<
+        'a,
+        #[cfg(feature = "send")] T: GStore + Send + Sync,
+        #[cfg(not(feature = "send"))] T: GStore,
+    > Sort<'a, T>
+{
     pub fn new(
         storage: &'a T,
-        context: Option<Rc<RowContext<'a>>>,
+        context: Option<Grc<RowContext<'a>>>,
         order_by: &'a [OrderByExpr],
     ) -> Self {
         Self {
@@ -42,12 +47,14 @@ impl<'a, T: GStore> Sort<'a, T> {
         }
     }
 
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(not(feature = "send"))]
     pub async fn apply(
         &self,
         rows: impl Stream<
                 Item = Result<(
-                    Option<Rc<HashMap<&'a Aggregate, Value>>>,
-                    Rc<RowContext<'a>>,
+                    Option<Grc<HashMap<&'a Aggregate, Value>>>,
+                    Grc<RowContext<'a>>,
                     Row,
                 )>,
             > + 'a,
@@ -109,24 +116,145 @@ impl<'a, T: GStore> Sort<'a, T> {
 
                 let filter_context = match &self.context {
                     Some(context) => {
-                        Rc::new(RowContext::concat(Rc::clone(&next), Rc::clone(context)))
+                        Grc::new(RowContext::concat(Grc::clone(&next), Grc::clone(context)))
                     }
-                    None => Rc::clone(&next),
+                    None => Grc::clone(&next),
                 };
 
                 async move {
                     let context = RowContext::new(table_alias, Cow::Borrowed(&row), None);
-                    let label_context = Rc::new(context);
-                    let filter_context = Rc::new(RowContext::concat(
+                    let label_context = Grc::new(context);
+                    let filter_context = Grc::new(RowContext::concat(
                         filter_context,
-                        Rc::clone(&label_context),
+                        Grc::clone(&label_context),
                     ));
 
                     let keys = order_by
                         .map(stream::iter)?
                         .then(|(sort_type, asc)| {
-                            let context = Some(Rc::clone(&filter_context));
-                            let aggregated = aggregated.as_ref().map(Rc::clone);
+                            let context = Some(Grc::clone(&filter_context));
+                            let aggregated = aggregated.as_ref().map(Grc::clone);
+
+                            async move {
+                                match sort_type {
+                                    SortType::Value(value) => value,
+                                    SortType::Expr(expr) => {
+                                        evaluate(self.storage, context, aggregated, expr)
+                                            .await?
+                                            .try_into()?
+                                    }
+                                }
+                                .try_into()
+                                .map(|key| (key, asc))
+                            }
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await?;
+
+                    drop(label_context);
+                    drop(filter_context);
+
+                    Ok((keys, row))
+                }
+            })
+            .try_collect::<Vec<(Vec<(Key, Option<bool>)>, Row)>>()
+            .await
+            .map(Vector::from)?
+            .sort_by(|(keys_a, ..), (keys_b, ..)| sort_by(keys_a, keys_b))
+            .into_iter()
+            .map(|(.., row)| Ok(row));
+
+        Ok(Rows::OrderBy(stream::iter(rows)))
+    }
+
+    // these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)
+    #[cfg(feature = "send")]
+    pub async fn apply(
+        &self,
+        rows: impl Stream<
+                Item = Result<(
+                    Option<Grc<HashMap<&'a Aggregate, Value>>>,
+                    Grc<RowContext<'a>>,
+                    Row,
+                )>,
+            > + Send
+            + 'a,
+        table_alias: &'a str,
+    ) -> Result<impl Stream<Item = Result<Row>> + Send + 'a> {
+        #[derive(futures_enum::Stream)]
+        enum Rows<I1, I2> {
+            NonOrderBy(I1),
+            OrderBy(I2),
+        }
+
+        if self.order_by.is_empty() {
+            let rows = rows.map_ok(|(.., row)| row);
+
+            return Ok(Rows::NonOrderBy(Box::pin(rows)));
+        }
+
+        let rows = rows
+            .and_then(|(aggregated, next, row)| {
+                enum SortType<'a> {
+                    Value(Value),
+                    Expr(&'a Expr),
+                }
+
+                let order_by = self.order_by;
+                let order_by = order_by
+                    .iter()
+                    .map(|OrderByExpr { expr, asc }| -> Result<_> {
+                        let big_decimal = match expr {
+                            Expr::Literal(AstLiteral::Number(n)) => Some(n),
+                            Expr::UnaryOp {
+                                op: UnaryOperator::Plus,
+                                expr,
+                            } => match expr.as_ref() {
+                                Expr::Literal(AstLiteral::Number(n)) => Some(n),
+                                _ => None,
+                            },
+                            _ => None,
+                        };
+
+                        match (big_decimal, &row) {
+                            (Some(n), Row::Vec { values, .. }) => {
+                                let index = n
+                                    .to_usize()
+                                    .ok_or_else(|| -> Error { SortError::Unreachable.into() })?;
+                                let zero_based = index.checked_sub(1).ok_or_else(|| -> Error {
+                                    SortError::ColumnIndexOutOfRange(index).into()
+                                })?;
+                                let value = values.get(zero_based).ok_or_else(|| -> Error {
+                                    SortError::ColumnIndexOutOfRange(index).into()
+                                })?;
+
+                                Ok((SortType::Value(value.clone()), *asc))
+                            }
+                            _ => Ok((SortType::Expr(expr), *asc)),
+                        }
+                    })
+                    .collect::<Result<Vec<_>>>();
+
+                let filter_context = match &self.context {
+                    Some(context) => {
+                        Grc::new(RowContext::concat(Grc::clone(&next), Grc::clone(context)))
+                    }
+                    None => Grc::clone(&next),
+                };
+
+                async move {
+                    let context = RowContext::new(table_alias, Cow::Borrowed(&row), None);
+                    let label_context = Grc::new(context);
+                    let filter_context = Grc::new(RowContext::concat(
+                        filter_context,
+                        Grc::clone(&label_context),
+                    ));
+
+                    let keys = order_by
+                        .map(stream::iter)?
+                        .then(|(sort_type, asc)| {
+                            let context = Some(Grc::clone(&filter_context));
+                            let aggregated = aggregated.as_ref().map(Grc::clone);
 
                             async move {
                                 match sort_type {

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -4,9 +4,9 @@ use {
         data::{Key, Value},
         result::Result,
         store::{DataRow, Store},
+        HashSet,
     },
     futures::stream::TryStreamExt,
-    im_rc::HashSet,
     serde::Serialize,
     std::fmt::Debug,
     thiserror::Error as ThisError,
@@ -82,7 +82,10 @@ impl UniqueConstraint {
     }
 }
 
-pub async fn validate_unique<T: Store>(
+pub async fn validate_unique<
+    #[cfg(feature = "send")] T: Store + Send,
+    #[cfg(not(feature = "send"))] T: Store,
+>(
     storage: &T,
     table_name: &str,
     column_validation: ColumnValidation<'_>,

--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -14,12 +14,15 @@ use {
     },
 };
 
-#[derive(Debug)]
 pub struct Glue<T: GStore + GStoreMut> {
     pub storage: T,
 }
 
-impl<T: GStore + GStoreMut> Glue<T> {
+impl<
+        #[cfg(feature = "send")] T: GStore + GStoreMut + Send + Sync,
+        #[cfg(not(feature = "send"))] T: GStore + GStoreMut,
+    > Glue<T>
+{
     pub fn new(storage: T) -> Self {
         Self { storage }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,3 +32,13 @@ pub mod prelude {
 pub mod error {
     pub use crate::result::*;
 }
+
+#[cfg(not(feature = "send"))]
+pub(crate) use std::rc::Rc as Grc;
+#[cfg(feature = "send")]
+pub(crate) use std::sync::Arc as Grc;
+
+#[cfg(feature = "send")]
+pub(crate) use im::{HashMap, HashSet};
+#[cfg(not(feature = "send"))]
+pub(crate) use im_rc::{HashMap, HashSet};

--- a/core/src/mock.rs
+++ b/core/src/mock.rs
@@ -35,13 +35,14 @@ pub struct MockStorage {
     schema_map: HashMap<String, Schema>,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl CustomFunction for MockStorage {}
 
-#[async_trait(?Send)]
+#[async_trait]
 impl CustomFunctionMut for MockStorage {}
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 impl Store for MockStorage {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
         if table_name == "__Err__" {
@@ -75,7 +76,8 @@ impl Store for MockStorage {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 impl StoreMut for MockStorage {
     async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         let table_name = schema.table_name.clone();

--- a/core/src/plan/context.rs
+++ b/core/src/plan/context.rs
@@ -1,15 +1,15 @@
-use std::rc::Rc;
+use crate::Grc;
 
 pub enum Context<'a> {
     Data {
         alias: String,
         columns: Vec<&'a str>,
         primary_key: Option<&'a str>,
-        next: Option<Rc<Context<'a>>>,
+        next: Option<Grc<Context<'a>>>,
     },
     Bridge {
-        left: Rc<Context<'a>>,
-        right: Rc<Context<'a>>,
+        left: Grc<Context<'a>>,
+        right: Grc<Context<'a>>,
     },
 }
 
@@ -18,7 +18,7 @@ impl<'a> Context<'a> {
         alias: String,
         columns: Vec<&'a str>,
         primary_key: Option<&'a str>,
-        next: Option<Rc<Context<'a>>>,
+        next: Option<Grc<Context<'a>>>,
     ) -> Self {
         Context::Data {
             alias,
@@ -29,11 +29,11 @@ impl<'a> Context<'a> {
     }
 
     pub fn concat(
-        left: Option<Rc<Context<'a>>>,
-        right: Option<Rc<Context<'a>>>,
-    ) -> Option<Rc<Self>> {
+        left: Option<Grc<Context<'a>>>,
+        right: Option<Grc<Context<'a>>>,
+    ) -> Option<Grc<Self>> {
         match (left, right) {
-            (Some(left), Some(right)) => Some(Rc::new(Self::Bridge { left, right })),
+            (Some(left), Some(right)) => Some(Grc::new(Self::Bridge { left, right })),
             (context @ Some(_), None) | (None, context @ Some(_)) => context,
             (None, None) => None,
         }

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -4,10 +4,11 @@ use {
         Expr, Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr, TableAlias,
         TableFactor, TableWithJoins, Values,
     },
-    std::{convert::identity, rc::Rc},
+    crate::Grc,
+    std::convert::identity,
 };
 
-pub fn check_expr(context: Option<Rc<Context<'_>>>, expr: &Expr) -> bool {
+pub fn check_expr(context: Option<Grc<Context<'_>>>, expr: &Expr) -> bool {
     match expr.into() {
         PlanExpr::None => true,
         PlanExpr::Identifier(ident) => context.map(|c| c.contains_column(ident)).unwrap_or(false),
@@ -21,24 +22,24 @@ pub fn check_expr(context: Option<Rc<Context<'_>>>, expr: &Expr) -> bool {
         }
         PlanExpr::Expr(expr) => check_expr(context, expr),
         PlanExpr::TwoExprs(expr, expr2) => {
-            check_expr(context.as_ref().map(Rc::clone), expr) && check_expr(context, expr2)
+            check_expr(context.as_ref().map(Grc::clone), expr) && check_expr(context, expr2)
         }
         PlanExpr::ThreeExprs(expr, expr2, expr3) => {
-            check_expr(context.as_ref().map(Rc::clone), expr)
-                && check_expr(context.as_ref().map(Rc::clone), expr2)
+            check_expr(context.as_ref().map(Grc::clone), expr)
+                && check_expr(context.as_ref().map(Grc::clone), expr2)
                 && check_expr(context, expr3)
         }
         PlanExpr::MultiExprs(exprs) => exprs
             .iter()
-            .all(|expr| check_expr(context.as_ref().map(Rc::clone), expr)),
+            .all(|expr| check_expr(context.as_ref().map(Grc::clone), expr)),
         PlanExpr::Query(query) => check_query(context, query),
         PlanExpr::QueryAndExpr { query, expr } => {
-            check_query(context.as_ref().map(Rc::clone), query) && check_expr(context, expr)
+            check_query(context.as_ref().map(Grc::clone), query) && check_expr(context, expr)
         }
     }
 }
 
-fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
+fn check_query(context: Option<Grc<Context<'_>>>, query: &Query) -> bool {
     let Query {
         body,
         order_by,
@@ -47,11 +48,11 @@ fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
     } = query;
 
     let body = match body {
-        SetExpr::Select(select) => check_select(context.as_ref().map(Rc::clone), select),
+        SetExpr::Select(select) => check_select(context.as_ref().map(Grc::clone), select),
         SetExpr::Values(Values(rows)) => rows
             .iter()
             .flatten()
-            .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
+            .map(|expr| check_expr(context.as_ref().map(Grc::clone), expr))
             .all(identity),
     };
 
@@ -62,7 +63,7 @@ fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
     let order_by = order_by
         .iter()
         .map(|order_by| &order_by.expr)
-        .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
+        .map(|expr| check_expr(context.as_ref().map(Grc::clone), expr))
         .all(identity);
     if !order_by {
         return false;
@@ -71,11 +72,11 @@ fn check_query(context: Option<Rc<Context<'_>>>, query: &Query) -> bool {
     limit
         .iter()
         .chain(offset.iter())
-        .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
+        .map(|expr| check_expr(context.as_ref().map(Grc::clone), expr))
         .all(identity)
 }
 
-fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
+fn check_select(context: Option<Grc<Context<'_>>>, select: &Select) -> bool {
     let Select {
         projection,
         from,
@@ -87,7 +88,7 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
     if !projection
         .iter()
         .map(|select_item| match select_item {
-            SelectItem::Expr { expr, .. } => check_expr(context.as_ref().map(Rc::clone), expr),
+            SelectItem::Expr { expr, .. } => check_expr(context.as_ref().map(Grc::clone), expr),
             SelectItem::QualifiedWildcard(_) | SelectItem::Wildcard => true,
         })
         .all(identity)
@@ -97,7 +98,7 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
 
     let TableWithJoins { relation, joins } = from;
 
-    if !check_table_factor(context.as_ref().map(Rc::clone), relation) {
+    if !check_table_factor(context.as_ref().map(Grc::clone), relation) {
         return false;
     }
 
@@ -110,14 +111,14 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
                 ..
             } = join;
 
-            if !check_table_factor(context.as_ref().map(Rc::clone), relation) {
+            if !check_table_factor(context.as_ref().map(Grc::clone), relation) {
                 return false;
             }
 
             match join_operator {
                 JoinOperator::Inner(JoinConstraint::On(expr))
                 | JoinOperator::LeftOuter(JoinConstraint::On(expr)) => {
-                    check_expr(context.as_ref().map(Rc::clone), expr)
+                    check_expr(context.as_ref().map(Grc::clone), expr)
                 }
                 JoinOperator::Inner(JoinConstraint::None)
                 | JoinOperator::LeftOuter(JoinConstraint::None) => true,
@@ -132,11 +133,11 @@ fn check_select(context: Option<Rc<Context<'_>>>, select: &Select) -> bool {
         .iter()
         .chain(group_by.iter())
         .chain(having.iter())
-        .map(|expr| check_expr(context.as_ref().map(Rc::clone), expr))
+        .map(|expr| check_expr(context.as_ref().map(Grc::clone), expr))
         .all(identity)
 }
 
-fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFactor) -> bool {
+fn check_table_factor(context: Option<Grc<Context<'_>>>, table_factor: &TableFactor) -> bool {
     let alias = match table_factor {
         TableFactor::Table { name, alias, .. } => alias
             .as_ref()
@@ -156,11 +157,10 @@ fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFact
 mod tests {
     use {
         super::{check_expr, Context},
-        crate::{parse_sql::parse_expr, translate::translate_expr},
-        std::rc::Rc,
+        crate::{parse_sql::parse_expr, translate::translate_expr, Grc},
     };
 
-    fn test(context: Option<Rc<Context<'_>>>, sql: &str, expected: bool) {
+    fn test(context: Option<Grc<Context<'_>>>, sql: &str, expected: bool) {
         let parsed = parse_expr(sql).unwrap();
         let expr = translate_expr(&parsed);
         let actual = match expr {
@@ -179,22 +179,22 @@ mod tests {
                 "Foo".to_owned(),
                 vec!["id", "name"],
                 None,
-                Some(Rc::new(left_child)),
+                Some(Grc::new(left_child)),
             );
             let right_child = Context::new("Src".to_owned(), Vec::new(), None, None);
             let right = Context::new(
                 "Bar".to_owned(),
                 vec!["id", "rate"],
                 None,
-                Some(Rc::new(right_child)),
+                Some(Grc::new(right_child)),
             );
 
-            Context::concat(Some(Rc::new(left)), Some(Rc::new(right)))
+            Context::concat(Some(Grc::new(left)), Some(Grc::new(right)))
         };
 
         macro_rules! test {
             ($sql: literal, $expected: expr) => {
-                test(context.as_ref().map(Rc::clone), $sql, $expected);
+                test(context.as_ref().map(Grc::clone), $sql, $expected);
             };
         }
 

--- a/core/src/plan/mod.rs
+++ b/core/src/plan/mod.rs
@@ -16,7 +16,13 @@ pub use {
     primary_key::plan as plan_primary_key, schema::fetch_schema_map,
 };
 
-pub async fn plan<T: Store>(storage: &T, statement: Statement) -> Result<Statement> {
+pub async fn plan<
+    #[cfg(feature = "send")] T: Store + Send + Sync,
+    #[cfg(not(feature = "send"))] T: Store,
+>(
+    storage: &T,
+    statement: Statement,
+) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
     validate(&schema_map, &statement)?;
     let statement = plan_primary_key(&schema_map, statement);

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -6,8 +6,9 @@ use {
             TableWithJoins,
         },
         data::Schema,
+        Grc,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::collections::HashMap,
 };
 
 pub fn plan(schema_map: &HashMap<String, Schema>, statement: Statement) -> Statement {
@@ -28,7 +29,7 @@ struct PrimaryKeyPlanner<'a> {
 }
 
 impl<'a> Planner<'a> for PrimaryKeyPlanner<'a> {
-    fn query(&self, outer_context: Option<Rc<Context<'a>>>, query: Query) -> Query {
+    fn query(&self, outer_context: Option<Grc<Context<'a>>>, query: Query) -> Query {
         let body = match query.body {
             SetExpr::Select(select) => {
                 let select = self.select(outer_context, *select);
@@ -55,7 +56,7 @@ enum PrimaryKey {
 }
 
 impl<'a> PrimaryKeyPlanner<'a> {
-    fn select(&self, outer_context: Option<Rc<Context<'a>>>, select: Select) -> Select {
+    fn select(&self, outer_context: Option<Grc<Context<'a>>>, select: Select) -> Select {
         let current_context = self.update_context(None, &select.from.relation);
         let current_context = select
             .from
@@ -100,8 +101,8 @@ impl<'a> PrimaryKeyPlanner<'a> {
 
     fn expr(
         &self,
-        outer_context: Option<Rc<Context<'a>>>,
-        current_context: Option<Rc<Context<'a>>>,
+        outer_context: Option<Grc<Context<'a>>>,
+        current_context: Option<Grc<Context<'a>>>,
         expr: Expr,
     ) -> PrimaryKey {
         let check_primary_key = |key: &Expr| {
@@ -128,7 +129,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
                 op: BinaryOperator::Eq,
                 right: key,
             } if check_primary_key(key.as_ref())
-                && check_evaluable(current_context.as_ref().map(Rc::clone), &key)
+                && check_evaluable(current_context.as_ref().map(Grc::clone), &key)
                 && check_evaluable(None, &value) =>
             {
                 let index_item = IndexItem::PrimaryKey(*value);
@@ -144,8 +145,8 @@ impl<'a> PrimaryKeyPlanner<'a> {
                 right,
             } => {
                 let primary_key = self.expr(
-                    outer_context.as_ref().map(Rc::clone),
-                    current_context.as_ref().map(Rc::clone),
+                    outer_context.as_ref().map(Grc::clone),
+                    current_context.as_ref().map(Grc::clone),
                     *left,
                 );
 

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -4,8 +4,9 @@ use {
         ast::{Expr, Join, Query, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins},
         data::Schema,
         result::Result,
+        Grc,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::collections::HashMap,
 };
 
 type SchemaMap = HashMap<String, Schema>;
@@ -44,22 +45,25 @@ pub fn validate(schema_map: &SchemaMap, statement: &Statement) -> Result<()> {
 enum Context<'a> {
     Data {
         labels: Option<Vec<&'a str>>,
-        next: Option<Rc<Context<'a>>>,
+        next: Option<Grc<Context<'a>>>,
     },
     Bridge {
-        left: Rc<Context<'a>>,
-        right: Rc<Context<'a>>,
+        left: Grc<Context<'a>>,
+        right: Grc<Context<'a>>,
     },
 }
 
 impl<'a> Context<'a> {
-    fn new(labels: Option<Vec<&'a str>>, next: Option<Rc<Context<'a>>>) -> Self {
+    fn new(labels: Option<Vec<&'a str>>, next: Option<Grc<Context<'a>>>) -> Self {
         Self::Data { labels, next }
     }
 
-    fn concat(left: Option<Rc<Context<'a>>>, right: Option<Rc<Context<'a>>>) -> Option<Rc<Self>> {
+    fn concat(
+        left: Option<Grc<Context<'a>>>,
+        right: Option<Grc<Context<'a>>>,
+    ) -> Option<Grc<Self>> {
         match (left, right) {
-            (Some(left), Some(right)) => Some(Rc::new(Self::Bridge { left, right })),
+            (Some(left), Some(right)) => Some(Grc::new(Self::Bridge { left, right })),
             (context @ Some(_), None) | (None, context @ Some(_)) => context,
             (None, None) => None,
         }
@@ -109,7 +113,10 @@ fn get_labels(schema: &Schema) -> Option<Vec<&str>> {
     })
 }
 
-fn contextualize_query<'a>(schema_map: &'a SchemaMap, query: &'a Query) -> Option<Rc<Context<'a>>> {
+fn contextualize_query<'a>(
+    schema_map: &'a SchemaMap,
+    query: &'a Query,
+) -> Option<Grc<Context<'a>>> {
     let Query { body, .. } = query;
     match body {
         SetExpr::Select(select) => {
@@ -129,16 +136,16 @@ fn contextualize_query<'a>(schema_map: &'a SchemaMap, query: &'a Query) -> Optio
 fn contextualize_table_factor<'a>(
     schema_map: &'a SchemaMap,
     table_factor: &'a TableFactor,
-) -> Option<Rc<Context<'a>>> {
+) -> Option<Grc<Context<'a>>> {
     match table_factor {
         TableFactor::Table { name, .. } => {
             let schema = schema_map.get(name);
-            schema.map(|schema| Rc::from(Context::new(get_labels(schema), None)))
+            schema.map(|schema| Grc::from(Context::new(get_labels(schema), None)))
         }
         TableFactor::Derived { subquery, .. } => contextualize_query(schema_map, subquery),
         TableFactor::Series { .. } | TableFactor::Dictionary { .. } => None,
     }
-    .map(Rc::from)
+    .map(Grc::from)
 }
 
 #[cfg(test)]

--- a/core/src/store/alter_table.rs
+++ b/core/src/store/alter_table.rs
@@ -32,7 +32,8 @@ pub enum AlterTableError {
     ConflictOnUnexpectedMapRowFound,
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait AlterTable: Store + StoreMut {
     async fn rename_schema(&mut self, table_name: &str, new_table_name: &str) -> Result<()> {
         let mut schema = self

--- a/core/src/store/function.rs
+++ b/core/src/store/function.rs
@@ -6,7 +6,8 @@ use {
     async_trait::async_trait,
 };
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait CustomFunction {
     async fn fetch_function(&self, _func_name: &str) -> Result<Option<&StructCustomFunction>> {
         Err(Error::StorageMsg(
@@ -20,7 +21,8 @@ pub trait CustomFunction {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait CustomFunctionMut {
     async fn insert_function(&mut self, _func: StructCustomFunction) -> Result<()> {
         Err(Error::StorageMsg(

--- a/core/src/store/index.rs
+++ b/core/src/store/index.rs
@@ -38,7 +38,8 @@ pub enum IndexError {
     ConflictOnIndexDataDeleteSync,
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait Index {
     async fn scan_indexed_data(
         &self,
@@ -53,7 +54,8 @@ pub trait Index {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait IndexMut {
     async fn create_index(
         &mut self,

--- a/core/src/store/metadata.rs
+++ b/core/src/store/metadata.rs
@@ -7,7 +7,8 @@ use {
 type ObjectName = String;
 pub type MetaIter = Box<dyn Iterator<Item = Result<(ObjectName, HashMap<String, Value>)>>>;
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait Metadata {
     async fn scan_table_meta(&self) -> Result<MetaIter> {
         Ok(Box::new(empty()))

--- a/core/src/store/transaction.rs
+++ b/core/src/store/transaction.rs
@@ -3,7 +3,8 @@ use {
     async_trait::async_trait,
 };
 
-#[async_trait(?Send)]
+#[cfg_attr(not(feature = "send"), async_trait(?Send))]
+#[cfg_attr(feature = "send", async_trait)]
 pub trait Transaction {
     async fn begin(&mut self, autocommit: bool) -> Result<bool> {
         if autocommit {

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -9,11 +9,13 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-gluesql-core.workspace = true
+#gluesql-core.workspace = true
+gluesql-core = { path = "../../core", version = "0.16.3" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 
 [dev-dependencies]
-test-suite.workspace = true
+#test-suite.workspace = true
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.16.3" }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/storages/shared-memory-storage/Cargo.toml
+++ b/storages/shared-memory-storage/Cargo.toml
@@ -12,8 +12,10 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-gluesql-core.workspace = true
-gluesql_memory_storage.workspace = true
+#gluesql-core = { workspace = true, features = ["send"] }
+#gluesql_memory_storage.workspace = true
+gluesql-core = { path = "../../core", version = "0.16.3", features = ["send"] }
+gluesql_memory_storage = { path = "../memory-storage", version = "0.16.3" }
 
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
@@ -21,5 +23,6 @@ tokio = { version = "1", features = ["sync"] }
 futures = "0.3"
 
 [dev-dependencies]
-test-suite.workspace = true
+#test-suite = { workspace = true, features = ["send"] }
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.16.3", features = ["send"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/storages/shared-memory-storage/src/alter_table.rs
+++ b/storages/shared-memory-storage/src/alter_table.rs
@@ -5,7 +5,7 @@ use {
     std::sync::Arc,
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl AlterTable for SharedMemoryStorage {
     async fn rename_schema(&mut self, table_name: &str, new_table_name: &str) -> Result<()> {
         let database = Arc::clone(&self.database);

--- a/storages/shared-memory-storage/src/index.rs
+++ b/storages/shared-memory-storage/src/index.rs
@@ -9,7 +9,7 @@ use {
     },
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Index for SharedMemoryStorage {
     async fn scan_indexed_data(
         &self,
@@ -24,7 +24,7 @@ impl Index for SharedMemoryStorage {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl IndexMut for SharedMemoryStorage {
     async fn create_index(
         &mut self,

--- a/storages/shared-memory-storage/src/lib.rs
+++ b/storages/shared-memory-storage/src/lib.rs
@@ -44,7 +44,7 @@ impl From<MemoryStorage> for SharedMemoryStorage {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Store for SharedMemoryStorage {
     async fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
         let database = Arc::clone(&self.database);
@@ -79,7 +79,7 @@ impl Store for SharedMemoryStorage {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl StoreMut for SharedMemoryStorage {
     async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         let database = Arc::clone(&self.database);

--- a/storages/shared-memory-storage/src/transaction.rs
+++ b/storages/shared-memory-storage/src/transaction.rs
@@ -7,7 +7,7 @@ use {
     },
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transaction for SharedMemoryStorage {
     async fn begin(&mut self, autocommit: bool) -> Result<bool> {
         if autocommit {

--- a/storages/shared-memory-storage/tests/shared_memory_storage.rs
+++ b/storages/shared-memory-storage/tests/shared_memory_storage.rs
@@ -7,7 +7,7 @@ struct SharedMemoryTester {
     glue: Glue<SharedMemoryStorage>,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Tester<SharedMemoryStorage> for SharedMemoryTester {
     async fn new(_: &str) -> Self {
         let storage = SharedMemoryStorage::new();

--- a/storages/sled-storage/Cargo.toml
+++ b/storages/sled-storage/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-gluesql-core.workspace = true
+#gluesql-core.workspace = true
+gluesql-core = { path = "../../core", version = "0.16.3", features = ["send"] }
 utils.workspace = true
 async-trait = "0.1"
 iter-enum = "1"
@@ -21,7 +22,8 @@ async-io = "1"
 futures = "0.3"
 
 [dev-dependencies]
-test-suite.workspace = true
+#test-suite.workspace = true
+test-suite = { package = "gluesql-test-suite", path = "../../test-suite", version = "0.16.3", features = ["send"] }
 criterion = "0.3"
 tokio = { version = "1", features = ["rt", "macros"] }
 

--- a/storages/sled-storage/src/alter_table.rs
+++ b/storages/sled-storage/src/alter_table.rs
@@ -20,7 +20,7 @@ use {
     utils::Vector,
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl AlterTable for SledStorage {
     async fn rename_schema(&mut self, table_name: &str, new_table_name: &str) -> Result<()> {
         let prefix = format!("data/{}/", table_name);

--- a/storages/sled-storage/src/index.rs
+++ b/storages/sled-storage/src/index.rs
@@ -18,7 +18,7 @@ use {
     utils::Vector,
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Index for SledStorage {
     async fn scan_indexed_data(
         &self,

--- a/storages/sled-storage/src/index_mut.rs
+++ b/storages/sled-storage/src/index_mut.rs
@@ -38,7 +38,7 @@ fn fetch_schema(
     Ok((key, schema_snapshot))
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl IndexMut for SledStorage {
     async fn create_index(
         &mut self,

--- a/storages/sled-storage/src/store.rs
+++ b/storages/sled-storage/src/store.rs
@@ -14,7 +14,7 @@ impl SledStorage {
     const SCHEMA_PREFIX: &'static str = "schema/";
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Store for SledStorage {
     async fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
         let (txid, created_at) = match self.state {

--- a/storages/sled-storage/src/store_mut.rs
+++ b/storages/sled-storage/src/store_mut.rs
@@ -17,7 +17,7 @@ use {
     sled::transaction::{ConflictableTransactionError, ConflictableTransactionResult},
 };
 
-#[async_trait(?Send)]
+#[async_trait]
 impl StoreMut for SledStorage {
     async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         let state = &self.state;

--- a/storages/sled-storage/src/transaction.rs
+++ b/storages/sled-storage/src/transaction.rs
@@ -26,7 +26,7 @@ pub enum TxPayload {
     RollbackAndRetry(u64),
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transaction for SledStorage {
     async fn begin(&mut self, autocommit: bool) -> Result<bool> {
         match (&self.state, autocommit) {

--- a/storages/sled-storage/tests/sled_storage.rs
+++ b/storages/sled-storage/tests/sled_storage.rs
@@ -7,7 +7,7 @@ struct SledTester {
     glue: Glue<SledStorage>,
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Tester<SledStorage> for SledTester {
     async fn new(namespace: &str) -> Self {
         let path = format!("data/{}", namespace);

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -8,8 +8,12 @@ license.workspace = true
 repository.workspace = true
 documentation.workspace = true
 
+[features]
+send = ["gluesql-core/send"]
+
 [dependencies]
-gluesql-core.workspace = true
+#gluesql-core.workspace = true
+gluesql-core = { path = "../core", version = "0.16.3" }
 async-trait = "0.1"
 bigdecimal = "0.4.2"
 chrono = "0.4.31"


### PR DESCRIPTION
Resolution for https://github.com/gluesql/gluesql/issues/1265, based on https://github.com/ever0de/gluesql/tree/feat/send-feature

This is based on @ever0de 's work (kudos!), rebased on actual `main` and mostly proceeds in the same direction. `send` feature for the `gluesql-core` crate is complete but the original issue misses an important problem - how this feature interacts with other crates given the additive nature of rust/cargo features. For example - `SharedMemoryStorage` can work with send but it's dependency `MemoryStorage` can't. Similar problems with the composite storage and in other gluesql crates. This PR includes messed up `Cargo.toml` files and I'm not sure how to fix them - cargo doesn't support having both `send` and non-`send` versions of `gluesql-core` in the dependency graph so current project structure breaks completely. Maybe I'm missing some solution due to lack of experience working with complex workspaces, but maybe solution will require some restructuring decisions, idk. Need help from the maintainers here.

Also, in review you might notice a few weird things so I want to highlight them and provide some context:

- `core/src/executor/evaluate/mod.rs` (`// not using stream try_filter due to cryptic lifetimes issues`) - slight rewrite from a `try_filter` to a `while` loop with no change in logic afaik, still very much readable so I think should be fine

- `core/src/executor/aggregate/state.rs` (`// using iter_chunks because itertools::Chunk is !Send, and the while loop because iter_chunks:Chunks is not an Iterator`) - comment pretty much says it all, performance etc should be about the same

- `core/src/executor/aggregate/mod.rs` (`// not using iters and chaining due to cryptic lifetimes issues`) - updated code adds just a few allocations and pretty straightforward so I think it's fine

- `// these two same fns can be replaced with a impl type alias for the return type once its stabilized (https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html)` in a few places, I've tried replacing with generics but in return positions they just create new problems. Since TAIT are already available in nightly I think it makes sense to await their stabilisation and just replace return types with `cfg`'d aliased types

- `test-suite/src/tester/mod.rs` (`// cfg(feature) shouldn't be inside macro because it will be expanded together with these directives`) - just a bit ugly and these duplicates won't be solved with TAIT, but can be minimised by splitting `cfg`'d part and the rest in different macros and combining them in another
