### PR TITLE
Ensure PyPI package uses README as long description

### DIFF
--- a/pkg/python/pyproject.toml
+++ b/pkg/python/pyproject.toml
@@ -10,6 +10,7 @@ features = ["include-python-workspace"]
 name = "gluesql"
 requires-python = ">=3.10"
 description = "GlueSQL is quite sticky. It attaches to anywhere."
+readme = "../../README.md"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## Summary
- ensure PyPI package uses README as long description

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_685111a1d968832ab99f89678c0c22e8