### PR TITLE
Fix cross-compiling Python wheels

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -91,6 +91,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Configure PyO3 cross
+        if: matrix.architecture == 'aarch64'
+        run: echo "PYO3_CROSS_PYTHON_VERSION=${{ env.PYTHON_VERSION }}" >> $GITHUB_ENV
 
       - name: Set Rust target for aarch64
         if: matrix.architecture == 'aarch64'

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,9 +11,6 @@ on:
         description: Dry run
         type: boolean
         default: true
-  pull_request:
-    # Run on any pull request for validation in dry-run mode
-    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,6 +11,9 @@ on:
         description: Dry run
         type: boolean
         default: true
+  pull_request:
+    # Run on any pull request for validation in dry-run mode
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ inputs.sha || github.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux
@@ -78,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ inputs.sha || github.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha || github.sha }}
+          ref: ${{ inputs.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha || github.sha }}
+          ref: ${{ inputs.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux


### PR DESCRIPTION
## Summary
- configure `PYO3_CROSS_PYTHON_VERSION` in publish-python workflow

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_685103a9746c832a9f9a304ab7153e47