### PR TITLE
test-suite(ast-builder::schemaless): add basic schemaless ast-builder test

### DIFF
--- a/test-suite/src/ast_builder.rs
+++ b/test-suite/src/ast_builder.rs
@@ -9,3 +9,4 @@ pub mod select;
 pub mod statements;
 pub mod update;
 pub mod values;
+pub mod schemaless;

--- a/test-suite/src/ast_builder/schemaless.rs
+++ b/test-suite/src/ast_builder/schemaless.rs
@@ -1,0 +1,1 @@
+pub mod basic;

--- a/test-suite/src/ast_builder/schemaless/basic.rs
+++ b/test-suite/src/ast_builder/schemaless/basic.rs
@@ -1,0 +1,65 @@
+use {
+    crate::*,
+    gluesql_core::{ast_builder::*, executor::Payload},
+    gluesql_core::prelude::Value::{self, *},
+    serde_json::json,
+};
+
+test_case!(basic, {
+    let glue = get_glue!();
+
+    let actual = table("Logs")
+        .create_table()
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    assert_eq!(actual, expected, "create schemaless table");
+
+    let row1 = json!({ "id": 1, "value": 30 }).to_string();
+    let row2 = json!({ "id": 2, "rate": 3.0, "list": [1, 2, 3] }).to_string();
+
+    let actual = table("Logs")
+        .insert()
+        .values(vec![
+            vec![text(&row1)],
+            vec![text(&row2)],
+        ])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(2));
+    assert_eq!(actual, expected, "insert schemaless data");
+
+    let actual = table("Logs")
+        .select()
+        .execute(glue)
+        .await;
+    let expected = Ok(select_map![
+        json!({ "id": 1, "value": 30 }),
+        json!({ "id": 2, "rate": 3.0, "list": [1, 2, 3] })
+    ]);
+    assert_eq!(actual, expected, "select schemaless data");
+
+    let actual = table("Logs")
+        .delete()
+        .filter("id = 1")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Delete(1));
+    assert_eq!(actual, expected, "delete schemaless row");
+
+    let actual = table("Logs")
+        .select()
+        .execute(glue)
+        .await;
+    let expected = Ok(select_map![
+        json!({ "id": 2, "rate": 3.0, "list": [1, 2, 3] })
+    ]);
+    assert_eq!(actual, expected, "select after delete");
+
+    let actual = table("Logs")
+        .drop_table()
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::DropTable(1));
+    assert_eq!(actual, expected, "drop schemaless table");
+});

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -298,6 +298,7 @@ macro_rules! generate_store_tests {
             ast_builder::function::text::position_and_indexing
         );
         glue!(ast_builder_index_by, ast_builder::index_by::index_by);
+        glue!(ast_builder_schemaless_basic, ast_builder::schemaless::basic::basic);
 
         // schemaless data support
         glue!(schemaless_basic, schemaless::basic);


### PR DESCRIPTION

- Create schemaless table
- Insert JSON-formatted records
- SELECT * returns Payload::SelectMap and verifies record contents
- DELETE row and re-SELECT to confirm deletion
- DROP TABLE and verify cleanup