### PR TITLE
Refactor Error Handling for Mongo Row Operations

### DIFF
--- a/storages/mongo-storage/src/row.rs
+++ b/storages/mongo-storage/src/row.rs
@@ -40,7 +40,7 @@ impl IntoRow for Document {
             .into_iter()
             .skip(1)
             .zip(data_types)
-            .map(|((_, bson), data_type)| bson.into_value(data_type))
+            .map(|((_, bson), data_type)| bson.into_value(data_type).map_storage_err())
             .collect::<Result<Vec<_>>>()?;
 
         Ok((key, DataRow::Vec(row)))


### PR DESCRIPTION
value & key modules in MongoStorage does not return any other Error only except for MongoStorageError.
this PR changes the return types of methods used in value & key modules from core::Error to MongoStorageError.

## Summary
- refactor `value` and `key` conversions to return `MongoStorageError`
- convert callers to map errors via `map_storage_err`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_685cc681a8a0832aab163fdee437b8f7