### PR TITLE
Remove obsolete aggregator comment

### DIFF
--- a/core/src/executor/select.rs
+++ b/core/src/executor/select.rs
@@ -144,16 +144,6 @@ where
         });
 
     let join = Join::new(storage, joins, filter_context.as_ref().map(Rc::clone));
-    /*
-    let aggregate = Aggregator::new(
-        /*
-        projection,
-        group_by,
-        having.as_ref(),
-        filter_context.as_ref().map(Rc::clone),
-        */
-    );
-    */
     let filter = Rc::new(Filter::new(
         storage,
         where_clause.as_ref(),


### PR DESCRIPTION
## Summary
- delete a stale commented `Aggregator::new` block in the select executor

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_685fea189b48832a8800a0518119ee38