### PR TITLE
Add data type to PrimaryKey index

### DIFF
--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Expr, IndexOperator, ToSqlUnquoted},
+    super::{DataType, Expr, IndexOperator, ToSqlUnquoted},
     crate::ast::ToSql,
     itertools::Itertools,
     serde::{Deserialize, Serialize},
@@ -48,7 +48,10 @@ pub struct TableWithJoins {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum IndexItem {
-    PrimaryKey(Expr),
+    PrimaryKey {
+        data_type: DataType,
+        expr: Expr,
+    },
     NonClustered {
         name: String,
         asc: Option<bool>,

--- a/core/src/ast_builder/index_item.rs
+++ b/core/src/ast_builder/index_item.rs
@@ -4,7 +4,7 @@ mod primary_key;
 
 use {
     super::{ExprNode, select::Prebuild},
-    crate::ast::{Expr, IndexOperator},
+    crate::ast::{DataType, Expr, IndexOperator},
 };
 pub use {
     crate::{ast::IndexItem, result::Result},
@@ -62,7 +62,10 @@ impl<'a> Prebuild<IndexItem> for IndexItemNode<'a> {
                     cmp_expr: cmp_expr_result,
                 })
             }
-            IndexItemNode::PrimaryKey(expr) => Ok(IndexItem::PrimaryKey(expr.try_into()?)),
+            IndexItemNode::PrimaryKey(expr) => Ok(IndexItem::PrimaryKey {
+                data_type: DataType::Int,
+                expr: expr.try_into()?,
+            }),
         }
     }
 }

--- a/core/src/ast_builder/index_item/primary_key.rs
+++ b/core/src/ast_builder/index_item/primary_key.rs
@@ -17,14 +17,17 @@ pub fn primary_key() -> PrimaryKeyNode {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{AstLiteral, Expr},
+        ast::{AstLiteral, Expr, DataType},
         ast_builder::{index_item::IndexItem, primary_key, select::Prebuild},
     };
 
     #[test]
     fn test() {
         let actual = primary_key().eq("1").prebuild().unwrap();
-        let expected = IndexItem::PrimaryKey(Expr::Literal(AstLiteral::Number(1.into())));
+        let expected = IndexItem::PrimaryKey {
+            data_type: DataType::Int,
+            expr: Expr::Literal(AstLiteral::Number(1.into())),
+        };
         assert_eq!(actual, expected);
     }
 }

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -153,29 +153,13 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
 
                         Rows::Indexed(rows)
                     }
