### PR TITLE
Update coverage.yml to run on GitHub-hosted runner

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,10 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v4
+      - name: Configure git user
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
       - run: rustup component add llvm-tools-preview
       - run: cargo install grcov
       - name: clean

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,16 @@ env:
 
 jobs:
   coverage:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add llvm-tools-preview
@@ -23,11 +32,9 @@ jobs:
       - name: clean
         run: |
           cargo clean
-          rm -rf ./target/debug/deps/gluesql*
-          rm *.profraw && rm **/*.profraw
-          cd storages/csv-storage && rm -rf ./tmp && cd ../..
-          cd storages/json-storage && rm -rf ./tmp && cd ../..
-          redis-cli flushall
+          find . -name '*.profraw' -delete
+          rm -rf storages/csv-storage/tmp
+          rm -rf storages/json-storage/tmp
       - name: build
         env:
           RUSTFLAGS: -Cinstrument-coverage


### PR DESCRIPTION
## Summary
- run coverage workflow on GitHub-hosted runners
- spin up Redis and MongoDB services for tests
- simplify cleanup for ephemeral environments

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68b3e2650198832a8e3e717212413b09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Chores
  - CI switched to a standard Ubuntu runner for improved stability.
  - Added Redis and MongoDB services to CI for integration testing.
  - CI now configures a global git user for pipeline steps.
  - Streamlined cleanup to remove profiling files and temporary storage directories; removed explicit Redis flush.

- Tests
  - Build, test, and coverage upload flow preserved.

- Bug Fixes
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->