### PR TITLE
Remove async from redb storage core

### DIFF
--- a/storages/redb-storage/src/core.rs
+++ b/storages/redb-storage/src/core.rs
@@ -169,7 +169,7 @@ impl StorageCore {
 
 // StoreMut
 impl StorageCore {
-    pub async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
+    pub fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         let data_def = self.data_table_def(&schema.table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(SCHEMA_TABLE)?;
@@ -180,7 +180,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
+    pub fn delete_schema(&mut self, table_name: &str) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(SCHEMA_TABLE)?;
@@ -190,7 +190,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
+    pub fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;
@@ -206,7 +206,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
+    pub fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;
@@ -221,7 +221,7 @@ impl StorageCore {
         Ok(())
     }
 
-    pub async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
+    pub fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
         let table_def = self.data_table_def(table_name)?;
         let txn = self.txn_mut()?;
         let mut table = txn.open_table(table_def)?;

--- a/storages/redb-storage/src/lib.rs
+++ b/storages/redb-storage/src/lib.rs
@@ -52,32 +52,23 @@ impl Store for RedbStorage {
 #[async_trait]
 impl StoreMut for RedbStorage {
     async fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
-        self.0.insert_schema(schema).await.map_err(Into::into)
+        self.0.insert_schema(schema).map_err(Into::into)
     }
 
     async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
-        self.0.delete_schema(table_name).await.map_err(Into::into)
+        self.0.delete_schema(table_name).map_err(Into::into)
     }
 
     async fn append_data(&mut self, table_name: &str, rows: Vec<DataRow>) -> Result<()> {
-        self.0
-            .append_data(table_name, rows)
-            .await
-            .map_err(Into::into)
+        self.0.append_data(table_name, rows).map_err(Into::into)
     }
 
     async fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, DataRow)>) -> Result<()> {
-        self.0
-            .insert_data(table_name, rows)
-            .await
-            .map_err(Into::into)
+        self.0.insert_data(table_name, rows).map_err(Into::into)
     }
 
     async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
-        self.0
-            .delete_data(table_name, keys)
-            .await
-            .map_err(Into::into)
+        self.0.delete_data(table_name, keys).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove unnecessary async from redb storage core
- streamline RedbStorage store mut impl

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-redb-storage`


------
https://chatgpt.com/codex/tasks/task_e_68c387bbc5e8832a8ccebe1bbeb83923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined storage operations by switching select tasks from asynchronous to synchronous execution, simplifying the code path and reducing overhead.
  - Expected improvements in responsiveness and resource usage under common workloads, with no change to observable behavior or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->