### PR TITLE
Wrap IDB storage resources with SendWrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
  "gluesql-core",
  "gluesql-test-suite",
  "idb",
+ "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -3158,6 +3159,12 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "seq-macro"

--- a/storages/idb-storage/Cargo.toml
+++ b/storages/idb-storage/Cargo.toml
@@ -24,3 +24,6 @@ send_wrapper = "0.6"
 [dev-dependencies]
 test-suite.workspace = true
 wasm-bindgen-test = "0.3.40"
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/storages/idb-storage/Cargo.toml
+++ b/storages/idb-storage/Cargo.toml
@@ -19,6 +19,7 @@ web-sys = { version = "0.3.67", features = ["console"] }
 serde_json = "1.0.111"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 futures = "0.3"
+send_wrapper = "0.6"
 
 [dev-dependencies]
 test-suite.workspace = true

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -48,7 +48,7 @@ impl IdbStorage {
         let error = Arc::new(Mutex::new(None));
         let open_request = {
             let error = Arc::clone(&error);
-            let mut open_request = factory.get().open(namespace.as_str(), None).err_into()?;
+            let mut open_request = factory.open(namespace.as_str(), None).err_into()?;
             open_request.on_upgrade_needed(move |event| {
                 let database = match event.database().err_into() {
                     Ok(database) => database,
@@ -104,11 +104,7 @@ impl IdbStorage {
     }
 
     pub async fn delete(&self) -> Result<()> {
-        self.factory
-            .get()
-            .delete(&self.namespace)
-            .into_future()
-            .await
+        self.factory.delete(&self.namespace).into_future().await
     }
 
     async fn alter_object_store(
@@ -116,15 +112,14 @@ impl IdbStorage {
         table_name: String,
         alter_type: AlterType,
     ) -> Result<()> {
-        let version = self.database.get().version().err_into()? + 1;
-        self.database.get().close();
+        let version = self.database.version().err_into()? + 1;
+        self.database.close();
 
         let error = Arc::new(Mutex::new(None));
         let open_request = {
             let error = Arc::clone(&error);
             let mut open_request = self
                 .factory
-                .get()
                 .open(self.namespace.as_str(), Some(version))
                 .err_into()?;
 
@@ -206,7 +201,6 @@ impl Store for IdbStorage {
     async fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
         let transaction = self
             .database
-            .get()
             .transaction(&[SCHEMA_STORE], TransactionMode::ReadOnly)
             .err_into()?;
 
@@ -231,7 +225,6 @@ impl Store for IdbStorage {
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
         let transaction = self
             .database
-            .get()
             .transaction(&[SCHEMA_STORE], TransactionMode::ReadOnly)
             .err_into()?;
 
@@ -255,7 +248,6 @@ impl Store for IdbStorage {
             .and_then(|schema| schema.column_defs);
         let transaction = self
             .database
-            .get()
             .transaction(&[table_name], TransactionMode::ReadOnly)
             .err_into()?;
 
@@ -281,7 +273,6 @@ impl Store for IdbStorage {
             .and_then(|schema| schema.column_defs);
         let transaction = self
             .database
-            .get()
             .transaction(&[table_name], TransactionMode::ReadOnly)
             .err_into()?;
 
@@ -339,7 +330,6 @@ impl StoreMut for IdbStorage {
 
         let transaction = self
             .database
-            .get()
             .transaction(&[SCHEMA_STORE], TransactionMode::ReadWrite)
             .err_into()?;
         let store = transaction.object_store(SCHEMA_STORE).err_into()?;
@@ -362,7 +352,6 @@ impl StoreMut for IdbStorage {
 
         let transaction = self
             .database
-            .get()
             .transaction(&[SCHEMA_STORE], TransactionMode::ReadWrite)
             .err_into()?;
         let store = transaction.object_store(SCHEMA_STORE).err_into()?;
@@ -376,7 +365,6 @@ impl StoreMut for IdbStorage {
     async fn append_data(&mut self, table_name: &str, new_rows: Vec<DataRow>) -> Result<()> {
         let transaction = self
             .database
-            .get()
             .transaction(&[table_name], TransactionMode::ReadWrite)
             .err_into()?;
         let store = transaction.object_store(table_name).err_into()?;
@@ -399,7 +387,6 @@ impl StoreMut for IdbStorage {
     async fn insert_data(&mut self, table_name: &str, new_rows: Vec<(Key, DataRow)>) -> Result<()> {
         let transaction = self
             .database
-            .get()
             .transaction(&[table_name], TransactionMode::ReadWrite)
             .err_into()?;
         let store = transaction.object_store(table_name).err_into()?;
@@ -425,7 +412,6 @@ impl StoreMut for IdbStorage {
     async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
         let transaction = self
             .database
-            .get()
             .transaction(&[table_name], TransactionMode::ReadWrite)
             .err_into()?;
         let store = transaction.object_store(table_name).err_into()?;


### PR DESCRIPTION
## Summary
- add `send_wrapper` dependency to idb-storage
- wrap `Factory` and `Database` in `SendWrapper` and adjust calls to access inner values

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_688df72ee82c832aa2f5066bf95187ff