### PR TITLE
Add unreachable variants to Plan & Alter

### DIFF
--- a/core/src/executor/alter/error.rs
+++ b/core/src/executor/alter/error.rs
@@ -87,4 +87,7 @@ pub enum AlterError {
 
     #[error("cannot drop column '{}.{}' referencing with '{}'", referencing.table_name, referencing.foreign_key.referencing_column_name, referencing)]
     CannotAlterReferencingColumn { referencing: Referencing },
+
+    #[error("unreachable")]
+    Unreachable,
 }

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -4,10 +4,10 @@ use {
         ast::{
             ColumnDef, ColumnUniqueOption, ForeignKey, Query, SetExpr, TableFactor, ToSql, Values,
         },
-        data::{Schema, TableError},
+        data::Schema,
         executor::{evaluate_stateless, select::select},
         prelude::{DataType, Value},
-        result::{Error, Result},
+        result::Result,
         store::{GStore, GStoreMut},
     },
     futures::stream::TryStreamExt,
@@ -63,7 +63,7 @@ pub async fn create_table<T: GStore + GStoreMut>(
                     Some(vec![column_def])
                 }
                 _ => {
-                    return Err(Error::Table(TableError::Unreachable));
+                    return Err(AlterError::Unreachable.into());
                 }
             },
             SetExpr::Values(Values(values_list)) => {

--- a/core/src/plan/error.rs
+++ b/core/src/plan/error.rs
@@ -6,4 +6,7 @@ pub enum PlanError {
     /// situation.
     #[error("column reference {0} is ambiguous, please specify the table name")]
     ColumnReferenceAmbiguous(String),
+
+    #[error("unreachable")]
+    Unreachable,
 }

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -1,11 +1,12 @@
 use {
+    super::PlanError,
     crate::{
         ast::{
             AstLiteral, BinaryOperator, Expr, Function, IndexItem, IndexOperator, OrderByExpr,
             Query, Select, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins,
         },
-        data::{Schema, SchemaIndex, SchemaIndexOrd, TableError},
-        result::{Error, Result},
+        data::{Schema, SchemaIndex, SchemaIndexOrd},
+        result::Result,
     },
     std::collections::HashMap,
     utils::Vector,
@@ -127,7 +128,7 @@ fn plan_query(schema_map: &HashMap<String, Schema>, query: Query) -> Result<Quer
                 TableFactor::Derived { .. }
                 | TableFactor::Series { .. }
                 | TableFactor::Dictionary { .. } => {
-                    return Err(Error::Table(TableError::Unreachable));
+                    return Err(PlanError::Unreachable.into());
                 }
             };
 
@@ -212,7 +213,7 @@ fn plan_select(
                 TableFactor::Derived { .. }
                 | TableFactor::Series { .. }
                 | TableFactor::Dictionary { .. } => {
-                    return Err(Error::Table(TableError::Unreachable));
+                    return Err(PlanError::Unreachable.into());
                 }
             };
 


### PR DESCRIPTION
## Summary
- add `Unreachable` to `PlanError` and `AlterError`
- return `PlanError::Unreachable` in index planner via `into`
- return `AlterError::Unreachable` in table creation

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68621086549c832ab92b01a5be995094