### PR TITLE
Add column-aware scan feature

### DIFF
--- a/storages/parquet-storage/src/store.rs
+++ b/storages/parquet-storage/src/store.rs
@@ -6,12 +6,22 @@ use {
     async_trait::async_trait,
     futures::stream::iter,
     gluesql_core::{
+        ast::ColumnUniqueOption,
         data::{Key, Schema},
         error::Result,
         store::{DataRow, RowIter, Store},
     },
-    std::{ffi::OsStr, fs},
+    parquet::{
+        file::{reader::FileReader, serialized_reader::SerializedFileReader},
+        record::Row,
+    },
+    std::{
+        ffi::OsStr,
+        fs::{self, File},
+    },
 };
+
+use crate::value::ParquetField;
 
 #[async_trait(?Send)]
 impl Store for ParquetStorage {
@@ -56,6 +66,83 @@ impl Store for ParquetStorage {
 
     async fn scan_data<'a>(&'a self, table_name: &str) -> Result<RowIter<'a>> {
         let rows = self.scan_data(table_name)?.0;
+        Ok(Box::pin(iter(rows)))
+    }
+
+    async fn scan_data_with_columns<'a>(
+        &'a self,
+        table_name: &str,
+        columns: &[String],
+    ) -> Result<RowIter<'a>> {
+        use parquet::schema::types::TypePtr;
+
+        let fetched_schema = self.fetch_schema(table_name)?.map_storage_err(
+            ParquetStorageError::TableDoesNotExist(table_name.to_owned()),
+        )?;
+
+        if fetched_schema.column_defs.is_none() {
+            return Store::scan_data_with_columns(self, table_name, columns).await;
+        }
+
+        let file = File::open(self.data_path(table_name)).map_storage_err()?;
+        let parquet_reader = SerializedFileReader::new(file).map_storage_err()?;
+        let file_schema = parquet_reader.metadata().file_metadata().schema();
+
+        let mut fields: Vec<TypePtr> = Vec::new();
+        let mut proj_defs = Vec::new();
+        if let Some(column_defs) = &fetched_schema.column_defs {
+            for (idx, field) in file_schema.get_fields().iter().enumerate() {
+                if columns.iter().any(|c| c == field.name()) {
+                    fields.push(field.clone());
+                    proj_defs.push(column_defs[idx].clone());
+                }
+            }
+        }
+
+        let proj_schema_type = parquet::schema::types::Type::group_type_builder("schema")
+            .with_fields(&mut fields)
+            .build()
+            .map_storage_err()?;
+
+        let row_iter = parquet_reader
+            .get_row_iter(Some(proj_schema_type))
+            .map_storage_err()?;
+
+        let proj_schema = Schema {
+            table_name: fetched_schema.table_name,
+            column_defs: Some(proj_defs),
+            indexes: vec![],
+            engine: None,
+            foreign_keys: vec![],
+            comment: None,
+        };
+
+        let mut rows = Vec::new();
+        let mut key_counter: u64 = 0;
+        for record in row_iter {
+            let record: Row = record.map_storage_err()?;
+            let mut row = Vec::new();
+            let mut key = None;
+
+            for (idx, (_, field)) in record.get_column_iter().enumerate() {
+                let value = ParquetField(field.clone()).to_value(&proj_schema, idx)?;
+                if let Some(column_defs) = &proj_schema.column_defs {
+                    if column_defs[idx].unique == Some(ColumnUniqueOption { is_primary: true }) {
+                        key = Key::try_from(&value).ok();
+                    }
+                }
+                row.push(value);
+            }
+
+            let generated_key = key.unwrap_or_else(|| {
+                let generated = Key::U64(key_counter);
+                key_counter += 1;
+                generated
+            });
+
+            rows.push(Ok((generated_key, DataRow::Vec(row))));
+        }
+
         Ok(Box::pin(iter(rows)))
     }
 }

--- a/storages/parquet-storage/tests/parquet_storage.rs
+++ b/storages/parquet-storage/tests/parquet_storage.rs
@@ -28,3 +28,41 @@ impl Tester<ParquetStorage> for ParquetTester {
 
 generate_store_tests!(tokio::test, ParquetTester);
 generate_alter_table_tests!(tokio::test, ParquetTester);
+
+macro_rules! exec {
+    ($glue: ident $sql: literal) => {
+        $glue.execute($sql).await.unwrap();
+    };
+}
+
+#[tokio::test]
+async fn scan_data_with_columns_parquet() {
+    use futures::TryStreamExt;
+    use gluesql_core::{
+        data::{Key, Value},
+        store::{DataRow, Store},
+    };
+
+    let path = "tmp/scan_columns_parquet";
+    let _ = remove_dir_all(path);
+    let storage = ParquetStorage::new(path).unwrap();
+    let mut glue = Glue::new(storage);
+
+    exec!(glue "CREATE TABLE Foo (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);");
+    exec!(glue "INSERT INTO Foo VALUES (1, 'a', 10), (2, 'b', 20);");
+
+    let rows = Store::scan_data_with_columns(&glue.storage, "Foo", &["name".to_owned()])
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            (Key::I64(1), DataRow::Vec(vec![Value::Str("a".to_owned())])),
+            (Key::I64(2), DataRow::Vec(vec![Value::Str("b".to_owned())]))
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- add `scan_data_with_columns` method to `Store` trait with default implementation
- test default method via memory storage integration test
- implement optimized projection for Parquet storage
- add Parquet integration test using new method

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_6862225bceb0832aae028b4b5082ca86