### PR TITLE
Use evaluated values for GROUP BY keys

### DIFF
--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ast::{Aggregate, AggregateFunction, CountArgExpr, DataType},
-        data::{Key, Value},
+        data::Value,
         executor::{
             context::RowContext,
             evaluate::{EvaluateError, evaluate},
@@ -15,7 +15,7 @@ use {
     utils::{IndexMap, Vector},
 };
 
-type Group = Arc<Vec<Key>>;
+type Group = Arc<Vec<Value>>;
 type ValuesMap<'a> = HashMap<&'a Aggregate, Value>;
 type Context<'a> = Arc<RowContext<'a>>;
 
@@ -406,14 +406,14 @@ impl<'a, T: GStore> State<'a, T> {
         State {
             storage,
             index: 0,
-            group: Arc::new(vec![Key::None]),
+            group: Arc::new(vec![Value::Null]),
             values: IndexMap::new(),
             groups: HashSet::new(),
             contexts: Vector::new(),
         }
     }
 
-    pub fn apply(self, index: usize, group: Vec<Key>, context: Arc<RowContext<'a>>) -> Self {
+    pub fn apply(self, index: usize, group: Vec<Value>, context: Arc<RowContext<'a>>) -> Self {
         let group = Arc::new(group);
         let (groups, contexts) = if self.groups.contains(&group) {
             (self.groups, self.contexts)

--- a/test-suite/src/data_type/list.rs
+++ b/test-suite/src/data_type/list.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        error::{KeyError, ValueError},
+        error::ValueError,
         prelude::Value::{self, *},
     },
 };
@@ -135,7 +135,7 @@ INSERT INTO ListType2 VALUES
 
     g.test(
         r#"SELECT id FROM ListType GROUP BY items"#,
-        Err(KeyError::ListTypeKeyNotSupported.into()),
+        Ok(select!(id; I64; 1; 2; 3)),
     )
     .await;
     g.test(

--- a/test-suite/src/data_type/map.rs
+++ b/test-suite/src/data_type/map.rs
@@ -1,7 +1,7 @@
 use {
     crate::*,
     gluesql_core::{
-        error::{EvaluateError, KeyError, ValueError},
+        error::{EvaluateError, ValueError},
         prelude::Value::{self, *},
     },
 };
@@ -153,7 +153,7 @@ INSERT INTO MapType2 VALUES
     .await;
     g.test(
         "SELECT id FROM MapType GROUP BY nested",
-        Err(KeyError::MapTypeKeyNotSupported.into()),
+        Ok(select!(id; I64; 1; 2; 3)),
     )
     .await;
     g.test(


### PR DESCRIPTION
## Summary
- group rows by evaluated values instead of AST keys
- allow MAP and LIST columns in GROUP BY by storing Values
- adjust tests for MAP/LIST grouping

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql_memory_storage map`
- `cargo test -p gluesql_memory_storage list`
- `cargo test -p gluesql_memory_storage group_by`


------
https://chatgpt.com/codex/tasks/task_e_68bbf893b130832ab6bb99744709ea58