### PR TITLE
Fix Redis storage test connection handling

### DIFF
--- a/storages/redis-storage/tests/redis_alter_table_errors.rs
+++ b/storages/redis-storage/tests/redis_alter_table_errors.rs
@@ -49,7 +49,7 @@ async fn add_column_schemaless_row_error() {
     redis::cmd("SET")
         .arg(&key)
         .arg(value)
-        .query::<()>(&mut glue.storage.conn.borrow_mut())
+        .query::<()>(&mut *glue.storage.conn.lock().unwrap())
         .unwrap();
 
     let column_def = ColumnDef {
@@ -93,7 +93,7 @@ async fn add_column_deserialize_error() {
     redis::cmd("SET")
         .arg(&key)
         .arg("not-json")
-        .query::<()>(&mut glue.storage.conn.borrow_mut())
+        .query::<()>(&mut *glue.storage.conn.lock().unwrap())
         .unwrap();
 
     let column_def = ColumnDef {
@@ -142,7 +142,7 @@ async fn drop_column_schemaless_row_error() {
     redis::cmd("SET")
         .arg(&key)
         .arg(value)
-        .query::<()>(&mut glue.storage.conn.borrow_mut())
+        .query::<()>(&mut *glue.storage.conn.lock().unwrap())
         .unwrap();
 
     let result = glue.storage.drop_column("dummy", "foo", false).await;
@@ -177,7 +177,7 @@ async fn drop_column_deserialize_error() {
     redis::cmd("SET")
         .arg(&key)
         .arg("not-json")
-        .query::<()>(&mut glue.storage.conn.borrow_mut())
+        .query::<()>(&mut *glue.storage.conn.lock().unwrap())
         .unwrap();
 
     let result = glue.storage.drop_column("dummy", "foo", false).await;


### PR DESCRIPTION
## Summary
- fix Redis alter table tests by locking the shared connection

## Testing
- `cargo clippy --all-targets --workspace --exclude gluesql-py -- -D warnings`
- `cargo test -p gluesql-redis-storage --features test-redis`


------
https://chatgpt.com/codex/tasks/task_e_689840f7e94c832abcdea9460b1ba1b6