### PR TITLE
feat(utils): support no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,3 +131,13 @@ jobs:
           cargo run --package gluesql --example sled_multi_threaded
           cargo run --package gluesql --example using_config
           cargo run --package gluesql --example hello_ast_builder
+
+  utils_no_std:
+    name: Utils no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cd utils
+          cargo check --verbose --no-default-features

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,6 +9,15 @@ repository.workspace = true
 documentation.workspace = true
 
 [dependencies]
-indexmap = "1"
+indexmap = { version = "1", default-features = false }
 pin-project = "1"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+
+[features]
+default = ["std"]
+std = [
+    "futures/std",
+    "futures/async-await",
+    "futures/executor",
+    "indexmap/std",
+]

--- a/utils/src/indexmap.rs
+++ b/utils/src/indexmap.rs
@@ -1,6 +1,6 @@
 use {
+    core::hash::Hash,
     indexmap::map::{IntoIter, Keys},
-    std::{cmp::Eq, hash::Hash},
 };
 
 /// HashMap which provides

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,12 +1,16 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(clippy::str_to_string)]
 
+extern crate alloc;
+
+#[cfg(feature = "std")]
 mod hashmap;
 mod indexmap;
 mod or_stream;
 mod tribool;
 mod vector;
 
-pub use {
-    self::indexmap::IndexMap, hashmap::HashMapExt, or_stream::OrStream, tribool::Tribool,
-    vector::Vector,
-};
+pub use {self::indexmap::IndexMap, or_stream::OrStream, tribool::Tribool, vector::Vector};
+
+#[cfg(feature = "std")]
+pub use hashmap::HashMapExt;

--- a/utils/src/tribool.rs
+++ b/utils/src/tribool.rs
@@ -19,7 +19,7 @@ impl Tribool {
     }
 }
 
-impl std::ops::Not for Tribool {
+impl core::ops::Not for Tribool {
     type Output = Self;
 
     fn not(self) -> Self::Output {

--- a/utils/src/vector.rs
+++ b/utils/src/vector.rs
@@ -1,4 +1,5 @@
-use std::{convert::From, vec::IntoIter};
+use alloc::{vec, vec::IntoIter, vec::Vec};
+use core::{cmp::Ordering, iter::FromIterator};
 
 pub struct Vector<T>(Vec<T>);
 
@@ -33,7 +34,7 @@ impl<T> Vector<T> {
 
     pub fn sort(mut self) -> Self
     where
-        T: std::cmp::Ord,
+        T: core::cmp::Ord,
     {
         self.0.sort();
 
@@ -42,7 +43,7 @@ impl<T> Vector<T> {
 
     pub fn sort_by<F>(mut self, compare: F) -> Self
     where
-        F: FnMut(&T, &T) -> std::cmp::Ordering,
+        F: FnMut(&T, &T) -> Ordering,
     {
         self.0.sort_by(compare);
 


### PR DESCRIPTION
## Summary
- add `no_std` support for gluesql-utils with an optional `std` feature
- adjust utils modules to use `core`/`alloc` and gate std-specific hashmap extension
- run utils' no_std build in CI to guard against regressions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql-utils`
- `cargo check -p gluesql-utils --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_68bd2fa99df8832abf062c5fdf7f22c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added no_std compatibility for the utils crate with alloc support.
  - Introduced an explicit std feature (enabled by default) to toggle std-dependent functionality.
  - Vector, IndexMap, and Tribool now operate on core/alloc, preserving behavior while broadening platform support.
  - HashMapExt is available only when the std feature is enabled.

- Chores
  - Added a CI job to validate no_std builds, improving reliability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->