### PR TITLE
Qualify Result usage in FromGlueRow derive

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -121,7 +121,7 @@ fn expand_from_glue_row(input: DeriveInput) -> Result<proc_macro2::TokenStream, 
                 &FIELDS
             }
             fn from_glue_row(
-                __labels: &[String],
+                __labels: &[::std::string::String],
                 __row: &[::gluesql::core::data::Value],
             ) -> ::core::result::Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
                 #(#field_inits)*
@@ -129,7 +129,7 @@ fn expand_from_glue_row(input: DeriveInput) -> Result<proc_macro2::TokenStream, 
             }
             fn from_glue_row_with_idx(
                 __idx: &[usize],
-                __labels: &[String],
+                __labels: &[::std::string::String],
                 __row: &[::gluesql::core::data::Value],
             ) -> ::core::result::Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
                 #(#field_inits_with_idx)*

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -120,11 +120,18 @@ fn expand_from_glue_row(input: DeriveInput) -> Result<proc_macro2::TokenStream, 
                 static FIELDS: [(&str, &str); #fields_len] = [ #(#fields_meta_pairs),* ];
                 &FIELDS
             }
-            fn from_glue_row(__labels: &[String], __row: &[::gluesql::core::data::Value]) -> Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
+            fn from_glue_row(
+                __labels: &[String],
+                __row: &[::gluesql::core::data::Value],
+            ) -> ::core::result::Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
                 #(#field_inits)*
                 Ok(Self { #(#field_idents),* })
             }
-            fn from_glue_row_with_idx(__idx: &[usize], __labels: &[String], __row: &[::gluesql::core::data::Value]) -> Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
+            fn from_glue_row_with_idx(
+                __idx: &[usize],
+                __labels: &[String],
+                __row: &[::gluesql::core::data::Value],
+            ) -> ::core::result::Result<Self, ::gluesql::core::row_conversion::RowConversionError> {
                 #(#field_inits_with_idx)*
                 Ok(Self { #(#field_idents),* })
             }


### PR DESCRIPTION
## Summary
- Qualify the Result type in the FromGlueRow derive expansion so user-defined aliases do not clash

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -p gluesql-macros

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized method signatures and fully-qualified return types for consistent API declarations; no change to runtime behavior or error outcomes.

- Chores
  - Internal formatting and type-path cleanups to align with coding conventions; no user-facing changes and existing functionality remains compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->