### PR TITLE
redis-storage: handle mutex lock errors gracefully

### DIFF
--- a/storages/redis-storage/src/mutex.rs
+++ b/storages/redis-storage/src/mutex.rs
@@ -1,0 +1,15 @@
+use {
+    gluesql_core::error::{Error, Result},
+    std::sync::{Mutex, MutexGuard},
+};
+
+pub trait MutexExt<T> {
+    fn lock_err(&self) -> Result<MutexGuard<T>>;
+}
+
+impl<T> MutexExt<T> for Mutex<T> {
+    fn lock_err(&self) -> Result<MutexGuard<T>> {
+        self.lock()
+            .map_err(|e| Error::StorageMsg(format!("[RedisStorage] failed to acquire lock: {e}",)))
+    }
+}


### PR DESCRIPTION
## Summary
- add a `MutexExt` trait to return `Result` when locking the Redis connection
- replace `conn.lock().unwrap()` with `lock_err()` calls across Redis storage

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68a17e2a0a74832a8f30bb5465d7fba6