### PR TITLE
Add unhex function 

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -167,6 +167,7 @@ pub enum Function {
         sub_expr: Expr,
         start: Option<Expr>,
     },
+    Unhex(Expr),
     Ascii(Expr),
     Chr(Expr),
     Md5(Expr),
@@ -426,6 +427,7 @@ impl ToSql for Function {
             Function::Extract { field, expr } => {
                 format!("EXTRACT({field} FROM {})", expr.to_sql())
             }
+            Function::Unhex(e) => format!("UNHEX({})", e.to_sql()),
             Function::Ascii(e) => format!("ASCII({})", e.to_sql()),
             Function::Chr(e) => format!("CHR({})", e.to_sql()),
             Function::Md5(e) => format!("MD5({})", e.to_sql()),
@@ -1247,6 +1249,22 @@ mod tests {
                 sub_expr: Expr::Literal(AstLiteral::QuotedString("goat".to_owned())),
                 start: None
             }))
+            .to_sql()
+        );
+
+        assert_eq!(
+            "UNHEX(10)",
+            &Expr::Function(Box::new(Function::Unhex(Expr::Literal(
+                AstLiteral::Number(BigDecimal::from_str("10").unwrap())
+            ))))
+            .to_sql()
+        );
+
+        assert_eq!(
+            "UNHEX('GlueSQL')",
+            &Expr::Function(Box::new(Function::Unhex(Expr::Literal(
+                AstLiteral::QuotedString("GlueSQL".to_owned())
+            ))))
             .to_sql()
         );
 

--- a/core/src/ast_builder/expr/function.rs
+++ b/core/src/ast_builder/expr/function.rs
@@ -141,6 +141,7 @@ pub enum FunctionNode<'a> {
         from_expr: ExprNode<'a>,
         sub_expr: ExprNode<'a>,
     },
+    Unhex(ExprNode<'a>),
     FindIdx {
         from_expr: ExprNode<'a>,
         sub_expr: ExprNode<'a>,
@@ -372,6 +373,10 @@ impl<'a> TryFrom<FunctionNode<'a>> for Function {
             FunctionNode::Extract { field, expr } => {
                 let expr = expr.try_into()?;
                 Ok(Function::Extract { field, expr })
+            }
+            FunctionNode::Unhex(expr) => {
+                let expr = expr.try_into()?;
+                Ok(Function::Unhex(expr))
             }
             FunctionNode::Ascii(expr) => expr.try_into().map(Function::Ascii),
             FunctionNode::Chr(expr) => expr.try_into().map(Function::Chr),
@@ -929,6 +934,10 @@ pub fn extract<'a, T: Into<ExprNode<'a>>>(field: DateTimeField, expr: T) -> Expr
         field,
         expr: expr.into(),
     }))
+}
+
+pub fn unhex<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
+    ExprNode::Function(Box::new(FunctionNode::Unhex(expr.into())))
 }
 
 pub fn ascii<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
@@ -1702,6 +1711,17 @@ mod tests {
 
         let actual = f::extract(DateTimeField::Year, expr("date"));
         let expected = "EXTRACT(YEAR FROM date)";
+        test_expr(actual, expected);
+    }
+
+    #[test]
+    fn function_unhex() {
+        let actual = f::unhex(text("476C756553514C"));
+        let expected = "UNHEX('476C756553514C')";
+        test_expr(actual, expected);
+
+        let actual = f::unhex(expr("FF"));
+        let expected = "UNHEX(FF)";
         test_expr(actual, expected);
     }
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -490,6 +490,10 @@ async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(
 
             return expr.substr(name, start, count);
         }
