### PR TITLE
Cover fetch_all_schemas error in MockStorage unit tests

### DIFF
--- a/core/src/mock.rs
+++ b/core/src/mock.rs
@@ -113,6 +113,7 @@ mod tests {
         assert!(block_on(storage.scan_data("Foo")).is_err());
         assert!(block_on(storage.fetch_data("Foo", &Key::None)).is_err());
         assert!(block_on(storage.fetch_schema("__Err__")).is_err());
+        assert!(block_on(storage.fetch_all_schemas()).is_err());
         assert!(block_on(storage.delete_schema("Foo")).is_err());
         assert!(block_on(storage.append_data("Foo", Vec::new())).is_err());
         assert!(block_on(storage.insert_data("Foo", Vec::new())).is_err());


### PR DESCRIPTION
## Summary
- add unit test ensuring MockStorage::fetch_all_schemas returns an error

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-core`


------
https://chatgpt.com/codex/tasks/task_e_68a4010fc30c832a886b9424f4ed80cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include error handling when requesting all schemas from mock storage in an empty state.
  * Confirms expected error behavior and strengthens coverage of edge cases.
  * Ensures consistency with current unsupported-operation behavior.
  * No changes to features, settings, UI, APIs, or performance. This update is limited to the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->