### PR TITLE
Reduce disk usage in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,31 +29,49 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space (pre-build)
+        continue-on-error: true
+        run: |
+          echo "Freeing disk space..."
+          echo "Disk before:"
+          df -h
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          if command -v docker >/dev/null 2>&1; then
+            timeout 60 docker image prune -af || true
+          fi
+          echo "Disk after:"
+          df -h
       - name: Configure git user
         run: |
           git config --global user.email "ci@example.com"
           git config --global user.name "CI"
       - run: rustup component add llvm-tools-preview
-      - run: cargo install grcov
-      - name: clean
+      - name: Install grcov (prebuilt)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: grcov@0.10.5
+      - name: Prepare coverage dirs
         run: |
-          cargo clean
-          find . -name '*.profraw' -delete
-          rm -rf storages/csv-storage/tmp
-          rm -rf storages/json-storage/tmp
-      - name: build
-        env:
-          RUSTFLAGS: -Cinstrument-coverage
-        run: cargo build --verbose
+          mkdir -p coverage/profraw
       - name: test
         env:
           RUSTFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: gluesql-%p-%m.profraw
+          LLVM_PROFILE_FILE: coverage/profraw/%p-%m.profraw
           GIT_REMOTE: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         run: GIT_REMOTE=$GIT_REMOTE cargo test --all-features --verbose
+      - name: Merge coverage profiles and free space
+        run: |
+          echo "Merging coverage profiles..."
+          LLVM_BIN=$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's|host: ||p')/bin
+          "$LLVM_BIN/llvm-profdata" merge -sparse coverage/profraw/*.profraw -o coverage/merged.profdata
+          echo "Removing incremental build artifacts to free space..."
+          rm -rf target/debug/incremental || true
+          echo "Removing Cargo registry/git caches to free space..."
+          rm -rf ~/.cargo/registry ~/.cargo/git || true
       - name: Run grcov
         run: |
-          mkdir coverage
           grcov . \
             --binary-path ./target/debug/ \
             -s . \
@@ -65,6 +83,11 @@ jobs:
             --ignore "cli/src/{cli,helper,lib,main}.rs" \
             --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)|(^test_case\!\([\d\w]+,)" \
             -o ./coverage/lcov.info
+      - name: Cleanup raw and merged profiles
+        if: always()
+        run: |
+          rm -f coverage/profraw/*.profraw || true
+          rm -f coverage/merged.profdata || true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -78,7 +101,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compress coverage report
-        run: xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
+        run: |
+          xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
+          rm -f coverage/lcov.info
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Create GitHub App token


### PR DESCRIPTION
This PR isolates coverage.yml changes from the feature work, so it can be reviewed and merged independently. It focuses on reducing runner disk usage and making the coverage job more reliable on GitHub-hosted runners.

What it does
- Free disk space before build: remove Android, .NET, GHC; prune Docker images (60s timeout). Print disk usage before/after.
- Use prebuilt grcov via taiki-e/install-action to avoid cargo install overhead.
- Write profraw files to coverage/profraw and merge with llvm-profdata into coverage/merged.profdata.
- Reduce disk usage: remove target/debug/incremental and Cargo registry/git caches after merging profiles.
- Cleanup intermediates: delete *.profraw and merged.profdata after generating LCOV.
- Compress LCOV to lcov.info.xz and remove the plain lcov.info.

What stays the same
- Coverage scope, grcov flags (source root, branches, ignore patterns), and Codecov upload remain unchanged.

Why
- Prevent intermittent "No space left on device" errors and speed up the job by avoiding unnecessary installs and keeping artifacts small.

Next steps
- it blocks https://github.com/gluesql/gluesql/pull/1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI disk usage during coverage jobs with pre/post checks and cleanups.
  * Switched to a prebuilt coverage tool for faster, consistent generation.
  * Streamlined coverage directories and file paths.
  * Merged raw profiles into a single artifact before report creation.
  * Compressed the final coverage report and removed temporary files.
  * Updated upload steps to align with the new coverage layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->