### PR TITLE
chore(core): bump sqlparser dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
 dependencies = [
  "bigdecimal",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ iter-enum = "1"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlparser = { version = "0.52", features = ["serde", "bigdecimal"] }
+sqlparser = { version = "0.53", features = ["serde", "bigdecimal"] }
 thiserror = "1.0"
 strum_macros = "0.25"
 bigdecimal = { version = "0.4.1", features = ["serde", "string-only"] }

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -23,12 +23,13 @@ use {
     ddl::translate_alter_table_operation,
     sqlparser::ast::{
         Assignment as SqlAssignment, AssignmentTarget as SqlAssignmentTarget,
-        CommentDef as SqlCommentDef, CreateFunctionBody as SqlCreateFunctionBody,
-        CreateIndex as SqlCreateIndex, CreateTable as SqlCreateTable, Delete as SqlDelete,
-        FromTable as SqlFromTable, Ident as SqlIdent, Insert as SqlInsert,
-        ObjectName as SqlObjectName, ObjectType as SqlObjectType,
-        ReferentialAction as SqlReferentialAction, Statement as SqlStatement,
-        TableConstraint as SqlTableConstraint, TableFactor, TableWithJoins,
+        CommentDef as SqlCommentDef, CreateFunction as SqlCreateFunction,
+        CreateFunctionBody as SqlCreateFunctionBody, CreateIndex as SqlCreateIndex,
+        CreateTable as SqlCreateTable, Delete as SqlDelete, FromTable as SqlFromTable,
+        Ident as SqlIdent, Insert as SqlInsert, ObjectName as SqlObjectName,
+        ObjectType as SqlObjectType, ReferentialAction as SqlReferentialAction, ShowStatementIn,
+        ShowStatementOptions, Statement as SqlStatement, TableConstraint as SqlTableConstraint,
+        TableFactor, TableWithJoins,
     },
 };
 
@@ -227,9 +228,19 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
         SqlStatement::Commit { .. } => Ok(Statement::Commit),
         SqlStatement::Rollback { .. } => Ok(Statement::Rollback),
         SqlStatement::ShowTables {
-            filter: None,
-            db_name: None,
-            ..
+            terse: false,
+            history: false,
+            extended: false,
+            full: false,
+            external: false,
+            show_options:
+                ShowStatementOptions {
+                    show_in: None,
+                    starts_with: None,
+                    limit: None,
+                    limit_from: None,
+                    filter_position: None,
+                },
         } => Ok(Statement::ShowVariable(Variable::Tables)),
         SqlStatement::ShowFunctions { filter: None } => {
             Ok(Statement::ShowVariable(Variable::Functions))
@@ -256,16 +267,31 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
                 TranslateError::UnsupportedShowVariableStatement(sql_statement.to_string()).into(),
             ),
         },
-        SqlStatement::ShowColumns { table_name, .. } => Ok(Statement::ShowColumns {
+        SqlStatement::ShowColumns {
+            extended: false,
+            full: false,
+            show_options:
+                ShowStatementOptions {
+                    show_in:
+                        Some(ShowStatementIn {
+                            parent_name: Some(table_name),
+                            ..
+                        }),
+                    starts_with: None,
+                    limit: None,
+                    limit_from: None,
+                    filter_position: None,
+                },
+        } => Ok(Statement::ShowColumns {
             table_name: translate_object_name(table_name)?,
         }),
-        SqlStatement::CreateFunction {
+        SqlStatement::CreateFunction(SqlCreateFunction {
             or_replace,
             name,
             args,
             function_body: Some(SqlCreateFunctionBody::Return(return_)),
             ..
-        } => {
+        }) => {
             let args = args
                 .as_ref()
                 .map(|args| {
@@ -281,9 +307,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
                 return_: translate_expr(return_)?,
             })
         }
-        SqlStatement::CreateFunction { .. } => {
-            Err(TranslateError::UnsupportedEmptyFunctionBody.into())
-        }
+        SqlStatement::CreateFunction(_) => Err(TranslateError::UnsupportedEmptyFunctionBody.into()),
         _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
     }
 }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -213,7 +213,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let function_arg_exprs = args
         .iter()
         .map(|arg| match arg {
-            SqlFunctionArg::Named { .. } => {
+            SqlFunctionArg::Named { .. } | SqlFunctionArg::ExprNamed { .. } => {
                 Err(TranslateError::NamedFunctionArgNotSupported.into())
             }
             SqlFunctionArg::Unnamed(arg_expr) => Ok(arg_expr),


### PR DESCRIPTION
## Summary
- bump `sqlparser` crate to 0.53
- adjust translation logic for updated sqlparser AST

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-core`


------
https://chatgpt.com/codex/tasks/task_e_68be879d2408832aac2d0889b859d5a9