### PR TITLE
Remove unused ToSql impl for AlterTableOperation, OperateFunctionArg and Assignment

### DIFF
--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -154,12 +154,6 @@ pub enum Variable {
     Version,
 }
 
-impl ToSql for Assignment {
-    fn to_sql(&self) -> String {
-        format!(r#""{}" = {}"#, self.id, self.value.to_sql())
-    }
-}
-
 impl ToSql for ForeignKey {
     fn to_sql(&self) -> String {
         let ForeignKey {

--- a/core/src/ast/ddl.rs
+++ b/core/src/ast/ddl.rs
@@ -47,30 +47,6 @@ pub struct OperateFunctionArg {
     pub default: Option<Expr>,
 }
 
-impl ToSql for AlterTableOperation {
-    fn to_sql(&self) -> String {
-        match self {
-            AlterTableOperation::AddColumn { column_def } => {
-                format!("ADD COLUMN {}", column_def.to_sql())
-            }
-            AlterTableOperation::DropColumn {
-                column_name,
-                if_exists,
-            } => match if_exists {
-                true => format!(r#"DROP COLUMN IF EXISTS "{column_name}""#),
-                false => format!(r#"DROP COLUMN "{column_name}""#),
-            },
-            AlterTableOperation::RenameColumn {
-                old_column_name,
-                new_column_name,
-            } => format!(r#"RENAME COLUMN "{old_column_name}" TO "{new_column_name}""#),
-            AlterTableOperation::RenameTable { table_name } => {
-                format!(r#"RENAME TO "{table_name}""#)
-            }
-        }
-    }
-}
-
 impl ToSql for ColumnDef {
     fn to_sql(&self) -> String {
         let ColumnDef {
@@ -115,26 +91,9 @@ impl ToSql for ColumnUniqueOption {
     }
 }
 
-impl ToSql for OperateFunctionArg {
-    fn to_sql(&self) -> String {
-        let OperateFunctionArg {
-            name,
-            data_type,
-            default,
-        } = self;
-        let default = default
-            .as_ref()
-            .map(|expr| format!(" DEFAULT {}", expr.to_sql()))
-            .unwrap_or_else(|| "".to_owned());
-        format!(r#""{name}" {data_type}{default}"#)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::ast::{
-        AstLiteral, ColumnDef, ColumnUniqueOption, DataType, Expr, OperateFunctionArg, ToSql,
-    };
+    use crate::ast::{AstLiteral, ColumnDef, ColumnUniqueOption, DataType, Expr, ToSql};
 
     #[test]
     fn to_sql_column_def() {
@@ -212,29 +171,6 @@ mod tests {
                 default: None,
                 unique: None,
                 comment: Some("this is comment".to_owned()),
-            }
-            .to_sql()
-        );
-    }
-
-    #[test]
-    fn to_sql_operate_function_arg() {
-        assert_eq!(
-            r#""name" TEXT"#,
-            OperateFunctionArg {
-                name: "name".to_owned(),
-                data_type: DataType::Text,
-                default: None,
-            }
-            .to_sql()
-        );
-
-        assert_eq!(
-            r#""accepted" BOOLEAN DEFAULT FALSE"#,
-            OperateFunctionArg {
-                name: "accepted".to_owned(),
-                data_type: DataType::Boolean,
-                default: Some(Expr::Literal(AstLiteral::Boolean(false))),
             }
             .to_sql()
         );


### PR DESCRIPTION
## Summary
- remove unused ToSql for AlterTableOperation, OperateFunctionArg, and Assignment
- drop OperateFunctionArg to_sql test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql-core`


------
https://chatgpt.com/codex/tasks/task_e_68adbe10d4e4832a91a4c5c6a8202ed2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal SQL generation for assignments and schema changes, reducing redundancy and maintenance overhead. Behavior and outputs remain unchanged for end-users.
* **Tests**
  * Removed obsolete tests tied to deprecated logic and updated related imports. Test suite adjusted accordingly and remains green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->