### PR TITLE
Enable FromGlueRow to emit UUID strings

### DIFF
--- a/core/src/row_conversion.rs
+++ b/core/src/row_conversion.rs
@@ -1,5 +1,17 @@
 use serde::Serialize;
 
+pub fn uuid_to_string(value: u128) -> String {
+    let hex = format!("{value:032x}");
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
 #[derive(Debug, thiserror::Error, PartialEq, Serialize)]
 pub enum RowConversionError {
     #[error("not a select payload")]
@@ -140,8 +152,17 @@ impl SelectResultExt for crate::result::Result<crate::executor::Payload> {
 
 #[cfg(test)]
 mod tests {
-    use super::{FromGlueRow, RowConversionError, SelectExt};
+    use super::{FromGlueRow, RowConversionError, SelectExt, uuid_to_string};
     use crate::{data::Value, executor::Payload};
+
+    #[test]
+    fn uuid_to_string_formats_hyphenated_lower() {
+        let value = 0x936DA01F9ABD4D9D80C702AF85C822A8u128;
+        assert_eq!(
+            uuid_to_string(value),
+            "936da01f-9abd-4d9d-80c7-02af85c822a8"
+        );
+    }
 
     #[derive(Debug, PartialEq)]
     struct Dummy {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -398,12 +398,13 @@ fn match_expected(
         return arms_copy!(Bool, "bool");
     }
     if is_string_type(base_ty) {
-        // Accept Value::Str as before, plus Date/Time, and format Timestamp to RFC3339 with trailing 'Z'
+        // Accept Value::Str as before, plus Date/Time/Timestamp (formatted to RFC3339 with trailing 'Z') and Uuid (hyphenated string)
         let by_ref = quote! {
             match __v {
                 ::gluesql::core::data::Value::Str(v) => v.clone(),
                 ::gluesql::core::data::Value::Date(v) => v.to_string(),
                 ::gluesql::core::data::Value::Time(v) => v.to_string(),
+                ::gluesql::core::data::Value::Uuid(v) => ::gluesql::core::row_conversion::uuid_to_string(*v),
                 ::gluesql::core::data::Value::Timestamp(v) => v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string(),
                 _ => { let __got: &str = #got_str; return Err(::gluesql::core::row_conversion::RowConversionError::TypeMismatch { field: Some(#field_name_literal), column: Some(__labels[__idx].clone()), expected: "String", got: __got }) }
             }
@@ -413,6 +414,7 @@ fn match_expected(
                 ::gluesql::core::data::Value::Str(v) => v.clone(),
                 ::gluesql::core::data::Value::Date(v) => v.to_string(),
                 ::gluesql::core::data::Value::Time(v) => v.to_string(),
+                ::gluesql::core::data::Value::Uuid(v) => ::gluesql::core::row_conversion::uuid_to_string(*v),
                 ::gluesql::core::data::Value::Timestamp(v) => v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string(),
                 _ => { let __got: &str = #got_str; return Err(::gluesql::core::row_conversion::RowConversionError::TypeMismatch { field: Some(#field_name_literal), column: Some(#column_name.to_string()), expected: "String", got: __got }) }
             }

--- a/macros/tests/runtime_ok_string_from_datetime.rs
+++ b/macros/tests/runtime_ok_string_from_datetime.rs
@@ -8,6 +8,11 @@ struct SString {
     v: String,
 }
 
+#[derive(Debug, PartialEq, FromGlueRow)]
+struct SStringOpt {
+    v: Option<String>,
+}
+
 #[test]
 fn date_to_string() {
     use chrono::NaiveDate;
@@ -51,4 +56,32 @@ fn timestamp_to_string() {
 
     let rows: Vec<SString> = payload.rows_as::<SString>().unwrap();
     assert_eq!(rows[0].v, "2023-04-05T01:02:03Z");
+}
+
+#[test]
+fn uuid_to_string() {
+    let uuid_u128 = 0x936DA01F9ABD4D9D80C702AF85C822A8u128;
+    let payload = Payload::Select {
+        labels: vec!["v".into()],
+        rows: vec![vec![Value::Uuid(uuid_u128)]],
+    };
+
+    let rows: Vec<SString> = payload.rows_as::<SString>().unwrap();
+    assert_eq!(rows[0].v, "936da01f-9abd-4d9d-80c7-02af85c822a8");
+}
+
+#[test]
+fn uuid_to_option_string() {
+    let uuid_u128 = 0x550E8400E29B41D4A716446655440000u128;
+    let payload = Payload::Select {
+        labels: vec!["v".into()],
+        rows: vec![vec![Value::Uuid(uuid_u128)], vec![Value::Null]],
+    };
+
+    let rows: Vec<SStringOpt> = payload.rows_as::<SStringOpt>().unwrap();
+    assert_eq!(
+        rows[0].v.as_deref(),
+        Some("550e8400-e29b-41d4-a716-446655440000")
+    );
+    assert_eq!(rows[1].v, None);
 }


### PR DESCRIPTION
## Summary
- allow  derive to populate  fields from UUID values without extra dependencies
- add a reusable UUID formatting helper so macro expansions do not reference the  crate directly
- cover the conversion with derive runtime tests and a unit test for the formatter

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -p gluesql-macros --test runtime_ok_string_from_datetime
