### PR TITLE
Add TRUNC function support

### DIFF
--- a/core/src/ast/function.rs
+++ b/core/src/ast/function.rs
@@ -67,6 +67,7 @@ pub enum Function {
     },
     Rand(Option<Expr>),
     Round(Expr),
+    Trunc(Expr),
     Floor(Expr),
     Trim {
         expr: Expr,
@@ -302,6 +303,7 @@ impl ToSql for Function {
                 None => "RAND()".to_owned(),
             },
             Function::Round(e) => format!("ROUND({})", e.to_sql()),
+            Function::Trunc(e) => format!("TRUNC({})", e.to_sql()),
             Function::Floor(e) => format!("FLOOR({})", e.to_sql()),
             Function::Trim {
                 expr,
@@ -846,6 +848,14 @@ mod tests {
         assert_eq!(
             r#"ROUND("num")"#,
             &Expr::Function(Box::new(Function::Round(Expr::Identifier(
+                "num".to_owned()
+            ))))
+            .to_sql()
+        );
+
+        assert_eq!(
+            r#"TRUNC("num")"#,
+            &Expr::Function(Box::new(Function::Trunc(Expr::Identifier(
                 "num".to_owned()
             ))))
             .to_sql()

--- a/core/src/ast_builder/expr/function.rs
+++ b/core/src/ast_builder/expr/function.rs
@@ -19,6 +19,7 @@ pub enum FunctionNode<'a> {
     Ceil(ExprNode<'a>),
     Rand(Option<ExprNode<'a>>),
     Round(ExprNode<'a>),
+    Trunc(ExprNode<'a>),
     Floor(ExprNode<'a>),
     Asin(ExprNode<'a>),
     Acos(ExprNode<'a>),
@@ -201,6 +202,7 @@ impl<'a> TryFrom<FunctionNode<'a>> for Function {
                 expr_node.map(TryInto::try_into).transpose()?,
             )),
             FunctionNode::Round(expr_node) => expr_node.try_into().map(Function::Round),
+            FunctionNode::Trunc(expr_node) => expr_node.try_into().map(Function::Trunc),
             FunctionNode::Floor(expr_node) => expr_node.try_into().map(Function::Floor),
             FunctionNode::Asin(expr_node) => expr_node.try_into().map(Function::Asin),
             FunctionNode::Acos(expr_node) => expr_node.try_into().map(Function::Acos),
@@ -434,6 +436,9 @@ impl<'a> ExprNode<'a> {
     pub fn round(self) -> ExprNode<'a> {
         round(self)
     }
+    pub fn trunc(self) -> ExprNode<'a> {
+        trunc(self)
+    }
     pub fn floor(self) -> ExprNode<'a> {
         floor(self)
     }
@@ -620,6 +625,9 @@ pub fn rand(expr: Option<ExprNode>) -> ExprNode {
 }
 pub fn round<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
     ExprNode::Function(Box::new(FunctionNode::Round(expr.into())))
+}
+pub fn trunc<'a, T: Into<ExprNode<'a>>>(expr: T) -> ExprNode<'a> {
+    ExprNode::Function(Box::new(FunctionNode::Trunc(expr.into())))
 }
 pub fn coalesce<'a, T: Into<ExprList<'a>>>(expr: T) -> ExprNode<'a> {
     ExprNode::Function(Box::new(FunctionNode::Coalesce(expr.into())))
@@ -1086,6 +1094,17 @@ mod tests {
 
         let actual = expr("base - 10").round();
         let expected = "ROUND(base - 10)";
+        test_expr(actual, expected);
+    }
+
+    #[test]
+    fn function_trunc() {
+        let actual = f::trunc(col("num"));
+        let expected = "trunc(num)";
+        test_expr(actual, expected);
+
+        let actual = expr("base - 10").trunc();
+        let expected = "TRUNC(base - 10)";
         test_expr(actual, expected);
     }
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -515,6 +515,7 @@ async fn evaluate_function<'a, 'b: 'a, 'c: 'a, T: GStore>(
             f::rand(name, expr)
         }
         Function::Round(expr) => f::round(name, eval(expr).await?),
+        Function::Trunc(expr) => f::trunc(name, eval(expr).await?),
         Function::Floor(expr) => f::floor(name, eval(expr).await?),
         Function::Radians(expr) => f::radians(name, eval(expr).await?),
         Function::Degrees(expr) => f::degrees(name, eval(expr).await?),

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -442,6 +442,10 @@ pub fn round<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
     eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.round())))
 }
 
+pub fn trunc<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
+    eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.trunc())))
+}
+
 pub fn floor<'a>(name: String, n: Evaluated<'_>) -> ControlFlow<Evaluated<'a>> {
     eval_to_float(&name, n).map(|n| Evaluated::Value(Value::F64(n.floor())))
 }

