### PR TITLE
Add redb storage to publish-rust.yml workflow

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -35,6 +35,7 @@ jobs:
               "gluesql_sled_storage"
               "gluesql_memory_storage"
               "gluesql-shared-memory-storage"
+              "gluesql-redb-storage"
               "gluesql-redis-storage"
               "gluesql-mongo-storage"
               "gluesql-web-storage"


### PR DESCRIPTION
## Summary
- include `gluesql-redb-storage` in the Rust publish workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_68568cc12c54832a832e19def44961fe