### PR TITLE
Simplify plan function generic bounds

### DIFF
--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -16,7 +16,7 @@ pub use {
     primary_key::plan as plan_primary_key, schema::fetch_schema_map,
 };
 
-pub async fn plan<T: Store + Send + Sync>(storage: &T, statement: Statement) -> Result<Statement> {
+pub async fn plan<T: Store>(storage: &T, statement: Statement) -> Result<Statement> {
     let schema_map = fetch_schema_map(storage, &statement).await?;
     validate(&schema_map, &statement)?;
     let statement = plan_primary_key(&schema_map, statement);


### PR DESCRIPTION
## Summary
- simplify `plan` signature to only require `Store`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68909e19061c832aabc9d27af9afc225