### PR TITLE
Update comments in gluesql-js web example README

### DIFF
--- a/pkg/javascript/examples/web/module/README.md
+++ b/pkg/javascript/examples/web/module/README.md
@@ -30,3 +30,11 @@ $ npx http-server
 
 # Remaining steps are same as `simple-http-server` section guide
 ```
+
+- Python [http.server](https://docs.python.org/3/library/http.server.html#module-http.server) module
+```sh
+# 1. Run the following command
+$ python3 -m http.server 3000
+
+# Steps 3 and onwards follow the same process as described in the simple-http-server section.
+```

--- a/pkg/javascript/examples/web/module/README.md
+++ b/pkg/javascript/examples/web/module/README.md
@@ -1,16 +1,12 @@
 ## Guide: Running module example
 
 ### How to run?
-0. Before going on, you should build and generate `dist` directory. So go to under `gluesql/gluesql-js/web`. And run these commands
+0. Before going on, you should build and generate `dist_web` directory. So go to `pkg/javascript` and run this command:
 ```sh
-# install dependencies
-$ yarn
-
-# build for examples/web/module
-$ yarn build:browser
+wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web
 ```
 
-1. Go to under `gluesql/gluesql-js` 
+1. Go to under `pkg/javascript`
 
 2. Serve files using proper application
 There are many http server applications. Here are some examples
@@ -20,7 +16,7 @@ There are many http server applications. Here are some examples
 # 1. install
 $ cargo install simple-http-server
 
-# 2. serve files under `gluesql/gluesql-js`. Now open the browser and go to `http://localhost:3030`
+# 2. serve files under `pkg/javascript`. Now open the browser and go to `http://localhost:3000`
 $ simple-http-server --port 3000
 
 # 3. navigate to `examples/web/module/index.html`. The url should be `http://localhost:3000/examples/web/module/index.html`


### PR DESCRIPTION
This pull request does:

- For `pkg/javascript/examples/web/module/README.md`
   - Updated some comments in the file.
   - Added a section explaining how to serve files using Python3's `http.server` module, since Python3 is typically installed by default on most systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README instructions for building and serving the module example, including simplified build steps and revised directory paths.
  * Changed example HTTP server port from 3030 to 3000.
  * Added instructions for serving files using Python’s built-in http.server module.
  * Clarified URLs and directory references for improved guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->