### PR TITLE
Refactor coverage workflow for GH actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,10 @@ jobs:
           git config --global user.name "GitStorage Bot"
       - run: rustup component add llvm-tools-preview
       - run: cargo install grcov
+      - name: Install redis-cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y redis-tools jq
       - name: clean
         run: |
           cargo clean

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,43 +15,38 @@ env:
 
 jobs:
   coverage:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: MongoDB in GitHub Actions
+        uses: supercharge/mongodb-github-action@v1.10.0
+      - name: Redis in GitHub Actions
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: 6
+      - name: Prepare git config
+        run: |
+          git config --global user.email "gitstorage.bot@gluesql.org"
+          git config --global user.name "GitStorage Bot"
       - run: rustup component add llvm-tools-preview
       - run: cargo install grcov
       - name: clean
         run: |
           cargo clean
           rm -rf ./target/debug/deps/gluesql*
-          rm *.profraw && rm **/*.profraw
+          find . -name '*.profraw' -delete
           cd storages/csv-storage && rm -rf ./tmp && cd ../..
           cd storages/json-storage && rm -rf ./tmp && cd ../..
           redis-cli flushall
       - name: build
         env:
           RUSTFLAGS: -Cinstrument-coverage
-        run: cargo build --verbose
-      - name: test
+        run: cargo build --workspace --all-features --verbose
+      - name: run coverage
         env:
-          RUSTFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: gluesql-%p-%m.profraw
           GIT_REMOTE: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-        run: GIT_REMOTE=$GIT_REMOTE cargo test --all-features --verbose
-      - name: Run grcov
-        run: |
-          mkdir coverage
-          grcov . \
-            --binary-path ./target/debug/ \
-            -s . \
-            -t lcov \
-            --branch \
-            --ignore-not-existing \
-            --ignore "/*" \
-            --ignore "pkg/rust/examples/*.rs" \
-            --ignore "cli/src/{cli,helper,lib,main}.rs" \
-            --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)|(^test_case\!\([\d\w]+,)" \
-            -o ./coverage/lcov.info
+        run: bash ./scripts/coverage.sh
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+packages=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' | grep -v -E '^(gluesql-js|gluesql-py|gluesql-test-suite)$')
+mkdir -p coverage/tmp
+export RUSTFLAGS="-Cinstrument-coverage"
+export LLVM_PROFILE_FILE="gluesql-%p-%m.profraw"
+
+for pkg in $packages; do
+  echo "::group::Running tests for $pkg"
+  GIT_REMOTE=${GIT_REMOTE:-} cargo test -p "$pkg" --all-features --verbose
+  grcov . \
+    --binary-path ./target/debug/ \
+    -s . \
+    -t lcov \
+    --branch \
+    --ignore-not-existing \
+    --ignore "/*" \
+    --ignore "pkg/rust/examples/*.rs" \
+    --ignore "cli/src/{cli,helper,lib,main}.rs" \
+    --excl-line "(#\\[derive\\()|(^\\s*.await[;,]?$)|(^test_case\\!\\([\\d\\w]+,)" \
+    -o coverage/tmp/"$pkg".info
+  find . -name '*.profraw' -delete
+  echo "::endgroup::"
+done
+
+cat coverage/tmp/*.info > coverage/lcov.info


### PR DESCRIPTION
## Summary
- run coverage job on GitHub-hosted runners
- start MongoDB and Redis services
- collect coverage incrementally per package using `scripts/coverage.sh`

## Testing
- `cargo check -p gluesql-core`

------
https://chatgpt.com/codex/tasks/task_e_68459c6dc1c4832aa835d355d83807d5