### PR TITLE
Fix single quotes escaping in AstLiteral::QuotedString

### DIFF
--- a/core/src/ast/ast_literal.rs
+++ b/core/src/ast/ast_literal.rs
@@ -19,7 +19,10 @@ impl ToSql for AstLiteral {
         match self {
             AstLiteral::Boolean(b) => b.to_string().to_uppercase(),
             AstLiteral::Number(n) => n.to_string(),
-            AstLiteral::QuotedString(qs) => format!("'{qs}'"),
+            AstLiteral::QuotedString(qs) => {
+                let escaped = qs.replace('\'', "''");
+                format!("'{escaped}'")
+            }
             AstLiteral::HexString(hs) => format!("'{hs}'"),
             AstLiteral::Null => "NULL".to_owned(),
         }
@@ -59,6 +62,10 @@ mod tests {
         assert_eq!(
             "'hello'",
             AstLiteral::QuotedString("hello".to_owned()).to_sql()
+        );
+        assert_eq!(
+            "'can''t'",
+            AstLiteral::QuotedString("can't".to_owned()).to_sql()
         );
         assert_eq!("NULL", AstLiteral::Null.to_sql());
     }


### PR DESCRIPTION
## Summary
- escape single quotes when generating SQL for `AstLiteral::QuotedString`
- add unit test verifying the escape logic

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: required dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac15a94c832ab90d2867dcb5b9c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of single quotes in string values to ensure correct SQL escaping.

* **Tests**
  * Added a test case to verify proper escaping of single quotes in SQL output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->