### PR TITLE
Add HEX function

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -1225,9 +1225,9 @@ mod tests {
 
         assert_eq!(
             "HEX(228)",
-            &Expr::Function(Box::new(Function::Hex(Expr::Literal(
-                AstLiteral::Number(BigDecimal::from_str("228").unwrap())
-            ))))
+            &Expr::Function(Box::new(Function::Hex(Expr::Literal(AstLiteral::Number(
+                BigDecimal::from(228)
+            )))))
             .to_sql()
         );
 

--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -170,6 +170,7 @@ pub enum Function {
     Ascii(Expr),
     Chr(Expr),
     Md5(Expr),
+    Hex(Expr),
     Append {
         expr: Expr,
         value: Expr,
@@ -428,6 +429,7 @@ impl ToSql for Function {
             Function::Ascii(e) => format!("ASCII({})", e.to_sql()),
             Function::Chr(e) => format!("CHR({})", e.to_sql()),
             Function::Md5(e) => format!("MD5({})", e.to_sql()),
+            Function::Hex(e) => format!("HEX({})", e.to_sql()),
             Function::Append { expr, value } => {
                 format!(
                     "APPEND({items}, {value})",
@@ -1216,6 +1218,22 @@ mod tests {
         assert_eq!(
             "MD5('GlueSQL')",
             &Expr::Function(Box::new(Function::Md5(Expr::Literal(
+                AstLiteral::QuotedString("GlueSQL".to_owned())
+            ))))
+            .to_sql()
+        );
+
+        assert_eq!(
+            "HEX(228)",
+            &Expr::Function(Box::new(Function::Hex(Expr::Literal(
+                AstLiteral::Number(BigDecimal::from_str("228").unwrap())
+            ))))
+            .to_sql()
+        );
+
+        assert_eq!(
+            "HEX('GlueSQL')",
+            &Expr::Function(Box::new(Function::Hex(Expr::Literal(
                 AstLiteral::QuotedString("GlueSQL".to_owned())
             ))))
             .to_sql()

--- a/core/src/ast_builder/expr/function.rs
+++ b/core/src/ast_builder/expr/function.rs
@@ -157,6 +157,7 @@ pub enum FunctionNode<'a> {
     Ascii(ExprNode<'a>),
     Chr(ExprNode<'a>),
     Md5(ExprNode<'a>),
+    Hex(ExprNode<'a>),
     Point {
         x: ExprNode<'a>,
         y: ExprNode<'a>,
@@ -375,6 +376,7 @@ impl<'a> TryFrom<FunctionNode<'a>> for Function {
             FunctionNode::Ascii(expr) => expr.try_into().map(Function::Ascii),
             FunctionNode::Chr(expr) => expr.try_into().map(Function::Chr),
             FunctionNode::Md5(expr) => expr.try_into().map(Function::Md5),
+            FunctionNode::Hex(expr) => expr.try_into().map(Function::Hex),
             FunctionNode::Point { x, y } => {
                 let x = x.try_into()?;
                 let y = y.try_into()?;
@@ -939,6 +941,10 @@ pub fn chr<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
 
 pub fn md5<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
     ExprNode::Function(Box::new(FunctionNode::Md5(expr.into())))
+}
+
+pub fn hex<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
+    ExprNode::Function(Box::new(FunctionNode::Hex(expr.into())))
 }
 
 pub fn point<'a, T: Into<ExprNode<'a>>, U: Into<ExprNode<'a>>>(x: T, y: U) -> ExprNode<'a> {
@@ -1717,6 +1723,21 @@ mod tests {
     fn function_md5() {
         let actual = f::md5(text("abc"));
         let expected = "MD5('abc')";
+        test_expr(actual, expected);
+    }
+
+    #[test]
+    fn function_hex() {
+        let actual = f::hex(num(10));
+        let expected = "HEX(10)";
+        test_expr(actual, expected);
+
+        let actual = f::hex(text("10"));
+        let expected = "HEX('10')";
+        test_expr(actual, expected);
+
+        let actual = f::hex(text("GlueSQL"));
+        let expected = "HEX('GlueSQL')";
         test_expr(actual, expected);
     }
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -489,6 +489,7 @@ async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(
         Function::Ascii(expr) => f::ascii(name, eval(expr).await?),
         Function::Chr(expr) => f::chr(name, eval(expr).await?),
         Function::Md5(expr) => f::md5(name, eval(expr).await?),
+        Function::Hex(expr) => f::hex(name, eval(expr).await?),
 
         // --- float ---
         Function::Abs(expr) => f::abs(name, eval(expr).await?),

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -17,6 +17,9 @@ pub enum EvaluateError {
     #[error("function requires string value: {0}")]
     FunctionRequiresStringValue(String),
 
+    #[error("function requires integer or string value: {0}")]
+    FunctionRequiresIntegerOrStringValue(String),
+
     #[error("function requires integer value: {0}")]
     FunctionRequiresIntegerValue(String),
 

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -344,6 +344,27 @@ pub fn md5<'a>(name: String, expr: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> 
     Continue(Evaluated::Value(Value::Str(result)))
 }
 
+pub fn hex<'a>(name: String, expr: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
+    match expr.try_into().break_if_null()? {
+        Value::I64(number) => {
+            let result = format!("{number:X}");
+            Continue(Evaluated::Value(Value::Str(result)))
+        }
+        Value::Str(string) => {
+            let result = string
+                .as_bytes()
+                .iter()
+                .map(|b| format!("{b:02X}"))
+                .collect::<String>();
+
+            Continue(Evaluated::Value(Value::Str(result)))
+        }
+        _ => Break(BreakCase::Err(
+            EvaluateError::FunctionRequiresIntegerOrStringValue(name).into(),
+        )),
+    }
+}
+
 // --- float ---
 
 pub fn abs<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -50,6 +50,7 @@ impl Function {
             | Self::Ascii(expr)
             | Self::Chr(expr)
             | Self::Md5(expr)
+            | Self::Hex(expr)
             | Self::LastDay(expr)
             | Self::Ltrim { expr, chars: None }
             | Self::Rtrim { expr, chars: None }
@@ -286,6 +287,7 @@ mod tests {
         test(r#"CAST(1 AS BOOLEAN)"#, &["1"]);
         test(r#"IS_EMPTY(col)"#, &["col"]);
         test(r#"VALUES(col)"#, &["col"]);
+        test(r#"HEX(10)"#, &["10"]);
 
         test(r#"ABS(1)"#, &["1"]);
         test(r#"ABS(-1)"#, &["-1"]);

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -562,6 +562,12 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             let expr = translate_expr(args[0])?;
             Ok(Expr::Function(Box::new(Function::Md5(expr))))
         }
+        "HEX" => {
+            check_len(name, args.len(), 1)?;
+
+            let expr = translate_expr(args[0])?;
+            Ok(Expr::Function(Box::new(Function::Hex(expr))))
+        }
         "LENGTH" => {
             check_len(name, args.len(), 1)?;
 

--- a/test-suite/src/function.rs
+++ b/test-suite/src/function.rs
@@ -24,6 +24,7 @@ pub mod gcd_lcm;
 pub mod generate_uuid;
 pub mod geometry;
 pub mod greatest;
+pub mod hex;
 pub mod ifnull;
 pub mod initcap;
 pub mod is_empty;

--- a/test-suite/src/function/hex.rs
+++ b/test-suite/src/function/hex.rs
@@ -1,0 +1,112 @@
+use {
+    crate::*,
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
+};
+
+test_case!(hex, {
+    let g = get_tester!();
+
+    g.test(
+        "VALUES(HEX('Hello World'))",
+        Ok(select!(
+            column1
+            Str;
+            "48656C6C6F20576F726C64".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX('ABC'))",
+        Ok(select!(
+            column1
+            Str;
+            "414243".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX(''))",
+        Ok(select!(
+            column1
+            Str;
+            "".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX('228'))",
+        Ok(select!(
+            column1
+            Str;
+            "323238".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX(228))",
+        Ok(select!(
+            column1
+            Str;
+            "E4".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX(0))",
+        Ok(select!(
+            column1
+            Str;
+            "0".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX(-123))",
+        Ok(select!(
+            column1
+            Str;
+            "FFFFFFFFFFFFFF85".to_owned()
+        )),
+    )
+    .await;
+
+    g.test(
+        "VALUES(HEX(3.14))",
+        Err(EvaluateError::FunctionRequiresIntegerOrStringValue("HEX".to_owned()).into()),
+    )
+    .await;
+
+    g.test(r#"VALUES(HEX(NULL))"#, Ok(select_with_null!(column1; Null)))
+        .await;
+
+    g.test(
+        r#"VALUES(HEX())"#,
+        Err(TranslateError::FunctionArgsLengthNotMatching {
+            name: "HEX".to_owned(),
+            expected: 1,
+            found: 0,
+        }
+        .into()),
+    )
+    .await;
+
+    g.test(
+        r#"VALUES(HEX('test', 'extra'))"#,
+        Err(TranslateError::FunctionArgsLengthNotMatching {
+            name: "HEX".to_owned(),
+            expected: 1,
+            found: 2,
+        }
+        .into()),
+    )
+    .await;
+});

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -170,6 +170,7 @@ macro_rules! generate_store_tests {
         glue!(function_keys, function::keys::keys);
         glue!(function_values, function::values::values);
         glue!(function_nullif, function::nullif::nullif);
+        glue!(function_hex, function::hex::hex);
         glue!(join, join::join);
         glue!(join_project, join::project);
         glue!(migrate, migrate::migrate);


### PR DESCRIPTION
# Add HEX function

## Summary

Implements the SQL standard `HEX` function to convert numbers and strings to hexadecimal representation, enhancing compatibility with standard SQL queries.

## Implementation Details

* **AST Extension**: Introduced a new `Hex` variant in the `Function` enum to represent `HEX` expressions in the abstract syntax tree.
* **Parser Support**: Extended `translate_function` to recognize and correctly parse the `HEX` function.
* **AST Serialization**: Implemented `to_sql()` formatting support to correctly serialize `HEX` expressions with proper syntax and parentheses.
* **Evaluation Logic**: Added evaluation logic to execute the semantics of `HEX`, supporting both numeric and string inputs with different conversion behaviors.
* **Pattern Matching**: Updated expression planning to support pattern matching for the new `HEX` function variant.

## Usage Examples

```sql
-- String conversion: each character to hex
SELECT HEX('GlueSQL');     -- '476C756553514C'
SELECT HEX('ABC');         -- '414243'
SELECT HEX('');            -- ''

-- Numeric conversion: number to hex
SELECT HEX(255);           -- 'FF'
SELECT HEX(123);           -- '7B'
SELECT HEX(0);             -- '0'
SELECT HEX(-123);          -- 'FFFFFFFFFFFFFF85'

-- Error cases
SELECT HEX();              -- Error: requires exactly 1 argument
SELECT HEX('test', 'extra'); -- Error: requires exactly 1 argument
SELECT HEX(3.14);          -- Error: float not supported
```

## SQL Standard Compliance

The `HEX` function behavior follows common SQL database implementations:

* **MySQL/SQLite Style**: Returns uppercase hexadecimal representation
* **Numeric Input**: Converts the number to its hexadecimal representation
* **String Input**: Converts each character to its hexadecimal representation
* **Float Support**: Not supported (returns error) - following PostgreSQL pattern for clarity
* **NULL Handling**: Returns NULL when input is NULL

## Implementation Behavior

* **Numbers**: `HEX(228)` → `"E4"` (number to hex)
* **Strings**: `HEX("228")` → `"323238"` (each character to hex)
* **Negative Numbers**: `HEX(-123)` → `"FFFFFFFFFFFFFF85"` (64-bit 2's complement)
* **Zero**: `HEX(0)` → `"0"`
* **Empty String**: `HEX("")` → `""`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for the HEX() SQL function to convert integers and strings into their hexadecimal string representation.

* **Bug Fixes**
  * Enhanced error handling for HEX() with clear messages for invalid argument types or counts.

* **Tests**
  * Added extensive tests validating HEX() function behavior across diverse inputs and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->