### PR TITLE
Add coverage report artifact upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     services:
       redis:
         image: redis
@@ -75,3 +78,10 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compress coverage report
+        run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ env.BRANCH_NAME }}-${{ env.COMMIT_SHA }}
+          path: coverage/lcov.info.xz


### PR DESCRIPTION
## Summary
- set `BRANCH_NAME` and `COMMIT_SHA` env vars in coverage workflow
- compress coverage report and upload as artifact

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql-core --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68b3fb773728832ab93771090ab74f22