--- a/core/src/plan/expr/function.rs
+++ b/core/src/plan/expr/function.rs
@@ -39,6 +39,7 @@ impl Function {
             | Self::Ceil(expr)
             | Self::Rand(Some(expr))
             | Self::Round(expr)
+            | Self::Trunc(expr)
             | Self::Floor(expr)
             | Self::Exp(expr)
             | Self::Ln(expr)
@@ -273,6 +274,7 @@ mod tests {
         test("CEIL(1.23)", &["1.23"]);
         test("Rand(1.23)", &["1.23"]);
         test("ROUND(1.23)", &["1.23"]);
+        test("TRUNC(1.23)", &["1.23"]);
         test("FLOOR(1.23)", &["1.23"]);
         test("EXP(1.23)", &["1.23"]);
         test("LN(col + 1)", &["col + 1"]);

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -381,6 +381,7 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             Ok(Expr::Function(Box::new(Function::Rand(v))))
         }
         "ROUND" => translate_function_one_arg(Function::Round, args, name),
+        "TRUNC" => translate_function_one_arg(Function::Trunc, args, name),
         "EXP" => translate_function_one_arg(Function::Exp, args, name),
         "LN" => translate_function_one_arg(Function::Ln, args, name),
         "LOG" => {

--- a/docs/docs/sql-syntax/functions/math/trunc.md
+++ b/docs/docs/sql-syntax/functions/math/trunc.md
@@ -1,0 +1,61 @@
+# TRUNC
+
+The `TRUNC` function is used to truncate a number towards zero, removing the fractional part without rounding. It takes a single floating-point or integer value as its argument and returns a floating-point value.
+
+## Syntax
+
+```sql
+TRUNC(value)
+```
+
+## Examples
+
+Let's consider a table named `SingleItem` with the following schema:
+
+```sql
+CREATE TABLE SingleItem (id INTEGER);
+```
+
+Insert a row into the `SingleItem` table:
+
+```sql
+INSERT INTO SingleItem VALUES (0);
+```
+
+### Example 1: Using TRUNC function
+
+```sql
+SELECT TRUNC(0.3) AS trunc1, TRUNC(-0.8) AS trunc2, TRUNC(10) AS trunc3, TRUNC(6.87421) AS trunc4 FROM SingleItem;
+```
+
+Result:
+
+```
+trunc1 | trunc2 | trunc3 | trunc4
+-------+--------+--------+--------
+   0.0 |    0.0 |   10.0 |    6.0
+```
+
+Note that the returned values are floating-point numbers, even though they represent integer values. The `TRUNC` function truncates towards zero, which means:
+- For positive numbers: removes the decimal part (6.87421 → 6.0)
+- For negative numbers: truncates towards zero (-0.8 → 0.0, -1.8 → -1.0)
+
+## Errors
+
+The `TRUNC` function expects a floating-point or integer value as its argument. Providing any other type, such as a string or boolean, will result in an error.
+
+### Example 2: Using TRUNC with a string argument
+
+```sql
+SELECT TRUNC('string') AS trunc FROM SingleItem;
+```
+
+Error: Function requires a floating-point or integer value.
+
+### Example 3: Using TRUNC with a boolean argument
+
+```sql
+SELECT TRUNC(TRUE) AS trunc FROM SingleItem;
+```
+
+Error: Function requires a floating-point or integer value.

--- a/test-suite/src/ast_builder/function/math/rounding.rs
+++ b/test-suite/src/ast_builder/function/math/rounding.rs
@@ -82,4 +82,22 @@ test_case!(rounding, {
         4     7.0                   7.0
     ));
     assert_eq!(actual, expected, "round");
+
+    //trunc
+    let actual = table("Number")
+        .select()
+        .project("id")
+        .project(f::trunc("number"))
+        .project(col("number").trunc())
+        .execute(glue)
+        .await;
+    let expected = Ok(select!(
+        id  | "TRUNC(\"number\")" | "TRUNC(\"number\")"
+        I64 | F64                 | F64;
+        1     0.0                   0.0;
+        2     0.0                   0.0;
+        3     10.0                  10.0;
+        4     6.0                   6.0
+    ));
+    assert_eq!(actual, expected, "trunc");
 });