-                    Some(IndexItem::PrimaryKey(expr)) => {
-                        let schema = storage
-                            .fetch_schema(name)
-                            .await?
-                            .ok_or(FetchError::Unreachable)?;
-
+                    Some(IndexItem::PrimaryKey { data_type, expr }) => {
                         let filter_context = filter_context.as_ref().map(Rc::clone);
                         let evaluated = evaluate(storage, filter_context, None, expr).await?;
 
                         let value = match evaluated {
                             Evaluated::Literal(literal) => {
-                                let data_type = schema
-                                    .column_defs
-                                    .as_ref()
-                                    .and_then(|column_defs| {
-                                        column_defs.iter().find(|column_def| {
-                                            column_def.unique.map(|u| u.is_primary) == Some(true)
-                                        })
-                                    })
-                                    .map(|column_def| &column_def.data_type)
-                                    .ok_or(FetchError::Unreachable)?;
-
-                                Value::try_from_literal(data_type, &literal)
+                                Value::try_from_literal(&data_type, &literal)
                             }
                             eval => eval.try_into(),
                         }?;

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -2,8 +2,8 @@ use {
     super::{context::Context, evaluable::check_expr as check_evaluable, planner::Planner},
     crate::{
         ast::{
-            BinaryOperator, Expr, IndexItem, Query, Select, SetExpr, Statement, TableFactor,
-            TableWithJoins,
+            BinaryOperator, DataType, Expr, IndexItem, Query, Select, SetExpr, Statement,
+            TableAlias, TableFactor, TableWithJoins, ColumnDef, ColumnUniqueOption,
         },
         data::Schema,
     },
@@ -25,6 +25,53 @@ pub fn plan(schema_map: &HashMap<String, Schema>, statement: Statement) -> State
 
 struct PrimaryKeyPlanner<'a> {
     schema_map: &'a HashMap<String, Schema>,
+}
+
+impl<'a> PrimaryKeyPlanner<'a> {
+    fn alias_map(table_with_joins: &TableWithJoins) -> HashMap<String, String> {
+        fn insert(map: &mut HashMap<String, String>, factor: &TableFactor) {
+            if let TableFactor::Table { name, alias, .. } = factor {
+                let key = alias
+                    .as_ref()
+                    .map(|TableAlias { name, .. }| name.clone())
+                    .unwrap_or_else(|| name.clone());
+                map.insert(key, name.clone());
+            }
+        }
+
+        let mut map = HashMap::new();
+        insert(&mut map, &table_with_joins.relation);
+        for join in &table_with_joins.joins {
+            insert(&mut map, &join.relation);
+        }
+        map
+    }
+
+    fn find_pk_data_type(
+        &self,
+        alias_map: &HashMap<String, String>,
+        alias: Option<&str>,
+        ident: &str,
+    ) -> Option<DataType> {
+        let tables: Vec<&String> = match alias {
+            Some(a) => alias_map.get(a).into_iter().collect(),
+            None => alias_map.values().collect(),
+        };
+
+        for table_name in tables {
+            if let Some(schema) = self.get_schema(table_name) {
+                if let Some(column_defs) = &schema.column_defs {
+                    if let Some(ColumnDef { data_type, .. }) = column_defs.iter().find(|c| {
+                        c.name == ident
+                            && c.unique == Some(ColumnUniqueOption { is_primary: true })
+                    }) {
+                        return Some(data_type.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
 }
 
 impl<'a> Planner<'a> for PrimaryKeyPlanner<'a> {
@@ -56,6 +103,7 @@ enum PrimaryKey {
 
 impl<'a> PrimaryKeyPlanner<'a> {
     fn select(&self, outer_context: Option<Rc<Context<'a>>>, select: Select) -> Select {
+        let alias_map = Self::alias_map(&select.from);
         let current_context = self.update_context(None, &select.from.relation);
         let current_context = select
             .from
@@ -67,7 +115,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
 
         let (index, selection) = select
             .selection
-            .map(|expr| self.expr(outer_context, current_context, expr))
+            .map(|expr| self.expr(&alias_map, outer_context, current_context, expr))
             .map(|primary_key| match primary_key {
                 PrimaryKey::Found { index_item, expr } => (Some(index_item), expr),
                 PrimaryKey::NotFound(expr) => (None, Some(expr)),
@@ -100,6 +148,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
 
     fn expr(
         &self,
+        alias_map: &HashMap<String, String>,
         outer_context: Option<Rc<Context<'a>>>,
         current_context: Option<Rc<Context<'a>>>,
         expr: Expr,
@@ -131,7 +180,18 @@ impl<'a> PrimaryKeyPlanner<'a> {
                 && check_evaluable(current_context.as_ref().map(Rc::clone), &key)
                 && check_evaluable(None, &value) =>
             {
-                let index_item = IndexItem::PrimaryKey(*value);
+                let (alias, ident) = match key.as_ref() {
+                    Expr::Identifier(ident) => (None, ident.as_str()),
+                    Expr::CompoundIdentifier { alias, ident } => (Some(alias.as_str()), ident.as_str()),
+                    _ => unreachable!(),
+                };
+                let data_type = self
+                    .find_pk_data_type(alias_map, alias, ident)
+                    .unwrap_or(DataType::Int);
+                let index_item = IndexItem::PrimaryKey {
+                    data_type,
+                    expr: *value,
+                };
 
                 PrimaryKey::Found {
                     index_item,
@@ -144,6 +204,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
                 right,
             } => {
                 let primary_key = self.expr(
+                    alias_map,
                     outer_context.as_ref().map(Rc::clone),
                     current_context.as_ref().map(Rc::clone),
                     *left,
@@ -168,7 +229,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
                     PrimaryKey::NotFound(expr) => expr,
                 };
 
-                match self.expr(outer_context, current_context, *right) {
+                match self.expr(alias_map, outer_context, current_context, *right) {
                     PrimaryKey::Found { index_item, expr } => {
                         let expr = match expr {
                             Some(right) => Expr::BinaryOp {
@@ -195,7 +256,7 @@ impl<'a> PrimaryKeyPlanner<'a> {
                     }
                 }
             }
-            Expr::Nested(expr) => match self.expr(outer_context, current_context, *expr) {
+            Expr::Nested(expr) => match self.expr(alias_map, outer_context, current_context, *expr) {
                 PrimaryKey::Found { index_item, expr } => {
                     let expr = expr.map(Box::new).map(Expr::Nested);
 
@@ -221,7 +282,7 @@ mod tests {
             ast::{
                 AstLiteral, BinaryOperator, Expr, IndexItem, Join, JoinConstraint, JoinExecutor,
                 JoinOperator, Query, Select, SelectItem, SetExpr, Statement, TableFactor,
-                TableWithJoins, Values,
+                TableWithJoins, Values, DataType,
             },
             mock::{MockStorage, run},
             parse_sql::{parse, parse_expr},
@@ -271,7 +332,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: Vec::new(),
             },
@@ -289,7 +353,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: Vec::new(),
             },
@@ -307,7 +374,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: Vec::new(),
             },
@@ -331,7 +401,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: Vec::new(),
             },
@@ -364,7 +437,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: Vec::new(),
             },
@@ -396,7 +472,10 @@ mod tests {
                 relation: TableFactor::Table {
                     name: "Player".to_owned(),
                     alias: None,
-                    index: Some(IndexItem::PrimaryKey(expr("1"))),
+                    index: Some(IndexItem::PrimaryKey {
+                        data_type: DataType::Int,
+                        expr: expr("1"),
+                    }),
                 },
                 joins: vec![Join {
                     relation: TableFactor::Table {
@@ -454,7 +533,10 @@ mod tests {
                         relation: TableFactor::Table {
                             name: "Player".to_owned(),
                             alias: None,
-                            index: Some(IndexItem::PrimaryKey(expr("1"))),
+                            index: Some(IndexItem::PrimaryKey {
+                                data_type: DataType::Int,
+                                expr: expr("1"),
+                            }),
                         },
                         joins: Vec::new(),
                     },


### PR DESCRIPTION
## Summary
- carry primary key data type in `IndexItem`
- update primary key planner to fill the new field
- adjust executor to use provided data type
- adapt AST builder and tests

## Testing
- `cargo test -p gluesql-core`

------
https://chatgpt.com/codex/tasks/task_e_6847c230a244832aa77e45cc89b53f57