### PR TITLE
Disable assign reviewers on draft prs

### DIFF
--- a/.github/auto-author-assign-config.yml
+++ b/.github/auto-author-assign-config.yml
@@ -7,5 +7,3 @@ reviewers:
   - devgony
   - zmrdltl
 numberOfReviewers: 0
-
-runOnDraft: true

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,6 +11,6 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.5
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           configuration-path: '.github/auto-author-assign-config.yml'

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -2,7 +2,7 @@ name: auto-author-assign
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This pull request mainly disables assigning reviewers on draft PRs. To trigger on PR state transition `draft` to `opened` too, it added [`ready_for_review`](https://docs.github.com/en/rest/using-the-rest-api/issue-event-types?apiVersion=2022-11-28#ready_for_review) type on the filter.