### PR TITLE
Ensure table names are quoted in INSERT statement to_sql output

### DIFF
--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -170,7 +170,10 @@ impl ToSql for Statement {
                     false => format!("({}) ", columns.join(", ")),
                 };
 
-                format!("INSERT INTO {table_name} {columns}{};", source.to_sql())
+                format!(
+                    r#"INSERT INTO "{table_name}" {columns}{};"#,
+                    source.to_sql()
+                )
             }
             Statement::Update {
                 table_name,
@@ -379,7 +382,7 @@ mod tests {
     #[test]
     fn to_sql_insert() {
         assert_eq!(
-            "INSERT INTO Test (id, num, name) VALUES (1, 2, 'Hello');",
+            r#"INSERT INTO "Test" (id, num, name) VALUES (1, 2, 'Hello');"#,
             Statement::Insert {
                 table_name: "Test".into(),
                 columns: vec!["id".to_owned(), "num".to_owned(), "name".to_owned()],


### PR DESCRIPTION
## Summary
- wrap table names with double quotes when generating INSERT statements
- update existing tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_6868aa8028b0832aaffd19f6f9ae2828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table names in generated SQL INSERT statements are now correctly enclosed in double quotes to improve compatibility and prevent potential errors with reserved words or special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->