### PR TITLE
Refactor group_by_having aggregation

### DIFF
--- a/core/src/executor.rs
+++ b/core/src/executor.rs
@@ -15,7 +15,6 @@ mod update;
 mod validate;
 
 pub use {
-    aggregate::AggregateError,
     alter::{AlterError, Referencing},
     context::RowContext,
     delete::DeleteError,

--- a/core/src/executor/aggregate.rs
+++ b/core/src/executor/aggregate.rs
@@ -1,4 +1,3 @@
-mod error;
 mod state;
 
 use {
@@ -18,8 +17,6 @@ use {
     futures::stream::{self, Stream, StreamExt, TryStreamExt},
     std::rc::Rc,
 };
-
-pub use error::AggregateError;
 
 #[derive(futures_enum::Stream)]
 enum S<T1, T2> {

--- a/core/src/executor/aggregate/error.rs
+++ b/core/src/executor/aggregate/error.rs
@@ -1,7 +1,4 @@
 use {serde::Serialize, std::fmt::Debug, thiserror::Error};
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
-pub enum AggregateError {
-    #[error("unreachable rc unwrap failure")]
-    UnreachableRcUnwrapFailure,
-}
+pub enum AggregateError {}

--- a/core/src/executor/aggregate/error.rs
+++ b/core/src/executor/aggregate/error.rs
@@ -1,4 +1,0 @@
-use {serde::Serialize, std::fmt::Debug, thiserror::Error};
-
-#[derive(Error, Serialize, Debug, PartialEq, Eq)]
-pub enum AggregateError {}

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -7,8 +7,8 @@ pub use crate::{
         StringExtError, TableError, ValueError,
     },
     executor::{
-        AggregateError, AlterError, DeleteError, EvaluateError, ExecuteError, FetchError,
-        InsertError, SelectError, SortError, UpdateError, ValidateError,
+        AlterError, DeleteError, EvaluateError, ExecuteError, FetchError, InsertError,
+        SelectError, SortError, UpdateError, ValidateError,
     },
     plan::PlanError,
     store::{AlterTableError, IndexError},
@@ -43,8 +43,6 @@ pub enum Error {
     Select(#[from] SelectError),
     #[error("evaluate: {0}")]
     Evaluate(#[from] EvaluateError),
-    #[error("aggregate: {0}")]
-    Aggregate(#[from] AggregateError),
     #[error("sort: {0}")]
     Sort(#[from] SortError),
     #[error("insert: {0}")]

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -7,8 +7,8 @@ pub use crate::{
         StringExtError, TableError, ValueError,
     },
     executor::{
-        AlterError, DeleteError, EvaluateError, ExecuteError, FetchError, InsertError,
-        SelectError, SortError, UpdateError, ValidateError,
+        AlterError, DeleteError, EvaluateError, ExecuteError, FetchError, InsertError, SelectError,
+        SortError, UpdateError, ValidateError,
     },
     plan::PlanError,
     store::{AlterTableError, IndexError},


### PR DESCRIPTION
## Summary
- simplify group_by_having in executor
- drop Rc wrapping of aggregated maps
- remove unreachable unwrap error variant

## Testing
- `cargo check -p gluesql-core`
- `cargo test -p gluesql-core`


------
https://chatgpt.com/codex/tasks/task_e_684eaea82af8832aa28b38106ae6d975