### PR TITLE
Add nested transaction test for Redb

### DIFF
--- a/storages/redb-storage/tests/nested_transaction.rs
+++ b/storages/redb-storage/tests/nested_transaction.rs
@@ -1,0 +1,25 @@
+use {
+    gluesql_core::prelude::{Error, Glue},
+    gluesql_redb_storage::RedbStorage,
+};
+
+#[tokio::test]
+async fn redb_nested_transaction() {
+    let _ = std::fs::create_dir("tmp");
+    let path = "tmp/redb_nested_transaction";
+    let _ = std::fs::remove_file(path);
+
+    let storage = RedbStorage::new(path).unwrap();
+    let mut glue = Glue::new(storage);
+
+    glue.execute("BEGIN").await.unwrap();
+    let result = glue.execute("BEGIN").await;
+    assert_eq!(
+        result,
+        Err(Error::StorageMsg(
+            "nested transaction is not supported".to_owned()
+        ))
+        .map(|payload| vec![payload])
+    );
+    glue.execute("COMMIT;").await.unwrap();
+}


### PR DESCRIPTION
## Summary
- revert macros in `redb_storage` tests
- add a dedicated integration test `redb_nested_transaction`
- rename test file to follow convention

## Testing
- `cargo test -p gluesql-redb-storage -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68452f04b24c832a89c809bb31a3b6f9