### PR TITLE
Fix coverage workflow to use PR head commit

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr-commit || github.sha }}
       - run: rustup component add llvm-tools-preview
       - run: cargo install grcov
       - name: clean


### PR DESCRIPTION
## Summary
- ensure coverage workflow checks out PR head commit when invoked via workflow_call

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b3d774acd4832a8e8423aaafdbae51