### PR TITLE
Fix macros dev dependency cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,9 @@ version = "0.18.0"
 dependencies = [
  "chrono",
  "futures",
- "gluesql",
+ "gluesql-core",
+ "gluesql_memory_storage",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "rust_decimal",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,9 +13,11 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
+proc-macro-crate = "3"
 
 [dev-dependencies]
-gluesql = { path = "../pkg/rust", version = "0.18.0" }
+gluesql-core.workspace = true
+gluesql_memory_storage.workspace = true
 futures = "0.3"
 chrono = "0.4"
 rust_decimal = "1"

--- a/macros/tests/compile-fail/bad_attr_parse.rs
+++ b/macros/tests/compile-fail/bad_attr_parse.rs
@@ -1,8 +1,7 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(FromGlueRow)]
 struct S {
     #[glue]
     v: i32,
 }
-

--- a/macros/tests/compile-fail/bad_rename_literal.rs
+++ b/macros/tests/compile-fail/bad_rename_literal.rs
@@ -1,8 +1,7 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(FromGlueRow)]
 struct S {
     #[glue(rename = 123)]
     v: i32,
 }
-

--- a/macros/tests/compile-fail/derive_on_enum.rs
+++ b/macros/tests/compile-fail/derive_on_enum.rs
@@ -1,7 +1,6 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(FromGlueRow)]
 enum E {
     A,
 }
-

--- a/macros/tests/compile-fail/tuple_struct.rs
+++ b/macros/tests/compile-fail/tuple_struct.rs
@@ -1,5 +1,4 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(FromGlueRow)]
 struct T(i32);
-

--- a/macros/tests/compile-fail/unsupported_ref_str.rs
+++ b/macros/tests/compile-fail/unsupported_ref_str.rs
@@ -1,7 +1,6 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(FromGlueRow)]
 struct S<'a> {
     v: &'a str,
 }
-

