### PR TITLE
Publish coverage report to gluesql.org/coverage

### DIFF
--- a/.github/workflows/coverage-publish.yml
+++ b/.github/workflows/coverage-publish.yml
@@ -1,0 +1,65 @@
+name: Publish Coverage
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types: [completed]
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.repository == 'gluesql/gluesql'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+      COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+    steps:
+      - name: Configure git user
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
+      - name: Sanitize branch name
+        run: echo "SANITIZED_BRANCH_NAME=${BRANCH_NAME//\//-}" >> $GITHUB_ENV
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ env.SANITIZED_BRANCH_NAME }}-${{ env.COMMIT_SHA }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+      - name: Publish coverage to gluesql.github.io
+        run: |
+          git clone https://github.com/gluesql/gluesql.github.io.git
+          cd gluesql.github.io
+          git checkout gh-pages
+          mkdir -p coverage/pr/${PR_NUMBER}
+          cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
+          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+      - name: Comment coverage link on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            const encodedTimestamp = process.env.TIMESTAMP.replace(/:/g, '%3A');
+            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${encodedTimestamp}.${process.env.COMMIT_SHA}.lcov.info.xz`;
+            const body = [
+              '### Coverage Report',
+              '',
+              `- **Commit:** \`${process.env.COMMIT_SHA}\``,
+              `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
+              `- **Report:** [View report](${url})`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,9 @@ env:
 
 jobs:
   coverage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -87,7 +90,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh repo clone gluesql/gluesql.github.io
+          git clone https://github.com/gluesql/gluesql.github.io.git
           cd gluesql.github.io
           git checkout gh-pages
           mkdir -p coverage/pr/${PR_NUMBER}
@@ -97,18 +100,29 @@ jobs:
           git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
       - name: Comment coverage link on PR
         if: github.repository == 'gluesql/gluesql' && github.event_name == 'pull_request'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ENCODED_TIMESTAMP=${TIMESTAMP//:/%3A}
-          URL="https://gluesql.org/coverage/?path=pr/$PR_NUMBER/$ENCODED_TIMESTAMP.${COMMIT_SHA}.lcov.info.xz"
-          MESSAGE="### Coverage Report\n\n- **Commit:** \`$COMMIT_SHA\`\n- **Timestamp:** \`$TIMESTAMP\`\n- **Report:** [View report]($URL)"
-          gh pr comment "$PR_NUMBER" --body "$MESSAGE"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const encodedTimestamp = process.env.TIMESTAMP.replace(/:/g, '%3A');
+            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${encodedTimestamp}.${process.env.COMMIT_SHA}.lcov.info.xz`;
+            const body = [
+              '### Coverage Report',
+              '',
+              `- **Commit:** \`${process.env.COMMIT_SHA}\``,
+              `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
+              `- **Report:** [View report](${url})`
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
       - name: Publish coverage to gluesql.github.io
         if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          gh repo clone gluesql/gluesql.github.io
+          git clone https://github.com/gluesql/gluesql.github.io.git
           cd gluesql.github.io
           git checkout gh-pages
           mkdir -p coverage/main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,6 +80,42 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compress coverage report
         run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+      - name: Publish PR coverage to gluesql.github.io
+        if: github.repository == 'gluesql/gluesql' && github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh repo clone gluesql/gluesql.github.io
+          cd gluesql.github.io
+          git checkout gh-pages
+          mkdir -p coverage/pr/${PR_NUMBER}
+          cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
+          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+      - name: Comment coverage link on PR
+        if: github.repository == 'gluesql/gluesql' && github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ENCODED_TIMESTAMP=${TIMESTAMP//:/%3A}
+          URL="https://gluesql.org/coverage/?path=pr/$PR_NUMBER/$ENCODED_TIMESTAMP.${COMMIT_SHA}.lcov.info.xz"
+          MESSAGE="### Coverage Report\n\n- **Commit:** \`$COMMIT_SHA\`\n- **Timestamp:** \`$TIMESTAMP\`\n- **Report:** [View report]($URL)"
+          gh pr comment "$PR_NUMBER" --body "$MESSAGE"
+      - name: Publish coverage to gluesql.github.io
+        if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          gh repo clone gluesql/gluesql.github.io
+          cd gluesql.github.io
+          git checkout gh-pages
+          mkdir -p coverage/main
+          cp ../coverage/lcov.info.xz coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git add coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          git commit -m "Coverage: main@${COMMIT_SHA}"
+          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
       - name: Sanitize branch name
         run: echo "SANITIZED_BRANCH_NAME=${BRANCH_NAME//\//-}" >> $GITHUB_ENV
       - name: Upload coverage artifact

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,9 +15,6 @@ env:
 
 jobs:
   coverage:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,9 +94,10 @@ jobs:
           git commit -m "Coverage: main@${COMMIT_SHA}"
           git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
       - name: Sanitize branch name
-        run: echo "SANITIZED_BRANCH_NAME=${BRANCH_NAME//\//-}" >> $GITHUB_ENV
+        id: sanitize
+        run: echo "value=${BRANCH_NAME//\//-}" >> $GITHUB_OUTPUT
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ env.SANITIZED_BRANCH_NAME }}-${{ env.COMMIT_SHA }}
+          name: coverage-${{ steps.sanitize.outputs.value }}-${{ env.COMMIT_SHA }}
           path: coverage/lcov.info.xz

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,40 +85,6 @@ jobs:
         run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-      - name: Publish PR coverage to gluesql.github.io
-        if: github.repository == 'gluesql/gluesql' && github.event_name == 'pull_request'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          git clone https://github.com/gluesql/gluesql.github.io.git
-          cd gluesql.github.io
-          git checkout gh-pages
-          mkdir -p coverage/pr/${PR_NUMBER}
-          cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
-          git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
-          git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
-          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
-      - name: Comment coverage link on PR
-        if: github.repository == 'gluesql/gluesql' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const encodedTimestamp = process.env.TIMESTAMP.replace(/:/g, '%3A');
-            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${encodedTimestamp}.${process.env.COMMIT_SHA}.lcov.info.xz`;
-            const body = [
-              '### Coverage Report',
-              '',
-              `- **Commit:** \`${process.env.COMMIT_SHA}\``,
-              `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
-              `- **Report:** [View report](${url})`
-            ].join('\n');
-            await github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
       - name: Publish coverage to gluesql.github.io
         if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Compress coverage report
         run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
       - name: Set timestamp
-        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io
         if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -32,7 +32,7 @@ jobs:
           name: coverage-${{ env.SANITIZED_BRANCH_NAME }}-${{ env.COMMIT_SHA }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Set timestamp
-        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io
         run: |
           git clone https://github.com/gluesql/gluesql.github.io.git
@@ -48,8 +48,7 @@ jobs:
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;
-            const encodedTimestamp = process.env.TIMESTAMP.replace(/:/g, '%3A');
-            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${encodedTimestamp}.${process.env.COMMIT_SHA}.lcov.info.xz`;
+            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
             const body = [
               '### Coverage Report',
               '',

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -41,6 +41,7 @@ jobs:
           git clone https://github.com/gluesql/gluesql.github.io.git
           cd gluesql.github.io
           git checkout gh-pages
+          git pull --rebase origin gh-pages
           mkdir -p coverage/pr/${PR_NUMBER}
           cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           name: coverage-${{ steps.sanitize.outputs.value }}-${{ env.COMMIT_SHA }}
           run-id: ${{ github.event.workflow_run.id }}
-          if-no-files-found: error
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -13,8 +13,9 @@ jobs:
       github.repository == 'gluesql/gluesql'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      actions: read
+      contents: read
+      issues: write
     env:
       BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
       COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -25,12 +26,14 @@ jobs:
           git config --global user.email "ci@example.com"
           git config --global user.name "CI"
       - name: Sanitize branch name
-        run: echo "SANITIZED_BRANCH_NAME=${BRANCH_NAME//\//-}" >> $GITHUB_ENV
+        id: sanitize
+        run: echo "value=${BRANCH_NAME//\//-}" >> $GITHUB_OUTPUT
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ env.SANITIZED_BRANCH_NAME }}-${{ env.COMMIT_SHA }}
+          name: coverage-${{ steps.sanitize.outputs.value }}-${{ env.COMMIT_SHA }}
           run-id: ${{ github.event.workflow_run.id }}
+          if-no-files-found: error
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io


### PR DESCRIPTION
## Summary
- publish coverage reports to `gluesql.github.io`
- comment coverage link on pull requests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --manifest-path core/Cargo.toml --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8e6742c832a82961918b8822433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Automated publishing of code coverage reports to the project website for main branches and pull requests, storing timestamped artifacts for traceability.
  - Adds pull request comments with direct links to the corresponding coverage reports, showing commit and timestamp details.
  - Improves artifact naming with sanitized branch identifiers and uses secure repository credentials for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->