### PR TITLE
Add Redb storage docs to supported-storages section

### DIFF
--- a/docs/docs/storages/supported-storages/redb-storage.md
+++ b/docs/docs/storages/supported-storages/redb-storage.md
@@ -1,0 +1,32 @@
+# Redb Storage
+
+RedbStorage allows GlueSQL to persist data using the [redb](https://github.com/cberner/redb) embedded key-value database. It provides ACID transactions, fast single-file access, and a stable API.
+
+RedbStorage implements GlueSQL's `Store`, `StoreMut`, and `Transaction` traits.
+## Example
+
+```rust
+use gluesql::{prelude::Glue, redb_storage::RedbStorage};
+
+#[tokio::main]
+async fn main() {
+    let storage = RedbStorage::new("data/my_db.redb").unwrap();
+    let mut glue = Glue::new(storage);
+
+    let sql = "
+        CREATE TABLE Foo (id INT, name TEXT);
+        INSERT INTO Foo VALUES (1, 'Alice'), (2, 'Bob');
+        SELECT * FROM Foo;
+    ";
+
+    let payloads = glue.execute(sql).await.unwrap();
+    println!("{:#?}", payloads);
+}
+```
+
+## Things to keep in mind
+
+- Nested transactions are not supported.
+- Only one RedbStorage instance should open the same database file at a time.
+
+RedbStorage gives you an embedded, serverless database that integrates seamlessly with GlueSQL. Use `RedbStorage::new` to open or create a database file and execute SQL through `Glue`.


### PR DESCRIPTION
## Summary
- document RedbStorage usage
- address feedback about version wording

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_6853891ac968832a9b6dd90fa6760e1f