### PR TITLE
Add AST Builder tests of current_time, current_date, current_timestamp and generate_uuid

### DIFF
--- a/test-suite/src/ast_builder/function.rs
+++ b/test-suite/src/ast_builder/function.rs
@@ -1,4 +1,5 @@
 pub mod datetime;
 pub mod math;
 pub mod other;
+pub mod reference;
 pub mod text;

--- a/test-suite/src/ast_builder/function/reference.rs
+++ b/test-suite/src/ast_builder/function/reference.rs
@@ -1,0 +1,9 @@
+mod current_date;
+mod current_time;
+mod current_timestamp;
+mod generate_uuid;
+
+pub use {
+    current_date::current_date, current_time::current_time, current_timestamp::current_timestamp,
+    generate_uuid::generate_uuid,
+};

--- a/test-suite/src/ast_builder/function/reference/current_date.rs
+++ b/test-suite/src/ast_builder/function/reference/current_date.rs
@@ -1,0 +1,54 @@
+use {
+    crate::*,
+    gluesql_core::{
+        ast_builder::{function as f, *},
+        prelude::{Payload, Value::*},
+    },
+};
+
+test_case!(current_date, {
+    macro_rules! date {
+        ($date: expr) => {
+            $date.parse().unwrap()
+        };
+    }
+
+    let glue = get_glue!();
+
+    // create table - Record
+    let actual = table("Record")
+        .create_table()
+        .add_column("id INTEGER PRIMARY KEY")
+        .add_column("date_stamp DATE")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    assert_eq!(actual, expected, "create table - Record");
+
+    // insert into Record
+    let actual = table("Record")
+        .insert()
+        .values(vec![
+            "1, '2022-12-23'",
+            "2, CURRENT_DATE()",
+            "3, '9999-12-31'",
+        ])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(3));
+    assert_eq!(actual, expected, "insert into Record");
+
+    // Current Date
+    let actual = table("Record")
+        .select()
+        .filter(col("date_stamp").gt(f::current_date()))
+        .project("id, date_stamp")
+        .execute(glue)
+        .await;
+    let expected = Ok(select!(
+        id  | date_stamp
+        I64 | Date;
+        3     date!("9999-12-31")
+    ));
+    assert_eq!(actual, expected, "current date");
+});

--- a/test-suite/src/ast_builder/function/reference/current_time.rs
+++ b/test-suite/src/ast_builder/function/reference/current_time.rs
@@ -1,0 +1,35 @@
+use {
+    crate::*,
+    gluesql_core::{
+        ast::DataType,
+        ast_builder::{function as f, *},
+        executor::Payload,
+    },
+};
+
+test_case!(current_time, {
+    let glue = get_glue!();
+
+    // create table - Record
+    let actual = table("Record")
+        .create_table()
+        .add_column("id INTEGER PRIMARY KEY")
+        .add_column("time_stamp TIME")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    assert_eq!(actual, expected, "create table - Record");
+
+    // insert into Record
+    let actual = table("Record")
+        .insert()
+        .values(vec!["1, CURRENT_TIME()"])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(1));
+    assert_eq!(actual, expected, "insert into Record");
+
+    // check if current_time() returns a Time type
+    let actual = values(vec![vec![f::current_time()]]).execute(glue).await;
+    type_match(&[DataType::Time], actual);
+});

--- a/test-suite/src/ast_builder/function/reference/current_timestamp.rs
+++ b/test-suite/src/ast_builder/function/reference/current_timestamp.rs
@@ -1,0 +1,54 @@
+use {
+    crate::*,
+    gluesql_core::{
+        ast_builder::{function as f, *},
+        prelude::{Payload, Value::*},
+    },
+};
+
+test_case!(current_timestamp, {
+    macro_rules! t {
+        ($timestamp: expr) => {
+            $timestamp.parse().unwrap()
+        };
+    }
+
+    let glue = get_glue!();
+
+    // create table - Record
+    let actual = table("Record")
+        .create_table()
+        .add_column("id INTEGER PRIMARY KEY")
+        .add_column("time_stamp TIMESTAMP")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    assert_eq!(actual, expected, "create table - Record");
+
+    // insert into Record
+    let actual = table("Record")
+        .insert()
+        .values(vec![
+            "1, '2022-12-23T05:30:11.164932863'",
+            "2, CURRENT_TIMESTAMP()",
+            "3, '9999-12-31T23:59:40.364832862'",
+        ])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(3));
+    assert_eq!(actual, expected, "insert into Record");
+
+    // Current timestamp
+    let actual = table("Record")
+        .select()
+        .filter(col("time_stamp").gt(f::now()))
+        .project("id, time_stamp")
+        .execute(glue)
+        .await;
+    let expected = Ok(select!(
+        id  | time_stamp
+        I64 | Timestamp;
+        3     t!("9999-12-31T23:59:40.364832862")
+    ));
+    assert_eq!(actual, expected, "current timestamp");
+});

--- a/test-suite/src/ast_builder/function/reference/generate_uuid.rs
+++ b/test-suite/src/ast_builder/function/reference/generate_uuid.rs
@@ -1,0 +1,35 @@
+use {
+    crate::*,
+    gluesql_core::{
+        ast::DataType,
+        ast_builder::{function as f, *},
+        executor::Payload,
+    },
+};
+
+test_case!(generate_uuid, {
+    let glue = get_glue!();
+
+    // create table - Foo
+    let actual = table("Foo")
+        .create_table()
+        .add_column("id UUID PRIMARY KEY")
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Create);
+    assert_eq!(actual, expected, "create table - Foo");
+
+    // insert into Foo
+    let actual = table("Foo")
+        .insert()
+        .columns("id")
+        .values(vec![vec![f::generate_uuid()]])
+        .execute(glue)
+        .await;
+    let expected = Ok(Payload::Insert(1));
+    assert_eq!(actual, expected, "insert into Foo");
+
+    // check if generate_uuid() returns a Uuid type
+    let actual = values(vec![vec![f::generate_uuid()]]).execute(glue).await;
+    type_match(&[DataType::Uuid], actual);
+});

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -305,6 +305,22 @@ macro_rules! generate_store_tests {
             ast_builder::function::datetime::current_date_and_time
         );
         glue!(
+            ast_builder_function_reference_current_date,
+            ast_builder::function::reference::current_date
+        );
+        glue!(
+            ast_builder_function_reference_current_time,
+            ast_builder::function::reference::current_time
+        );
+        glue!(
+            ast_builder_function_reference_current_timestamp,
+            ast_builder::function::reference::current_timestamp
+        );
+        glue!(
+            ast_builder_function_reference_generate_uuid,
+            ast_builder::function::reference::generate_uuid
+        );
+        glue!(
             ast_builder_function_text_position_and_indexing,
             ast_builder::function::text::position_and_indexing
         );


### PR DESCRIPTION
Adding AST Builder tests of `current_time`, `current_date`, `current_timestamp` and `generate_uuid`.
Use type_match to `current_time` test.