### PR TITLE
Bump redis crate to v0.32 in RedisStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,16 +2799,17 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.3"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+checksum = "7cd3650deebc68526b304898b192fa4102a4ef0b9ada24da096559cb60e0eef8"
 dependencies = [
  "combine",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.6.0",
  "url",
 ]
 
@@ -3383,6 +3384,16 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/storages/redis-storage/Cargo.toml
+++ b/storages/redis-storage/Cargo.toml
@@ -15,7 +15,7 @@ documentation.workspace = true
 gluesql-core.workspace = true
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
-redis = "0.23.3"
+redis = "0.32"
 serde_json = "1.0.105"
 chrono = { version = "0.4.31", features = ["serde", "wasmbind"] }
 futures = "0.3"


### PR DESCRIPTION
## Summary
- update redis crate to 0.32

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-redis-storage`


------
https://chatgpt.com/codex/tasks/task_e_68be8748bcb0832ab1d3130d915eadba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the Redis client dependency to the latest major version. This brings improved compatibility with newer Redis servers, includes security and stability updates, and may offer minor performance enhancements. No functional or behavioral changes are expected for end-users, and no configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->