### PR TITLE
Remove unused comment in core/src/lib.rs

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::str_to_string)]
-// #![allow(clippy::result_large_err)]
 
 // re-export
 pub use {chrono, sqlparser};


### PR DESCRIPTION
## Summary
- delete obsolete clippy directive comment in core/src/lib.rs

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_685fea1ed6dc832a894b1affe762bc80