### PR TITLE
Update docs to demonstrate FromGlueRow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,20 @@ GlueSQL supports both SQL and its own query builder (AST Builder). Unlike other 
 - example: [pkg/rust/examples/hello_world.rs](./pkg/rust/examples/hello_world.rs)
 
 ```rust
+#[derive(gluesql::FromGlueRow)]
+struct Row {
+    id: i64,
+    name: String,
+}
+
 let storage = MemoryStorage::default();
 let mut glue = Glue::new(storage);
 
-let payloads = glue.execute("SELECT * FROM Foo;").await.unwrap();
+let rows = glue
+    .execute("SELECT id, name FROM Foo;")
+    .await
+    .rows_as::<Row>()
+    .unwrap();
 ```
 
 ### SQL Example


### PR DESCRIPTION
## Summary
- show how to derive `FromGlueRow` in the README snippet
- switch the `hello_world` example to the derive macro helpers

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to demonstrate deriving a row struct and retrieving strongly typed rows from a SELECT, replacing generic payload handling. Clarifies the async flow and error handling.

* **Examples**
  * Revised Rust “hello world” example to decode query results into a typed row struct, improving clarity and safety. Simplified imports and streamlined result handling for easier adoption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->