### PR TITLE
Change the return type of evaluate_eq

### DIFF
--- a/core/src/data/literal.rs
+++ b/core/src/data/literal.rs
@@ -91,10 +91,10 @@ fn unsupported_binary_op(left: &Literal, op: BinaryOperator, right: &Literal) ->
 }
 
 impl<'a> Literal<'a> {
-    pub fn evaluate_eq(&self, other: &Literal<'_>) -> bool {
+    pub fn evaluate_eq(&self, other: &Literal<'_>) -> Self {
         match (self, other) {
-            (Null, Null) => false,
-            _ => self == other,
+            (Null, _) | (_, Null) => Null,
+            _ => Boolean(self == other),
         }
     }
 
@@ -530,26 +530,29 @@ mod tests {
         }
 
         //Boolean
-        assert!(Boolean(true).evaluate_eq(&Boolean(true)));
-        assert!(!Boolean(true).evaluate_eq(&Boolean(false)));
+        assert_eq!(Boolean(true), Boolean(true).evaluate_eq(&Boolean(true)));
+        assert_eq!(Boolean(false), Boolean(true).evaluate_eq(&Boolean(false)));
         //Number
-        assert!(num!("123").evaluate_eq(&num!("123")));
-        assert!(num!("12.0").evaluate_eq(&num!("12.0")));
-        assert!(num!("12.0").evaluate_eq(&num!("12")));
-        assert!(!num!("12.0").evaluate_eq(&num!("12.123")));
-        assert!(!num!("123").evaluate_eq(&num!("12.3")));
-        assert!(!num!("123").evaluate_eq(&text!("Foo")));
-        assert!(!num!("123").evaluate_eq(&Null));
+        assert_eq!(Boolean(true), num!("123").evaluate_eq(&num!("123")));
+        assert_eq!(Boolean(true), num!("12.0").evaluate_eq(&num!("12.0")));
+        assert_eq!(Boolean(true), num!("12.0").evaluate_eq(&num!("12")));
+        assert_eq!(Boolean(false), num!("12.0").evaluate_eq(&num!("12.123")));
+        assert_eq!(Boolean(false), num!("123").evaluate_eq(&num!("12.3")));
+        assert_eq!(Boolean(false), num!("123").evaluate_eq(&text!("Foo")));
+        assert_eq!(Boolean(false), num!("123").evaluate_eq(&Null));
         //Text
-        assert!(text!("Foo").evaluate_eq(&text!("Foo")));
-        assert!(!text!("Foo").evaluate_eq(&text!("Bar")));
-        assert!(!text!("Foo").evaluate_eq(&Null));
+        assert_eq!(Boolean(true), text!("Foo").evaluate_eq(&text!("Foo")));
+        assert_eq!(Boolean(false), text!("Foo").evaluate_eq(&text!("Bar")));
+        assert_eq!(Boolean(false), text!("Foo").evaluate_eq(&Null));
         //Bytea
-        assert!(bytea!("12A456").evaluate_eq(&bytea!("12A456")));
-        assert!(!bytea!("1230").evaluate_eq(&num!("1230")));
-        assert!(!bytea!("12").evaluate_eq(&Null));
+        assert_eq!(
+            Boolean(true),
+            bytea!("12A456").evaluate_eq(&bytea!("12A456"))
+        );
+        assert_eq!(Boolean(false), bytea!("1230").evaluate_eq(&num!("1230")));
+        assert_eq!(Boolean(false), bytea!("12").evaluate_eq(&Null));
         // Null
-        assert!(!Null.evaluate_eq(&Null));
+        assert_eq!(Boolean(false), Null.evaluate_eq(&Null));
     }
 
     #[test]

--- a/core/src/data/literal.rs
+++ b/core/src/data/literal.rs
@@ -539,20 +539,20 @@ mod tests {
         assert_eq!(Boolean(false), num!("12.0").evaluate_eq(&num!("12.123")));
         assert_eq!(Boolean(false), num!("123").evaluate_eq(&num!("12.3")));
         assert_eq!(Boolean(false), num!("123").evaluate_eq(&text!("Foo")));
-        assert_eq!(Boolean(false), num!("123").evaluate_eq(&Null));
+        assert_eq!(Null, num!("123").evaluate_eq(&Null));
         //Text
         assert_eq!(Boolean(true), text!("Foo").evaluate_eq(&text!("Foo")));
         assert_eq!(Boolean(false), text!("Foo").evaluate_eq(&text!("Bar")));
-        assert_eq!(Boolean(false), text!("Foo").evaluate_eq(&Null));
+        assert_eq!(Null, text!("Foo").evaluate_eq(&Null));
         //Bytea
         assert_eq!(
             Boolean(true),
             bytea!("12A456").evaluate_eq(&bytea!("12A456"))
         );
         assert_eq!(Boolean(false), bytea!("1230").evaluate_eq(&num!("1230")));
-        assert_eq!(Boolean(false), bytea!("12").evaluate_eq(&Null));
+        assert_eq!(Null, bytea!("12").evaluate_eq(&Null));
         // Null
-        assert_eq!(Boolean(false), Null.evaluate_eq(&Null));
+        assert_eq!(Null, Null.evaluate_eq(&Null));
     }
 
     #[test]

--- a/core/src/data/value.rs
+++ b/core/src/data/value.rs
@@ -3234,4 +3234,13 @@ mod tests {
         map2.insert("a".to_owned(), I64(1));
         assert_eq!(Map(map1), Map(map2));
     }
+
+    #[test]
+    fn test_conversion_from_tribool() {
+        use {super::Value, utils::Tribool};
+
+        assert_eq!(Value::from(Tribool::True), Value::Bool(true));
+        assert_eq!(Value::from(Tribool::False), Value::Bool(false));
+        assert_eq!(Value::from(Tribool::Null), Value::Null);
+    }
 }

