### PR TITLE
Add explicit AGENTS instructions to always run clippy and fmt in Codex workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md
+- After editing code, run `cargo clippy --all-targets -- -D warnings`.
+- Then run `cargo fmt --all`.
+- Commit only when both commands succeed.


### PR DESCRIPTION
Background: When working with Codex and using AGENTS to automate tasks, it’s easy to forget to run cargo clippy and cargo fmt. This often leads to overlooked lint or formatting issues, which could have been caught earlier in the workflow.

This PR adds clear instructions to always run clippy and fmt as part of the AGENTS workflow for Codex. The goal is to ensure code quality and consistency by proactively catching formatting and lint errors before submitting or merging changes.

------
https://chatgpt.com/codex/tasks/task_e_684d06ea90d8832a89cc0c22192061cc