### PR TITLE
Update pkg/rust - add gluesql-redb-storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,7 @@ dependencies = [
  "gluesql-json-storage",
  "gluesql-mongo-storage",
  "gluesql-parquet-storage",
+ "gluesql-redb-storage",
  "gluesql-redis-storage",
  "gluesql-shared-memory-storage",
  "gluesql-test-suite",

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -21,6 +21,7 @@ test-suite = { workspace = true, optional = true }
 gluesql_memory_storage = { workspace = true, optional = true }
 gluesql-shared-memory-storage = { workspace = true, optional = true }
 gluesql_sled_storage = { workspace = true, optional = true }
+gluesql-redb-storage = { workspace = true, optional = true }
 gluesql-json-storage = { workspace = true, optional = true }
 gluesql-csv-storage = { workspace = true, optional = true }
 gluesql-composite-storage = { workspace = true, optional = true }
@@ -43,6 +44,7 @@ default = [
   "gluesql_memory_storage",
   "gluesql-shared-memory-storage",
   "gluesql_sled_storage",
+  "gluesql-redb-storage",
   "gluesql-json-storage",
   "gluesql-parquet-storage",
   "gluesql-csv-storage",

--- a/pkg/rust/src/lib.rs
+++ b/pkg/rust/src/lib.rs
@@ -18,6 +18,9 @@ pub use gluesql_shared_memory_storage;
 #[cfg(feature = "gluesql_sled_storage")]
 pub use gluesql_sled_storage;
 
+#[cfg(feature = "gluesql-redb-storage")]
+pub use gluesql_redb_storage;
+
 #[cfg(feature = "gluesql-json-storage")]
 pub use gluesql_json_storage;
 
@@ -59,6 +62,9 @@ pub mod prelude {
 
     #[cfg(feature = "gluesql_sled_storage")]
     pub use gluesql_sled_storage::SledStorage;
+
+    #[cfg(feature = "gluesql-redb-storage")]
+    pub use gluesql_redb_storage::RedbStorage;
 
     #[cfg(feature = "gluesql-json-storage")]
     pub use gluesql_json_storage::JsonStorage;


### PR DESCRIPTION
## Summary
- include `gluesql-redb-storage` as an optional dependency for the Rust package
- enable `gluesql-redb-storage` in the default feature set
- re-export `RedbStorage` from `pkg/rust` library

## Testing
- `cargo fmt --all`
- `cargo clippy -q`
- `cargo test -q --lib --bins --tests --examples --no-default-features --features "gluesql_memory_storage gluesql_sled_storage"` *(fails: operation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684905cfc964832aaef6f7bdd9c800b3