### PR TITLE
Add conflict errors to MongoStorageError

### DIFF
--- a/storages/mongo-storage/src/error.rs
+++ b/storages/mongo-storage/src/error.rs
@@ -29,6 +29,12 @@ pub enum MongoStorageError {
     #[error("unreachable")]
     Unreachable,
 
+    #[error("conflict when fetching data")]
+    ConflictFetchData,
+
+    #[error("conflict when appending data")]
+    ConflictAppendData,
+
     #[error("unsupported bson type")]
     UnsupportedBsonType,
 

--- a/storages/mongo-storage/src/store.rs
+++ b/storages/mongo-storage/src/store.rs
@@ -52,7 +52,7 @@ impl Store for MongoStorage {
         let column_defs = self
             .get_column_defs(table_name)
             .await?
-            .map_storage_err(MongoStorageError::Unreachable)?;
+            .map_storage_err(MongoStorageError::ConflictFetchData)?;
 
         let primary_key = get_primary_key(&column_defs)
             .ok_or(MongoStorageError::Unreachable)

--- a/storages/mongo-storage/src/store_mut.rs
+++ b/storages/mongo-storage/src/store_mut.rs
@@ -204,7 +204,7 @@ impl StoreMut for MongoStorage {
             .map(|row| match row {
                 DataRow::Vec(values) => column_defs
                     .as_ref()
-                    .map_storage_err(MongoStorageError::Unreachable)?
+                    .map_storage_err(MongoStorageError::ConflictAppendData)?
                     .iter()
                     .zip(values.into_iter())
                     .try_fold(Document::new(), |mut acc, (column_def, value)| {

--- a/storages/mongo-storage/tests/mongo_storage_conflict.rs
+++ b/storages/mongo-storage/tests/mongo_storage_conflict.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "test-mongo")]
+
+use {
+    gluesql_core::{
+        data::Key,
+        error::Error,
+        prelude::{Glue, Value},
+        store::{DataRow, Store, StoreMut},
+    },
+    gluesql_mongo_storage::{MongoStorage, error::MongoStorageError},
+};
+
+#[tokio::test]
+async fn mongo_storage_conflict_errors() {
+    let conn_str = "mongodb://localhost:27017";
+
+    let storage = MongoStorage::new(conn_str, "mongo_storage_conflict")
+        .await
+        .expect("MongoStorage::new");
+    storage.drop_database().await.expect("database dropped");
+
+    let mut glue = Glue::new(storage);
+
+    glue.execute("CREATE TABLE Logs").await.unwrap();
+
+    let actual = glue.storage.fetch_data("Logs", &Key::I64(1)).await;
+    let expected = Err(Error::StorageMsg(
+        MongoStorageError::ConflictFetchData.to_string(),
+    ));
+    assert_eq!(
+        actual, expected,
+        "fetch_data on schemaless table should return conflict error"
+    );
+
+    let actual = glue
+        .storage
+        .append_data("Logs", vec![DataRow::Vec(vec![Value::I64(1)])])
+        .await;
+    let expected = Err(Error::StorageMsg(
+        MongoStorageError::ConflictAppendData.to_string(),
+    ));
+    assert_eq!(
+        actual, expected,
+        "append_data with DataRow::Vec should return conflict error"
+    );
+}


### PR DESCRIPTION
- Introduces two new error variants: ConflictFetchData and ConflictAppendData to MongoStorageError
- Modifies related error handling in src/store.rs and src/store_mut.rs
- Adds tests for these new conflict errors


## Summary
- add `ConflictFetchData` and `ConflictAppendData` error variants for Mongo storage
- use distinct conflict errors for `fetch_data` and `append_data`
- refine conflict test expectations

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68620485227c832a8a7eaad872e200f4