### PR TITLE
Fix publish-coverage action - artifact download & PR comment

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -62,19 +62,9 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME }}
           run-id: ${{ env.RUN_ID }}
-          path: .
+          path: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Normalize downloaded artifact path
-        run: |
-          set -euo pipefail
-          # Expect the artifact to extract to ./coverage/lcov.info.xz
-          if [ -f ./coverage/lcov.info.xz ]; then
-            echo "Found ./coverage/lcov.info.xz"
-          else
-            echo "coverage/lcov.info.xz not found after download"
-            find . -maxdepth 3 -type f -name lcov.info.xz -print | sed 's/^/FOUND: /' || true
-            exit 1
-          fi
+      # No normalization needed: file will be at ./coverage/lcov.info.xz
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -70,16 +70,14 @@ jobs:
           mkdir -p coverage
           if [ -f "./coverage/lcov.info.xz" ]; then
             echo "Found ./coverage/lcov.info.xz"
+          elif [ -f "./coverage/coverage/lcov.info.xz" ]; then
+            echo "Found ./coverage/coverage/lcov.info.xz; moving to ./coverage/lcov.info.xz"
+            mv ./coverage/coverage/lcov.info.xz ./coverage/lcov.info.xz
+            rmdir ./coverage/coverage || true
           else
-            found=$(find . -maxdepth 3 -type f -name lcov.info.xz | head -n1 || true)
-            if [ -n "$found" ]; then
-              echo "Moving $found -> ./coverage/lcov.info.xz"
-              mv "$found" ./coverage/lcov.info.xz
-            else
-              echo "lcov.info.xz not found after download"
-              find . -maxdepth 3 -type f | sed 's/^/FILE: /'
-              exit 1
-            fi
+            echo "lcov.info.xz not found at expected locations"
+            find . -maxdepth 3 -type f -name lcov.info.xz -print | sed 's/^/FOUND: /' || true
+            exit 1
           fi
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -37,7 +37,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
     steps:
       - name: Configure git user
         run: |

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -67,18 +67,12 @@ jobs:
       - name: Normalize downloaded artifact path
         run: |
           set -euo pipefail
-          mkdir -p coverage
-          if [ -f "./coverage/lcov.info.xz" ]; then
-            echo "Found ./coverage/lcov.info.xz"
-          elif [ -f "./coverage/coverage/lcov.info.xz" ]; then
-            echo "Found ./coverage/coverage/lcov.info.xz; moving to ./coverage/lcov.info.xz"
-            mv ./coverage/coverage/lcov.info.xz ./coverage/lcov.info.xz
-            rmdir ./coverage/coverage || true
-          else
-            echo "lcov.info.xz not found at expected locations"
-            find . -maxdepth 3 -type f -name lcov.info.xz -print | sed 's/^/FOUND: /' || true
-            exit 1
-          fi
+          # Expected location after download-artifact@v4 with path: .
+          # The artifact contains coverage/lcov.info.xz and is placed under an
+          # artifact-name directory (coverage), resulting in coverage/coverage/lcov.info.xz
+          test -f ./coverage/coverage/lcov.info.xz
+          mv ./coverage/coverage/lcov.info.xz ./coverage/lcov.info.xz
+          rmdir ./coverage/coverage || true
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -67,12 +67,14 @@ jobs:
       - name: Normalize downloaded artifact path
         run: |
           set -euo pipefail
-          # Expected location after download-artifact@v4 with path: .
-          # The artifact contains coverage/lcov.info.xz and is placed under an
-          # artifact-name directory (coverage), resulting in coverage/coverage/lcov.info.xz
-          test -f ./coverage/coverage/lcov.info.xz
-          mv ./coverage/coverage/lcov.info.xz ./coverage/lcov.info.xz
-          rmdir ./coverage/coverage || true
+          # Expect the artifact to extract to ./coverage/lcov.info.xz
+          if [ -f ./coverage/lcov.info.xz ]; then
+            echo "Found ./coverage/lcov.info.xz"
+          else
+            echo "coverage/lcov.info.xz not found after download"
+            find . -maxdepth 3 -type f -name lcov.info.xz -print | sed 's/^/FOUND: /' || true
+            exit 1
+          fi
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -63,6 +63,24 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           run-id: ${{ env.RUN_ID }}
           path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Normalize downloaded artifact path
+        run: |
+          set -euo pipefail
+          mkdir -p coverage
+          if [ -f "./coverage/lcov.info.xz" ]; then
+            echo "Found ./coverage/lcov.info.xz"
+          else
+            found=$(find . -maxdepth 3 -type f -name lcov.info.xz | head -n1 || true)
+            if [ -n "$found" ]; then
+              echo "Moving $found -> ./coverage/lcov.info.xz"
+              mv "$found" ./coverage/lcov.info.xz
+            else
+              echo "lcov.info.xz not found after download"
+              find . -maxdepth 3 -type f | sed 's/^/FILE: /'
+              exit 1
+            fi
+          fi
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Publish coverage to gluesql.github.io
@@ -79,6 +97,7 @@ jobs:
       - name: Comment coverage link on PR
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GLUESQL_ORG }}
           script: |
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;


### PR DESCRIPTION
Summary
- Download coverage artifact by run-id with explicit github-token (v4 requirement across runs)
- Extract to path=coverage so file is at ./coverage/lcov.info.xz deterministically
- Use PAT (secrets.GLUESQL_ORG) for commenting on PR to avoid GITHUB_TOKEN write limitations in some contexts
- Keep workflow_dispatch for manual testing (run_id/pr_number/commit_sha/artifact_name)

Why
- Fixes intermittent/consistent failures where artifact existed but actions/download-artifact@v4 could not fetch by name without token
- Removes path ambiguity that caused cp to fail
- Ensures comment step works reliably regardless of workflow permission settings

Notes
- No code changes to Rust; CI-only update
- Manual verification done on a dedicated branch; this PR contains the minimal, cleaned changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the code coverage publishing workflow by tightening permissions and adding proper authentication.
  * Corrected artifact handling so coverage reports are reliably retrieved and linked in pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->