--- a/core/src/data/value.rs
+++ b/core/src/data/value.rs
@@ -67,30 +67,32 @@ pub enum Value {
 }
 
 impl Value {
-    pub fn evaluate_eq(&self, other: &Value) -> bool {
+    pub fn evaluate_eq(&self, other: &Value) -> Self {
         match (self, other) {
-            (Value::I8(l), _) => l == other,
-            (Value::I16(l), _) => l == other,
-            (Value::I32(l), _) => l == other,
-            (Value::I64(l), _) => l == other,
-            (Value::I128(l), _) => l == other,
-            (Value::U8(l), _) => l == other,
-            (Value::U16(l), _) => l == other,
-            (Value::U32(l), _) => l == other,
-            (Value::U64(l), _) => l == other,
-            (Value::U128(l), _) => l == other,
-            (Value::F32(l), _) => l == other,
-            (Value::F64(l), _) => l == other,
-            (Value::Date(l), Value::Timestamp(r)) => l
-                .and_hms_opt(0, 0, 0)
-                .map(|date_time| &date_time == r)
-                .unwrap_or(false),
-            (Value::Timestamp(l), Value::Date(r)) => r
-                .and_hms_opt(0, 0, 0)
-                .map(|date_time| l == &date_time)
-                .unwrap_or(false),
-            (Value::Null, Value::Null) => false,
-            _ => self == other,
+            (Value::I8(l), _) => Value::Bool(l == other),
+            (Value::I16(l), _) => Value::Bool(l == other),
+            (Value::I32(l), _) => Value::Bool(l == other),
+            (Value::I64(l), _) => Value::Bool(l == other),
+            (Value::I128(l), _) => Value::Bool(l == other),
+            (Value::U8(l), _) => Value::Bool(l == other),
+            (Value::U16(l), _) => Value::Bool(l == other),
+            (Value::U32(l), _) => Value::Bool(l == other),
+            (Value::U64(l), _) => Value::Bool(l == other),
+            (Value::U128(l), _) => Value::Bool(l == other),
+            (Value::F32(l), _) => Value::Bool(l == other),
+            (Value::F64(l), _) => Value::Bool(l == other),
+            (Value::Date(l), Value::Timestamp(r)) => Value::Bool(
+                l.and_hms_opt(0, 0, 0)
+                    .map(|date_time| &date_time == r)
+                    .unwrap_or(false),
+            ),
+            (Value::Timestamp(l), Value::Date(r)) => Value::Bool(
+                r.and_hms_opt(0, 0, 0)
+                    .map(|date_time| l == &date_time)
+                    .unwrap_or(false),
+            ),
+            (Value::Null, _) | (_, Value::Null) => Value::Null,
+            _ => Value::Bool(self == other),
         }
     }
 
@@ -1004,52 +1006,65 @@ mod tests {
         let inet = |v: &str| Inet(IpAddr::from_str(v).unwrap());
 
         assert_eq!(Null, Null);
-        assert!(!Null.evaluate_eq(&Null));
-        assert!(Bool(true).evaluate_eq(&Bool(true)));
-        assert!(I8(1).evaluate_eq(&I8(1)));
-        assert!(I16(1).evaluate_eq(&I16(1)));
-        assert!(I32(1).evaluate_eq(&I32(1)));
-        assert!(I64(1).evaluate_eq(&I64(1)));
-        assert!(I128(1).evaluate_eq(&I128(1)));
-        assert!(U8(1).evaluate_eq(&U8(1)));
-        assert!(U16(1).evaluate_eq(&U16(1)));
-        assert!(U32(1).evaluate_eq(&U32(1)));
-        assert!(U64(1).evaluate_eq(&U64(1)));
-        assert!(U128(1).evaluate_eq(&U128(1)));
-        assert!(I64(1).evaluate_eq(&F64(1.0)));
-        assert!(F32(1.0_f32).evaluate_eq(&I64(1)));
-        assert!(F32(6.11_f32).evaluate_eq(&F64(6.11)));
-        assert!(F64(1.0).evaluate_eq(&I64(1)));
-        assert!(F64(6.11).evaluate_eq(&F64(6.11)));
-        assert!(Str("Glue".to_owned()).evaluate_eq(&Str("Glue".to_owned())));
-        assert!(bytea("1004").evaluate_eq(&bytea("1004")));
-        assert!(inet("::1").evaluate_eq(&inet("::1")));
-        assert!(Interval(Interval::Month(1)).evaluate_eq(&Interval(Interval::Month(1))));
-        assert!(
+        assert_eq!(Null, Null.evaluate_eq(&Null));
+        assert_eq!(Bool(true), Bool(true).evaluate_eq(&Bool(true)));
+        assert_eq!(Bool(true), I8(1).evaluate_eq(&I8(1)));
+        assert_eq!(Bool(true), I16(1).evaluate_eq(&I16(1)));
+        assert_eq!(Bool(true), I32(1).evaluate_eq(&I32(1)));
+        assert_eq!(Bool(true), I64(1).evaluate_eq(&I64(1)));
+        assert_eq!(Bool(true), I128(1).evaluate_eq(&I128(1)));
+        assert_eq!(Bool(true), U8(1).evaluate_eq(&U8(1)));
+        assert_eq!(Bool(true), U16(1).evaluate_eq(&U16(1)));
+        assert_eq!(Bool(true), U32(1).evaluate_eq(&U32(1)));
+        assert_eq!(Bool(true), U64(1).evaluate_eq(&U64(1)));
+        assert_eq!(Bool(true), U128(1).evaluate_eq(&U128(1)));
+        assert_eq!(Bool(true), I64(1).evaluate_eq(&F64(1.0)));
+        assert_eq!(Bool(true), F32(1.0_f32).evaluate_eq(&I64(1)));
+        assert_eq!(Bool(true), F32(6.11_f32).evaluate_eq(&F64(6.11)));
+        assert_eq!(Bool(true), F64(1.0).evaluate_eq(&I64(1)));
+        assert_eq!(Bool(true), F64(6.11).evaluate_eq(&F64(6.11)));
+        assert_eq!(
+            Bool(true),
+            Str("Glue".to_owned()).evaluate_eq(&Str("Glue".to_owned()))
+        );
+        assert_eq!(Bool(true), bytea("1004").evaluate_eq(&bytea("1004")));
+        assert_eq!(Bool(true), inet("::1").evaluate_eq(&inet("::1")));
+        assert_eq!(
+            Bool(true),
+            Interval(Interval::Month(1)).evaluate_eq(&Interval(Interval::Month(1)))
+        );
+        assert_eq!(
+            Bool(true),
             Time(NaiveTime::from_hms_opt(12, 30, 11).unwrap())
                 .evaluate_eq(&Time(NaiveTime::from_hms_opt(12, 30, 11).unwrap()))
         );
-        assert!(decimal(1).evaluate_eq(&decimal(1)));
-        assert!(
+        assert_eq!(Bool(true), decimal(1).evaluate_eq(&decimal(1)));
+        assert_eq!(
+            Bool(true),
             Date("2020-05-01".parse().unwrap()).evaluate_eq(&Date("2020-05-01".parse().unwrap()))
         );
-        assert!(
+        assert_eq!(
+            Bool(true),
             Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap()).evaluate_eq(
                 &Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap())
             )
         );
-        assert!(
+        assert_eq!(
+            Bool(true),
             Uuid(parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap()).evaluate_eq(&Uuid(
                 parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap()
             ))
         );
-        assert!(Point(Point::new(1.0, 2.0)).evaluate_eq(&Point(Point::new(1.0, 2.0))));
+        assert_eq!(
+            Bool(true),
+            Point(Point::new(1.0, 2.0)).evaluate_eq(&Point(Point::new(1.0, 2.0)))
+        );
 
         let date = Date("2020-05-01".parse().unwrap());
         let timestamp = Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap());
 
-        assert!(date.evaluate_eq(&timestamp));
-        assert!(timestamp.evaluate_eq(&date));
+        assert_eq!(Bool(true), date.evaluate_eq(&timestamp));
+        assert_eq!(Bool(true), timestamp.evaluate_eq(&date));
     }
 
     #[test]
@@ -1217,7 +1232,7 @@ mod tests {
 
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert!($a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2001,7 +2016,7 @@ mod tests {
 
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert!($a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2163,7 +2178,7 @@ mod tests {
 
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert!($a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2785,7 +2800,7 @@ mod tests {
     fn bitwise_and() {
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert!($a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 

--- a/core/src/data/value.rs
+++ b/core/src/data/value.rs
@@ -18,6 +18,7 @@ use {
         mem::discriminant,
         net::IpAddr,
     },
+    utils::Tribool,
 };
 
 mod binary_op;
@@ -66,33 +67,44 @@ pub enum Value {
     Null,
 }
 
+impl From<Tribool> for Value {
+    fn from(t: Tribool) -> Self {
+        match t {
+            Tribool::True => Value::Bool(true),
+            Tribool::False => Value::Bool(false),
+            Tribool::Null => Value::Null,
+        }
+    }
+}
+
 impl Value {
-    pub fn evaluate_eq(&self, other: &Value) -> Self {
+    pub fn evaluate_eq(&self, other: &Value) -> Tribool {
+        use Value::*;
         match (self, other) {
-            (Value::I8(l), _) => Value::Bool(l == other),
-            (Value::I16(l), _) => Value::Bool(l == other),
-            (Value::I32(l), _) => Value::Bool(l == other),
-            (Value::I64(l), _) => Value::Bool(l == other),
-            (Value::I128(l), _) => Value::Bool(l == other),
-            (Value::U8(l), _) => Value::Bool(l == other),
-            (Value::U16(l), _) => Value::Bool(l == other),
-            (Value::U32(l), _) => Value::Bool(l == other),
-            (Value::U64(l), _) => Value::Bool(l == other),
-            (Value::U128(l), _) => Value::Bool(l == other),
-            (Value::F32(l), _) => Value::Bool(l == other),
-            (Value::F64(l), _) => Value::Bool(l == other),
-            (Value::Date(l), Value::Timestamp(r)) => Value::Bool(
+            (Null, _) | (_, Null) => Tribool::Null,
+            (I8(l), _) => Tribool::from(l == other),
+            (I16(l), _) => Tribool::from(l == other),
+            (I32(l), _) => Tribool::from(l == other),
+            (I64(l), _) => Tribool::from(l == other),
+            (I128(l), _) => Tribool::from(l == other),
+            (U8(l), _) => Tribool::from(l == other),
+            (U16(l), _) => Tribool::from(l == other),
+            (U32(l), _) => Tribool::from(l == other),
+            (U64(l), _) => Tribool::from(l == other),
+            (U128(l), _) => Tribool::from(l == other),
+            (F32(l), _) => Tribool::from(l == other),
+            (F64(l), _) => Tribool::from(l == other),
+            (Date(l), Timestamp(r)) => Tribool::from(
                 l.and_hms_opt(0, 0, 0)
                     .map(|date_time| &date_time == r)
                     .unwrap_or(false),
             ),
-            (Value::Timestamp(l), Value::Date(r)) => Value::Bool(
+            (Timestamp(l), Date(r)) => Tribool::from(
                 r.and_hms_opt(0, 0, 0)
                     .map(|date_time| l == &date_time)
                     .unwrap_or(false),
             ),
-            (Value::Null, _) | (_, Value::Null) => Value::Null,
-            _ => Value::Bool(self == other),
+            _ => Tribool::from(self == other),
         }
     }
 
@@ -997,6 +1009,7 @@ mod tests {
     #[allow(clippy::eq_op)]
     #[test]
     fn evaluate_eq() {
+        use utils::Tribool;
         use {
             super::Interval,
             chrono::{NaiveDateTime, NaiveTime},
@@ -1005,66 +1018,66 @@ mod tests {
         let bytea = |v: &str| Bytea(hex::decode(v).unwrap());
         let inet = |v: &str| Inet(IpAddr::from_str(v).unwrap());
 
-        assert_eq!(Null, Null);
-        assert_eq!(Null, Null.evaluate_eq(&Null));
-        assert_eq!(Bool(true), Bool(true).evaluate_eq(&Bool(true)));
-        assert_eq!(Bool(true), I8(1).evaluate_eq(&I8(1)));
-        assert_eq!(Bool(true), I16(1).evaluate_eq(&I16(1)));
-        assert_eq!(Bool(true), I32(1).evaluate_eq(&I32(1)));
-        assert_eq!(Bool(true), I64(1).evaluate_eq(&I64(1)));
-        assert_eq!(Bool(true), I128(1).evaluate_eq(&I128(1)));
-        assert_eq!(Bool(true), U8(1).evaluate_eq(&U8(1)));
-        assert_eq!(Bool(true), U16(1).evaluate_eq(&U16(1)));
-        assert_eq!(Bool(true), U32(1).evaluate_eq(&U32(1)));
-        assert_eq!(Bool(true), U64(1).evaluate_eq(&U64(1)));
-        assert_eq!(Bool(true), U128(1).evaluate_eq(&U128(1)));
-        assert_eq!(Bool(true), I64(1).evaluate_eq(&F64(1.0)));
-        assert_eq!(Bool(true), F32(1.0_f32).evaluate_eq(&I64(1)));
-        assert_eq!(Bool(true), F32(6.11_f32).evaluate_eq(&F64(6.11)));
-        assert_eq!(Bool(true), F64(1.0).evaluate_eq(&I64(1)));
-        assert_eq!(Bool(true), F64(6.11).evaluate_eq(&F64(6.11)));
+        assert_eq!(Tribool::Null, Tribool::Null); // structural equality
+        assert_eq!(Tribool::Null, Null.evaluate_eq(&Null));
+        assert_eq!(Tribool::True, Bool(true).evaluate_eq(&Bool(true)));
+        assert_eq!(Tribool::True, I8(1).evaluate_eq(&I8(1)));
+        assert_eq!(Tribool::True, I16(1).evaluate_eq(&I16(1)));
+        assert_eq!(Tribool::True, I32(1).evaluate_eq(&I32(1)));
+        assert_eq!(Tribool::True, I64(1).evaluate_eq(&I64(1)));
+        assert_eq!(Tribool::True, I128(1).evaluate_eq(&I128(1)));
+        assert_eq!(Tribool::True, U8(1).evaluate_eq(&U8(1)));
+        assert_eq!(Tribool::True, U16(1).evaluate_eq(&U16(1)));
+        assert_eq!(Tribool::True, U32(1).evaluate_eq(&U32(1)));
+        assert_eq!(Tribool::True, U64(1).evaluate_eq(&U64(1)));
+        assert_eq!(Tribool::True, U128(1).evaluate_eq(&U128(1)));
+        assert_eq!(Tribool::True, I64(1).evaluate_eq(&F64(1.0)));
+        assert_eq!(Tribool::True, F32(1.0_f32).evaluate_eq(&I64(1)));
+        assert_eq!(Tribool::True, F32(6.11_f32).evaluate_eq(&F64(6.11)));
+        assert_eq!(Tribool::True, F64(1.0).evaluate_eq(&I64(1)));
+        assert_eq!(Tribool::True, F64(6.11).evaluate_eq(&F64(6.11)));
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Str("Glue".to_owned()).evaluate_eq(&Str("Glue".to_owned()))
         );
-        assert_eq!(Bool(true), bytea("1004").evaluate_eq(&bytea("1004")));
-        assert_eq!(Bool(true), inet("::1").evaluate_eq(&inet("::1")));
+        assert_eq!(Tribool::True, bytea("1004").evaluate_eq(&bytea("1004")));
+        assert_eq!(Tribool::True, inet("::1").evaluate_eq(&inet("::1")));
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Interval(Interval::Month(1)).evaluate_eq(&Interval(Interval::Month(1)))
         );
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Time(NaiveTime::from_hms_opt(12, 30, 11).unwrap())
                 .evaluate_eq(&Time(NaiveTime::from_hms_opt(12, 30, 11).unwrap()))
         );
-        assert_eq!(Bool(true), decimal(1).evaluate_eq(&decimal(1)));
+        assert_eq!(Tribool::True, decimal(1).evaluate_eq(&decimal(1)));
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Date("2020-05-01".parse().unwrap()).evaluate_eq(&Date("2020-05-01".parse().unwrap()))
         );
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap()).evaluate_eq(
                 &Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap())
             )
         );
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Uuid(parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap()).evaluate_eq(&Uuid(
                 parse_uuid("936DA01F9ABD4d9d80C702AF85C822A8").unwrap()
             ))
         );
         assert_eq!(
-            Bool(true),
+            Tribool::True,
             Point(Point::new(1.0, 2.0)).evaluate_eq(&Point(Point::new(1.0, 2.0)))
         );
 
         let date = Date("2020-05-01".parse().unwrap());
         let timestamp = Timestamp("2020-05-01T00:00:00".parse::<NaiveDateTime>().unwrap());
 
-        assert_eq!(Bool(true), date.evaluate_eq(&timestamp));
-        assert_eq!(Bool(true), timestamp.evaluate_eq(&date));
+        assert_eq!(Tribool::True, date.evaluate_eq(&timestamp));
+        assert_eq!(Tribool::True, timestamp.evaluate_eq(&date));
     }
 
     #[test]
@@ -1230,9 +1243,10 @@ mod tests {
     fn arithmetic() {
         use chrono::{NaiveDate, NaiveTime};
 
+        use utils::Tribool::True;
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(True, $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2014,9 +2028,10 @@ mod tests {
     fn bitwise_shift_left() {
         use {super::convert::ConvertError, crate::ast::DataType};
 
+        use utils::Tribool::True;
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(True, $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2176,9 +2191,10 @@ mod tests {
     fn bitwise_shift_right() {
         use {super::convert::ConvertError, crate::ast::DataType};
 
+        use utils::Tribool::True;
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(True, $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 
@@ -2798,9 +2814,10 @@ mod tests {
 
     #[test]
     fn bitwise_and() {
+        use utils::Tribool::True;
         macro_rules! test {
             ($op: ident $a: expr, $b: expr => $c: expr) => {
-                assert_eq!(Bool(true), $a.$op(&$b).unwrap().evaluate_eq(&$c));
+                assert_eq!(True, $a.$op(&$b).unwrap().evaluate_eq(&$c));
             };
         }
 

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -274,42 +274,50 @@ mod tests {
     #[test]
     fn json_to_value() {
         assert!(Value::try_from(JsonValue::Null).unwrap().is_null());
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Bool(false))
                 .unwrap()
                 .evaluate_eq(&Value::Bool(false))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I32(54321))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I64(54321))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I128(54321))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Number(JsonNumber::from_f64(3.21).unwrap()))
                 .unwrap()
                 .evaluate_eq(&Value::F64(3.21))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::String("world".to_owned()))
                 .unwrap()
                 .evaluate_eq(&Value::Str("world".to_owned()))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(JsonValue::Array(vec![JsonValue::Bool(true)]))
                 .unwrap()
                 .evaluate_eq(&Value::List(vec![Value::Bool(true)]))
         );
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
             Value::try_from(json!({ "a": true }))
                 .unwrap()
                 .evaluate_eq(&Value::Map(

--- a/core/src/data/value/json.rs
+++ b/core/src/data/value/json.rs
@@ -274,50 +274,51 @@ mod tests {
     #[test]
     fn json_to_value() {
         assert!(Value::try_from(JsonValue::Null).unwrap().is_null());
+        use utils::Tribool::True;
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Bool(false))
                 .unwrap()
                 .evaluate_eq(&Value::Bool(false))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I32(54321))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I64(54321))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Number(54321.into()))
                 .unwrap()
                 .evaluate_eq(&Value::I128(54321))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Number(JsonNumber::from_f64(3.21).unwrap()))
                 .unwrap()
                 .evaluate_eq(&Value::F64(3.21))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::String("world".to_owned()))
                 .unwrap()
                 .evaluate_eq(&Value::Str("world".to_owned()))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(JsonValue::Array(vec![JsonValue::Bool(true)]))
                 .unwrap()
                 .evaluate_eq(&Value::List(vec![Value::Bool(true)]))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::try_from(json!({ "a": true }))
                 .unwrap()
                 .evaluate_eq(&Value::Map(

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -49,51 +49,77 @@ impl TryFrom<Literal<'_>> for Value {
 }
 
 impl Value {
-    pub fn evaluate_eq_with_literal(&self, other: &Literal<'_>) -> bool {
+    pub fn evaluate_eq_with_literal(&self, other: &Literal<'_>) -> Self {
         match (self, other) {
-            (Value::Bool(l), Literal::Boolean(r)) => l == r,
-            (Value::I8(l), Literal::Number(r)) => r.to_i8().map(|r| *l == r).unwrap_or(false),
-            (Value::I16(l), Literal::Number(r)) => r.to_i16().map(|r| *l == r).unwrap_or(false),
-            (Value::I32(l), Literal::Number(r)) => r.to_i32().map(|r| *l == r).unwrap_or(false),
-            (Value::I64(l), Literal::Number(r)) => r.to_i64().map(|r| *l == r).unwrap_or(false),
-            (Value::I128(l), Literal::Number(r)) => r.to_i128().map(|r| *l == r).unwrap_or(false),
-            (Value::U8(l), Literal::Number(r)) => r.to_u8().map(|r| *l == r).unwrap_or(false),
-            (Value::U16(l), Literal::Number(r)) => r.to_u16().map(|r| *l == r).unwrap_or(false),
-            (Value::U32(l), Literal::Number(r)) => r.to_u32().map(|r| *l == r).unwrap_or(false),
-            (Value::U64(l), Literal::Number(r)) => r.to_u64().map(|r| *l == r).unwrap_or(false),
-            (Value::U128(l), Literal::Number(r)) => r.to_u128().map(|r| *l == r).unwrap_or(false),
-            (Value::F32(l), Literal::Number(r)) => r.to_f32().map(|r| *l == r).unwrap_or(false),
-            (Value::F64(l), Literal::Number(r)) => r.to_f64().map(|r| *l == r).unwrap_or(false),
-            (Value::Str(l), Literal::Text(r)) => l == r.as_ref(),
-            (Value::Bytea(l), Literal::Bytea(r)) => l == r,
+            (Value::Bool(l), Literal::Boolean(r)) => Value::Bool(l == r),
+            (Value::I8(l), Literal::Number(r)) => {
+                Value::Bool(r.to_i8().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::I16(l), Literal::Number(r)) => {
+                Value::Bool(r.to_i16().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::I32(l), Literal::Number(r)) => {
+                Value::Bool(r.to_i32().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::I64(l), Literal::Number(r)) => {
+                Value::Bool(r.to_i64().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::I128(l), Literal::Number(r)) => {
+                Value::Bool(r.to_i128().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::U8(l), Literal::Number(r)) => {
+                Value::Bool(r.to_u8().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::U16(l), Literal::Number(r)) => {
+                Value::Bool(r.to_u16().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::U32(l), Literal::Number(r)) => {
+                Value::Bool(r.to_u32().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::U64(l), Literal::Number(r)) => {
+                Value::Bool(r.to_u64().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::U128(l), Literal::Number(r)) => {
+                Value::Bool(r.to_u128().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::F32(l), Literal::Number(r)) => {
+                Value::Bool(r.to_f32().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::F64(l), Literal::Number(r)) => {
+                Value::Bool(r.to_f64().map(|r| *l == r).unwrap_or(false))
+            }
+            (Value::Str(l), Literal::Text(r)) => Value::Bool(l == r.as_ref()),
+            (Value::Bytea(l), Literal::Bytea(r)) => Value::Bool(l == r),
             (Value::Date(l), Literal::Text(r)) => match r.parse::<NaiveDate>() {
-                Ok(r) => l == &r,
-                Err(_) => false,
+                Ok(r) => Value::Bool(l == &r),
+                Err(_) => Value::Bool(false),
             },
             (Value::Timestamp(l), Literal::Text(r)) => match parse_timestamp(r) {
-                Some(r) => l == &r,
-                None => false,
+                Some(r) => Value::Bool(l == &r),
+                None => Value::Bool(false),
             },
             (Value::Time(l), Literal::Text(r)) => match parse_time(r) {
-                Some(r) => l == &r,
-                None => false,
+                Some(r) => Value::Bool(l == &r),
+                None => Value::Bool(false),
             },
-            (Value::Uuid(l), Literal::Text(r)) => parse_uuid(r).map(|r| l == &r).unwrap_or(false),
+            (Value::Uuid(l), Literal::Text(r)) => {
+                Value::Bool(parse_uuid(r).map(|r| l == &r).unwrap_or(false))
+            }
             (Value::Inet(l), Literal::Text(r)) => match IpAddr::from_str(r) {
-                Ok(x) => l == &x,
-                Err(_) => false,
+                Ok(x) => Value::Bool(l == &x),
+                Err(_) => Value::Bool(false),
             },
             (Value::Inet(l), Literal::Number(r)) => {
                 if let Some(x) = r.to_u32() {
-                    l == &Ipv4Addr::from(x)
+                    Value::Bool(l == &Ipv4Addr::from(x))
                 } else if let Some(x) = r.to_u128() {
-                    l == &Ipv6Addr::from(x)
+                    Value::Bool(l == &Ipv6Addr::from(x))
                 } else {
-                    false
+                    Value::Bool(false)
                 }
             }
-            (Value::Null, Literal::Null) => false,
-            _ => false,
+            (Value::Null, _) | (_, Literal::Null) => Value::Null,
+            _ => Value::Bool(false),
         }
     }
 
@@ -537,42 +563,128 @@ mod tests {
         let bytea = || hex::decode("123456").unwrap();
         let inet = |v: &str| Value::Inet(IpAddr::from_str(v).unwrap());
 
-        assert!(Value::Bool(true).evaluate_eq_with_literal(&Literal::Boolean(true)));
-        assert!(Value::I8(8).evaluate_eq_with_literal(num!("8")));
-        assert!(Value::I32(32).evaluate_eq_with_literal(num!("32")));
-        assert!(Value::I16(16).evaluate_eq_with_literal(num!("16")));
-        assert!(Value::I32(32).evaluate_eq_with_literal(num!("32")));
-        assert!(Value::I64(64).evaluate_eq_with_literal(num!("64")));
-        assert!(Value::I128(128).evaluate_eq_with_literal(num!("128")));
-        assert!(Value::U8(7).evaluate_eq_with_literal(num!("7")));
-        assert!(Value::U16(64).evaluate_eq_with_literal(num!("64")));
-        assert!(Value::U32(64).evaluate_eq_with_literal(num!("64")));
-        assert!(Value::U64(64).evaluate_eq_with_literal(num!("64")));
-        assert!(Value::U128(64).evaluate_eq_with_literal(num!("64")));
-        assert!(Value::F32(7.123).evaluate_eq_with_literal(num!("7.123")));
-        assert!(Value::F64(7.123).evaluate_eq_with_literal(num!("7.123")));
-        assert!(Value::Str("Hello".to_owned()).evaluate_eq_with_literal(text!("Hello")));
-        assert!(Value::Bytea(bytea()).evaluate_eq_with_literal(&Literal::Bytea(bytea())));
-        assert!(inet("127.0.0.1").evaluate_eq_with_literal(text!("127.0.0.1")));
-        assert!(inet("::1").evaluate_eq_with_literal(text!("::1")));
-        assert!(inet("0.0.0.0").evaluate_eq_with_literal(num!("0")));
-        assert!(!inet("::1").evaluate_eq_with_literal(num!("0")));
-        assert!(inet("::2:4cb0:16ea").evaluate_eq_with_literal(num!("9876543210")));
-        assert!(!inet("::1").evaluate_eq_with_literal(text!("-1")));
-        assert!(!inet("::1").evaluate_eq_with_literal(num!("-1")));
-        assert!(Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("2021-11-20")));
-        assert!(!Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("202=abcdef")));
-        assert!(
+        assert_eq!(
+            Value::Bool(true),
+            Value::Bool(true).evaluate_eq_with_literal(&Literal::Boolean(true))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I8(8).evaluate_eq_with_literal(num!("8"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I32(32).evaluate_eq_with_literal(num!("32"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I16(16).evaluate_eq_with_literal(num!("16"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I32(32).evaluate_eq_with_literal(num!("32"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I64(64).evaluate_eq_with_literal(num!("64"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::I128(128).evaluate_eq_with_literal(num!("128"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::U8(7).evaluate_eq_with_literal(num!("7"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::U16(64).evaluate_eq_with_literal(num!("64"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::U32(64).evaluate_eq_with_literal(num!("64"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::U64(64).evaluate_eq_with_literal(num!("64"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::U128(64).evaluate_eq_with_literal(num!("64"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::F32(7.123).evaluate_eq_with_literal(num!("7.123"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::F64(7.123).evaluate_eq_with_literal(num!("7.123"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::Str("Hello".to_owned()).evaluate_eq_with_literal(text!("Hello"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::Bytea(bytea()).evaluate_eq_with_literal(&Literal::Bytea(bytea()))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            inet("127.0.0.1").evaluate_eq_with_literal(text!("127.0.0.1"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            inet("::1").evaluate_eq_with_literal(text!("::1"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            inet("0.0.0.0").evaluate_eq_with_literal(num!("0"))
+        );
+        assert_eq!(
+            Value::Bool(false),
+            inet("::1").evaluate_eq_with_literal(num!("0"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            inet("::2:4cb0:16ea").evaluate_eq_with_literal(num!("9876543210"))
+        );
+        assert_eq!(
+            Value::Bool(false),
+            inet("::1").evaluate_eq_with_literal(text!("-1"))
+        );
+        assert_eq!(
+            Value::Bool(false),
+            inet("::1").evaluate_eq_with_literal(num!("-1"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("2021-11-20"))
+        );
+        assert_eq!(
+            Value::Bool(false),
+            Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("202=abcdef"))
+        );
+        assert_eq!(
+            Value::Bool(true),
             Value::Timestamp(date_time(2021, 11, 20, 10, 0, 0, 0))
                 .evaluate_eq_with_literal(text!("2021-11-20T10:00:00Z"))
         );
-        assert!(
-            !Value::Timestamp(date_time(2021, 11, 20, 10, 0, 0, 0))
+        assert_eq!(
+            Value::Bool(false),
+            Value::Timestamp(date_time(2021, 11, 20, 10, 0, 0, 0))
                 .evaluate_eq_with_literal(text!("2021-11-Hello"))
         );
-        assert!(Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("10:00:00")));
-        assert!(!Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("FALSE")));
-        assert!(Value::Uuid(uuid).evaluate_eq_with_literal(text!(uuid_text)));
+        assert_eq!(
+            Value::Bool(true),
+            Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("10:00:00"))
+        );
+        assert_eq!(
+            Value::Bool(false),
+            Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("FALSE"))
+        );
+        assert_eq!(
+            Value::Bool(true),
+            Value::Uuid(uuid).evaluate_eq_with_literal(text!(uuid_text))
+        );
     }
 
     #[test]
@@ -870,7 +982,10 @@ mod tests {
 
         macro_rules! test {
             ($from: expr, $expected: expr) => {
-                assert!(Value::try_from($from).unwrap().evaluate_eq(&$expected));
+                assert_eq!(
+                    Value::Bool(true),
+                    Value::try_from($from).unwrap().evaluate_eq(&$expected)
+                );
             };
         }
 

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        Value,
+        Tribool, Value,
         date::{parse_date, parse_time, parse_timestamp},
         error::ValueError,
     },
@@ -49,77 +49,77 @@ impl TryFrom<Literal<'_>> for Value {
 }
 
 impl Value {
-    pub fn evaluate_eq_with_literal(&self, other: &Literal<'_>) -> Self {
+    pub fn evaluate_eq_with_literal(&self, other: &Literal<'_>) -> Tribool {
         match (self, other) {
-            (Value::Bool(l), Literal::Boolean(r)) => Value::Bool(l == r),
+            (Value::Bool(l), Literal::Boolean(r)) => Tribool::from(l == r),
             (Value::I8(l), Literal::Number(r)) => {
-                Value::Bool(r.to_i8().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_i8().map(|r| *l == r).unwrap_or(false))
             }
             (Value::I16(l), Literal::Number(r)) => {
-                Value::Bool(r.to_i16().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_i16().map(|r| *l == r).unwrap_or(false))
             }
             (Value::I32(l), Literal::Number(r)) => {
-                Value::Bool(r.to_i32().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_i32().map(|r| *l == r).unwrap_or(false))
             }
             (Value::I64(l), Literal::Number(r)) => {
-                Value::Bool(r.to_i64().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_i64().map(|r| *l == r).unwrap_or(false))
             }
             (Value::I128(l), Literal::Number(r)) => {
-                Value::Bool(r.to_i128().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_i128().map(|r| *l == r).unwrap_or(false))
             }
             (Value::U8(l), Literal::Number(r)) => {
-                Value::Bool(r.to_u8().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_u8().map(|r| *l == r).unwrap_or(false))
             }
             (Value::U16(l), Literal::Number(r)) => {
-                Value::Bool(r.to_u16().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_u16().map(|r| *l == r).unwrap_or(false))
             }
             (Value::U32(l), Literal::Number(r)) => {
-                Value::Bool(r.to_u32().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_u32().map(|r| *l == r).unwrap_or(false))
             }
             (Value::U64(l), Literal::Number(r)) => {
-                Value::Bool(r.to_u64().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_u64().map(|r| *l == r).unwrap_or(false))
             }
             (Value::U128(l), Literal::Number(r)) => {
-                Value::Bool(r.to_u128().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_u128().map(|r| *l == r).unwrap_or(false))
             }
             (Value::F32(l), Literal::Number(r)) => {
-                Value::Bool(r.to_f32().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_f32().map(|r| *l == r).unwrap_or(false))
             }
             (Value::F64(l), Literal::Number(r)) => {
-                Value::Bool(r.to_f64().map(|r| *l == r).unwrap_or(false))
+                Tribool::from(r.to_f64().map(|r| *l == r).unwrap_or(false))
             }
-            (Value::Str(l), Literal::Text(r)) => Value::Bool(l == r.as_ref()),
-            (Value::Bytea(l), Literal::Bytea(r)) => Value::Bool(l == r),
+            (Value::Str(l), Literal::Text(r)) => Tribool::from(l == r.as_ref()),
+            (Value::Bytea(l), Literal::Bytea(r)) => Tribool::from(l == r),
             (Value::Date(l), Literal::Text(r)) => match r.parse::<NaiveDate>() {
-                Ok(r) => Value::Bool(l == &r),
-                Err(_) => Value::Bool(false),
+                Ok(r) => Tribool::from(l == &r),
+                Err(_) => Tribool::from(false),
             },
             (Value::Timestamp(l), Literal::Text(r)) => match parse_timestamp(r) {
-                Some(r) => Value::Bool(l == &r),
-                None => Value::Bool(false),
+                Some(r) => Tribool::from(l == &r),
+                None => Tribool::from(false),
             },
             (Value::Time(l), Literal::Text(r)) => match parse_time(r) {
-                Some(r) => Value::Bool(l == &r),
-                None => Value::Bool(false),
+                Some(r) => Tribool::from(l == &r),
+                None => Tribool::from(false),
             },
             (Value::Uuid(l), Literal::Text(r)) => {
-                Value::Bool(parse_uuid(r).map(|r| l == &r).unwrap_or(false))
+                Tribool::from(parse_uuid(r).map(|r| l == &r).unwrap_or(false))
             }
             (Value::Inet(l), Literal::Text(r)) => match IpAddr::from_str(r) {
-                Ok(x) => Value::Bool(l == &x),
-                Err(_) => Value::Bool(false),
+                Ok(x) => Tribool::from(l == &x),
+                Err(_) => Tribool::from(false),
             },
             (Value::Inet(l), Literal::Number(r)) => {
                 if let Some(x) = r.to_u32() {
-                    Value::Bool(l == &Ipv4Addr::from(x))
+                    Tribool::from(l == &Ipv4Addr::from(x))
                 } else if let Some(x) = r.to_u128() {
-                    Value::Bool(l == &Ipv6Addr::from(x))
+                    Tribool::from(l == &Ipv6Addr::from(x))
                 } else {
-                    Value::Bool(false)
+                    Tribool::from(false)
                 }
             }
-            (Value::Null, _) | (_, Literal::Null) => Value::Null,
-            _ => Value::Bool(false),
+            (Value::Null, _) | (_, Literal::Null) => Tribool::Null,
+            _ => Tribool::from(false),
         }
     }
 
@@ -545,6 +545,8 @@ mod tests {
 
     #[test]
     fn evaluate_eq_with_literal() {
+        use utils::Tribool::*;
+
         macro_rules! num {
             ($num: expr) => {
                 &Literal::Number(Cow::Owned(BigDecimal::from_str($num).unwrap()))
@@ -564,125 +566,77 @@ mod tests {
         let inet = |v: &str| Value::Inet(IpAddr::from_str(v).unwrap());
 
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Bool(true).evaluate_eq_with_literal(&Literal::Boolean(true))
         );
+        assert_eq!(True, Value::I8(8).evaluate_eq_with_literal(num!("8")));
+        assert_eq!(True, Value::I32(32).evaluate_eq_with_literal(num!("32")));
+        assert_eq!(True, Value::I16(16).evaluate_eq_with_literal(num!("16")));
+        assert_eq!(True, Value::I32(32).evaluate_eq_with_literal(num!("32")));
+        assert_eq!(True, Value::I64(64).evaluate_eq_with_literal(num!("64")));
+        assert_eq!(True, Value::I128(128).evaluate_eq_with_literal(num!("128")));
+        assert_eq!(True, Value::U8(7).evaluate_eq_with_literal(num!("7")));
+        assert_eq!(True, Value::U16(64).evaluate_eq_with_literal(num!("64")));
+        assert_eq!(True, Value::U32(64).evaluate_eq_with_literal(num!("64")));
+        assert_eq!(True, Value::U64(64).evaluate_eq_with_literal(num!("64")));
+        assert_eq!(True, Value::U128(64).evaluate_eq_with_literal(num!("64")));
         assert_eq!(
-            Value::Bool(true),
-            Value::I8(8).evaluate_eq_with_literal(num!("8"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::I32(32).evaluate_eq_with_literal(num!("32"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::I16(16).evaluate_eq_with_literal(num!("16"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::I32(32).evaluate_eq_with_literal(num!("32"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::I64(64).evaluate_eq_with_literal(num!("64"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::I128(128).evaluate_eq_with_literal(num!("128"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::U8(7).evaluate_eq_with_literal(num!("7"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::U16(64).evaluate_eq_with_literal(num!("64"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::U32(64).evaluate_eq_with_literal(num!("64"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::U64(64).evaluate_eq_with_literal(num!("64"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            Value::U128(64).evaluate_eq_with_literal(num!("64"))
-        );
-        assert_eq!(
-            Value::Bool(true),
+            True,
             Value::F32(7.123).evaluate_eq_with_literal(num!("7.123"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::F64(7.123).evaluate_eq_with_literal(num!("7.123"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Str("Hello".to_owned()).evaluate_eq_with_literal(text!("Hello"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Bytea(bytea()).evaluate_eq_with_literal(&Literal::Bytea(bytea()))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             inet("127.0.0.1").evaluate_eq_with_literal(text!("127.0.0.1"))
         );
+        assert_eq!(True, inet("::1").evaluate_eq_with_literal(text!("::1")));
+        assert_eq!(True, inet("0.0.0.0").evaluate_eq_with_literal(num!("0")));
+        assert_eq!(False, inet("::1").evaluate_eq_with_literal(num!("0")));
         assert_eq!(
-            Value::Bool(true),
-            inet("::1").evaluate_eq_with_literal(text!("::1"))
-        );
-        assert_eq!(
-            Value::Bool(true),
-            inet("0.0.0.0").evaluate_eq_with_literal(num!("0"))
-        );
-        assert_eq!(
-            Value::Bool(false),
-            inet("::1").evaluate_eq_with_literal(num!("0"))
-        );
-        assert_eq!(
-            Value::Bool(true),
+            True,
             inet("::2:4cb0:16ea").evaluate_eq_with_literal(num!("9876543210"))
         );
+        assert_eq!(False, inet("::1").evaluate_eq_with_literal(text!("-1")));
+        assert_eq!(False, inet("::1").evaluate_eq_with_literal(num!("-1")));
         assert_eq!(
-            Value::Bool(false),
-            inet("::1").evaluate_eq_with_literal(text!("-1"))
-        );
-        assert_eq!(
-            Value::Bool(false),
-            inet("::1").evaluate_eq_with_literal(num!("-1"))
-        );
-        assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("2021-11-20"))
         );
         assert_eq!(
-            Value::Bool(false),
+            False,
             Value::Date(date(2021, 11, 20)).evaluate_eq_with_literal(text!("202=abcdef"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Timestamp(date_time(2021, 11, 20, 10, 0, 0, 0))
                 .evaluate_eq_with_literal(text!("2021-11-20T10:00:00Z"))
         );
         assert_eq!(
-            Value::Bool(false),
+            False,
             Value::Timestamp(date_time(2021, 11, 20, 10, 0, 0, 0))
                 .evaluate_eq_with_literal(text!("2021-11-Hello"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("10:00:00"))
         );
         assert_eq!(
-            Value::Bool(false),
+            False,
             Value::Time(time(10, 0, 0, 0)).evaluate_eq_with_literal(text!("FALSE"))
         );
         assert_eq!(
-            Value::Bool(true),
+            True,
             Value::Uuid(uuid).evaluate_eq_with_literal(text!(uuid_text))
         );
     }
@@ -983,7 +937,7 @@ mod tests {
         macro_rules! test {
             ($from: expr, $expected: expr) => {
                 assert_eq!(
-                    Value::Bool(true),
+                    utils::Tribool::True,
                     Value::try_from($from).unwrap().evaluate_eq(&$expected)
                 );
             };

--- a/core/src/data/value/literal.rs
+++ b/core/src/data/value/literal.rs
@@ -639,6 +639,18 @@ mod tests {
             True,
             Value::Uuid(uuid).evaluate_eq_with_literal(text!(uuid_text))
         );
+        // NULL-handling
+        assert_eq!(Null, Value::Null.evaluate_eq_with_literal(&Literal::Null));
+        assert_eq!(Null, Value::Null.evaluate_eq_with_literal(text!("STRING")));
+        assert_eq!(Null, Value::Null.evaluate_eq_with_literal(num!("123.456")));
+        assert_eq!(
+            Null,
+            Value::I128(1024).evaluate_eq_with_literal(&Literal::Null)
+        );
+        assert_eq!(
+            Null,
+            Value::Str("STRING".into()).evaluate_eq_with_literal(&Literal::Null)
+        );
     }
 
     #[test]

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -6,6 +6,7 @@ use {
         result::{Error, Result},
     },
     std::{borrow::Cow, cmp::Ordering, collections::BTreeMap, ops::Range},
+    utils::Tribool,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -126,26 +127,28 @@ pub fn exceptional_int_val_to_eval<'a>(name: String, v: Value) -> Result<Evaluat
     }
 }
 
+impl From<Tribool> for Evaluated<'_> {
+    fn from(x: Tribool) -> Self {
+        Evaluated::Value(Value::from(x))
+    }
+}
+
 impl<'a> Evaluated<'a> {
-    pub fn evaluate_eq(&self, other: &Evaluated<'a>) -> Evaluated<'a> {
+    pub fn evaluate_eq(&self, other: &Evaluated<'a>) -> Tribool {
         match (self, other) {
-            (Evaluated::Literal(a), Evaluated::Literal(b)) => Evaluated::Literal(a.evaluate_eq(b)),
+            (Evaluated::Literal(a), Evaluated::Literal(b)) => a.evaluate_eq(b),
             (Evaluated::Literal(b), Evaluated::Value(a))
-            | (Evaluated::Value(a), Evaluated::Literal(b)) => {
-                Evaluated::Value(a.evaluate_eq_with_literal(b))
-            }
-            (Evaluated::Value(a), Evaluated::Value(b)) => Evaluated::Value(a.evaluate_eq(b)),
+            | (Evaluated::Value(a), Evaluated::Literal(b)) => a.evaluate_eq_with_literal(b),
+            (Evaluated::Value(a), Evaluated::Value(b)) => a.evaluate_eq(b),
             (Evaluated::Literal(a), Evaluated::StrSlice { source, range })
             | (Evaluated::StrSlice { source, range }, Evaluated::Literal(a)) => {
                 let b = &source[range.clone()];
-
-                Evaluated::Literal(a.evaluate_eq(&Literal::Text(Cow::Borrowed(b))))
+                a.evaluate_eq(&Literal::Text(Cow::Borrowed(b)))
             }
             (Evaluated::Value(a), Evaluated::StrSlice { source, range })
             | (Evaluated::StrSlice { source, range }, Evaluated::Value(a)) => {
                 let b = &source[range.clone()];
-
-                Evaluated::Value(a.evaluate_eq_with_literal(&Literal::Text(Cow::Borrowed(b))))
+                a.evaluate_eq_with_literal(&Literal::Text(Cow::Borrowed(b)))
             }
             (
                 Evaluated::StrSlice { source, range },
@@ -153,9 +156,7 @@ impl<'a> Evaluated<'a> {
                     source: source2,
                     range: range2,
                 },
-            ) => Evaluated::Value(Value::Bool(
-                source[range.clone()] == source2[range2.clone()],
-            )),
+            ) => Tribool::from(source[range.clone()] == source2[range2.clone()]),
         }
     }
 

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -50,8 +50,8 @@ pub fn binary_op<'a>(
         BinaryOperator::Divide => l.divide(&r),
         BinaryOperator::Modulo => l.modulo(&r),
         BinaryOperator::StringConcat => l.concat(r),
-        BinaryOperator::Eq => Ok(l.evaluate_eq(&r)),
-        BinaryOperator::NotEq => l.evaluate_eq(&r).unary_not(),
+        BinaryOperator::Eq => Ok(Evaluated::from(l.evaluate_eq(&r))),
+        BinaryOperator::NotEq => Ok(Evaluated::from(!l.evaluate_eq(&r))),
         BinaryOperator::Lt => cmp!(l.evaluate_cmp(&r) == Some(Ordering::Less)),
         BinaryOperator::LtEq => cmp!(matches!(
             l.evaluate_cmp(&r),

--- a/core/src/executor/evaluate/expr.rs
+++ b/core/src/executor/evaluate/expr.rs
@@ -50,8 +50,8 @@ pub fn binary_op<'a>(
         BinaryOperator::Divide => l.divide(&r),
         BinaryOperator::Modulo => l.modulo(&r),
         BinaryOperator::StringConcat => l.concat(r),
-        BinaryOperator::Eq => cmp!(l.evaluate_eq(&r)),
-        BinaryOperator::NotEq => cmp!(!l.evaluate_eq(&r)),
+        BinaryOperator::Eq => Ok(l.evaluate_eq(&r)),
+        BinaryOperator::NotEq => l.evaluate_eq(&r).unary_not(),
         BinaryOperator::Lt => cmp!(l.evaluate_cmp(&r) == Some(Ordering::Less)),
         BinaryOperator::LtEq => cmp!(matches!(
             l.evaluate_cmp(&r),

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,6 +3,10 @@
 mod hashmap;
 mod indexmap;
 mod or_stream;
+mod tribool;
 mod vector;
 
-pub use {self::indexmap::IndexMap, hashmap::HashMapExt, or_stream::OrStream, vector::Vector};
+pub use {
+    self::indexmap::IndexMap, hashmap::HashMapExt, or_stream::OrStream, tribool::Tribool,
+    vector::Vector,
+};

--- a/utils/src/tribool.rs
+++ b/utils/src/tribool.rs
@@ -1,0 +1,38 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tribool {
+    True,
+    False,
+    Null,
+}
+
+impl Tribool {
+    pub fn is_true(self) -> bool {
+        matches!(self, Self::True)
+    }
+
+    pub fn is_false(self) -> bool {
+        matches!(self, Self::False)
+    }
+
+    pub fn is_null(self) -> bool {
+        matches!(self, Self::Null)
+    }
+}
+
+impl std::ops::Not for Tribool {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Self::True => Self::False,
+            Self::False => Self::True,
+            Self::Null => Self::Null,
+        }
+    }
+}
+
+impl From<bool> for Tribool {
+    fn from(v: bool) -> Self {
+        if v { Self::True } else { Self::False }
+    }
+}

--- a/utils/src/tribool.rs
+++ b/utils/src/tribool.rs
@@ -36,3 +36,40 @@ impl From<bool> for Tribool {
         if v { Self::True } else { Self::False }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tribool() {
+        let t = Tribool::True;
+        let f = Tribool::False;
+        let n = Tribool::Null;
+
+        assert!(t.is_true());
+        assert!(!t.is_false());
+        assert!(!t.is_null());
+
+        assert!(!f.is_true());
+        assert!(f.is_false());
+        assert!(!f.is_null());
+
+        assert!(!n.is_true());
+        assert!(!n.is_false());
+        assert!(n.is_null());
+    }
+
+    #[test]
+    fn test_conversion_from_bool() {
+        assert_eq!(Tribool::from(true), Tribool::True);
+        assert_eq!(Tribool::from(false), Tribool::False);
+    }
+
+    #[test]
+    fn test_not_operator() {
+        assert_eq!(!Tribool::True, Tribool::False);
+        assert_eq!(!Tribool::False, Tribool::True);
+        assert_eq!(!Tribool::Null, Tribool::Null);
+    }
+}


### PR DESCRIPTION
~~This pull request will be ready for review after #1685 merged.~~

---

This pull request follows #1685. This pull request changes the return type of functions with the name `evaluate_eq` to represent `NULL`-related operations. For instance, `NULL = NULL` should return `NULL` but the `bool` type cannot represent `NULL` well.

This pull request changed too many lines, so I recommend reviewing at the commit level. I separated the changes into two commits: the first commit changes only implementation-related lines, and the second changes only test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a tri-state boolean (True / False / Null) and made it available across the system.

* **Bug Fixes**
  * Equality and membership checks now propagate Null when any operand is null instead of treating it as false.

* **Refactor**
  * Unified equality to return tri-state results throughout values, literals, evaluated expressions, and expression handling.
  * Added conversions to represent tri-state results as runtime values.

* **Tests**
  * Updated tests to assert tri-state semantics (True/False/Null).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->