### PR TITLE
Add storage-level Redb error test

### DIFF
--- a/storages/redb-storage/tests/redb_interface_error.rs
+++ b/storages/redb-storage/tests/redb_interface_error.rs
@@ -1,0 +1,23 @@
+use gluesql_core::error::Error;
+use gluesql_redb_storage::RedbStorage;
+use std::fs::{create_dir, remove_file};
+
+#[tokio::test]
+async fn redb_storage_interface_error() {
+    let _ = create_dir("tmp");
+    let path = "tmp/redb_storage_interface_error";
+    let _ = remove_file(path);
+
+    let storage1 = RedbStorage::new(path).expect("open first storage");
+
+    // Attempt to open the same database again using the storage interface
+    let result = RedbStorage::new(path);
+    let err = result.err().expect("second open should fail");
+
+    match err {
+        Error::StorageMsg(msg) => assert!(msg.contains("Database already open")),
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    drop(storage1);
+}


### PR DESCRIPTION
## Summary
- add integration test redb_interface_error to ensure storage surfaces Redb errors
- remove obsolete redb_error_conversion test
- keep error module private

## Testing
- `cargo test -p gluesql-redb-storage --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845238ae2d0832a8bede7c800f26af2