### PR TITLE
Add TRUNC function

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -218,6 +218,7 @@ pub enum Function {
         values: Option<Expr>,
     },
     Dedup(Expr),
+    Trunc(Expr),
 }
 
 impl ToSql for Function {
@@ -507,6 +508,7 @@ impl ToSql for Function {
                 ),
             },
             Function::Dedup(list) => format!("DEDUP({})", list.to_sql()),
+            Function::Trunc(e) => format!("TRUNC({})", e.to_sql()),
         }
     }
 }
@@ -1468,7 +1470,15 @@ mod tests {
                 "list".to_owned()
             ))))
             .to_sql(),
-        )
+        );
+
+        assert_eq!(
+            r#"TRUNC("num")"#,
+            &Expr::Function(Box::new(Function::Trunc(Expr::Identifier(
+                "num".to_owned()
+            ))))
+            .to_sql()
+        );
     }
 
     #[test]

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -561,6 +561,7 @@ async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(
 
             f::lcm(name, left, right)
         }
+        Function::Trunc(expr) => f::trunc(name, eval(expr).await?),
 
         // --- spatial ---
         Function::Point { x, y } => {

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -458,6 +458,10 @@ pub fn exp<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
     eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.exp())))
 }
 
+pub fn trunc<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
+    eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.trunc())))
+}
+
 pub fn log<'a>(
     name: String,
     antilog: Evaluated<'_>,

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -459,7 +459,26 @@ pub fn exp<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
 }
 
 pub fn trunc<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
