### PR TITLE
docs: highlight opened files in collapsible sections

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -51,3 +51,13 @@ h3, h4, h5, h6 {
 footer.footer--dark {
   background-color: #2a3439;
 }
+
+/* Highlight opened files in collapsible sections */
+details > summary {
+  cursor: pointer;
+}
+
+details[open] > summary {
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}


### PR DESCRIPTION
## Summary
- highlight expanded file names in documentation collapse blocks

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68a3e8356424832a9e4f11cd0da5309e