### PR TITLE
Reject unsupported translate clauses

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -529,7 +529,6 @@ mod tests {
         ];
 
         for (sql, err) in cases {
-            #[allow(deprecated)]
             assert_translate_error(sql, err);
         }
     }

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -115,7 +115,6 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             })
         }
         SqlStatement::Delete(SqlDelete {
-            tables,
             from,
             using,
             selection,
@@ -124,9 +123,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
             limit,
             ..
         }) => {
-            let violation = if !tables.is_empty() {
-                Some("multiple tables")
-            } else if using.is_some() {
+            let violation = if using.is_some() {
                 Some("USING clause")
             } else if returning.is_some() {
                 Some("RETURNING clause")

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -480,12 +480,8 @@ pub fn translate_foreign_key(table_constraint: &SqlTableConstraint) -> Result<Fo
 mod tests {
     use {super::*, crate::parse_sql::parse};
 
-    fn translate_one(sql: &str) -> crate::result::Result<Statement> {
-        parse(sql).and_then(|parsed| translate(&parsed[0]))
-    }
-
     fn assert_translate_error(sql: &str, error: TranslateError) {
-        let actual = translate_one(sql);
+        let actual = parse(sql).and_then(|parsed| translate(&parsed[0]));
         let expected = Err::<Statement, _>(error.into());
         assert_eq!(actual, expected);
     }

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -26,7 +26,7 @@ use {
         CommentDef as SqlCommentDef, CreateFunctionBody as SqlCreateFunctionBody,
         CreateIndex as SqlCreateIndex, CreateTable as SqlCreateTable, Delete as SqlDelete,
         FromTable as SqlFromTable, Ident as SqlIdent, Insert as SqlInsert,
-        ObjectName as SqlObjectName, ObjectType as SqlObjectType, Query as SqlQuery,
+        ObjectName as SqlObjectName, ObjectType as SqlObjectType,
         ReferentialAction as SqlReferentialAction, Statement as SqlStatement,
         TableConstraint as SqlTableConstraint, TableFactor, TableWithJoins,
     },
@@ -34,10 +34,7 @@ use {
 
 pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
     match sql_statement {
-        SqlStatement::Query(query) => {
-            reject_query_options(query)?;
-            translate_query(query).map(Statement::Query)
-        }
+        SqlStatement::Query(query) => translate_query(query).map(Statement::Query),
         SqlStatement::Insert(SqlInsert {
             table_name,
             columns,
@@ -361,21 +358,6 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
     }
 }
 
-fn reject_query_options(query: &SqlQuery) -> Result<()> {
-    if query.with.is_some()
-        || !query.limit_by.is_empty()
-        || query.fetch.is_some()
-        || !query.locks.is_empty()
-        || query.for_clause.is_some()
-        || query.settings.is_some()
-        || query.format_clause.is_some()
-    {
-        return Err(TranslateError::UnsupportedQueryOption(query.to_string()).into());
-    }
-
-    Ok(())
-}
-
 pub fn translate_assignment(sql_assignment: &SqlAssignment) -> Result<Assignment> {
     let SqlAssignment { target, value } = sql_assignment;
 
@@ -496,29 +478,12 @@ pub fn translate_foreign_key(table_constraint: &SqlTableConstraint) -> Result<Fo
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::{parse_sql::parse, result::Error},
-    };
+    use {super::*, crate::parse_sql::parse};
 
     fn assert_translate_error(sql: &str, error: TranslateError) {
         let actual = parse(sql).and_then(|parsed| translate(&parsed[0]));
         let expected = Err::<Statement, _>(error.into());
         assert_eq!(actual, expected);
-    }
-
-    fn assert_query_option_error(sql: &str) {
-        match parse(sql).and_then(|parsed| translate(&parsed[0])) {
-            Err(Error::Translate(TranslateError::UnsupportedQueryOption(_))) => {}
-            other => panic!("expected UnsupportedQueryOption, got {other:?} for `{sql}`"),
-        }
-    }
-
-    fn assert_select_option_error(sql: &str) {
-        match parse(sql).and_then(|parsed| translate(&parsed[0])) {
-            Err(Error::Translate(TranslateError::UnsupportedSelectOption(_))) => {}
-            other => panic!("expected UnsupportedSelectOption, got {other:?} for `{sql}`"),
-        }
     }
 
     #[test]
@@ -632,18 +597,5 @@ mod tests {
             "DELETE FROM Foo WHERE id = 1 LIMIT 1",
             TranslateError::UnsupportedDeleteOption("LIMIT clause"),
         );
-    }
-
-    #[test]
-    fn query_with_options_not_supported() {
-        assert_query_option_error("WITH t AS (SELECT 1) SELECT * FROM t");
-        assert_query_option_error("SELECT * FROM Foo FETCH FIRST 1 ROW ONLY");
-        assert_query_option_error("SELECT * FROM Foo FOR UPDATE");
-    }
-
-    #[test]
-    fn select_with_options_not_supported() {
-        assert_select_option_error("SELECT * INTO Foo FROM Bar");
-        assert_select_option_error("SELECT * FROM Foo WINDOW w AS (PARTITION BY id)");
     }
 }

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -556,40 +556,12 @@ mod tests {
     }
 
     #[test]
-    fn delete_using_not_supported() {
-        assert_translate_error(
-            "DELETE FROM Foo USING Bar",
-            TranslateError::UnsupportedDeleteOption("USING clause"),
-        );
-    }
-
-    #[test]
-    fn delete_returning_not_supported() {
-        assert_translate_error(
-            "DELETE FROM Foo WHERE id = 1 RETURNING *",
-            TranslateError::UnsupportedDeleteOption("RETURNING clause"),
-        );
-    }
-
-    #[test]
-    fn delete_order_by_not_supported() {
-        assert_translate_error(
-            "DELETE FROM Foo WHERE id = 1 ORDER BY id",
-            TranslateError::UnsupportedDeleteOption("ORDER BY clause"),
-        );
-    }
-
-    #[test]
-    fn delete_limit_not_supported() {
-        assert_translate_error(
-            "DELETE FROM Foo WHERE id = 1 LIMIT 1",
-            TranslateError::UnsupportedDeleteOption("LIMIT clause"),
-        );
-    }
-
-    #[test]
     fn delete_options_not_supported() {
         let cases = [
+            (
+                "DELETE FROM Foo USING Bar",
+                TranslateError::UnsupportedDeleteOption("USING clause"),
+            ),
             (
                 "DELETE FROM Foo WHERE id = 1 RETURNING *",
                 TranslateError::UnsupportedDeleteOption("RETURNING clause"),

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -503,68 +503,56 @@ mod tests {
     }
 
     #[test]
-    fn insert_returning_not_supported() {
-        assert_translate_error(
-            "INSERT INTO Foo VALUES (1) RETURNING *",
-            TranslateError::UnsupportedInsertOption("RETURNING clause"),
-        );
+    fn insert_options_not_supported() {
+        let cases = [
+            (
+                "INSERT INTO Foo VALUES (1) RETURNING *",
+                TranslateError::UnsupportedInsertOption("RETURNING clause"),
+            ),
+            (
+                "INSERT INTO Foo VALUES (1) ON CONFLICT DO NOTHING",
+                TranslateError::UnsupportedInsertOption("ON CONFLICT clause"),
+            ),
+            (
+                "INSERT INTO Foo AS f VALUES (1)",
+                TranslateError::UnsupportedInsertOption("table alias"),
+            ),
+            (
+                "INSERT INTO Foo PARTITION (bar = 1) VALUES (1)",
+                TranslateError::UnsupportedInsertOption("PARTITION clause"),
+            ),
+            (
+                "INSERT OVERWRITE TABLE Foo VALUES (1)",
+                TranslateError::UnsupportedInsertOption("OVERWRITE clause"),
+            ),
+            (
+                "INSERT TABLE Foo VALUES (1)",
+                TranslateError::UnsupportedInsertOption("TABLE keyword"),
+            ),
+        ];
+
+        for (sql, err) in cases {
+            #[allow(deprecated)]
+            assert_translate_error(sql, err);
+        }
     }
 
     #[test]
-    fn insert_on_conflict_not_supported() {
-        assert_translate_error(
-            "INSERT INTO Foo VALUES (1) ON CONFLICT DO NOTHING",
-            TranslateError::UnsupportedInsertOption("ON CONFLICT clause"),
-        );
-    }
+    fn update_options_not_supported() {
+        let cases = [
+            (
+                "UPDATE Foo SET id = 1 FROM Bar",
+                TranslateError::UnsupportedUpdateOption("FROM clause"),
+            ),
+            (
+                "UPDATE Foo SET id = 1 WHERE id = 1 RETURNING *",
+                TranslateError::UnsupportedUpdateOption("RETURNING clause"),
+            ),
+        ];
 
-    #[test]
-    fn insert_table_alias_not_supported() {
-        assert_translate_error(
-            "INSERT INTO Foo AS f VALUES (1)",
-            TranslateError::UnsupportedInsertOption("table alias"),
-        );
-    }
-
-    #[test]
-    fn insert_partition_not_supported() {
-        assert_translate_error(
-            "INSERT INTO Foo PARTITION (bar = 1) VALUES (1)",
-            TranslateError::UnsupportedInsertOption("PARTITION clause"),
-        );
-    }
-
-    #[test]
-    fn insert_overwrite_not_supported() {
-        assert_translate_error(
-            "INSERT OVERWRITE TABLE Foo VALUES (1)",
-            TranslateError::UnsupportedInsertOption("OVERWRITE clause"),
-        );
-    }
-
-    #[test]
-    fn insert_table_keyword_not_supported() {
-        #[allow(deprecated)]
-        assert_translate_error(
-            "INSERT TABLE Foo VALUES (1)",
-            TranslateError::UnsupportedInsertOption("TABLE keyword"),
-        );
-    }
-
-    #[test]
-    fn update_from_not_supported() {
-        assert_translate_error(
-            "UPDATE Foo SET id = 1 FROM Bar",
-            TranslateError::UnsupportedUpdateOption("FROM clause"),
-        );
-    }
-
-    #[test]
-    fn update_returning_not_supported() {
-        assert_translate_error(
-            "UPDATE Foo SET id = 1 WHERE id = 1 RETURNING *",
-            TranslateError::UnsupportedUpdateOption("RETURNING clause"),
-        );
+        for (sql, err) in cases {
+            assert_translate_error(sql, err);
+        }
     }
 
     #[test]

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -598,4 +598,26 @@ mod tests {
             TranslateError::UnsupportedDeleteOption("LIMIT clause"),
         );
     }
+
+    #[test]
+    fn delete_options_not_supported() {
+        let cases = [
+            (
+                "DELETE FROM Foo WHERE id = 1 RETURNING *",
+                TranslateError::UnsupportedDeleteOption("RETURNING clause"),
+            ),
+            (
+                "DELETE FROM Foo WHERE id = 1 ORDER BY id",
+                TranslateError::UnsupportedDeleteOption("ORDER BY clause"),
+            ),
+            (
+                "DELETE FROM Foo WHERE id = 1 LIMIT 1",
+                TranslateError::UnsupportedDeleteOption("LIMIT clause"),
+            ),
+        ];
+
+        for (sql, err) in cases {
+            assert_translate_error(sql, err);
+        }
+    }
 }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -78,10 +78,10 @@ pub enum TranslateError {
     UnsupportedDeleteOption(&'static str),
 
     #[error("unsupported query option: {0}")]
-    UnsupportedQueryOption(String),
+    UnsupportedQueryOption(&'static str),
 
     #[error("unsupported SELECT option: {0}")]
-    UnsupportedSelectOption(String),
+    UnsupportedSelectOption(&'static str),
 
     #[error(
         "unsupported trim chars: expected: `TRIM((BOTH | LEADING | TRAILING) <text> FROM <expr>)`, got: `TRIM(<expr> [<chars>, ..])` syntax"

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -77,6 +77,12 @@ pub enum TranslateError {
     #[error("unsupported DELETE option: {0}")]
     UnsupportedDeleteOption(&'static str),
 
+    #[error("unsupported query option: {0}")]
+    UnsupportedQueryOption(String),
+
+    #[error("unsupported SELECT option: {0}")]
+    UnsupportedSelectOption(String),
+
     #[error(
         "unsupported trim chars: expected: `TRIM((BOTH | LEADING | TRAILING) <text> FROM <expr>)`, got: `TRIM(<expr> [<chars>, ..])` syntax"
     )]

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -68,6 +68,9 @@ pub enum TranslateError {
     #[error("unsupported unnamed index")]
     UnsupportedUnnamedIndex,
 
+    #[error("unsupported INSERT option: {0}")]
+    UnsupportedInsertOption(&'static str),
+
     #[error(
         "unsupported trim chars: expected: `TRIM((BOTH | LEADING | TRAILING) <text> FROM <expr>)`, got: `TRIM(<expr> [<chars>, ..])` syntax"
     )]

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -71,6 +71,12 @@ pub enum TranslateError {
     #[error("unsupported INSERT option: {0}")]
     UnsupportedInsertOption(&'static str),
 
+    #[error("unsupported UPDATE option: {0}")]
+    UnsupportedUpdateOption(&'static str),
+
+    #[error("unsupported DELETE option: {0}")]
+    UnsupportedDeleteOption(&'static str),
+
     #[error(
         "unsupported trim chars: expected: `TRIM((BOTH | LEADING | TRAILING) <text> FROM <expr>)`, got: `TRIM(<expr> [<chars>, ..])` syntax"
     )]

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -354,4 +354,13 @@ mod tests {
             TranslateError::UnsupportedSelectOption("WINDOW clause"),
         );
     }
+
+    #[test]
+    #[should_panic(expected = "expected query statement")]
+    fn query_option_helper_panics_on_non_query() {
+        assert_query_error(
+            "INSERT INTO Foo VALUES (1)",
+            TranslateError::UnsupportedQueryOption("unused"),
+        );
+    }
 }

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -43,7 +43,7 @@ pub fn translate_query(sql_query: &SqlQuery) -> Result<Query> {
     };
 
     if let Some(reason) = violation {
-        return Err(TranslateError::UnsupportedQueryOption(reason.to_owned()).into());
+        return Err(TranslateError::UnsupportedQueryOption(reason).into());
     }
 
     let body = translate_set_expr(body)?;
@@ -92,9 +92,9 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
     } = sql_select;
 
     if into.is_some() {
-        return Err(TranslateError::UnsupportedSelectOption("INTO clause".to_owned()).into());
+        return Err(TranslateError::UnsupportedSelectOption("INTO clause").into());
     } else if !named_window.is_empty() {
-        return Err(TranslateError::UnsupportedSelectOption("WINDOW clause".to_owned()).into());
+        return Err(TranslateError::UnsupportedSelectOption("WINDOW clause").into());
     }
 
     if from.len() > 1 {
@@ -331,15 +331,15 @@ mod tests {
     fn query_options_rejected() {
         assert_query_error(
             "WITH t AS (SELECT 1) SELECT * FROM t",
-            TranslateError::UnsupportedQueryOption("WITH clause".to_owned()),
+            TranslateError::UnsupportedQueryOption("WITH clause"),
         );
         assert_query_error(
             "SELECT * FROM Foo FETCH FIRST 1 ROW ONLY",
-            TranslateError::UnsupportedQueryOption("FETCH clause".to_owned()),
+            TranslateError::UnsupportedQueryOption("FETCH clause"),
         );
         assert_query_error(
             "SELECT * FROM Foo FOR UPDATE",
-            TranslateError::UnsupportedQueryOption("LOCK clause".to_owned()),
+            TranslateError::UnsupportedQueryOption("LOCK clause"),
         );
     }
 
@@ -347,11 +347,11 @@ mod tests {
     fn select_options_rejected() {
         assert_query_error(
             "SELECT * INTO Foo FROM Bar",
-            TranslateError::UnsupportedSelectOption("INTO clause".to_owned()),
+            TranslateError::UnsupportedSelectOption("INTO clause"),
         );
         assert_query_error(
             "SELECT * FROM Foo WINDOW w AS (PARTITION BY id)",
-            TranslateError::UnsupportedSelectOption("WINDOW clause".to_owned()),
+            TranslateError::UnsupportedSelectOption("WINDOW clause"),
         );
     }
 }

--- a/storages/file-storage/tests/file_storage.rs
+++ b/storages/file-storage/tests/file_storage.rs
@@ -41,7 +41,7 @@ async fn scan_data_to_ignore_directory_items() {
     glue.execute("CREATE TABLE Foo (id INTEGER);")
         .await
         .unwrap();
-    glue.execute("INSERT TABLE Foo VALUES (1), (2), (3);")
+    glue.execute("INSERT INTO Foo VALUES (1), (2), (3);")
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- treat WITH / FETCH / FOR UPDATE as unsupported query options during translation
- reject SELECT variants that introduce INTO, TOP, WINDOW, etc., via `UnsupportedSelectOption`
- add focused unit tests covering each new guard

## Testing
- cargo test -p gluesql-core translate::query::tests::query_options_rejected -- --exact
- cargo test -p gluesql-core translate::query::tests::select_options_rejected -- --exact
- cargo test -p gluesql-core translate::tests::delete_limit_not_supported -- --exact
- cargo clippy --all-targets -- -D warnings],

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earlier, clearer errors for unsupported SQL options across INSERT, UPDATE, DELETE, queries and SELECT, returning specific reasons for clauses like RETURNING, ON CONFLICT, DEFAULT VALUES, FROM, USING, ORDER BY, LIMIT, WITH, FETCH, LOCK, INTO, WINDOW.
  * Added new public error variants to represent those unsupported option cases.

* **Tests**
  * Expanded tests covering the new error paths and messages.
  * Fixed a test SQL statement to use a valid INSERT so expected rows are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->