-    eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.trunc())))
+    let value = match n.try_into().break_if_null()? {
+        Value::I8(v) => Value::I8(v),
+        Value::I16(v) => Value::I16(v),
+        Value::I32(v) => Value::I32(v),
+        Value::I64(v) => Value::I64(v),
+        Value::I128(v) => Value::I128(v),
+        Value::U8(v) => Value::U8(v),
+        Value::U16(v) => Value::U16(v),
+        Value::U32(v) => Value::U32(v),
+        Value::U64(v) => Value::U64(v),
+        Value::U128(v) => Value::U128(v),
+        Value::Decimal(v) => Value::Decimal(v.trunc()),
+        Value::F32(v) => Value::F32(v.trunc()),
+        Value::F64(v) => Value::F64(v.trunc()),
+        _ => {
+            return Err(EvaluateError::FunctionRequiresFloatValue(name).into()).into_control_flow();
+        }
+    };
+
+    Continue(Evaluated::Value(value))
 }
 
 pub fn log<'a>(

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -474,7 +474,8 @@ pub fn trunc<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
         Value::F32(v) => Value::F32(v.trunc()),
         Value::F64(v) => Value::F64(v.trunc()),
         _ => {
-            return Err(EvaluateError::FunctionRequiresFloatValue(name).into()).into_control_flow();
+            return Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(name).into())
+                .into_control_flow();
         }
     };
 

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -69,6 +69,7 @@ impl Function {
             | Self::Dedup(expr)
             | Self::Entries(expr)
             | Self::Keys(expr)
+            | Self::Trunc(expr)
             | Self::Values(expr) => Exprs::Single([expr].into_iter()),
             Self::Left { expr, size: expr2 }
             | Self::Right { expr, size: expr2 }
@@ -304,6 +305,7 @@ mod tests {
         test(r#"SIGN(-3.0)"#, &["-3.0"]);
 
         test(r#"DEDUP(list)"#, &["list"]);
+        test(r#"TRUNC(42.8)"#, &["42.8"]);
 
         // Double
         test(r#"LEFT("hello", 2)"#, &[r#""hello""#, "2"]);

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -714,6 +714,11 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             let list = translate_expr(args[0])?;
             Ok(Expr::Function(Box::new(Function::Dedup(list))))
         }
+        "TRUNC" => {
+            check_len(name, args.len(), 1)?;
+            let expr = translate_expr(args[0])?;
+            Ok(Expr::Function(Box::new(Function::Trunc(expr))))
+        }
         _ => {
             let exprs = args
                 .into_iter()

--- a/test-suite/src/function.rs
+++ b/test-suite/src/function.rs
@@ -57,5 +57,6 @@ pub mod substr;
 pub mod take;
 pub mod to_date;
 pub mod trim;
+pub mod trunc;
 pub mod upper_lower;
 pub mod values;

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -1,25 +1,32 @@
-use {
-    crate::*,
-    gluesql_core::{
-        error::{EvaluateError, TranslateError},
-        prelude::Value::*,
-    },
-};
+use {crate::*, gluesql_core::prelude::Value::*};
 
 test_case!(trunc, {
     let g = get_tester!();
 
-    let test_cases = [(
-        "SELECT
+    let test_cases = [
+        (
+            "SELECT
                 TRUNC(-42.8) AS trunc1,
                 TRUNC(42.8) AS trunc2
             ;",
-        Ok(select!(
-            "trunc1" | "trunc2";
-            F64 | F64;
-            -42.0 42.0
-        )),
-    )];
+            Ok(select!(
+                "trunc1" | "trunc2";
+                F64 | F64;
+                -42.0 42.0
+            )),
+        ),
+        (
+            "SELECT
+                TRUNC(-42) AS trunc1,
+                TRUNC(42) AS trunc2
+            ;",
+            Ok(select!(
+                "trunc1" | "trunc2";
+                I64 | I64;
+                -42 42
+            )),
+        ),
+    ];
 
     for (sql, expected) in test_cases {
         g.test(sql, expected).await;

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -1,0 +1,27 @@
+use {
+    crate::*,
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
+};
+
+test_case!(trunc, {
+    let g = get_tester!();
+
+    let test_cases = [(
+        "SELECT
+                TRUNC(-42.8) AS trunc1,
+                TRUNC(42.8) AS trunc2
+            ;",
+        Ok(select!(
+            "trunc1" | "trunc2";
+            F64 | F64;
+            -42.0 42.0
+        )),
+    )];
+
+    for (sql, expected) in test_cases {
+        g.test(sql, expected).await;
+    }
+});

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -4,6 +4,7 @@ use {
         error::{EvaluateError, TranslateError},
         prelude::Value::*,
     },
+    rust_decimal::prelude::Decimal as D,
 };
 
 test_case!(trunc, {
@@ -33,6 +34,20 @@ test_case!(trunc, {
             "trunc1" | "trunc2";
             I64 | I64;
             -42 42
+        )),
+    )
+    .await;
+
+    g.named_test(
+        "truncate decimals",
+        "SELECT
+                TRUNC(CAST('-42.8' AS DECIMAL)) AS trunc1,
+                TRUNC(CAST('42.8' AS DECIMAL)) AS trunc2
+            ;",
+        Ok(select!(
+            "trunc1" | "trunc2";
+            Decimal | Decimal;
+            D::new(-42, 0) D::new(42, 0)
         )),
     )
     .await;

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -1,4 +1,10 @@
-use {crate::*, gluesql_core::prelude::Value::*};
+use {
+    crate::*,
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
+};
 
 test_case!(trunc, {
     let g = get_tester!();
@@ -25,6 +31,31 @@ test_case!(trunc, {
                 I64 | I64;
                 -42 42
             )),
+        ),
+        (
+            "SELECT TRUNC('string') AS trunc;",
+            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC(TRUE) AS trunc;",
+            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC(FALSE) AS trunc;",
+            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC(NULL) AS trunc;",
+            Ok(select_with_null!(trunc; Null)),
+        ),
+        (
+            "SELECT TRUNC('string', 'string2') AS trunc;",
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "TRUNC".to_owned(),
+                expected: 1,
+                found: 2,
+            }
+            .into()),
         ),
     ];
 

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -9,57 +9,71 @@ use {
 test_case!(trunc, {
     let g = get_tester!();
 
-    let test_cases = [
-        (
-            "SELECT
+    g.named_test(
+        "truncate floats",
+        "SELECT
                 TRUNC(-42.8) AS trunc1,
                 TRUNC(42.8) AS trunc2
             ;",
-            Ok(select!(
-                "trunc1" | "trunc2";
-                F64 | F64;
-                -42.0 42.0
-            )),
-        ),
-        (
-            "SELECT
+        Ok(select!(
+            "trunc1" | "trunc2";
+            F64 | F64;
+            -42.0 42.0
+        )),
+    )
+    .await;
+
+    g.named_test(
+        "truncate integers",
+        "SELECT
                 TRUNC(-42) AS trunc1,
                 TRUNC(42) AS trunc2
             ;",
-            Ok(select!(
-                "trunc1" | "trunc2";
-                I64 | I64;
-                -42 42
-            )),
-        ),
-        (
-            "SELECT TRUNC('string') AS trunc;",
-            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC(TRUE) AS trunc;",
-            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC(FALSE) AS trunc;",
-            Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC(NULL) AS trunc;",
-            Ok(select_with_null!(trunc; Null)),
-        ),
-        (
-            "SELECT TRUNC('string', 'string2') AS trunc;",
-            Err(TranslateError::FunctionArgsLengthNotMatching {
-                name: "TRUNC".to_owned(),
-                expected: 1,
-                found: 2,
-            }
-            .into()),
-        ),
-    ];
+        Ok(select!(
+            "trunc1" | "trunc2";
+            I64 | I64;
+            -42 42
+        )),
+    )
+    .await;
 
-    for (sql, expected) in test_cases {
-        g.test(sql, expected).await;
-    }
+    g.named_test(
+        "error on string",
+        "SELECT TRUNC('string') AS trunc;",
+        Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+    )
+    .await;
+
+    g.named_test(
+        "error on TRUE",
+        "SELECT TRUNC(TRUE) AS trunc;",
+        Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+    )
+    .await;
+
+    g.named_test(
+        "error on FALSE",
+        "SELECT TRUNC(FALSE) AS trunc;",
+        Err(EvaluateError::FunctionRequiresFloatOrIntegerValue(String::from("TRUNC")).into()),
+    )
+    .await;
+
+    g.named_test(
+        "null input",
+        "SELECT TRUNC(NULL) AS trunc;",
+        Ok(select_with_null!(trunc; Null)),
+    )
+    .await;
+
+    g.named_test(
+        "error on too many args",
+        "SELECT TRUNC('string', 'string2') AS trunc;",
+        Err(TranslateError::FunctionArgsLengthNotMatching {
+            name: "TRUNC".to_owned(),
+            expected: 1,
+            found: 2,
+        }
+        .into()),
+    )
+    .await;
 });

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -174,6 +174,7 @@ macro_rules! generate_store_tests {
         glue!(function_values, function::values::values);
         glue!(function_nullif, function::nullif::nullif);
         glue!(function_hex, function::hex::hex);
+        glue!(function_trunc, function::trunc::trunc);
         glue!(join, join::join);
         glue!(join_project, join::project);
         glue!(migrate, migrate::migrate);


### PR DESCRIPTION
## Summary
Implement `TRUNC(expr)` to truncate numeric expressions toward zero. The function supports `float`, `integer`, and `decimal` inputs.

## Implementation Details
- Added TRUNC(expr) function to the ast, translate, plan, and executor.
- Implemented truncate logic that removes the fractional part (truncation toward zero).
- The function is type‑preserving: it returns the same type as the input expression (F64 → F64, I64 → I64, Decimal → Decimal), with no implicit coercion. 
- Added dedicated tests for TRUNC, covering float, integer, and decimal cases.

## Usage Examples
```sql
SELECT TRUNC(3.14); -- 3
SELECT TRUNC(-3.14); -- -3
SELECT TRUNC(42); -- 42
SELECT TRUNC(CAST('42.8' AS DECIMAL)) -- 42.0
```

## Notes
- ast_builder is not implemented in this PR.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TRUNC function for SQL queries to truncate numeric values to their integer component.
  * Supports integers, floats, and decimals; returns the same type with fractional part removed.
  * Propagates NULL inputs.
  * Enforces a single-argument signature and returns clear errors for non-numeric types or wrong argument counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->