### PR TITLE
ci: simplify coverage artifact naming

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -93,11 +93,8 @@ jobs:
           git add coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git commit -m "Coverage: main@${COMMIT_SHA}"
           git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
-      - name: Sanitize branch name
-        id: sanitize
-        run: echo "value=${BRANCH_NAME//\//-}" >> $GITHUB_OUTPUT
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ steps.sanitize.outputs.value }}-${{ env.COMMIT_SHA }}
+          name: coverage
           path: coverage/lcov.info.xz

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -25,14 +25,12 @@ jobs:
         run: |
           git config --global user.email "ci@example.com"
           git config --global user.name "CI"
-      - name: Sanitize branch name
-        id: sanitize
-        run: echo "value=${BRANCH_NAME//\//-}" >> $GITHUB_OUTPUT
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ steps.sanitize.outputs.value }}-${{ env.COMMIT_SHA }}
+          name: coverage
           run-id: ${{ github.event.workflow_run.id }}
+          path: .
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io


### PR DESCRIPTION
- Upload artifact as 'coverage' in coverage.yml
- Download by name in publish-coverage.yml using run-id

This removes fragile branch/commit-based naming mismatches and stabilizes the Publish Coverage workflow.