### PR TITLE
Add data_type info to ast::IndexItem::PrimaryKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
 name = "gluesql"
 version = "0.16.2"
 dependencies = [
+ "anyhow",
  "futures",
  "gluesql-cli",
  "gluesql-composite-storage",
@@ -1239,6 +1240,7 @@ dependencies = [
  "gluesql-web-storage",
  "gluesql_memory_storage",
  "gluesql_sled_storage",
+ "uuid",
 ]
 
 [[package]]

--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -3,7 +3,7 @@ use {
     strum_macros::Display,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum DataType {
     Boolean,

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -1,6 +1,5 @@
 use {
-    super::{Expr, IndexOperator, ToSqlUnquoted},
-    crate::ast::ToSql,
+    super::{Expr, IndexOperator, ToSqlUnquoted, DataType, ToSql},
     itertools::Itertools,
     serde::{Deserialize, Serialize},
     strum_macros::Display,
@@ -48,7 +47,10 @@ pub struct TableWithJoins {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum IndexItem {
-    PrimaryKey(Expr),
+    PrimaryKey {
+        data_type: DataType,
+        expr: Expr,
+    },
     NonClustered {
         name: String,
         asc: Option<bool>,

--- a/core/src/ast_builder/index_item/mod.rs
+++ b/core/src/ast_builder/index_item/mod.rs
@@ -3,7 +3,7 @@ mod non_clustered;
 mod primary_key;
 
 use {
-    super::{select::Prebuild, ExprNode},
+    super::{select::Prebuild, ExprNode, DataTypeNode},
     crate::ast::{Expr, IndexOperator},
 };
 pub use {
@@ -20,7 +20,11 @@ pub enum IndexItemNode<'a> {
         asc: Option<bool>,
         cmp_expr: Option<(IndexOperator, ExprNode<'a>)>,
     },
-    PrimaryKey(ExprNode<'a>),
+    // PrimaryKey(ExprNode<'a>),
+    PrimaryKey {
+        data_type: DataTypeNode,
+        expr: exprNode<'a>,
+    }
 }
 
 impl<'a> From<CmpExprNode<'a>> for IndexItemNode<'a> {

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -147,7 +147,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
 
                         Rows::Indexed(rows)
                     }
-                    Some(IndexItem::PrimaryKey(expr)) => {
+                    Some(IndexItem::PrimaryKey { expr, .. }) => {
                         let filter_context = filter_context.as_ref().map(Rc::clone);
                         let key = evaluate(storage, filter_context, None, expr)
                             .await

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -33,6 +33,8 @@ gluesql-git-storage = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures = "0.3"
+anyhow = "1.0"
+uuid = { version = "1", features = ["v7"] }
 
 [features]
 # DB User

--- a/pkg/rust/examples/test.rs
+++ b/pkg/rust/examples/test.rs
@@ -1,0 +1,70 @@
+use anyhow::{anyhow, Result};
+use gluesql::prelude::{Glue, MemoryStorage};
+
+fn main() {
+    futures::executor::block_on(run()).expect("hey");
+}
+
+async fn run() -> Result<()> {
+    let mem = MemoryStorage::default();
+    let mut mem = Glue::new(mem);
+
+    mem.execute(
+        r#"
+            CREATE TABLE IF NOT EXISTS posts (
+                id UUID PRIMARY KEY,
+                title TEXT NOT NULL,
+                text TEXT NOT NULL,
+                id_2 UUID NOT NULL
+            )
+        "#,
+    )
+    .await?;
+
+    let uuid = uuid::Uuid::now_v7();
+    let temp = mem.execute(format!(
+        r#"INSERT INTO "posts" ("id", "title", "text", "id_2") VALUES ('{uuid}', 'Homo', 'いいよ、来いよ', '{uuid}')"#
+    )).await?;
+    println!("DEBUG insert: {:#?}", temp);
+
+    let temp = mem.execute("SELECT * from posts").await?;
+    println!("DEBUG query all: {:#?}", temp);
+    let temp = temp[0]
+        .select()
+        .ok_or(anyhow!("No result"))?
+        .next()
+        .ok_or(anyhow!("No next"))?;
+    let temp = temp
+        .get("id")
+        .cloned()
+        .ok_or(anyhow!("Cannot get id"))?
+        .clone();
+    let uuid_2 = match temp {
+        gluesql::prelude::Value::Uuid(val) => uuid::Uuid::from_u128(val),
+        _ => todo!(),
+    };
+    assert_eq!(uuid, uuid_2);
+    println!("DEBUG query first uuid: {:?}", uuid_2);
+
+    let temp = format!("SELECT * from posts where id = CAST({} AS UUID)", uuid_2.as_u128());
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!("SELECT * from posts where id = UUID '{}'", uuid_2.to_string());
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!("SELECT * from posts where text = '{}'", "いいよ、来いよ");
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!("SELECT * from posts where id_2 = '{}'", uuid_2.to_string());
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    Ok(())
+}


### PR DESCRIPTION
- [ ] Currently, the implementation calls fetch_schema multiple times, leading to inefficiencies. This should be improved through refactoring.

ref. https://github.com/gluesql/gluesql/pull/1582