### PR TITLE
chore: remove permissions block from coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,9 +15,6 @@ env:
 
 jobs:
   coverage:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- remove explicit permissions block from coverage workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace --lib`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd7f849c832a99c0c061d225b44f