### PR TITLE
Implement data prefix for Redb storage

### DIFF
--- a/storages/redb-storage/src/core.rs
+++ b/storages/redb-storage/src/core.rs
@@ -29,8 +29,9 @@ impl StorageCore {
     }
 
     fn data_table_def(table_name: &str) -> Result<TableDefinition<&'static [u8], Vec<u8>>> {
-        // let table_name = format!("data_{}", table_name);
-        // todo
+        let table_name = format!("data_{table_name}");
+        let table_name: &'static str = Box::leak(table_name.into_boxed_str());
+
         Ok(TableDefinition::new(table_name))
     }
 }


### PR DESCRIPTION
## Summary
- prepend `data_` prefix when defining Redb data tables

## Testing
- `cargo test -p gluesql-redb-storage` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68451887c2b4832ab82100a6a9c13350