### PR TITLE
Relax IndexMut trait bounds

### DIFF
--- a/core/src/store/index.rs
+++ b/core/src/store/index.rs
@@ -54,7 +54,7 @@ pub trait Index {
 }
 
 #[async_trait]
-pub trait IndexMut: Send + Sync {
+pub trait IndexMut {
     async fn create_index(
         &mut self,
         _table_name: &str,


### PR DESCRIPTION
## Summary
- remove `Send + Sync` constraints from `IndexMut` trait

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6890aa5253a8832aa1879ff2d4313856