+        Function::Unhex(expr) => {
+            let expr = eval(expr).await?;
+            f::unhex(name, expr)
+        }
         Function::Ascii(expr) => f::ascii(name, eval(expr).await?),
         Function::Chr(expr) => f::chr(name, eval(expr).await?),
         Function::Md5(expr) => f::md5(name, eval(expr).await?),

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -38,6 +38,9 @@ pub enum EvaluateError {
     #[error("function requires map value: {0}")]
     FunctionRequiresMapValue(String),
 
+    #[error("invalid hexadecimal string: {0}")]
+    InvalidHexadecimal(String),
+
     #[error("function requires point value: {0}")]
     FunctionRequiresPointValue(String),
 

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -47,6 +47,7 @@ impl Function {
             | Self::Sqrt(expr)
             | Self::Abs(expr)
             | Self::Sign(expr)
+            | Self::Unhex(expr)
             | Self::Ascii(expr)
             | Self::Chr(expr)
             | Self::Md5(expr)

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -261,6 +261,8 @@ mod tests {
 
         // Single
         test("LOWER(id)", &["id"]);
+        test("UNHEX('4142')", &["'4142'"]);
+        test("UNHEX('476C756553514C')", &["'476C756553514C'"]);
         test("INITCAP(id)", &["id"]);
         test(r#"UPPER("Hello")"#, &[r#""Hello""#]);
         test("SIN(3.14)", &["3.14"]);

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -553,6 +553,11 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
 
             Ok(Expr::Function(Box::new(Function::AddMonth { expr, size })))
         }
+        "UNHEX" => {
+            check_len(name, args.len(), 1)?;
+            let expr = translate_expr(args[0])?;
+            Ok(Expr::Function(Box::new(Function::Unhex(expr))))
+        }
         "ASCII" => {
             check_len(name, args.len(), 1)?;
 

--- a/test-suite/src/function.rs
+++ b/test-suite/src/function.rs
@@ -57,5 +57,6 @@ pub mod substr;
 pub mod take;
 pub mod to_date;
 pub mod trim;
+pub mod unhex;
 pub mod upper_lower;
 pub mod values;

--- a/test-suite/src/function/unhex.rs
+++ b/test-suite/src/function/unhex.rs
@@ -1,0 +1,90 @@
+use {
+    crate::*,
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
+};
+
+test_case!(unhex, {
+    let g = get_tester!();
+
+    let test_cases = [
+        (
+            "SELECT UNHEX('476C756553514C') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "GlueSQL".to_string()
+            )),
+        ),
+        (
+            "SELECT UNHEX('FF') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                {
+                    let bytes = vec![0xFF];
+                    String::from_utf8_lossy(&bytes).to_string()
+                }
+            )),
+        ),
+        (
+            "SELECT UNHEX('48656C6C6F') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "Hello".to_string()
+            )),
+        ),
+        (
+            "SELECT UNHEX('0x414243') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "ABC".to_string()
+            )),
+        ),
+        (
+            "SELECT UNHEX(NULL) AS unhex",
+            Ok(select_with_null!(unhex; Null)),
+        ),
+        (
+            "SELECT UNHEX('00') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "\0".to_string()
+            )),
+        ),
+        (
+            "SELECT UNHEX() AS unhex",
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "UNHEX".to_owned(),
+                expected: 1,
+                found: 0,
+            }
+            .into()),
+        ),
+        (
+            "SELECT UNHEX([1, 2, 3]) AS unhex",
+            Err(EvaluateError::FunctionRequiresStringValue("UNHEX".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX(TRUE) AS unhex",
+            Err(EvaluateError::FunctionRequiresStringValue("UNHEX".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX(FALSE) AS unhex",
+            Err(EvaluateError::FunctionRequiresStringValue("UNHEX".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX('INVALID') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("INVALID".to_owned()).into()),
+        ),
+    ];
+
+    for (sql, expected) in test_cases {
+        g.test(sql, expected).await;
+    }
+});

--- a/test-suite/src/function/unhex.rs
+++ b/test-suite/src/function/unhex.rs
@@ -46,6 +46,22 @@ test_case!(unhex, {
             )),
         ),
         (
+            "SELECT UNHEX('0X414243') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "ABC".to_string()
+            )),
+        ),
+        (
+            "SELECT UNHEX('4a4B') AS unhex",
+            Ok(select!(
+                unhex
+                Str;
+                "JK".to_string()
+            )),
+        ),
+        (
             "SELECT UNHEX(NULL) AS unhex",
             Ok(select_with_null!(unhex; Null)),
         ),
@@ -65,6 +81,10 @@ test_case!(unhex, {
                 found: 0,
             }
             .into()),
