### PR TITLE
Run Coverage action only if pull request target is main branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - "docs/**"
   pull_request:
+    branches: [main]
     paths-ignore:
       - "docs/**"
 


### PR DESCRIPTION
## Description

This PR updates the workflow so that the Coverage Action only runs when the pull request target branch is main.

## Background & Motivation

We often use Codex to work on branches other than main. However, with the current setup, the Coverage Action runs for every PR, regardless of the target branch, causing unnecessary duplication and inefficient use of CI resources.

By applying this change, the Coverage Action will only be triggered for pull requests targeting the main branch. This will help reduce redundant runs and optimize our CI usage.