### PR TITLE
fix(redb-storage): avoid blocking in async

### DIFF
--- a/storages/redb-storage/Cargo.toml
+++ b/storages/redb-storage/Cargo.toml
@@ -12,6 +12,7 @@ documentation.workspace = true
 gluesql-core.workspace = true
 redb = "2.6"
 async-trait = "0.1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 thiserror = "2.0.3"
@@ -21,4 +22,4 @@ async-stream = "0.3.6"
 
 [dev-dependencies]
 test-suite.workspace = true
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/storages/redb-storage/src/core.rs
+++ b/storages/redb-storage/src/core.rs
@@ -169,7 +169,7 @@ impl StorageCore {
 
 // StoreMut
 impl StorageCore {
-    pub async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
+    pub fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         let data_def = self.data_table_def(&schema.table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(SCHEMA_TABLE)?;
@@ -180,7 +180,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
+    pub fn delete_schema(&mut self, table_name: &str) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(SCHEMA_TABLE)?;
@@ -190,7 +190,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
+    pub fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;
@@ -206,7 +206,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
+    pub fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;
@@ -221,7 +221,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
+    pub fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;


### PR DESCRIPTION
## Summary
- prevent runtime blocking by wrapping redb operations in `run_blocking`
- add tokio multi-thread runtime dependency
- make redb core mutators synchronous

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p gluesql-redb-storage`


------
https://chatgpt.com/codex/tasks/task_e_68c00934bdb8832aa920181f0b3bd818