### PR TITLE
refactor: unify redis key prefix

### DIFF
--- a/storages/redis-storage/src/metadata.rs
+++ b/storages/redis-storage/src/metadata.rs
@@ -42,17 +42,16 @@ impl Metadata for RedisStorage {
                     ))
                 })?;
 
-                // [0]: empty because key starts with '#'
+                // [0]: namespace
                 // [1]: 'metadata'
-                // [2]: namespace
-                // [3]: tablename
-                // [4]: metadata_name
+                // [2]: tablename
+                // [3]: metadata_name
                 let tokens = redis_key.split('#').collect::<Vec<&str>>();
-                if let Some(meta_table) = all_metadata.get_mut(tokens[3]) {
-                    meta_table.insert(tokens[4].to_owned(), value);
+                if let Some(meta_table) = all_metadata.get_mut(tokens[2]) {
+                    meta_table.insert(tokens[3].to_owned(), value);
                 } else {
-                    let meta_table = HashMap::from([(tokens[4].to_owned(), value)]);
-                    let meta = HashMap::from([(tokens[3].to_owned(), meta_table)]);
+                    let meta_table = HashMap::from([(tokens[3].to_owned(), value)]);
+                    let meta = HashMap::from([(tokens[2].to_owned(), meta_table)]);
                     all_metadata.extend(meta);
                 }
             }


### PR DESCRIPTION
## Summary
- namespace-prefix all Redis keys so schema, metadata and data live under `{namespace}#`
- adjust key parsing and metadata scanning for the new layout

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68945cd2d2d8832ab1a8bf90c4768f5c