### PR TITLE
Restrict auto-author-assign workflow to main branch

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -3,6 +3,8 @@ name: auto-author-assign
 on:
   pull_request_target:
     types: [opened, ready_for_review]
+    branches:
+      - main
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description

This PR updates the workflow so that the auto-author-assign action only runs when the pull request target branch is main.

## Background & Motivation

We often use Codex to work on branches other than main. However, with the current setup, the author assign action runs for every PR, regardless of the target branch, causing unnecessary hassle to current reviewers.

By applying this change, the author assign will only be triggered for pull requests targeting the main branch. This will help reduce redundant runs and optimize our CI usage. -> oh it is not for reduce system resource, it is for us, reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to run auto-author assignment only on pull requests targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->