### PR TITLE
ci: enable workflow_dispatch for publish-coverage (manual test)

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -4,31 +4,64 @@ on:
   workflow_run:
     workflows: ["Coverage"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of the triggering Coverage workflow"
+        required: true
+        type: string
+      pr_number:
+        description: "Pull Request number"
+        required: true
+        type: string
+      commit_sha:
+        description: "Head commit SHA for the PR run"
+        required: true
+        type: string
+      artifact_name:
+        description: "Artifact name to download (default: coverage)"
+        required: false
+        default: coverage
+        type: string
 
 jobs:
   publish:
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.repository == 'gluesql/gluesql'
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.repository == 'gluesql/gluesql'
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       issues: write
-    env:
-      COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
       - name: Configure git user
         run: |
           git config --global user.email "ci@example.com"
           git config --global user.name "CI"
+      - name: Set variables for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "RUN_ID=${{ inputs.run_id }}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${{ inputs.commit_sha }}" >> $GITHUB_ENV
+          echo "PR_NUMBER=${{ inputs.pr_number }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ inputs.artifact_name }}" >> $GITHUB_ENV
+      - name: Set variables for workflow_run
+        if: github.event_name == 'workflow_run'
+        run: |
+          echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+          echo "PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=coverage" >> $GITHUB_ENV
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
-          name: coverage
-          run-id: ${{ github.event.workflow_run.id }}
+          name: ${{ env.ARTIFACT_NAME }}
+          run-id: ${{ env.RUN_ID }}
           path: .
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV


### PR DESCRIPTION
Add workflow_dispatch inputs to publish-coverage to allow manual testing:
- run_id: Coverage workflow run ID to fetch artifact from
- pr_number: Target PR number for publishing and commenting
- commit_sha: Head commit SHA for the PR run
- artifact_name: defaults to 'coverage'

Job condition updated to run for workflow_dispatch as well. This helps verify whether download failures are due to timing by letting us trigger later.