+        ),
+        (
+            "SELECT UNHEX('A') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("A".to_owned()).into()),
         ),
         (
             "SELECT UNHEX([1, 2, 3]) AS unhex",

--- a/test-suite/src/function/unhex.rs
+++ b/test-suite/src/function/unhex.rs
@@ -14,51 +14,144 @@ test_case!(unhex, {
             "SELECT UNHEX('476C756553514C') AS unhex",
             Ok(select!(
                 unhex
-                Str;
-                "GlueSQL".to_string()
-            )),
-        ),
-        (
-            "SELECT UNHEX('FF') AS unhex",
-            Ok(select!(
-                unhex
-                Str;
-                {
-                    let bytes = vec![0xFF];
-                    String::from_utf8_lossy(&bytes).to_string()
-                }
+                Bytea;
+                vec![0x47, 0x6C, 0x75, 0x65, 0x53, 0x51, 0x4C]
             )),
         ),
         (
             "SELECT UNHEX('48656C6C6F') AS unhex",
             Ok(select!(
                 unhex
-                Str;
-                "Hello".to_string()
+                Bytea;
+                vec![0x48, 0x65, 0x6C, 0x6C, 0x6F]
+            )),
+        ),
+        (
+            "SELECT UNHEX('FF') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0xFF]
+            )),
+        ),
+        (
+            "SELECT UNHEX('FF00FF') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0xFF, 0x00, 0xFF]
             )),
         ),
         (
             "SELECT UNHEX('0x414243') AS unhex",
             Ok(select!(
                 unhex
-                Str;
-                "ABC".to_string()
+                Bytea;
+                vec![0x41, 0x42, 0x43]
             )),
         ),
         (
             "SELECT UNHEX('0X414243') AS unhex",
             Ok(select!(
                 unhex
-                Str;
-                "ABC".to_string()
+                Bytea;
+                vec![0x41, 0x42, 0x43]
             )),
         ),
         (
             "SELECT UNHEX('4a4B') AS unhex",
             Ok(select!(
                 unhex
-                Str;
-                "JK".to_string()
+                Bytea;
+                vec![0x4A, 0x4B]
+            )),
+        ),
+        (
+            "SELECT UNHEX('4a4B4c') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x4A, 0x4B, 0x4C]
+            )),
+        ),
+        (
+            "SELECT UNHEX('deadBEEF') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0xDE, 0xAD, 0xBE, 0xEF]
+            )),
+        ),
+        (
+            "SELECT UNHEX('A') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x0A]
+            )),
+        ),
+        (
+            "SELECT UNHEX('ABC') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x0A, 0xBC]
+            )),
+        ),
+        (
+            "SELECT UNHEX('0xA') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x0A]
+            )),
+        ),
+        (
+            "SELECT UNHEX('12345') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x01, 0x23, 0x45]
+            )),
+        ),
+        (
+            "SELECT UNHEX('00') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x00]
+            )),
+        ),
+        (
+            "SELECT UNHEX('000000') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![0x00, 0x00, 0x00]
+            )),
+        ),
+        (
+            "SELECT UNHEX('') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![]
+            )),
+        ),
+        (
+            "SELECT UNHEX('0x') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![]
+            )),
+        ),
+        (
+            "SELECT UNHEX('0X') AS unhex",
+            Ok(select!(
+                unhex
+                Bytea;
+                vec![]
             )),
         ),
         (
@@ -66,12 +159,24 @@ test_case!(unhex, {
             Ok(select_with_null!(unhex; Null)),
         ),
         (
-            "SELECT UNHEX('00') AS unhex",
-            Ok(select!(
-                unhex
-                Str;
-                "\0".to_string()
-            )),
+            "SELECT UNHEX('GH') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("GH".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX('INVALID') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("INVALID".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX('41 42') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("41 42".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX('41-42-43') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("41-42-43".to_owned()).into()),
+        ),
+        (
+            "SELECT UNHEX('0xGH') AS unhex",
+            Err(EvaluateError::InvalidHexadecimal("0xGH".to_owned()).into()),
         ),
         (
             "SELECT UNHEX() AS unhex",
@@ -83,8 +188,17 @@ test_case!(unhex, {
             .into()),
         ),
         (
-            "SELECT UNHEX('A') AS unhex",
-            Err(EvaluateError::InvalidHexadecimal("A".to_owned()).into()),
+            "SELECT UNHEX('41', '42') AS unhex",
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "UNHEX".to_owned(),
+                expected: 1,
+                found: 2,
+            }
+            .into()),
+        ),
+        (
+            "SELECT UNHEX(123) AS unhex",
+            Err(EvaluateError::FunctionRequiresStringValue("UNHEX".to_owned()).into()),
         ),
         (
             "SELECT UNHEX([1, 2, 3]) AS unhex",
@@ -97,10 +211,6 @@ test_case!(unhex, {
         (
             "SELECT UNHEX(FALSE) AS unhex",
             Err(EvaluateError::FunctionRequiresStringValue("UNHEX".to_owned()).into()),
-        ),
-        (
-            "SELECT UNHEX('INVALID') AS unhex",
-            Err(EvaluateError::InvalidHexadecimal("INVALID".to_owned()).into()),
         ),
     ];
 

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -154,6 +154,7 @@ macro_rules! generate_store_tests {
         glue!(function_sign, function::sign::sign);
         glue!(function_skip, function::skip::skip);
         glue!(function_to_date, function::to_date::to_date);
+        glue!(function_unhex, function::unhex::unhex);
         glue!(function_ascii, function::ascii::ascii);
         glue!(function_chr, function::chr::chr);
         glue!(function_mod, function::md5::md5);


### PR DESCRIPTION
## Add UNHEX function implementation

### Summary
Implements the `UNHEX` function that converts hexadecimal strings to their binary representation.

### Changes
- Added `UNHEX` function to convert hex strings to binary data
- Added `InvalidHexadecimal` error type for invalid hex input
- Supports optional `0x`/`0X` prefix handling
- Uses `String::from_utf8_lossy` for safe UTF-8 conversion
- Added comprehensive test cases covering valid/invalid inputs

### Examples
```sql
SELECT UNHEX('476C756553514C'); -- Returns "GlueSQL"
SELECT UNHEX('0x414243');       -- Returns "ABC"
SELECT UNHEX('FF');             -- Returns byte 255 as string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UNHEX function: accepts a string hex value (optionally 0x/0X-prefixed) and returns binary bytes.

* **Bug Fixes**
  * Clearer errors for invalid hexadecimal input and when a non-string argument is supplied.

* **Tests**
  * Added end-to-end tests covering valid hex (upper/lower), 0x prefix, NULL, invalid hex, wrong-argument counts, and type errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->