### PR TITLE
docs: document personal agent instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 **/*.rs.bk
 
 __pycache__
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,6 @@
 - Run tests related to your changes when available; running the entire test suite is not required.
 - Commit only when the above steps succeed.
 - Branch names may contain only lowercase a-z, dashes (-), and slashes (/).
+
+## Personal Instructions
+- Store collaborator-specific guidance in `AGENTS.local.md`. This file is gitignored and should remain local to each contributor.


### PR DESCRIPTION
## Summary
- document how collaborator-specific instructions should be stored locally
- ignore AGENTS.local.md so the personal notes stay untracked

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings