### PR TITLE
Update existing PR coverage comment instead of creating new one

### DIFF
--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -100,11 +100,15 @@ jobs:
               `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
               `- **Report:** [View report](${url})`
             ].join('\n');
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
             const comment = comments.find(c => c.body.startsWith('### Coverage Report'));
             if (comment) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -100,9 +100,24 @@ jobs:
               `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
               `- **Report:** [View report](${url})`
             ].join('\n');
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: prNumber,
               owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
+              repo: context.repo.repo
             });
+            const comment = comments.find(c => c.body.startsWith('### Coverage Report'));
+            if (comment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -94,7 +94,7 @@ jobs:
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
             const body = [
-              '### Coverage Report',
+              '### GlueSQL Coverage Report',
               '',
               `- **Commit:** \`${process.env.COMMIT_SHA}\``,
               `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
@@ -109,7 +109,7 @@ jobs:
                 per_page: 100,
               },
             );
-            const comment = comments.find(c => c.body.startsWith('### Coverage Report'));
+            const comment = comments.find(c => c.body.startsWith('### GlueSQL Coverage Report'));
             if (comment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- update publish-coverage workflow to update existing coverage comment

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c646fa8284832a8851bb14004551ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now updates a single "GlueSQL Coverage Report" comment on pull requests instead of posting duplicates, keeping PR discussions cleaner and providing one consistently updated coverage summary per PR. The comment preserves commit, timestamp, and report link so contributors always see the latest coverage info. No impact on application behavior for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->