### PR TITLE
Rename coverage publish workflow and simplify timestamp

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -32,7 +32,7 @@ jobs:
           name: coverage-${{ env.SANITIZED_BRANCH_NAME }}-${{ env.COMMIT_SHA }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Set timestamp
-        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+        run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io
         run: |
           git clone https://github.com/gluesql/gluesql.github.io.git
@@ -48,8 +48,7 @@ jobs:
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;
-            const encodedTimestamp = process.env.TIMESTAMP.replace(/:/g, '%3A');
-            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${encodedTimestamp}.${process.env.COMMIT_SHA}.lcov.info.xz`;
+            const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
             const body = [
               '### Coverage Report',
               '',


### PR DESCRIPTION
## Summary
- rename coverage-publish.yml to publish-coverage.yml for naming consistency
- remove colons from timestamp and drop URL-encoding step

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace --lib`


------
https://chatgpt.com/codex/tasks/task_e_68bbd15c1398832a87d9fb5754f53499