### PR TITLE
Simplify conditional logic in `plan_query`

### DIFF
--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -111,58 +111,55 @@ fn plan_query(schema_map: &HashMap<String, Schema>, query: Query) -> Result<Quer
             })
     });
 
-    match index {
-        index if index.is_some() => {
-            let Select {
-                projection,
-                from,
-                selection,
-                group_by,
-                having,
-            } = *select;
+    if index.is_some() {
+        let Select {
+            projection,
+            from,
+            selection,
+            group_by,
+            having,
+        } = *select;
 
-            let TableWithJoins { relation, joins } = from;
-            let (name, alias) = match relation {
-                TableFactor::Table { name, alias, .. } => (name, alias),
-                TableFactor::Derived { .. }
-                | TableFactor::Series { .. }
-                | TableFactor::Dictionary { .. } => {
-                    return Err(Error::Table(TableError::Unreachable));
-                }
-            };
+        let TableWithJoins { relation, joins } = from;
+        let (name, alias) = match relation {
+            TableFactor::Table { name, alias, .. } => (name, alias),
+            TableFactor::Derived { .. }
+            | TableFactor::Series { .. }
+            | TableFactor::Dictionary { .. } => {
+                return Err(Error::Table(TableError::Unreachable));
+            }
+        };
 
-            let from = TableWithJoins {
-                relation: TableFactor::Table { name, alias, index },
-                joins,
-            };
+        let from = TableWithJoins {
+            relation: TableFactor::Table { name, alias, index },
+            joins,
+        };
 
-            let select = Select {
-                projection,
-                from,
-                selection,
-                group_by,
-                having,
-            };
+        let select = Select {
+            projection,
+            from,
+            selection,
+            group_by,
+            having,
+        };
 
-            Ok(Query {
-                body: SetExpr::Select(Box::new(select)),
-                order_by: Vector::from(order_by).pop().0.into(),
-                limit,
-                offset,
-            })
-        }
-        _ => {
-            let select = plan_select(schema_map, &indexes, *select)?;
-            let body = SetExpr::Select(Box::new(select));
-            let query = Query {
-                body,
-                order_by,
-                limit,
-                offset,
-            };
+        Ok(Query {
+            body: SetExpr::Select(Box::new(select)),
+            order_by: Vector::from(order_by).pop().0.into(),
+            limit,
+            offset,
+        })
+    } else {
+        let select = plan_select(schema_map, &indexes, *select)?;
+        let body = SetExpr::Select(Box::new(select));
+        let query = Query {
+            body,
+            order_by,
+            limit,
+            offset,
+        };
 
-            Ok(query)
-        }
+        Ok(query)
     }
 }
 


### PR DESCRIPTION
This pull request include only cosmetic changes. In `plan_query` function at `core/src/plan/index.rs`, it used `match` keyword to detect the `index` variable is `Option::Some` and used the `index` variable, not inner value again.

So I though it can be simplified by using `if-else` syntax with `index.is_some()` condition and this pull request includes such changes.