### PR TITLE
ci: switch coverage publish/comment to GitHub App token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,6 +81,14 @@ jobs:
         run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
+      - name: Create GitHub App token
+        if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COVERAGE_APP_ID }}
+          installation-id: ${{ secrets.COVERAGE_APP_INSTALLATION_ID }}
+          private-key: ${{ secrets.COVERAGE_APP_PRIVATE_KEY }}
       - name: Publish coverage to gluesql.github.io
         if: github.repository == 'gluesql/gluesql' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
@@ -91,7 +99,7 @@ jobs:
           cp ../coverage/lcov.info.xz coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git add coverage/main/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git commit -m "Coverage: main@${COMMIT_SHA}"
-          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+          git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/gluesql/gluesql.github.io.git
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -42,6 +42,13 @@ jobs:
         run: |
           git config --global user.email "ci@example.com"
           git config --global user.name "CI"
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COVERAGE_APP_ID }}
+          installation-id: ${{ secrets.COVERAGE_APP_INSTALLATION_ID }}
+          private-key: ${{ secrets.COVERAGE_APP_PRIVATE_KEY }}
       - name: Set variables for workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -76,11 +83,11 @@ jobs:
           cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
           git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
-          git push https://panarch:${{ secrets.GLUESQL_ORG }}@github.com/gluesql/gluesql.github.io.git
+          git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/gluesql/gluesql.github.io.git
       - name: Comment coverage link on PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GLUESQL_ORG }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;


### PR DESCRIPTION
Use a GitHub App installation token for coverage publishing and PR comments.

Changes
- publish-coverage.yml: generate token via actions/create-github-app-token and use it for
  - pushing to gluesql.github.io (x-access-token URL)
  - commenting on the PR (github-script with app token)
- coverage.yml (main push): generate token and use it to push coverage to gluesql.github.io

Prereqs
- Secrets set in repo: COVERAGE_APP_ID, COVERAGE_APP_INSTALLATION_ID, COVERAGE_APP_PRIVATE_KEY

Behavior
- Keeps artifact download using GITHUB_TOKEN (actions: read)
- No change to artifact naming or paths

This removes reliance on personal tokens and adopts least-privilege app tokens.