### PR TITLE
Use NEW_GLUESQL_ORG PAT for coverage publish/comment

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,7 +91,7 @@ jobs:
           cp ../coverage/lcov.info.xz coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git add coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git commit -m "Coverage: main@${COMMIT_SHA}"
-          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+          git push https://panarch:${{ secrets.NEW_GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -76,11 +76,11 @@ jobs:
           cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
-          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+          git push https://panarch:${{ secrets.NEW_GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
       - name: Comment coverage link on PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GLUESQL_ORG }}
+          github-token: ${{ secrets.NEW_GLUESQL_ORG }}
           script: |
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;


### PR DESCRIPTION
Switch coverage-related workflows to use the new fine‑grained PAT secret :
- publish-coverage.yml: push to gluesql.github.io and PR comment use NEW_GLUESQL_ORG
- coverage.yml (main push path): publish to gluesql.github.io uses NEW_GLUESQL_ORG

No behavior change beyond secret name; existing logic unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration used by the coverage publishing workflow to ensure continued delivery of coverage reports.
  * Adjusted the token used for posting coverage links on pull requests to maintain reliable PR comments.
  * No changes to how coverage artifacts are built, stored, or displayed.
  * No user-facing behavior changes; coverage reports and PR comments will continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->