### PR TITLE
remove send sync constraint from customfunctionmut

### DIFF
--- a/core/src/store/function.rs
+++ b/core/src/store/function.rs
@@ -25,7 +25,7 @@ pub trait CustomFunction {
 }
 
 #[async_trait]
-pub trait CustomFunctionMut: Send + Sync {
+pub trait CustomFunctionMut {
     async fn insert_function(&mut self, _func: StructCustomFunction) -> Result<()> {
         Err(Error::StorageMsg(
             "[Storage] CustomFunction is not supported".to_owned(),


### PR DESCRIPTION
## Summary
- allow custom function implementations without requiring Send or Sync by removing these bounds from `CustomFunctionMut`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_6890aa55bb58832a87ff2616516eb8f8