### PR TITLE
Update MD5 VALUES tests

### DIFF
--- a/test-suite/src/function/md5.rs
+++ b/test-suite/src/function/md5.rs
@@ -1,9 +1,6 @@
 use {
     crate::*,
-    gluesql_core::{
-        error::TranslateError,
-        prelude::{Payload, Value::*},
-    },
+    gluesql_core::{error::TranslateError, prelude::Value::*},
 };
 
 test_case!(md5, {
@@ -20,35 +17,20 @@ test_case!(md5, {
     .await;
 
     g.test(
-        "CREATE TABLE MD5 (id INTEGER, text TEXT);",
-        Ok(Payload::Create),
-    )
-    .await;
-
-    g.test(
-        "INSERT INTO MD5 VALUES (1, 'GlueSQL Hi');",
-        Ok(Payload::Insert(1)),
-    )
-    .await;
-
-    g.test(
-        "SELECT MD5(text) AS md5 FROM MD5;",
+        "VALUES(MD5('GlueSQL Hi'))",
         Ok(select!(
-            md5
+            column1
             Str;
             "eab30259ac1a92b66794f301a6ac3ff3".to_owned()
         )),
     )
     .await;
 
-    g.test(
-        r#"SELECT MD5(NULL) AS md5 FROM MD5;"#,
-        Ok(select_with_null!(md5; Null)),
-    )
-    .await;
+    g.test(r#"VALUES(MD5(NULL))"#, Ok(select_with_null!(column1; Null)))
+        .await;
 
     g.test(
-        r#"SELECT MD5() FROM MD5;"#,
+        r#"VALUES(MD5())"#,
         Err(TranslateError::FunctionArgsLengthNotMatching {
             name: "MD5".to_owned(),
             expected: 1,


### PR DESCRIPTION
## Summary
- revise `md5` function tests to use only `VALUES` queries
- remove temporary table creation

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql_memory_storage -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68490097fec4832a9fe3bc9e71f4db52