### PR TITLE
Move ValueError cases in evaluate module to EvaluateError variants

### DIFF
--- a/core/src/data/value/error.rs
+++ b/core/src/data/value/error.rs
@@ -81,12 +81,6 @@ pub enum ValueError {
     #[error("unary factorial operation overflow")]
     FactorialOverflow,
 
-    #[error("GCD or LCM calculation overflowed on trying to get the absolute value of {0}")]
-    GcdLcmOverflow(i64),
-
-    #[error("LCM calculation resulted in a value out of the i64 range")]
-    LcmResultOutOfRange,
-
     #[error("unary bit_not operation for non numeric value")]
     UnaryBitwiseNotOnNonNumeric,
 
@@ -101,9 +95,6 @@ pub enum ValueError {
 
     #[error("failed to cast from hex string to bytea: {0}")]
     CastFromHexToByteaFailed(String),
-
-    #[error("function CONCAT requires at least 1 argument")]
-    EmptyArgNotAllowedInConcat,
 
     // Cast errors from literal to value
     #[error("literal cast failed from text to integer: {0}")]
@@ -227,9 +218,6 @@ pub enum ValueError {
 
     #[error("failed to convert Value to Expr")]
     ValueToExprConversionFailure,
-
-    #[error("failed to convert Value to u32: {0}")]
-    I64ToU32ConversionFailure(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Display)]

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -166,6 +166,18 @@ pub enum EvaluateError {
 
     #[error("function requires at least one argument: {0}")]
     FunctionRequiresAtLeastOneArgument(String),
+
+    #[error("function CONCAT requires at least 1 argument")]
+    EmptyArgNotAllowedInConcat,
+
+    #[error("LCM calculation resulted in a value out of the i64 range")]
+    LcmResultOutOfRange,
+
+    #[error("GCD or LCM calculation overflowed on trying to get the absolute value of {0}")]
+    GcdLcmOverflow(i64),
+
+    #[error("failed to convert Value to u32: {0}")]
+    I64ToU32ConversionFailure(String),
 }
 
 fn error_serialize<S>(error: &chrono::format::ParseError, serializer: S) -> Result<S::Ok, S::Error>

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -2,7 +2,7 @@ use {
     super::{EvaluateError, Evaluated},
     crate::{
         ast::DateTimeField,
-        data::{Key, Point, Value, ValueError},
+        data::{Key, Point, Value},
         result::{Error, Result},
     },
     chrono::{Datelike, Duration, Months},
@@ -153,7 +153,7 @@ pub fn concat(exprs: Vec<Evaluated<'_>>) -> ControlFlow<Evaluated> {
             Some(left) => left.concat(right).break_if_null().map(Some),
         })?;
 
-    value.continue_or_break(ValueError::EmptyArgNotAllowedInConcat.into())
+    value.continue_or_break(EvaluateError::EmptyArgNotAllowedInConcat.into())
 }
 
 pub fn concat_ws<'a>(
@@ -526,7 +526,7 @@ pub fn lcm<'a>(
         let result = (a * b).abs().checked_div(gcd_val).unwrap_or(0);
 
         i64::try_from(result)
-            .map_err(|_| ValueError::LcmResultOutOfRange.into())
+            .map_err(|_| EvaluateError::LcmResultOutOfRange.into())
             .into_control_flow()
     }
 
@@ -536,10 +536,10 @@ pub fn lcm<'a>(
 fn gcd_i64(a: i64, b: i64) -> ControlFlow<i64> {
     let mut a = a
         .checked_abs()
-        .continue_or_break(ValueError::GcdLcmOverflow(a).into())?;
+        .continue_or_break(EvaluateError::GcdLcmOverflow(a).into())?;
     let mut b = b
         .checked_abs()
-        .continue_or_break(ValueError::GcdLcmOverflow(b).into())?;
+        .continue_or_break(EvaluateError::GcdLcmOverflow(b).into())?;
 
     while b > 0 {
         (a, b) = (b, a % b);
@@ -832,7 +832,7 @@ pub fn add_month<'a>(
         let size_as_u32 = size
             .abs()
             .try_into()
-            .map_err(|_| ValueError::I64ToU32ConversionFailure(name).into())
+            .map_err(|_| EvaluateError::I64ToU32ConversionFailure(name).into())
             .into_control_flow()?;
         let new_months = chrono::Months::new(size_as_u32);
 

--- a/test-suite/src/function/add_month.rs
+++ b/test-suite/src/function/add_month.rs
@@ -2,7 +2,7 @@ use {
     crate::*,
     chrono::format::ParseErrorKind,
     gluesql_core::{
-        error::{EvaluateError, ValueError},
+        error::EvaluateError,
         prelude::{Error, Value},
     },
 };
@@ -76,7 +76,7 @@ test_case!(add_month, {
     g.named_test(
         "out of range test with i64::MAX",
         "SELECT ADD_MONTH('2017-01-31',9223372036854775807) AS test;",
-        Err(ValueError::I64ToU32ConversionFailure("ADD_MONTH".to_owned()).into()),
+        Err(EvaluateError::I64ToU32ConversionFailure("ADD_MONTH".to_owned()).into()),
     )
     .await;
     g.named_test(

--- a/test-suite/src/function/concat.rs
+++ b/test-suite/src/function/concat.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{error::ValueError, prelude::Value::*},
+    gluesql_core::{
+        error::{EvaluateError, ValueError},
+        prelude::Value::*,
+    },
 };
 
 test_case!(concat, {
@@ -51,7 +54,7 @@ test_case!(concat, {
     // test with zero arguments
     g.test(
         r#"select concat() as myconcat;"#,
-        Err(ValueError::EmptyArgNotAllowedInConcat.into()),
+        Err(EvaluateError::EmptyArgNotAllowedInConcat.into()),
     )
     .await;
 

--- a/test-suite/src/function/gcd_lcm.rs
+++ b/test-suite/src/function/gcd_lcm.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        error::{EvaluateError, ValueError},
+        error::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };
@@ -117,7 +117,7 @@ test_case!(gcd_lcm, {
         (
             // check i64::MIN overflow error
             "SELECT GCD(-9223372036854775808, -9223372036854775808)",
-            Err(ValueError::GcdLcmOverflow(i64::MIN).into()),
+            Err(EvaluateError::GcdLcmOverflow(i64::MIN).into()),
         ),
         (
             "SELECT LCM(0, 0) as test",
@@ -138,14 +138,14 @@ test_case!(gcd_lcm, {
         (
             // check i64::MIN overflow error
             "SELECT LCM(-9223372036854775808, -9223372036854775808)",
-            Err(ValueError::GcdLcmOverflow(i64::MIN).into()),
+            Err(EvaluateError::GcdLcmOverflow(i64::MIN).into()),
         ),
         (
             // 10^10 + 19 and 10^10 + 33 are prime numbers
             // LCM(10^10+19, 10^10+33) = (10^10+19)*(10^10+33)
             // this result is out of i64 range.
             "SELECT LCM(10000000019, 10000000033)",
-            Err(ValueError::LcmResultOutOfRange.into()),
+            Err(EvaluateError::LcmResultOutOfRange.into()),
         ),
         (
             "SELECT gcd(1.0, 1);",


### PR DESCRIPTION
## Summary
- add additional `EvaluateError` variants
- swap `ValueError` usages in function evaluator for new `EvaluateError` variants
- remove now-unused `ValueError` import
- remove moved variants from `ValueError`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_686210819310832aa3cc817631044530