### PR TITLE
Enhance `data_type::int128` testsuite

### DIFF
--- a/test-suite/src/data_type/int128.rs
+++ b/test-suite/src/data_type/int128.rs
@@ -35,6 +35,15 @@ test_case!(int128, {
     )
     .await;
 
+    g.test(
+        &format!(
+            "INSERT INTO Item VALUES ({}, {})",
+            invalid_small_str, invalid_small_str
+        ),
+        Err(ValueError::FailedToParseNumber.into()),
+    )
+    .await;
+
     // cast i128::MAX+1
     g.test(
         &format!("select cast({} as INT128) from Item", invalid_large_str),

--- a/test-suite/src/data_type/int128.rs
+++ b/test-suite/src/data_type/int128.rs
@@ -21,26 +21,39 @@ test_case!(int128, {
 
     let parse_i128 = |text: &str| -> i128 { text.parse().unwrap() };
 
-    let max_str = "170141183460469231731687303715884105728";
-    let min_str = "-170141183460469231731687303715884105729";
+    // int128::MAX+1
+    let invalid_large_str = "170141183460469231731687303715884105728";
+    // int128::MIN-1
+    let invalid_small_str = "-170141183460469231731687303715884105729";
 
     g.test(
-        &format!("INSERT INTO Item VALUES ({}, {})", max_str, max_str),
+        &format!(
+            "INSERT INTO Item VALUES ({}, {})",
+            invalid_large_str, invalid_large_str
+        ),
         Err(ValueError::FailedToParseNumber.into()),
     )
     .await;
 
     // cast i128::MAX+1
     g.test(
-        &format!("select cast({} as INT128) from Item", max_str),
-        Err(ValueError::LiteralCastToDataTypeFailed(DataType::Int128, max_str.to_owned()).into()),
+        &format!("select cast({} as INT128) from Item", invalid_large_str),
+        Err(ValueError::LiteralCastToDataTypeFailed(
+            DataType::Int128,
+            invalid_large_str.to_owned(),
+        )
+        .into()),
     )
     .await;
 
     // cast i128::MIN-1
     g.test(
-        &format!("select cast({} as INT128) from Item", min_str),
-        Err(ValueError::LiteralCastToDataTypeFailed(DataType::Int128, min_str.to_owned()).into()),
+        &format!("select cast({} as INT128) from Item", invalid_small_str),
+        Err(ValueError::LiteralCastToDataTypeFailed(
+            DataType::Int128,
+            invalid_small_str.to_owned(),
+        )
+        .into()),
     )
     .await;
 


### PR DESCRIPTION
This pull request does:

 - Clarified variable name (e.g., `max_str` → `invalid_large_str`) because I felt `max_str` means `i128::MAX` when looking only the variable name. If this is just my personal feeling, please let me know comfortably, and I'll exclude that change.
 - Added a testcase to parse `i128::MIN-1` like `&format!("INSERT INTO Item VALUES ({}, {})", max_str, max_str)` does.