### PR TITLE
Remove Send Sync bounds from Transaction trait

### DIFF
--- a/core/src/store/transaction.rs
+++ b/core/src/store/transaction.rs
@@ -4,7 +4,7 @@ use {
 };
 
 #[async_trait]
-pub trait Transaction: Send + Sync {
+pub trait Transaction {
     async fn begin(&mut self, autocommit: bool) -> Result<bool> {
         if autocommit {
             return Ok(false);


### PR DESCRIPTION
## Summary
- remove `Send + Sync` bounds from `Transaction` trait

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6890aa567980832aae4690960d999300