### PR TITLE
Add tests for aggregate BETWEEN and CASE expressions

### DIFF
--- a/test-suite/src/aggregate.rs
+++ b/test-suite/src/aggregate.rs
@@ -1,6 +1,7 @@
 pub mod avg;
 pub mod count;
 pub mod error;
+pub mod expr;
 pub mod group_by;
 pub mod max;
 pub mod min;

--- a/test-suite/src/aggregate/expr.rs
+++ b/test-suite/src/aggregate/expr.rs
@@ -1,0 +1,49 @@
+use {crate::*, gluesql_core::prelude::Value::*};
+
+test_case!(expr, {
+    let g = get_tester!();
+
+    g.run(
+        "
+        CREATE TABLE Item (
+            id INTEGER,
+            quantity INTEGER,
+            age INTEGER NULL,
+            total INTEGER
+        );
+    ",
+    )
+    .await;
+    g.run(
+        "
+        INSERT INTO Item (id, quantity, age, total) VALUES
+            (1, 10,   11, 1),
+            (2,  0,   90, 2),
+            (3,  9, NULL, 3),
+            (4,  3,    3, 1),
+            (5, 25, NULL, 1);
+    ",
+    )
+    .await;
+
+    g.named_test(
+        "BETWEEN with aggregates",
+        "SELECT SUM(quantity) BETWEEN MIN(quantity) AND MAX(quantity) AS test FROM Item;",
+        Ok(select!("test" Bool; false)),
+    )
+    .await;
+
+    g.named_test(
+        "CASE comparing aggregates",
+        "SELECT CASE SUM(quantity) WHEN MIN(quantity) THEN MAX(id) ELSE COUNT(id) END AS test FROM Item;",
+        Ok(select!("test" I64; 5)),
+    )
+    .await;
+
+    g.named_test(
+        "CASE WHEN with aggregate condition",
+        "SELECT CASE WHEN SUM(quantity) > 30 THEN MAX(id) ELSE MIN(id) END AS test FROM Item;",
+        Ok(select!("test" I64; 5)),
+    )
+    .await;
+});

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -87,6 +87,7 @@ macro_rules! generate_store_tests {
         glue!(aggregate_sum, aggregate::sum::sum);
         glue!(aggregate_variance, aggregate::variance::variance);
         glue!(aggregate_error, aggregate::error::error);
+        glue!(aggregate_expr, aggregate::expr::expr);
         glue!(arithmetic_error, arithmetic::error::error);
         glue!(arithmetic_project, arithmetic::project::project);
         glue!(arithmetic_on_where, arithmetic::on_where::on_where);


### PR DESCRIPTION
Add test cases to cover aggregate functions used with BETWEEN and CASE expressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify aggregate functions combined with expressions and conditional logic in SQL queries.
  * Introduced a new test suite with sample data to ensure correct handling of aggregate expressions.
  * Registered the new aggregate expression test suite in the overall test framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->