### PR TITLE
Add Algoria domain verfication meta tag to /docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -64,6 +64,7 @@ const config = {
   ],
 
   themeConfig: {
+    metadata: [{ name: 'algolia-site-verification', content: 'CC2C02E45AAD3CFE' }],
     colorMode: {
       disableSwitch: false,
       respectPrefersColorScheme: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Algolia site verification metadata to the documentation site's HTML head.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->