### PR TITLE
Introduce send feature and Shared alias in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "futures-enum",
  "gluesql-utils",
  "hex",
+ "im",
  "im-rc",
  "iter-enum",
  "itertools 0.12.1",
@@ -1772,6 +1773,20 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,8 @@ futures-enum = "0.1.17"
 futures = "0.3"
 chrono = { version = "0.4.38", features = ["serde", "wasmbind"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
-im-rc = "15"
+im-rc = { version = "15", optional = true }
+im = { version = "15", optional = true }
 iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
@@ -42,3 +43,7 @@ features = ["v4"]
 
 [dev-dependencies]
 pretty_assertions = "1"
+
+[features]
+default = ["im-rc"]
+send = ["im"]

--- a/core/src/data/row.rs
+++ b/core/src/data/row.rs
@@ -1,7 +1,7 @@
 use {
-    crate::{data::Value, executor::RowContext, result::Result},
+    crate::{data::Value, executor::RowContext, result::Result, shared::Rc},
     serde::Serialize,
-    std::{collections::HashMap, fmt::Debug, rc::Rc},
+    std::{collections::HashMap, fmt::Debug},
     thiserror::Error,
 };
 

--- a/core/src/executor/aggregate.rs
+++ b/core/src/executor/aggregate.rs
@@ -8,6 +8,7 @@ use {
         evaluate::{Evaluated, evaluate},
         filter::check_expr,
     },
+    crate::shared::Rc,
     crate::{
         ast::{Expr, SelectItem},
         data::Key,
@@ -16,7 +17,6 @@ use {
     },
     async_recursion::async_recursion,
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
-    std::rc::Rc,
 };
 
 pub use error::AggregateError;

--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -1,4 +1,5 @@
 use {
+    crate::shared::{HashMap, HashSet, Rc},
     crate::{
         ast::{Aggregate, CountArgExpr, DataType},
         data::{Key, Value},
@@ -7,9 +8,8 @@ use {
         store::GStore,
     },
     futures::stream::{self, StreamExt, TryStreamExt},
-    im_rc::{HashMap, HashSet},
     itertools::Itertools,
-    std::{cmp::Ordering, rc::Rc},
+    std::cmp::Ordering,
     utils::{IndexMap, Vector},
 };
 

--- a/core/src/executor/context/aggregate_context.rs
+++ b/core/src/executor/context/aggregate_context.rs
@@ -1,8 +1,11 @@
 use {
     super::RowContext,
-    crate::{ast::Aggregate, data::Value},
-    im_rc::HashMap,
-    std::{fmt::Debug, rc::Rc},
+    crate::{
+        ast::Aggregate,
+        data::Value,
+        shared::{HashMap, Rc},
+    },
+    std::fmt::Debug,
 };
 
 #[derive(Debug)]

--- a/core/src/executor/context/row_context.rs
+++ b/core/src/executor/context/row_context.rs
@@ -1,6 +1,7 @@
 use {
     crate::data::{Row, Value},
-    std::{borrow::Cow, collections::HashMap, fmt::Debug, rc::Rc},
+    crate::shared::Rc,
+    std::{borrow::Cow, collections::HashMap, fmt::Debug},
 };
 
 #[derive(Debug)]

--- a/core/src/executor/delete.rs
+++ b/core/src/executor/delete.rs
@@ -3,6 +3,7 @@ use {
         Payload, Referencing,
         fetch::{fetch, fetch_columns},
     },
+    crate::shared::Rc,
     crate::{
         ast::{BinaryOperator, Expr, ForeignKey, ReferentialAction},
         result::{Error, Result},
@@ -10,7 +11,6 @@ use {
     },
     futures::stream::{StreamExt, TryStreamExt},
     serde::Serialize,
-    std::rc::Rc,
     thiserror::Error as ThisError,
 };
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -6,6 +6,7 @@ mod function;
 use {
     self::function::BreakCase,
     super::{context::RowContext, select::select},
+    crate::shared::{HashMap, Rc},
     crate::{
         ast::{Aggregate, Expr, Function},
         data::{CustomFunction, Interval, Literal, Row, Value},
@@ -19,8 +20,7 @@ use {
         future::{ready, try_join_all},
         stream::{self, StreamExt, TryStreamExt},
     },
-    im_rc::HashMap,
-    std::{borrow::Cow, ops::ControlFlow, rc::Rc},
+    std::{borrow::Cow, ops::ControlFlow},
 };
 
 pub use {error::EvaluateError, evaluated::Evaluated};

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -11,6 +11,7 @@ use {
         update::Update,
         validate::{ColumnValidation, validate_unique},
     },
+    crate::shared::Rc,
     crate::{
         ast::{
             AstLiteral, BinaryOperator, DataType, Dictionary, Expr, Query, SelectItem, SetExpr,
@@ -22,7 +23,7 @@ use {
     },
     futures::stream::{StreamExt, TryStreamExt},
     serde::{Deserialize, Serialize},
-    std::{collections::HashMap, env::var, fmt::Debug, rc::Rc},
+    std::{collections::HashMap, env::var, fmt::Debug},
     thiserror::Error as ThisError,
 };
 

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -1,5 +1,6 @@
 use {
     super::{context::RowContext, evaluate::evaluate_stateless, filter::check_expr},
+    crate::shared::Rc,
     crate::{
         ast::{
             ColumnDef, ColumnUniqueOption, Dictionary, Expr, IndexItem, Join, Query, Select,
@@ -20,7 +21,7 @@ use {
         stream::{self, Stream, StreamExt, TryStreamExt},
     },
     serde::Serialize,
-    std::{borrow::Cow, collections::HashMap, fmt::Debug, iter, rc::Rc},
+    std::{borrow::Cow, collections::HashMap, fmt::Debug, iter},
     thiserror::Error as ThisError,
 };
 

--- a/core/src/executor/filter.rs
+++ b/core/src/executor/filter.rs
@@ -1,13 +1,12 @@
 use {
     super::{context::RowContext, evaluate::evaluate},
+    crate::shared::{HashMap, Rc},
     crate::{
         ast::{Aggregate, Expr},
         data::Value,
         result::Result,
         store::GStore,
     },
-    im_rc::HashMap,
-    std::rc::Rc,
 };
 
 pub struct Filter<'a, T: GStore> {

--- a/core/src/executor/insert.rs
+++ b/core/src/executor/insert.rs
@@ -3,6 +3,7 @@ use {
         select::select,
         validate::{ColumnValidation, validate_unique},
     },
+    crate::shared::Rc,
     crate::{
         ast::{ColumnDef, ColumnUniqueOption, Expr, ForeignKey, Query, SetExpr, Values},
         data::{Key, Row, Schema, Value},
@@ -12,7 +13,7 @@ use {
     },
     futures::stream::{self, StreamExt, TryStreamExt},
     serde::Serialize,
-    std::{fmt::Debug, rc::Rc},
+    std::fmt::Debug,
     thiserror::Error as ThisError,
 };
 

--- a/core/src/executor/join.rs
+++ b/core/src/executor/join.rs
@@ -1,5 +1,6 @@
 use {
     super::fetch::{fetch_relation_columns, fetch_relation_rows},
+    crate::shared::Rc,
     crate::{
         ast::{
             Expr, Join as AstJoin, JoinConstraint, JoinExecutor as AstJoinExecutor,
@@ -15,7 +16,7 @@ use {
         stream::{self, Stream, StreamExt, TryStreamExt, empty, once},
     },
     itertools::Itertools,
-    std::{borrow::Cow, collections::HashMap, pin::Pin, rc::Rc},
+    std::{borrow::Cow, collections::HashMap, pin::Pin},
     utils::OrStream,
 };
 

--- a/core/src/executor/select.rs
+++ b/core/src/executor/select.rs
@@ -15,6 +15,7 @@ use {
         limit::Limit,
         sort::Sort,
     },
+    crate::shared::Rc,
     crate::{
         ast::{Expr, OrderByExpr, Query, Select, SetExpr, TableWithJoins, Values},
         data::{Key, Row, Value, get_alias},
@@ -23,7 +24,7 @@ use {
     },
     async_recursion::async_recursion,
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
-    std::{borrow::Cow, rc::Rc},
+    std::borrow::Cow,
     utils::Vector,
 };
 

--- a/core/src/executor/select/project.rs
+++ b/core/src/executor/select/project.rs
@@ -1,4 +1,5 @@
 use {
+    crate::shared::{HashMap, Rc},
     crate::{
         ast::{Aggregate, SelectItem},
         data::{Row, Value},
@@ -7,8 +8,6 @@ use {
         store::GStore,
     },
     futures::stream::{self, StreamExt, TryStreamExt},
-    im_rc::HashMap,
-    std::rc::Rc,
 };
 
 pub struct Project<'a, T: GStore> {

--- a/core/src/executor/sort.rs
+++ b/core/src/executor/sort.rs
@@ -1,5 +1,6 @@
 use {
     super::{context::RowContext, evaluate::evaluate},
+    crate::shared::{HashMap, Rc},
     crate::{
         ast::{Aggregate, AstLiteral, Expr, OrderByExpr, UnaryOperator},
         data::{Key, Row, Value},
@@ -8,9 +9,8 @@ use {
     },
     bigdecimal::ToPrimitive,
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
-    im_rc::HashMap,
     serde::Serialize,
-    std::{borrow::Cow, cmp::Ordering, fmt::Debug, rc::Rc},
+    std::{borrow::Cow, cmp::Ordering, fmt::Debug},
     thiserror::Error as ThisError,
     utils::Vector,
 };

--- a/core/src/executor/update.rs
+++ b/core/src/executor/update.rs
@@ -3,6 +3,7 @@ use {
         context::RowContext,
         evaluate::{Evaluated, evaluate},
     },
+    crate::shared::Rc,
     crate::{
         ast::{Assignment, ColumnDef, ColumnUniqueOption, ForeignKey},
         data::{Key, Row, Value},
@@ -11,7 +12,7 @@ use {
     },
     futures::stream::{self, StreamExt, TryStreamExt},
     serde::Serialize,
-    std::{borrow::Cow, fmt::Debug, rc::Rc},
+    std::{borrow::Cow, fmt::Debug},
     thiserror::Error,
     utils::HashMapExt,
 };

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -1,4 +1,5 @@
 use {
+    crate::shared::HashSet,
     crate::{
         ast::{ColumnDef, ColumnUniqueOption},
         data::{Key, Value},
@@ -6,7 +7,6 @@ use {
         store::{DataRow, Store},
     },
     futures::stream::TryStreamExt,
-    im_rc::HashSet,
     serde::Serialize,
     std::fmt::Debug,
     thiserror::Error as ThisError,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod data;
 pub mod executor;
 pub mod parse_sql;
 pub mod plan;
+pub mod shared;
 pub mod store;
 pub mod translate;
 

--- a/core/src/plan/context.rs
+++ b/core/src/plan/context.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use crate::shared::Rc;
 
 pub enum Context<'a> {
     Data {

--- a/core/src/plan/evaluable.rs
+++ b/core/src/plan/evaluable.rs
@@ -4,7 +4,7 @@ use {
         Expr, Join, JoinConstraint, JoinOperator, Query, Select, SelectItem, SetExpr, TableAlias,
         TableFactor, TableWithJoins, Values,
     },
-    std::rc::Rc,
+    crate::shared::Rc,
 };
 
 pub fn check_expr(context: Option<Rc<Context<'_>>>, expr: &Expr) -> bool {
@@ -144,8 +144,7 @@ fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFact
 mod tests {
     use {
         super::{Context, check_expr},
-        crate::{parse_sql::parse_expr, translate::translate_expr},
-        std::rc::Rc,
+        crate::{parse_sql::parse_expr, shared::Rc, translate::translate_expr},
     };
 
     fn test(context: Option<Rc<Context<'_>>>, sql: &str, expected: bool) {

--- a/core/src/plan/join.rs
+++ b/core/src/plan/join.rs
@@ -1,5 +1,6 @@
 use {
     super::{context::Context, evaluable::check_expr as check_evaluable, planner::Planner},
+    crate::shared::Rc,
     crate::{
         ast::{
             BinaryOperator, Expr, Join, JoinConstraint, JoinExecutor, JoinOperator, Query, Select,
@@ -7,7 +8,7 @@ use {
         },
         data::Schema,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::collections::HashMap,
     utils::Vector,
 };
 

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -1,10 +1,10 @@
 use {
     super::context::Context,
+    crate::shared::Rc,
     crate::{
         ast::{ColumnDef, ColumnUniqueOption, Expr, Function, Query, TableAlias, TableFactor},
         data::Schema,
     },
-    std::rc::Rc,
 };
 
 pub trait Planner<'a> {

--- a/core/src/plan/primary_key.rs
+++ b/core/src/plan/primary_key.rs
@@ -1,5 +1,6 @@
 use {
     super::{context::Context, evaluable::check_expr as check_evaluable, planner::Planner},
+    crate::shared::Rc,
     crate::{
         ast::{
             BinaryOperator, Expr, IndexItem, Query, Select, SetExpr, Statement, TableFactor,
@@ -7,7 +8,7 @@ use {
         },
         data::Schema,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::collections::HashMap,
 };
 
 pub fn plan(schema_map: &HashMap<String, Schema>, statement: Statement) -> Statement {

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -1,11 +1,12 @@
 use {
     super::PlanError,
+    crate::shared::Rc,
     crate::{
         ast::{Expr, Join, Query, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins},
         data::Schema,
         result::Result,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::collections::HashMap,
 };
 
 type SchemaMap = HashMap<String, Schema>;

--- a/core/src/shared.rs
+++ b/core/src/shared.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "send"))]
+pub use std::rc::Rc;
+#[cfg(feature = "send")]
+pub use std::sync::Arc as Rc;
+
+#[cfg(feature = "send")]
+pub use im::{HashMap, HashSet};
+#[cfg(not(feature = "send"))]
+pub use im_rc::{HashMap, HashSet};


### PR DESCRIPTION
## Summary
- add optional `send` feature to `gluesql-core`
- create `core/src/shared.rs` for `Rc`/`Arc` and im collection aliases
- replace direct `Rc`/`im_rc` uses with new shared aliases
- keep workspace compiling with and without `send` feature

## Testing
- `cargo check -p gluesql-core`
- `cargo check -p gluesql-core --features send`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684d07334c34832a8c0b742564339f92