### PR TITLE
test: add len and is_empty tests for Vector

### DIFF
--- a/utils/src/vector.rs
+++ b/utils/src/vector.rs
@@ -103,3 +103,24 @@ impl<T> From<Vector<T>> for Vec<T> {
         vector.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Vector;
+
+    #[test]
+    fn len() {
+        let vector = Vector::new().push(1).push(2).push(3);
+
+        assert_eq!(3, vector.len());
+    }
+
+    #[test]
+    fn is_empty() {
+        let vector = Vector::<i32>::new();
+        assert!(vector.is_empty());
+
+        let vector = vector.push(1);
+        assert!(!vector.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `Vector::len` and `Vector::is_empty`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-utils`


------
https://chatgpt.com/codex/tasks/task_e_68908bc3be40832aa004968e4a6a6d10