### PR TITLE
fix idb storage reuse

### DIFF
--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -45,7 +45,7 @@ impl IdbStorage {
         let namespace = namespace.as_deref().unwrap_or(DEFAULT_NAMESPACE).to_owned();
 
         let error = Arc::new(Mutex::new(None));
-        let open_request = {
+        let database = {
             let error = Arc::clone(&error);
             let mut open_request = factory.open(namespace.as_str(), None).err_into()?;
             open_request.on_upgrade_needed(move |event| {
@@ -83,10 +83,8 @@ impl IdbStorage {
                 }
             });
 
-            open_request
+            open_request.await.err_into()?
         };
-
-        let database = open_request.await.err_into()?;
         if let Some(e) = Arc::try_unwrap(error)
             .map_err(|_| Error::StorageMsg("infallible - Arc::try_unwrap failed".to_owned()))?
             .into_inner()

--- a/storages/idb-storage/tests/idb_storage.rs
+++ b/storages/idb-storage/tests/idb_storage.rs
@@ -30,3 +30,18 @@ impl Tester<IdbStorage> for IdbStorageTester {
 
 generate_store_tests!(wasm_bindgen_test, IdbStorageTester);
 generate_alter_table_tests!(wasm_bindgen_test, IdbStorageTester);
+
+#[wasm_bindgen_test]
+async fn create_idb_storage_twice_with_same_namespace() {
+    let namespace = "idb_storage_twice";
+
+    let storage = IdbStorage::new(Some(namespace.to_owned()))
+        .await
+        .expect("first open should succeed");
+    drop(storage);
+
+    let storage = IdbStorage::new(Some(namespace.to_owned()))
+        .await
+        .expect("second open should succeed");
+    storage.delete().await.expect("delete should succeed");
+}


### PR DESCRIPTION
## Summary
- ensure open request dropped before checking error so IdbStorage can reopen same namespace
- add regression test for reopening same namespace

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-idb-storage --target wasm32-unknown-unknown` (fails: Exec format error)
- `wasm-pack test --node storages/idb-storage` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689485374050832abcce535496a97123