### PR TITLE
Update getting started docs to v0.16

### DIFF
--- a/docs/docs/getting-started/rust.md
+++ b/docs/docs/getting-started/rust.md
@@ -8,7 +8,7 @@ To install and use GlueSQL in your Rust project, you'll first need to add it as 
 
 ```toml
 [dependencies]
-gluesql = "0.15"
+gluesql = "0.16"
 ```
 
 By default, all available storage features are included with GlueSQL. Here's a list of the available features:
@@ -25,7 +25,7 @@ If you don't need all the default storage features, you can disable them and sel
 
 ```toml
 [dependencies.gluesql]
-version = "0.15"
+version = "0.16"
 default-features = false
 features = ["gluesql_memory_storage", "gluesql-json-storage"]
 ```


### PR DESCRIPTION
## Summary
- bump version references in Rust getting started guide to `0.16`

## Testing
- `cargo test --workspace --locked --no-run` *(fails: build takes too long in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6847a6384a6c832a8eb38105a6707650