### PR TITLE
fix(storage-idb): "Arc::try_unwrap failed" on multiple connections

### DIFF
--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -87,11 +87,10 @@ impl IdbStorage {
         };
 
         let database = open_request.await.err_into()?;
-        if let Some(e) = Arc::try_unwrap(error)
-            .map_err(|_| Error::StorageMsg("infallible - Arc::try_unwrap failed".to_owned()))?
-            .into_inner()
-            .err_into()?
-        {
+        let mut error = error
+            .lock()
+            .map_err(|_| Error::StorageMsg("infallible - lock acquire failed".to_owned()))?;
+        if let Some(e) = error.take() {
             return Err(e);
         }
 
@@ -183,11 +182,10 @@ impl IdbStorage {
         };
 
         self.database = open_request.await.err_into()?;
-        if let Some(e) = Arc::try_unwrap(error)
-            .map_err(|_| Error::StorageMsg("infallible - Arc::try_unwrap failed".to_owned()))?
-            .into_inner()
-            .err_into()?
-        {
+        let mut error = error
+            .lock()
+            .map_err(|_| Error::StorageMsg("infallible - lock acquire failed".to_owned()))?;
+        if let Some(e) = error.take() {
             return Err(e);
         }
 

--- a/storages/idb-storage/tests/idb_storage.rs
+++ b/storages/idb-storage/tests/idb_storage.rs
@@ -30,3 +30,17 @@ impl Tester<IdbStorage> for IdbStorageTester {
 
 generate_store_tests!(wasm_bindgen_test, IdbStorageTester);
 generate_alter_table_tests!(wasm_bindgen_test, IdbStorageTester);
+
+#[wasm_bindgen_test]
+async fn multiple_instances() {
+    {
+        let _ = IdbStorage::new(Some("multiple_instances".to_owned()))
+            .await
+            .unwrap();
+    }
+    {
+        let _ = IdbStorage::new(Some("multiple_instances".to_owned()))
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
The `on_upgrade_needed` callback for IndexedDB open requests was holding a reference to an `Arc`, which was not being released when the `IdbStorage` instance was dropped. This caused `Arc::try_unwrap` to fail when a new `IdbStorage` instance was created with the same namespace.

This commit fixes the issue by replacing the `Arc::try_unwrap` logic with a safer approach that locks the mutex and takes the error value. This avoids the panic while still correctly handling errors from the callback.

A test case has been added to reproduce the issue and verify the fix.

Fixes #1717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for IndexedDB operations to ensure more reliable error extraction and messaging.

* **Tests**
  * Added a new test to verify that multiple storage instances can be created with the same namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->