--- a/macros/tests/e2e_memory_storage.rs
+++ b/macros/tests/e2e_memory_storage.rs
@@ -1,4 +1,4 @@
-use gluesql::FromGlueRow;
+use gluesql_macros::FromGlueRow;
 
 #[derive(Debug, PartialEq, FromGlueRow)]
 struct User {
@@ -9,9 +9,9 @@ struct User {
 
 #[test]
 fn end_to_end_with_memory_storage() {
-    use gluesql::{
-        core::row_conversion::SelectResultExt,
-        prelude::{Glue, MemoryStorage},
+    use {
+        gluesql_core::{prelude::Glue, row_conversion::SelectResultExt},
+        gluesql_memory_storage::MemoryStorage,
     };
 
     let fut = async move {

--- a/macros/tests/runtime_err_basic.rs
+++ b/macros/tests/runtime_err_basic.rs
@@ -1,10 +1,10 @@
-use gluesql::{
-    FromGlueRow,
-    core::{
+use {
+    gluesql_core::{
         data::Value,
         executor::Payload,
         row_conversion::{RowConversionError, SelectExt},
     },
+    gluesql_macros::FromGlueRow,
 };
 
 #[allow(dead_code)]

--- a/macros/tests/runtime_err_got_matrix.rs
+++ b/macros/tests/runtime_err_got_matrix.rs
@@ -1,10 +1,10 @@
-use gluesql::{
-    FromGlueRow,
-    core::{
-        data::Value,
+use {
+    gluesql_core::{
+        data::{Interval, Point, Value},
         executor::Payload,
         row_conversion::{RowConversionError, SelectExt},
     },
+    gluesql_macros::FromGlueRow,
 };
 
 #[allow(dead_code)]
@@ -124,7 +124,7 @@ fn got_list_expected_time() {
 #[allow(dead_code)]
 #[derive(Debug, FromGlueRow)]
 struct IntervalField {
-    v: gluesql::core::data::Interval,
+    v: Interval,
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn got_bool_expected_list() {
 
 #[derive(Debug, FromGlueRow)]
 struct PointOptField {
-    v: Option<gluesql::core::data::Point>,
+    v: Option<Point>,
 }
 
 #[test]

--- a/macros/tests/runtime_err_last_select.rs
+++ b/macros/tests/runtime_err_last_select.rs
@@ -1,10 +1,10 @@
-use gluesql::{
-    FromGlueRow,
-    core::{
+use {
+    gluesql_core::{
         data::Value,
         executor::Payload,
         row_conversion::{RowConversionError, SelectExt},
     },
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_basic.rs
+++ b/macros/tests/runtime_ok_basic.rs
@@ -1,9 +1,11 @@
 use {
     chrono::{NaiveDate, NaiveDateTime, NaiveTime},
-    gluesql::{
-        FromGlueRow,
-        core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_core::{
+        data::{Interval, Point, Value},
+        executor::Payload,
+        row_conversion::SelectExt,
     },
+    gluesql_macros::FromGlueRow,
     rust_decimal::Decimal,
     std::{
         collections::BTreeMap,
@@ -93,18 +95,16 @@ struct AllTypes {
     ts_: NaiveDateTime,
     time_: NaiveTime,
     dec_: Decimal,
-    interval_: gluesql::core::data::Interval,
+    interval_: Interval,
     map_: BTreeMap<String, Value>,
     list_: Vec<Value>,
-    point_: gluesql::core::data::Point,
+    point_: Point,
     opt_s_none: Option<String>,
     opt_i64_some: Option<i64>,
 }
 
 #[test]
 fn all_types_ok() {
-    use gluesql::core::data::{Interval, Point};
-
     let date = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
     let time = NaiveTime::from_hms_opt(3, 4, 5).unwrap();
     let ts = NaiveDateTime::new(date, time);

--- a/macros/tests/runtime_ok_btreemap_t.rs
+++ b/macros/tests/runtime_ok_btreemap_t.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_from_glue_row.rs
+++ b/macros/tests/runtime_ok_from_glue_row.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, row_conversion::FromGlueRow as _},
+use {
+    gluesql_core::{data::Value, row_conversion::FromGlueRow as _},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]
@@ -38,7 +38,7 @@ struct DirectNonNull {
 
 #[test]
 fn direct_from_glue_row_null_not_allowed() {
-    use gluesql::core::row_conversion::RowConversionError;
+    use gluesql_core::row_conversion::RowConversionError;
     let labels = vec!["v".to_string()];
     let row = vec![Value::Null];
     let err = DirectNonNull::from_glue_row(&labels, &row).unwrap_err();
@@ -53,7 +53,7 @@ struct DirectMismatch {
 
 #[test]
 fn direct_from_glue_row_type_mismatch() {
-    use gluesql::core::row_conversion::RowConversionError;
+    use gluesql_core::row_conversion::RowConversionError;
     let labels = vec!["v".to_string()];
     let row = vec![Value::I64(1)];
     let err = DirectMismatch::from_glue_row(&labels, &row).unwrap_err();

--- a/macros/tests/runtime_ok_hashmap_t.rs
+++ b/macros/tests/runtime_ok_hashmap_t.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_idx_cache.rs
+++ b/macros/tests/runtime_ok_idx_cache.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_map_option.rs
+++ b/macros/tests/runtime_ok_map_option.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, row_conversion::FromGlueRow as _},
+use {
+    gluesql_core::{data::Value, row_conversion::FromGlueRow as _},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]
@@ -10,7 +10,7 @@ struct BMOptI64 {
 
 #[test]
 fn btreemap_option_i64_rows_as_and_direct() {
-    use gluesql::core::{executor::Payload, row_conversion::SelectExt};
+    use gluesql_core::{executor::Payload, row_conversion::SelectExt};
     use std::collections::BTreeMap;
 
     let mut m = BTreeMap::new();
@@ -42,7 +42,7 @@ struct HMOptStr {
 
 #[test]
 fn hashmap_option_string_rows_as_and_direct() {
-    use gluesql::core::{executor::Payload, row_conversion::SelectExt};
+    use gluesql_core::{executor::Payload, row_conversion::SelectExt};
     use std::collections::BTreeMap;
 
     let mut m = BTreeMap::new();
@@ -72,7 +72,7 @@ struct HMValue {
 
 #[test]
 fn hashmap_value_rows_as_and_direct() {
-    use gluesql::core::{executor::Payload, row_conversion::SelectExt};
+    use gluesql_core::{executor::Payload, row_conversion::SelectExt};
     use std::collections::BTreeMap;
 
     let mut m = BTreeMap::new();

--- a/macros/tests/runtime_ok_nested_containers.rs
+++ b/macros/tests/runtime_ok_nested_containers.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_result_ext.rs
+++ b/macros/tests/runtime_ok_result_ext.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, error::Error, executor::Payload, row_conversion::SelectResultExt},
+use {
+    gluesql_core::{data::Value, error::Error, executor::Payload, row_conversion::SelectResultExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]
@@ -21,8 +21,7 @@ fn result_rows_as_ok() {
 
 #[test]
 fn result_rows_as_not_select_payload_maps_error() {
-    use gluesql::core::error::Error as CoreError;
-    use gluesql::core::row_conversion::RowConversionError;
+    use gluesql_core::{error::Error as CoreError, row_conversion::RowConversionError};
 
     let res: Result<Vec<Payload>, Error> = Ok(vec![Payload::Insert(1)]);
     let err = res.rows_as::<User>().unwrap_err();

--- a/macros/tests/runtime_ok_string_from_datetime.rs
+++ b/macros/tests/runtime_ok_string_from_datetime.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_unknown_attr.rs
+++ b/macros/tests/runtime_ok_unknown_attr.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, row_conversion::FromGlueRow as _},
+use {
+    gluesql_core::{data::Value, row_conversion::FromGlueRow as _},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]

--- a/macros/tests/runtime_ok_vec_t.rs
+++ b/macros/tests/runtime_ok_vec_t.rs
@@ -1,6 +1,6 @@
-use gluesql::{
-    FromGlueRow,
-    core::{data::Value, executor::Payload, row_conversion::SelectExt},
+use {
+    gluesql_core::{data::Value, executor::Payload, row_conversion::SelectExt},
+    gluesql_macros::FromGlueRow,
 };
 
 #[derive(Debug, PartialEq, FromGlueRow)]


### PR DESCRIPTION
## Summary
- replace the macro crate's dev-dependency on gluesql with gluesql-core + gluesql_memory_storage to remove the publish blocker
- add dynamic crate path resolution via proc-macro-crate so the derive works in all consumers
- update macro integration and compile-fail tests to use the new imports

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all
- cargo test -p gluesql-macros


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Derive macros now auto-detect the GlueSQL core path, working seamlessly with either gluesql or gluesql-core setups.
  - Improved compatibility with the memory storage backend.
  - Clearer compile-time errors when the GlueSQL crate cannot be located.

- Tests
  - Expanded compile-time coverage and updated test imports to reflect the new crate layout.

- Chores
  - Aligned dev-dependencies with workspace resolution and added a compile-time testing tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->