### PR TITLE
Remove Send/Sync bound from Metadata trait

### DIFF
--- a/core/src/store/metadata.rs
+++ b/core/src/store/metadata.rs
@@ -8,7 +8,7 @@ type ObjectName = String;
 pub type MetaIter = Box<dyn Iterator<Item = Result<(ObjectName, HashMap<String, Value>)>>>;
 
 #[async_trait]
-pub trait Metadata: Send + Sync {
+pub trait Metadata {
     async fn scan_table_meta(&self) -> Result<MetaIter> {
         Ok(Box::new(empty()))
     }


### PR DESCRIPTION
## Summary
- drop Send + Sync requirement from Metadata trait

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6890aa512d30832aa1f5cf0f0bbfdddf