### PR TITLE
Add Python README and fix pyproject path

### DIFF
--- a/pkg/python/README.md
+++ b/pkg/python/README.md
@@ -1,0 +1,44 @@
+# GlueSQL.py
+
+GlueSQL.py is a Python binding for the [GlueSQL](https://github.com/gluesql/gluesql) database engine. It provides an embedded SQL database that works with a selection of storage backends.
+
+Supported storages:
+
+- `MemoryStorage`
+- `JsonStorage`
+- `SharedMemoryStorage`
+- `SledStorage`
+
+Learn more at **<https://gluesql.org/docs>**.
+
+## Installation
+
+Install from PyPI:
+
+```bash
+pip install gluesql
+```
+
+## Usage
+
+```python
+from gluesql import Glue, MemoryStorage
+
+storage = MemoryStorage()
+
+engine = Glue(storage)
+
+engine.query(
+    """
+    CREATE TABLE User (id INTEGER, name TEXT);
+    INSERT INTO User VALUES (1, 'Hello'), (2, 'World');
+    """
+)
+
+result = engine.query("SELECT * FROM User;")
+print(result)
+```
+
+## License
+
+This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](https://raw.githubusercontent.com/gluesql/gluesql/main/LICENSE) file for details.

--- a/pkg/python/pyproject.toml
+++ b/pkg/python/pyproject.toml
@@ -10,7 +10,7 @@ features = ["include-python-workspace"]
 name = "gluesql"
 requires-python = ">=3.10"
 description = "GlueSQL is quite sticky. It attaches to anywhere."
-readme = "../../README.md"
+readme = "README.md"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## Summary
- add a dedicated README for the Python package
- reference the new README from `pyproject.toml`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_6856a2479a2c832a8c1526293ce588fd