### PR TITLE
ci: configure git user for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,10 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v4
+      - name: Configure git user
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
       - run: rustup component add llvm-tools-preview
       - run: cargo install grcov
       - name: clean


### PR DESCRIPTION
## Summary
- configure global git user for coverage workflow to avoid identity errors
- revert test-based git configuration

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql-git-storage command_ext::tests::test_command_ext`

------
https://chatgpt.com/codex/tasks/task_e_68b3eacaa7fc832aa5355f6b71bafffc