--- a/test-suite/src/function.rs
+++ b/test-suite/src/function.rs
@@ -57,5 +57,6 @@ pub mod substr;
 pub mod take;
 pub mod to_date;
 pub mod trim;
+pub mod trunc;
 pub mod upper_lower;
 pub mod values;

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -1,56 +1,64 @@
 use {
     crate::*,
-    gluesql_core::{
-        error::{EvaluateError, TranslateError},
-        prelude::Value::*,
-    },
+    gluesql_core::{executor::EvaluateError, prelude::Value::*},
 };
 
 test_case!(trunc, {
     let g = get_tester!();
 
-    let test_cases = [
-        (
-            "SELECT
-                TRUNC(0.3) AS trunc1,
-                TRUNC(-0.8) AS trunc2,
-                TRUNC(10) AS trunc3,
-                TRUNC(6.87421) AS trunc4
-            ;",
-            Ok(select!(
-                trunc1 | trunc2 | trunc3 | trunc4
-                F64    | F64    | F64    | F64;
-                0.0      0.0      10.0     6.0
-            )),
-        ),
-        (
-            "SELECT TRUNC('string') AS trunc",
-            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC(NULL) AS trunc",
-            Ok(select_with_null!(trunc; Null)),
-        ),
-        (
-            "SELECT TRUNC(TRUE) AS trunc",
-            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC(FALSE) AS trunc",
-            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
-        ),
-        (
-            "SELECT TRUNC('string', 'string2') AS trunc",
-            Err(TranslateError::FunctionArgsLengthNotMatching {
-                name: "TRUNC".to_owned(),
-                expected: 1,
-                found: 2,
-            }
-            .into()),
-        ),
-    ];
+    g.named_test(
+        "TRUNC(0.3) should return 0.0",
+        "SELECT TRUNC(0.3) as actual",
+        Ok(select!(actual F64; 0.0)),
+    )
+    .await;
 
-    for (sql, expected) in test_cases {
-        g.test(sql, expected).await;
-    }
+    g.named_test(
+        "TRUNC(-0.8) should return -0.0 (truncate toward zero)",
+        "SELECT TRUNC(-0.8) as actual",
+        Ok(select!(actual F64; -0.0)),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC(10) should return 10.0 (integer unchanged)",
+        "SELECT TRUNC(10) as actual",
+        Ok(select!(actual F64; 10.0)),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC(6.87421) should return 6.0",
+        "SELECT TRUNC(6.87421) as actual",
+        Ok(select!(actual F64; 6.0)),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC(-3.7) should return -3.0 (truncate toward zero)",
+        "SELECT TRUNC(-3.7) as actual",
+        Ok(select!(actual F64; -3.0)),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC with string should return EvaluateError::FunctionRequiresFloatValue",
+        "SELECT TRUNC('string') AS actual",
+        Err(EvaluateError::FunctionRequiresFloatValue("TRUNC".to_owned()).into()),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC with boolean should return EvaluateError::FunctionRequiresFloatValue",
+        "SELECT TRUNC(TRUE) AS actual",
+        Err(EvaluateError::FunctionRequiresFloatValue("TRUNC".to_owned()).into()),
+    )
+    .await;
+
+    g.named_test(
+        "TRUNC with NULL should return NULL",
+        "SELECT TRUNC(NULL) AS actual",
+        Ok(select_with_null!(actual; Null)),
+    )
+    .await;
 });

