### PR TITLE
Remove unused tester run function

### DIFF
--- a/test-suite/src/tester.rs
+++ b/test-suite/src/tester.rs
@@ -18,21 +18,6 @@ pub fn expr(sql: &str) -> Expr {
     translate_expr(&parsed).unwrap()
 }
 
-pub async fn run<T: GStore + GStoreMut>(
-    sql: &str,
-    glue: &mut Glue<T>,
-    indexes: Option<Vec<IndexItem>>,
-) -> Result<Payload> {
-    println!("[SQL] {sql}");
-    let parsed = parse(sql)?;
-    let statement = translate(&parsed[0])?;
-    let statement = plan(&glue.storage, statement).await?;
-
-    test_indexes(&statement, indexes);
-
-    glue.execute_stmt(&statement).await
-}
-
 pub fn test_indexes(statement: &Statement, indexes: Option<Vec<IndexItem>>) {
     if let Some(expected) = indexes {
         let found = find_indexes(statement);


### PR DESCRIPTION
## Summary
- remove unused `run` helper from test-suite's `tester` module

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68a3e7deb8f8832aa582ff7d53c06058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified the test execution flow by consolidating parsing, translation, planning, and execution into a single internal path, removing redundant wrappers for improved maintainability and consistency.

- Tests
  - Streamlined index verification to run through a dedicated test path, aligning checks with the unified execution flow.

- Chores
  - Internal cleanup of test utilities. No user-facing changes or behavior impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->