### PR TITLE
Add UUID index planning support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
 name = "gluesql"
 version = "0.16.3"
 dependencies = [
+ "anyhow",
  "futures",
  "gluesql-cli",
  "gluesql-composite-storage",
@@ -1241,6 +1242,7 @@ dependencies = [
  "gluesql-web-storage",
  "gluesql_memory_storage",
  "gluesql_sled_storage",
+ "uuid",
 ]
 
 [[package]]

--- a/core/src/ast/data_type.rs
+++ b/core/src/ast/data_type.rs
@@ -3,7 +3,7 @@ use {
     strum_macros::Display,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum DataType {
     Boolean,

--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -1,6 +1,5 @@
 use {
-    super::{Expr, IndexOperator, ToSqlUnquoted},
-    crate::ast::ToSql,
+    super::{DataType, Expr, IndexOperator, ToSql, ToSqlUnquoted},
     itertools::Itertools,
     serde::{Deserialize, Serialize},
     strum_macros::Display,
@@ -48,7 +47,10 @@ pub struct TableWithJoins {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum IndexItem {
-    PrimaryKey(Expr),
+    PrimaryKey {
+        data_type: DataType,
+        expr: Expr,
+    },
     NonClustered {
         name: String,
         asc: Option<bool>,

--- a/core/src/ast_builder/index_item.rs
+++ b/core/src/ast_builder/index_item.rs
@@ -3,8 +3,8 @@ mod non_clustered;
 mod primary_key;
 
 use {
-    super::{ExprNode, select::Prebuild},
-    crate::ast::{Expr, IndexOperator},
+    super::{DataTypeNode, ExprNode, select::Prebuild},
+    crate::ast::{DataType, Expr, IndexOperator},
 };
 pub use {
     crate::{ast::IndexItem, result::Result},
@@ -20,7 +20,10 @@ pub enum IndexItemNode<'a> {
         asc: Option<bool>,
         cmp_expr: Option<(IndexOperator, ExprNode<'a>)>,
     },
-    PrimaryKey(ExprNode<'a>),
+    PrimaryKey {
+        data_type: DataTypeNode,
+        expr: ExprNode<'a>,
+    },
 }
 
 impl<'a> From<CmpExprNode<'a>> for IndexItemNode<'a> {
@@ -62,7 +65,13 @@ impl<'a> Prebuild<IndexItem> for IndexItemNode<'a> {
                     cmp_expr: cmp_expr_result,
                 })
             }
-            IndexItemNode::PrimaryKey(expr) => Ok(IndexItem::PrimaryKey(expr.try_into()?)),
+            IndexItemNode::PrimaryKey { data_type, expr } => {
+                let data_type: DataType = data_type.try_into()?;
+                Ok(IndexItem::PrimaryKey {
+                    data_type,
+                    expr: expr.try_into()?,
+                })
+            }
         }
     }
 }

--- a/core/src/ast_builder/index_item/primary_key.rs
+++ b/core/src/ast_builder/index_item/primary_key.rs
@@ -1,30 +1,49 @@
-use {super::IndexItemNode, crate::ast_builder::ExprNode};
+use {
+    super::IndexItemNode,
+    crate::ast_builder::{DataTypeNode, ExprNode},
+};
 
 #[derive(Clone, Debug)]
-pub struct PrimaryKeyNode;
+pub struct PrimaryKeyNode {
+    data_type: DataTypeNode,
+}
+
+impl PrimaryKeyNode {
+    pub fn new<T: Into<DataTypeNode>>(data_type: T) -> Self {
+        Self {
+            data_type: data_type.into(),
+        }
+    }
+}
 
 impl<'a> PrimaryKeyNode {
     pub fn eq<T: Into<ExprNode<'a>>>(self, expr: T) -> IndexItemNode<'a> {
-        IndexItemNode::PrimaryKey(expr.into())
+        IndexItemNode::PrimaryKey {
+            data_type: self.data_type,
+            expr: expr.into(),
+        }
     }
 }
 
 /// Entry point function to Primary Key
-pub fn primary_key() -> PrimaryKeyNode {
-    PrimaryKeyNode
+pub fn primary_key<T: Into<DataTypeNode>>(data_type: T) -> PrimaryKeyNode {
+    PrimaryKeyNode::new(data_type)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{AstLiteral, Expr},
+        ast::{AstLiteral, DataType, Expr},
         ast_builder::{index_item::IndexItem, primary_key, select::Prebuild},
     };
 
     #[test]
     fn test() {
-        let actual = primary_key().eq("1").prebuild().unwrap();
-        let expected = IndexItem::PrimaryKey(Expr::Literal(AstLiteral::Number(1.into())));
+        let actual = primary_key("INTEGER").eq("1").prebuild().unwrap();
+        let expected = IndexItem::PrimaryKey {
+            data_type: DataType::Int,
+            expr: Expr::Literal(AstLiteral::Number(1.into())),
+        };
         assert_eq!(actual, expected);
     }
 }

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -153,29 +153,13 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
 
                         Rows::Indexed(rows)
                     }
-                    Some(IndexItem::PrimaryKey(expr)) => {
-                        let schema = storage
-                            .fetch_schema(name)
-                            .await?
-                            .ok_or(FetchError::Unreachable)?;
-
+                    Some(IndexItem::PrimaryKey { data_type, expr }) => {
                         let filter_context = filter_context.as_ref().map(Rc::clone);
                         let evaluated = evaluate(storage, filter_context, None, expr).await?;
 
                         let value = match evaluated {
                             Evaluated::Literal(literal) => {
-                                let data_type = schema
-                                    .column_defs
-                                    .as_ref()
-                                    .and_then(|column_defs| {
-                                        column_defs.iter().find(|column_def| {
-                                            column_def.unique.map(|u| u.is_primary) == Some(true)
-                                        })
-                                    })
-                                    .map(|column_def| &column_def.data_type)
-                                    .ok_or(FetchError::Unreachable)?;
-
-                                Value::try_from_literal(data_type, &literal)
+                                Value::try_from_literal(&data_type, &literal)
                             }
                             eval => eval.try_into(),
                         }?;

--- a/core/src/plan/context.rs
+++ b/core/src/plan/context.rs
@@ -1,10 +1,10 @@
-use std::rc::Rc;
+use {crate::ast::DataType, std::rc::Rc};
 
 pub enum Context<'a> {
     Data {
         alias: String,
         columns: Vec<&'a str>,
-        primary_key: Option<&'a str>,
+        primary_key: Option<PrimaryKey<'a>>,
         next: Option<Rc<Context<'a>>>,
     },
     Bridge {
@@ -17,7 +17,7 @@ impl<'a> Context<'a> {
     pub fn new(
         alias: String,
         columns: Vec<&'a str>,
-        primary_key: Option<&'a str>,
+        primary_key: Option<PrimaryKey<'a>>,
         next: Option<Rc<Context<'a>>>,
     ) -> Self {
         Context::Data {
@@ -81,20 +81,23 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn contains_primary_key(&self, target_column: &str) -> bool {
+    pub fn contains_primary_key(&self, target_column: &str) -> Option<DataType> {
         match self {
             Self::Data {
                 primary_key: Some(primary_key),
                 ..
-            } if primary_key == &target_column => true,
+            } if primary_key.column == target_column => Some(primary_key.data_type),
             Self::Data { next, .. } => next
                 .as_ref()
-                .map(|next| next.contains_primary_key(target_column))
-                .unwrap_or(false),
-            Self::Bridge { left, right } => {
-                left.contains_primary_key(target_column)
-                    || right.contains_primary_key(target_column)
-            }
+                .and_then(|next| next.contains_primary_key(target_column)),
+            Self::Bridge { left, right } => left
+                .contains_primary_key(target_column)
+                .or_else(|| right.contains_primary_key(target_column)),
         }
     }
+}
+
+pub struct PrimaryKey<'a> {
+    pub data_type: DataType,
+    pub column: &'a str,
 }

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -34,6 +34,8 @@ gluesql-git-storage = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures = "0.3"
+anyhow = "1.0"
+uuid = { version = "1", features = ["v7"] }
 
 [features]
 # DB User

--- a/pkg/rust/examples/test.rs
+++ b/pkg/rust/examples/test.rs
@@ -1,0 +1,78 @@
+use anyhow::{Result, anyhow};
+use gluesql::prelude::{Glue, MemoryStorage};
+
+fn main() {
+    futures::executor::block_on(run()).expect("hey");
+}
+
+async fn run() -> Result<()> {
+    let mem = MemoryStorage::default();
+    let mut mem = Glue::new(mem);
+
+    mem.execute(
+        r#"
+            CREATE TABLE IF NOT EXISTS posts (
+                id UUID PRIMARY KEY,
+                title TEXT NOT NULL,
+                text TEXT NOT NULL,
+                id_2 UUID NOT NULL
+            )
+        "#,
+    )
+    .await?;
+
+    let uuid = uuid::Uuid::now_v7();
+    let temp = mem
+        .execute(format!(
+            r#"INSERT INTO "posts" ("id", "title", "text", "id_2") VALUES ('{uuid}', 'Homo', 'いいよ、来いよ', '{uuid}')"#
+        ))
+        .await?;
+    println!("DEBUG insert: {:#?}", temp);
+
+    let temp = mem.execute("SELECT * from posts").await?;
+    println!("DEBUG query all: {:#?}", temp);
+    let temp = temp[0]
+        .select()
+        .ok_or(anyhow!("No result"))?
+        .next()
+        .ok_or(anyhow!("No next"))?;
+    let temp = temp
+        .get("id")
+        .cloned()
+        .ok_or(anyhow!("Cannot get id"))?
+        .clone();
+    let uuid_2 = match temp {
+        gluesql::prelude::Value::Uuid(val) => uuid::Uuid::from_u128(val),
+        _ => todo!(),
+    };
+    assert_eq!(uuid, uuid_2);
+    println!("DEBUG query first uuid: {:?}", uuid_2);
+
+    let temp = format!(
+        "SELECT * from posts where id = CAST({} AS UUID)",
+        uuid_2.as_u128()
+    );
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!(
+        "SELECT * from posts where id = UUID '{}'",
+        uuid_2.to_string()
+    );
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!("SELECT * from posts where text = '{}'", "いいよ、来いよ");
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    let temp = format!("SELECT * from posts where id_2 = '{}'", uuid_2.to_string());
+    println!("DEBUG SQL: {temp}");
+    let temp = mem.execute(temp).await?;
+    println!("DEBUG sub query: {:?}", temp);
+
+    Ok(())
+}

--- a/test-suite/src/ast_builder/index_by.rs
+++ b/test-suite/src/ast_builder/index_by.rs
@@ -28,7 +28,7 @@ test_case!(index_by, {
     assert_eq!(actual, expected, "insert - specifying columns");
 
     let actual = table("Foo")
-        .index_by(primary_key().eq("1"))
+        .index_by(primary_key("INTEGER").eq("1"))
         .select()
         .project("id, name")
         .execute(glue)


### PR DESCRIPTION
## Summary
- add `Copy` derive for `DataType`
- include data type info in `IndexItem::PrimaryKey`
- adjust AST builder to specify primary key data types
- update planner, executor and context logic for typed primary keys
- add example demonstrating UUID handling
- update test-suite for new `primary_key` builder

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6847b58d9748832a9259c07aec390681