--- a/test-suite/src/function/trunc.rs
+++ b/test-suite/src/function/trunc.rs
@@ -1,0 +1,56 @@
+use {
+    crate::*,
+    gluesql_core::{
+        error::{EvaluateError, TranslateError},
+        prelude::Value::*,
+    },
+};
+
+test_case!(trunc, {
+    let g = get_tester!();
+
+    let test_cases = [
+        (
+            "SELECT
+                TRUNC(0.3) AS trunc1,
+                TRUNC(-0.8) AS trunc2,
+                TRUNC(10) AS trunc3,
+                TRUNC(6.87421) AS trunc4
+            ;",
+            Ok(select!(
+                trunc1 | trunc2 | trunc3 | trunc4
+                F64    | F64    | F64    | F64;
+                0.0      0.0      10.0     6.0
+            )),
+        ),
+        (
+            "SELECT TRUNC('string') AS trunc",
+            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC(NULL) AS trunc",
+            Ok(select_with_null!(trunc; Null)),
+        ),
+        (
+            "SELECT TRUNC(TRUE) AS trunc",
+            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC(FALSE) AS trunc",
+            Err(EvaluateError::FunctionRequiresFloatValue(String::from("TRUNC")).into()),
+        ),
+        (
+            "SELECT TRUNC('string', 'string2') AS trunc",
+            Err(TranslateError::FunctionArgsLengthNotMatching {
+                name: "TRUNC".to_owned(),
+                expected: 1,
+                found: 2,
+            }
+            .into()),
+        ),
+    ];
+
+    for (sql, expected) in test_cases {
+        g.test(sql, expected).await;
+    }
+});

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -135,6 +135,7 @@ macro_rules! generate_store_tests {
         glue!(function_abs, function::abs::abs);
         glue!(function_ceil, function::ceil::ceil);
         glue!(function_round, function::round::round);
+        glue!(function_trunc, function::trunc::trunc);
         glue!(function_rand, function::rand::rand);
         glue!(function_floor, function::floor::floor);
         glue!(function_format, function::format::format);


### PR DESCRIPTION
### **Summary**
* implement TRUNC function in AST with ToSql support
* add TRUNC function to AST builder with trunc() method  
* implement TRUNC function execution using f64::trunc()
* add TRUNC function to planner and SQL translator
* add comprehensive test suite for TRUNC function behavior
* register TRUNC function in test suite infrastructure
* add TRUNC function documentation

This PR implements the TRUNC function as requested in issue #1772. The TRUNC function truncates numbers toward zero without rounding, following standard SQL behavior. For positive numbers, it removes the decimal part (6.87421 → 6.0). For negative numbers, it truncates toward zero (-0.8 → -0.0, -1.8 → -1.0).

### **Testing**
* `cargo test -p gluesql-core`
* `cargo test -p gluesql-test-suite`
* `cargo test function_trunc`
* `cargo test ast_builder_function_math_rounding`

**Addresses #1772**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TRUNC() SQL function to truncate numbers toward zero. Accepts one numeric argument (integer or float), returns a float. NULL returns NULL; non-numeric inputs error.
* **Documentation**
  * Added TRUNC function page with syntax, examples, and behavior notes.
* **Tests**
  * Added tests covering literals, column usage, positive/negative values, integer/float inputs, NULL handling, and invalid types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->