### PR TITLE
Remove data prefix and reserve schema table name

### DIFF
--- a/storages/redb-storage/src/error.rs
+++ b/storages/redb-storage/src/error.rs
@@ -23,6 +23,9 @@ pub enum StorageError {
 
     #[error(transparent)]
     Bincode(#[from] bincode::Error),
+
+    #[error("cannot create table with reserved name: {0}")]
+    ReservedTableName(String),
 }
 
 impl From<StorageError> for Error {
@@ -36,3 +39,4 @@ impl From<redb::TransactionError> for StorageError {
         StorageError::RedbTransaction(Box::new(e))
     }
 }
+

--- a/storages/redb-storage/tests/reserved_table_name.rs
+++ b/storages/redb-storage/tests/reserved_table_name.rs
@@ -1,0 +1,25 @@
+use {
+    gluesql_core::prelude::{Error, Glue},
+    gluesql_redb_storage::RedbStorage,
+    std::fs::{create_dir, remove_file},
+};
+
+#[tokio::test]
+async fn reserved_table_name() {
+    let _ = create_dir("tmp");
+    let path = "tmp/redb_reserved_table_name";
+    let _ = remove_file(path);
+
+    let storage = RedbStorage::new(path).unwrap();
+    let mut glue = Glue::new(storage);
+
+    let result = glue.execute("CREATE TABLE __SCHEMA__ (id INTEGER);").await;
+
+    assert_eq!(
+        result,
+        Err(Error::StorageMsg(
+            "cannot create table with reserved name: __SCHEMA__".to_owned(),
+        ))
+        .map(|payload| vec![payload])
+    );
+}


### PR DESCRIPTION
## Summary
- simplify redb-storage table naming by removing `DATA/` prefix
- reserve `__SCHEMA__` for metadata table
- error out if attempting to create a table with the reserved name
- drop table name cache for simpler lifetimes
- test reserved table name rejection

## Testing
- `cargo clippy --all-targets --workspace -- -D warnings`
- `cargo test -p gluesql-redb-storage`


------
https://chatgpt.com/codex/tasks/task_e_684578b6c444832ab113da54cf6294f4