### PR TITLE
Add Etcd storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +276,53 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -297,6 +350,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
@@ -422,7 +481,7 @@ dependencies = [
  "bitvec",
  "chrono",
  "hex",
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "js-sys",
  "once_cell",
  "rand",
@@ -956,6 +1015,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f998f8294bc5e7d4f8ea31bd08a1e4a69f94e79d88bc289ea48e9eb7c33b39"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1070,12 @@ checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
  "toml 0.5.11",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -1353,6 +1434,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gluesql-etcd-storage"
+version = "0.17.0"
+dependencies = [
+ "async-trait",
+ "etcd-client",
+ "futures",
+ "gluesql-core",
+ "gluesql-test-suite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "gluesql-file-storage"
 version = "0.17.0"
 dependencies = [
@@ -1618,6 +1714,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.10.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1763,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -1709,6 +1830,107 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1801,12 +2023,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1847,7 +2069,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -2079,6 +2301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2339,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
@@ -2189,6 +2423,12 @@ dependencies = [
  "uuid",
  "webpki-roots",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nibble_vec"
@@ -2457,6 +2697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.10.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,6 +2863,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.12.1",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.89",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3221,7 +3533,7 @@ version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3367,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3499,6 +3811,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tabled"
@@ -3707,7 +4025,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -3730,6 +4048,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3783,7 +4112,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -3794,11 +4123,132 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow 0.6.18",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3845,6 +4295,12 @@ dependencies = [
  "tokio",
  "trust-dns-proto",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -3972,6 +4428,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ gluesql-web-storage = { path = "./storages/web-storage", version = "0.17.0" }
 gluesql-idb-storage = { path = "./storages/idb-storage", version = "0.17.0" }
 gluesql-redis-storage = { path = "./storages/redis-storage", version = "0.17.0" }
 gluesql-mongo-storage = { path = "./storages/mongo-storage", version = "0.17.0" }
+gluesql-etcd-storage = { path = "./storages/etcd-storage", version = "0.17.0" }
 gluesql-parquet-storage = { path = "./storages/parquet-storage", version = "0.17.0" }
 gluesql-file-storage = { path = "./storages/file-storage", version = "0.17.0" }
 gluesql-git-storage = { path = "./storages/git-storage", version = "0.17.0" }

--- a/storages/etcd-storage/Cargo.toml
+++ b/storages/etcd-storage/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gluesql-etcd-storage"
+authors = ["OpenAI" ]
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+
+[dependencies]
+async-trait = "0.1"
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+etcd-client = "0.15"
+uuid = { version = "1", features = ["v7"] }
+gluesql-core.workspace = true
+
+[dev-dependencies]
+test-suite.workspace = true
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[features]
+test-etcd = []

--- a/storages/etcd-storage/src/lib.rs
+++ b/storages/etcd-storage/src/lib.rs
@@ -1,0 +1,51 @@
+#![deny(clippy::str_to_string)]
+
+mod store;
+mod store_mut;
+
+use gluesql_core::{
+    data::Key,
+    error::Result,
+    store::{
+        AlterTable, CustomFunction, CustomFunctionMut, Index, IndexMut, Metadata, Transaction,
+    },
+};
+
+pub struct EtcdStorage {
+    pub client: etcd_client::Client,
+    pub prefix: String,
+}
+
+impl EtcdStorage {
+    pub async fn new(endpoints: &[&str], prefix: &str) -> Result<Self> {
+        let client = etcd_client::Client::connect(endpoints, None)
+            .await
+            .map_err(|e| gluesql_core::error::Error::StorageMsg(e.to_string()))?;
+        Ok(Self {
+            client,
+            prefix: prefix.to_owned(),
+        })
+    }
+
+    fn schema_key(&self, table_name: &str) -> String {
+        format!("{}/schema/{}", self.prefix, table_name)
+    }
+
+    fn data_key(&self, table_name: &str, key: &Key) -> Result<String> {
+        let key_ser = serde_json::to_string(key)
+            .map_err(|e| gluesql_core::error::Error::StorageMsg(e.to_string()))?;
+        Ok(format!("{}/data/{}/{}", self.prefix, table_name, key_ser))
+    }
+
+    fn data_prefix(&self, table_name: &str) -> String {
+        format!("{}/data/{}/", self.prefix, table_name)
+    }
+}
+
+impl AlterTable for EtcdStorage {}
+impl Index for EtcdStorage {}
+impl IndexMut for EtcdStorage {}
+impl Transaction for EtcdStorage {}
+impl Metadata for EtcdStorage {}
+impl CustomFunction for EtcdStorage {}
+impl CustomFunctionMut for EtcdStorage {}

--- a/storages/etcd-storage/src/store.rs
+++ b/storages/etcd-storage/src/store.rs
@@ -1,0 +1,106 @@
+use {
+    crate::EtcdStorage,
+    async_trait::async_trait,
+    futures::stream,
+    gluesql_core::{
+        data::{Key, Schema},
+        error::{Error, Result},
+        store::{DataRow, RowIter, Store},
+    },
+};
+
+#[async_trait(?Send)]
+impl Store for EtcdStorage {
+    async fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
+        let prefix = format!("{}/schema/", self.prefix);
+        let resp = self
+            .client
+            .kv_client()
+            .get(
+                prefix.clone(),
+                Some(etcd_client::GetOptions::new().with_prefix()),
+            )
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        let mut schemas = Vec::new();
+        for kv in resp.kvs() {
+            let value = kv
+                .value_str()
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+            if let Ok(schema) = Schema::from_ddl(value) {
+                schemas.push(schema);
+            }
+        }
+        schemas.sort_by(|a, b| a.table_name.cmp(&b.table_name));
+        Ok(schemas)
+    }
+
+    async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
+        let key = self.schema_key(table_name);
+        let resp = self
+            .client
+            .kv_client()
+            .get(key, None)
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        if let Some(kv) = resp.kvs().first() {
+            let value = kv
+                .value_str()
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+            Ok(Some(Schema::from_ddl(value)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn fetch_data(&self, table_name: &str, key: &Key) -> Result<Option<DataRow>> {
+        let key = self.data_key(table_name, key)?;
+        let resp = self
+            .client
+            .kv_client()
+            .get(key, None)
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        if let Some(kv) = resp.kvs().first() {
+            let value = kv
+                .value_str()
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+            let row = serde_json::from_str(value).map_err(|e| Error::StorageMsg(e.to_string()))?;
+            Ok(Some(row))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn scan_data<'a>(&'a self, table_name: &str) -> Result<RowIter<'a>> {
+        let prefix = self.data_prefix(table_name);
+        let resp = self
+            .client
+            .kv_client()
+            .get(
+                prefix.clone(),
+                Some(etcd_client::GetOptions::new().with_prefix()),
+            )
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        let rows = resp
+            .kvs()
+            .iter()
+            .map(|kv| {
+                let key_str = kv.key_str().map_err(|e| Error::StorageMsg(e.to_string()))?;
+                let key_part = key_str
+                    .strip_prefix(&prefix)
+                    .ok_or_else(|| Error::StorageMsg("invalid key".to_owned()))?;
+                let key: Key =
+                    serde_json::from_str(key_part).map_err(|e| Error::StorageMsg(e.to_string()))?;
+                let value = kv
+                    .value_str()
+                    .map_err(|e| Error::StorageMsg(e.to_string()))?;
+                let row: DataRow =
+                    serde_json::from_str(value).map_err(|e| Error::StorageMsg(e.to_string()))?;
+                Ok((key, row))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Box::pin(stream::iter(rows.into_iter().map(Ok))))
+    }
+}

--- a/storages/etcd-storage/src/store_mut.rs
+++ b/storages/etcd-storage/src/store_mut.rs
@@ -1,0 +1,83 @@
+use {
+    crate::EtcdStorage,
+    async_trait::async_trait,
+    gluesql_core::{
+        data::{Key, Schema},
+        error::{Error, Result},
+        store::{DataRow, StoreMut},
+    },
+};
+
+#[async_trait(?Send)]
+impl StoreMut for EtcdStorage {
+    async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
+        let key = self.schema_key(&schema.table_name);
+        let ddl = schema.to_ddl();
+        self.client
+            .kv_client()
+            .put(key, ddl, None)
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
+        let schema_key = self.schema_key(table_name);
+        self.client
+            .kv_client()
+            .delete(schema_key, None)
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        let data_prefix = self.data_prefix(table_name);
+        self.client
+            .kv_client()
+            .delete(
+                data_prefix,
+                Some(etcd_client::DeleteOptions::new().with_prefix()),
+            )
+            .await
+            .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
+        for row in rows {
+            let key = Key::Uuid(uuid::Uuid::now_v7().as_u128());
+            let data_key = self.data_key(table_name, &key)?;
+            let value =
+                serde_json::to_string(&row).map_err(|e| Error::StorageMsg(e.to_string()))?;
+            self.client
+                .kv_client()
+                .put(data_key, value, None)
+                .await
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
+        for (key, row) in rows {
+            let data_key = self.data_key(table_name, &key)?;
+            let value =
+                serde_json::to_string(&row).map_err(|e| Error::StorageMsg(e.to_string()))?;
+            self.client
+                .kv_client()
+                .put(data_key, value, None)
+                .await
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
+        for key in keys {
+            let data_key = self.data_key(table_name, &key)?;
+            self.client
+                .kv_client()
+                .delete(data_key, None)
+                .await
+                .map_err(|e| Error::StorageMsg(e.to_string()))?;
+        }
+        Ok(())
+    }
+}

--- a/storages/etcd-storage/tests/etcd_storage.rs
+++ b/storages/etcd-storage/tests/etcd_storage.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "test-etcd")]
+
+use {
+    async_trait::async_trait, gluesql_core::prelude::Glue, gluesql_etcd_storage::EtcdStorage,
+    test_suite::*,
+};
+
+struct EtcdTester {
+    glue: Glue<EtcdStorage>,
+}
+
+#[async_trait(?Send)]
+impl Tester<EtcdStorage> for EtcdTester {
+    async fn new(namespace: &str) -> Self {
+        let endpoints = ["localhost:2379"];
+        let mut storage = EtcdStorage::new(&endpoints, namespace).await.expect("etcd");
+        // clean existing data
+        let prefix = format!("{}/", namespace);
+        let _ = storage
+            .client
+            .kv_client()
+            .delete(
+                prefix.clone(),
+                Some(etcd_client::DeleteOptions::new().with_prefix()),
+            )
+            .await;
+        let glue = Glue::new(storage);
+
+        EtcdTester { glue }
+    }
+
+    fn get_glue(&mut self) -> &mut Glue<EtcdStorage> {
+        &mut self.glue
+    }
+}
+
+generate_store_tests!(tokio::test, EtcdTester);
+generate_alter_table_tests!(tokio::test, EtcdTester);


### PR DESCRIPTION
## Summary
- implement new `EtcdStorage` crate under `storages/`
- wire storage into workspace
- provide basic CRUD operations using etcd

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6868afe0751c8320b22e03a2eaa30101