### PR TITLE
Update AGENTS.md to document grouped use convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 - After editing code, run `cargo clippy --all-targets -- -D warnings`.
 - Then run `cargo fmt --all`.
+- When importing items, group them under a single `use` statement whenever possible.
 - Run tests related to your changes when available; running the entire test suite is not required.
 - Commit only when the above steps succeed.
 - Branch names may contain only lowercase a-z, dashes (-), and slashes (/).


### PR DESCRIPTION
## Summary
- document single-`use` grouping rule in AGENTS instructions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --manifest-path core/Cargo.toml --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c6742e1620832a8bdafe9c3ef56f23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guideline to group imports under a single “use” statement where possible.
  * Clarifies import formatting conventions for consistency and readability.
  * No changes to functionality, tests, or runtime behavior.
  * No impact on public APIs or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->