### PR TITLE
Add Redb storage option to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "gluesql-file-storage",
  "gluesql-json-storage",
  "gluesql-parquet-storage",
+ "gluesql-redb-storage",
  "gluesql_memory_storage",
  "gluesql_sled_storage",
  "rustyline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ gluesql-json-storage.workspace = true
 gluesql-csv-storage.workspace = true
 gluesql-parquet-storage.workspace = true
 gluesql-file-storage.workspace = true
+gluesql-redb-storage.workspace = true
 
 clap = { version = "3.2.2", features = ["derive"] }
 rustyline = "9.1"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -23,6 +23,7 @@ use {
     gluesql_json_storage::JsonStorage,
     gluesql_memory_storage::MemoryStorage,
     gluesql_parquet_storage::ParquetStorage,
+    gluesql_redb_storage::RedbStorage,
     gluesql_sled_storage::SledStorage,
     std::{
         fmt::Debug,
@@ -56,6 +57,7 @@ struct Args {
 enum Storage {
     Memory,
     Sled,
+    Redb,
     Json,
     Csv,
     Parquet,
@@ -80,6 +82,14 @@ pub fn run() -> Result<()> {
 
             run(
                 SledStorage::new(path).expect("failed to load sled-storage"),
+                args.execute,
+            );
+        }
+        (Some(path), Some(Storage::Redb), _) => {
+            println!("[redb-storage] connected to {}", path);
+
+            run(
+                RedbStorage::new(path).expect("failed to load redb-storage"),
                 args.execute,
             );
         }


### PR DESCRIPTION
## Summary
- support gluesql-redb-storage in CLI

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68538908f3c8832aa1eabcd7d6dfee47