### PR TITLE
Support only indexed placeholders for parameter binding

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
         plan::plan,
         result::{Error, Result},
         row_conversion::{SelectExt, SelectResultExt},
-        translate::translate,
+        translate::{ParamLiteral, translate, translate_with_params},
     };
 }
 

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -197,4 +197,13 @@ pub enum TranslateError {
 
     #[error("unsupported constraint: {0}")]
     UnsupportedConstraint(String),
+
+    #[error("parameter index {index} is out of range (total parameters: {len})")]
+    ParameterIndexOutOfRange { index: usize, len: usize },
+
+    #[error("invalid parameter placeholder: {placeholder}")]
+    InvalidPlaceholder { placeholder: String },
+
+    #[error("failed to convert parameter {index} into expression: {reason}")]
+    ParameterTypeConversionFailed { index: usize, reason: String },
 }

--- a/core/src/translate/expr.rs
+++ b/core/src/translate/expr.rs
@@ -1,24 +1,25 @@
 use {
     super::{
-        TranslateError,
+        ParamLiteral, TranslateError,
         ast_literal::{translate_ast_literal, translate_datetime_field},
+        bind_placeholder,
         data_type::translate_data_type,
         function::{
-            translate_cast, translate_ceil, translate_extract, translate_floor, translate_function,
-            translate_position,
+            translate_cast_with_params, translate_ceil_with_params, translate_extract_with_params,
+            translate_floor_with_params, translate_function_with_params,
+            translate_position_with_params, translate_trim_with_params,
         },
         operator::{translate_binary_operator, translate_unary_operator},
-        translate_idents, translate_query,
+        translate_idents, translate_query_with_params,
     },
     crate::{
         ast::{Expr, OrderByExpr},
         result::Result,
-        translate::function::translate_trim,
     },
     sqlparser::ast::{
         Array, CeilFloorKind as SqlCeilFloorKind, DateTimeField as SqlDateTimeField,
         Expr as SqlExpr, Interval as SqlInterval, OrderByExpr as SqlOrderByExpr,
-        Subscript as SqlSubscript,
+        Subscript as SqlSubscript, Value as SqlValue,
     },
 };
 
@@ -30,7 +31,10 @@ use {
 /// This is because it follows the parsed result of `sqlparser-rs` as it is. <br>
 /// It is ambiguous whether the parsed tokens will be classified as a lower level of [`Expr`] or a lower level of [`Expr::Function`]. <br>
 /// In `GlueSQL`, if an argument is received wrapped in `( )` in the sql statement, the standard is set to translate in the form of `Expr::Function(Box<Function::Cast>)` rather than `Expr::Cast`.
-pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
+pub(crate) fn translate_expr_with_params(
+    sql_expr: &SqlExpr,
+    params: &[ParamLiteral],
+) -> Result<Expr> {
     match sql_expr {
         SqlExpr::Identifier(ident) => Ok(Expr::Identifier(ident.value.clone())),
         SqlExpr::CompoundIdentifier(idents) => (idents.len() == 2)
@@ -41,15 +45,22 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             .ok_or_else(|| {
                 TranslateError::UnsupportedExpr(translate_idents(idents).join(".")).into()
             }),
-        SqlExpr::IsNull(expr) => translate_expr(expr).map(Box::new).map(Expr::IsNull),
-        SqlExpr::IsNotNull(expr) => translate_expr(expr).map(Box::new).map(Expr::IsNotNull),
+        SqlExpr::IsNull(expr) => translate_expr_with_params(expr, params)
+            .map(Box::new)
+            .map(Expr::IsNull),
+        SqlExpr::IsNotNull(expr) => translate_expr_with_params(expr, params)
+            .map(Box::new)
+            .map(Expr::IsNotNull),
         SqlExpr::InList {
             expr,
             list,
             negated,
         } => Ok(Expr::InList {
-            expr: translate_expr(expr).map(Box::new)?,
-            list: list.iter().map(translate_expr).collect::<Result<_>>()?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
+            list: list
+                .iter()
+                .map(|expr| translate_expr_with_params(expr, params))
+                .collect::<Result<_>>()?,
             negated: *negated,
         }),
         SqlExpr::InSubquery {
@@ -57,8 +68,8 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             subquery,
             negated,
         } => Ok(Expr::InSubquery {
-            expr: translate_expr(expr).map(Box::new)?,
-            subquery: translate_query(subquery).map(Box::new)?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
+            subquery: translate_query_with_params(subquery, params).map(Box::new)?,
             negated: *negated,
         }),
         SqlExpr::Between {
@@ -67,10 +78,10 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             low,
             high,
         } => Ok(Expr::Between {
-            expr: translate_expr(expr).map(Box::new)?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
             negated: *negated,
-            low: translate_expr(low).map(Box::new)?,
-            high: translate_expr(high).map(Box::new)?,
+            low: translate_expr_with_params(low, params).map(Box::new)?,
+            high: translate_expr_with_params(high, params).map(Box::new)?,
         }),
         SqlExpr::Like {
             expr,
@@ -79,9 +90,9 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             escape_char: None,
             ..
         } => Ok(Expr::Like {
-            expr: translate_expr(expr).map(Box::new)?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
             negated: *negated,
-            pattern: translate_expr(pattern).map(Box::new)?,
+            pattern: translate_expr_with_params(pattern, params).map(Box::new)?,
         }),
         SqlExpr::ILike {
             expr,
@@ -90,27 +101,32 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             escape_char: None,
             ..
         } => Ok(Expr::ILike {
-            expr: translate_expr(expr).map(Box::new)?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
             negated: *negated,
-            pattern: translate_expr(pattern).map(Box::new)?,
+            pattern: translate_expr_with_params(pattern, params).map(Box::new)?,
         }),
         SqlExpr::BinaryOp { left, op, right } => Ok(Expr::BinaryOp {
-            left: translate_expr(left).map(Box::new)?,
+            left: translate_expr_with_params(left, params).map(Box::new)?,
             op: translate_binary_operator(op)?,
-            right: translate_expr(right).map(Box::new)?,
+            right: translate_expr_with_params(right, params).map(Box::new)?,
         }),
         SqlExpr::UnaryOp { op, expr } => Ok(Expr::UnaryOp {
             op: translate_unary_operator(op)?,
-            expr: translate_expr(expr).map(Box::new)?,
+            expr: translate_expr_with_params(expr, params).map(Box::new)?,
         }),
-        SqlExpr::Extract { field, expr, .. } => translate_extract(field, expr),
-        SqlExpr::Nested(expr) => translate_expr(expr).map(Box::new).map(Expr::Nested),
-        SqlExpr::Value(value) => translate_ast_literal(value).map(Expr::Literal),
+        SqlExpr::Extract { field, expr, .. } => translate_extract_with_params(params, field, expr),
+        SqlExpr::Nested(expr) => translate_expr_with_params(expr, params)
+            .map(Box::new)
+            .map(Expr::Nested),
+        SqlExpr::Value(value) => match value {
+            SqlValue::Placeholder(placeholder) => bind_placeholder(params, placeholder),
+            _ => translate_ast_literal(value).map(Expr::Literal),
+        },
         SqlExpr::TypedString { data_type, value } => Ok(Expr::TypedString {
             data_type: translate_data_type(data_type)?,
             value: value.to_owned(),
         }),
-        SqlExpr::Function(function) => translate_function(function),
+        SqlExpr::Function(function) => translate_function_with_params(params, function),
         SqlExpr::Trim {
             expr,
             trim_where,
@@ -121,7 +137,7 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
                 return Err(TranslateError::UnsupportedTrimChars.into());
             }
 
-            translate_trim(expr, trim_where, trim_what)
+            translate_trim_with_params(params, expr, trim_where, trim_what)
         }
         SqlExpr::Floor { expr, field } => {
             if !matches!(
@@ -131,7 +147,7 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
                 return Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into());
             }
 
-            translate_floor(expr)
+            translate_floor_with_params(params, expr)
         }
         SqlExpr::Ceil { expr, field } => {
             if !matches!(
@@ -141,13 +157,15 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
                 return Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into());
             }
 
-            translate_ceil(expr)
+            translate_ceil_with_params(params, expr)
         }
         SqlExpr::Exists { subquery, negated } => Ok(Expr::Exists {
-            subquery: translate_query(subquery).map(Box::new)?,
+            subquery: translate_query_with_params(subquery, params).map(Box::new)?,
             negated: *negated,
         }),
-        SqlExpr::Subquery(query) => translate_query(query).map(Box::new).map(Expr::Subquery),
+        SqlExpr::Subquery(query) => translate_query_with_params(query, params)
+            .map(Box::new)
+            .map(Expr::Subquery),
         SqlExpr::Case {
             operand,
             conditions,
@@ -156,43 +174,46 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
         } => Ok(Expr::Case {
             operand: operand
                 .as_ref()
-                .map(|expr| translate_expr(expr.as_ref()).map(Box::new))
+                .map(|expr| translate_expr_with_params(expr.as_ref(), params).map(Box::new))
                 .transpose()?,
             when_then: conditions
                 .iter()
                 .zip(results)
                 .map(|(when, then)| {
-                    let when = translate_expr(when)?;
-                    let then = translate_expr(then)?;
+                    let when = translate_expr_with_params(when, params)?;
+                    let then = translate_expr_with_params(then, params)?;
 
                     Ok((when, then))
                 })
                 .collect::<Result<Vec<_>>>()?,
             else_result: else_result
                 .as_ref()
-                .map(|expr| translate_expr(expr.as_ref()).map(Box::new))
+                .map(|expr| translate_expr_with_params(expr.as_ref(), params).map(Box::new))
                 .transpose()?,
         }),
         SqlExpr::Subscript { expr, subscript } => match subscript.as_ref() {
             SqlSubscript::Index { index } => Ok(Expr::ArrayIndex {
-                obj: translate_expr(expr).map(Box::new)?,
-                indexes: vec![translate_expr(index)?],
+                obj: translate_expr_with_params(expr, params).map(Box::new)?,
+                indexes: vec![translate_expr_with_params(index, params)?],
             }),
             SqlSubscript::Slice { .. } => {
                 Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into())
             }
         },
         SqlExpr::Array(Array { elem, .. }) => Ok(Expr::Array {
-            elem: elem.iter().map(translate_expr).collect::<Result<_>>()?,
+            elem: elem
+                .iter()
+                .map(|expr| translate_expr_with_params(expr, params))
+                .collect::<Result<_>>()?,
         }),
-        SqlExpr::Position { expr, r#in } => translate_position(expr, r#in),
+        SqlExpr::Position { expr, r#in } => translate_position_with_params(params, expr, r#in),
         SqlExpr::Interval(SqlInterval {
             value,
             leading_field,
             last_field,
             ..
         }) => Ok(Expr::Interval {
-            expr: translate_expr(value).map(Box::new)?,
+            expr: translate_expr_with_params(value, params).map(Box::new)?,
             leading_field: leading_field
                 .as_ref()
                 .map(translate_datetime_field)
@@ -207,13 +228,21 @@ pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
             data_type,
             format,
             kind,
-        } => translate_cast(kind, expr, data_type, format.as_ref()),
+        } => translate_cast_with_params(params, kind, expr, data_type, format.as_ref()),
 
         _ => Err(TranslateError::UnsupportedExpr(sql_expr.to_string()).into()),
     }
 }
 
-pub fn translate_order_by_expr(sql_order_by_expr: &SqlOrderByExpr) -> Result<OrderByExpr> {
+pub fn translate_expr(sql_expr: &SqlExpr) -> Result<Expr> {
+    const NO_PARAMS: [ParamLiteral; 0] = [];
+    translate_expr_with_params(sql_expr, &NO_PARAMS)
+}
+
+pub(crate) fn translate_order_by_expr_with_params(
+    sql_order_by_expr: &SqlOrderByExpr,
+    params: &[ParamLiteral],
+) -> Result<OrderByExpr> {
     let SqlOrderByExpr {
         expr,
         asc,
@@ -226,7 +255,12 @@ pub fn translate_order_by_expr(sql_order_by_expr: &SqlOrderByExpr) -> Result<Ord
     }
 
     Ok(OrderByExpr {
-        expr: translate_expr(expr)?,
+        expr: translate_expr_with_params(expr, params)?,
         asc: *asc,
     })
+}
+
+pub fn translate_order_by_expr(sql_order_by_expr: &SqlOrderByExpr) -> Result<OrderByExpr> {
+    const NO_PARAMS: [ParamLiteral; 0] = [];
+    translate_order_by_expr_with_params(sql_order_by_expr, &NO_PARAMS)
 }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -1,8 +1,8 @@
 use {
     super::{
-        TranslateError,
+        ParamLiteral, TranslateError,
         ast_literal::{translate_datetime_field, translate_trim_where_field},
-        expr::translate_expr,
+        expr::translate_expr_with_params,
         translate_data_type, translate_object_name,
     },
     crate::{
@@ -18,16 +18,17 @@ use {
     },
 };
 
-pub fn translate_trim(
+pub(crate) fn translate_trim_with_params(
+    params: &[ParamLiteral],
     expr: &SqlExpr,
     trim_where: &Option<SqlTrimWhereField>,
     trim_what: &Option<Box<SqlExpr>>,
 ) -> Result<Expr> {
-    let expr = translate_expr(expr)?;
+    let expr = translate_expr_with_params(expr, params)?;
     let trim_where_field = trim_where.as_ref().map(translate_trim_where_field);
     let filter_chars = trim_what
         .as_ref()
-        .map(|expr| translate_expr(expr.as_ref()))
+        .map(|expr| translate_expr_with_params(expr.as_ref(), params))
         .transpose()?;
 
     Ok(Expr::Function(Box::new(Function::Trim {
@@ -37,28 +38,33 @@ pub fn translate_trim(
     })))
 }
 
-pub fn translate_floor(expr: &SqlExpr) -> Result<Expr> {
-    let expr = translate_expr(expr)?;
+pub(crate) fn translate_floor_with_params(params: &[ParamLiteral], expr: &SqlExpr) -> Result<Expr> {
+    let expr = translate_expr_with_params(expr, params)?;
 
     Ok(Expr::Function(Box::new(Function::Floor(expr))))
 }
 
-pub fn translate_ceil(expr: &SqlExpr) -> Result<Expr> {
-    let expr = translate_expr(expr)?;
+pub(crate) fn translate_ceil_with_params(params: &[ParamLiteral], expr: &SqlExpr) -> Result<Expr> {
+    let expr = translate_expr_with_params(expr, params)?;
 
     Ok(Expr::Function(Box::new(Function::Ceil(expr))))
 }
 
-pub fn translate_position(sub_expr: &SqlExpr, from_expr: &SqlExpr) -> Result<Expr> {
-    let from_expr = translate_expr(from_expr)?;
-    let sub_expr = translate_expr(sub_expr)?;
+pub(crate) fn translate_position_with_params(
+    params: &[ParamLiteral],
+    sub_expr: &SqlExpr,
+    from_expr: &SqlExpr,
+) -> Result<Expr> {
+    let from_expr = translate_expr_with_params(from_expr, params)?;
+    let sub_expr = translate_expr_with_params(sub_expr, params)?;
     Ok(Expr::Function(Box::new(Function::Position {
         from_expr,
         sub_expr,
     })))
 }
 
-pub fn translate_cast(
+pub(crate) fn translate_cast_with_params(
+    params: &[ParamLiteral],
     kind: &SqlCastKind,
     expr: &SqlExpr,
     data_type: &SqlDataType,
@@ -72,14 +78,18 @@ pub fn translate_cast(
         return Err(TranslateError::UnsupportedCastFormat(format.to_string()).into());
     }
 
-    let expr = translate_expr(expr)?;
+    let expr = translate_expr_with_params(expr, params)?;
     let data_type = translate_data_type(data_type)?;
     Ok(Expr::Function(Box::new(Function::Cast { expr, data_type })))
 }
 
-pub fn translate_extract(field: &SqlDateTimeField, expr: &SqlExpr) -> Result<Expr> {
+pub(crate) fn translate_extract_with_params(
+    params: &[ParamLiteral],
+    field: &SqlDateTimeField,
+    expr: &SqlExpr,
+) -> Result<Expr> {
     let field = translate_datetime_field(field)?;
-    let expr = translate_expr(expr)?;
+    let expr = translate_expr_with_params(expr, params)?;
     Ok(Expr::Function(Box::new(Function::Extract { field, expr })))
 }
 
@@ -135,19 +145,21 @@ fn translate_function_zero_arg(func: Function, args: Vec<&SqlExpr>, name: String
 }
 
 fn translate_function_one_arg<T: FnOnce(Expr) -> Function>(
+    params: &[ParamLiteral],
     func: T,
     args: Vec<&SqlExpr>,
     name: String,
 ) -> Result<Expr> {
     check_len(name, args.len(), 1)?;
 
-    translate_expr(args[0])
+    translate_expr_with_params(args[0], params)
         .map(func)
         .map(Box::new)
         .map(Expr::Function)
 }
 
 fn translate_aggregate_one_arg<T: FnOnce(Expr, bool) -> Aggregate>(
+    params: &[ParamLiteral],
     func: T,
     args: Vec<&SqlExpr>,
     name: String,
@@ -155,24 +167,25 @@ fn translate_aggregate_one_arg<T: FnOnce(Expr, bool) -> Aggregate>(
 ) -> Result<Expr> {
     check_len(name, args.len(), 1)?;
 
-    translate_expr(args[0])
+    translate_expr_with_params(args[0], params)
         .map(|expr| func(expr, distinct))
         .map(Box::new)
         .map(Expr::Aggregate)
 }
 
 fn translate_function_trim<T: FnOnce(Expr, Option<Expr>) -> Function>(
+    params: &[ParamLiteral],
     func: T,
     args: Vec<&SqlExpr>,
     name: String,
 ) -> Result<Expr> {
     check_len_range(name, args.len(), 1, 2)?;
 
-    let expr = translate_expr(args[0])?;
+    let expr = translate_expr_with_params(args[0], params)?;
     let chars = if args.len() == 1 {
         None
     } else {
-        Some(translate_expr(args[1])?)
+        Some(translate_expr_with_params(args[1], params)?)
     };
 
     let result = func(expr, chars);
@@ -194,7 +207,10 @@ pub fn translate_function_arg_exprs(
         .collect::<Result<Vec<_>>>()
 }
 
-pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
+pub(crate) fn translate_function_with_params(
+    params: &[ParamLiteral],
+    sql_function: &SqlFunction,
+) -> Result<Expr> {
     let SqlFunction { name, args, .. } = sql_function;
     let name = translate_object_name(name)?.to_uppercase();
     let (args, distinct) = match args {
@@ -224,7 +240,9 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         check_len(name, args.len(), 1)?;
 
         let count_arg = match function_arg_exprs[0] {
-            SqlFunctionArgExpr::Expr(expr) => CountArgExpr::Expr(translate_expr(expr)?),
+            SqlFunctionArgExpr::Expr(expr) => {
+                CountArgExpr::Expr(translate_expr_with_params(expr, params)?)
+            }
             SqlFunctionArgExpr::QualifiedWildcard(idents) => {
                 let table_name = translate_object_name(idents)?;
                 let idents = format!("{table_name}.*");
@@ -242,33 +260,35 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
     let args = translate_function_arg_exprs(function_arg_exprs)?;
 
     match name.as_str() {
-        "SUM" => translate_aggregate_one_arg(Aggregate::sum, args, name, distinct),
-        "MIN" => translate_aggregate_one_arg(Aggregate::min, args, name, distinct),
-        "MAX" => translate_aggregate_one_arg(Aggregate::max, args, name, distinct),
-        "AVG" => translate_aggregate_one_arg(Aggregate::avg, args, name, distinct),
-        "VARIANCE" => translate_aggregate_one_arg(Aggregate::variance, args, name, distinct),
-        "STDEV" => translate_aggregate_one_arg(Aggregate::stdev, args, name, distinct),
+        "SUM" => translate_aggregate_one_arg(params, Aggregate::sum, args, name, distinct),
+        "MIN" => translate_aggregate_one_arg(params, Aggregate::min, args, name, distinct),
+        "MAX" => translate_aggregate_one_arg(params, Aggregate::max, args, name, distinct),
+        "AVG" => translate_aggregate_one_arg(params, Aggregate::avg, args, name, distinct),
+        "VARIANCE" => {
+            translate_aggregate_one_arg(params, Aggregate::variance, args, name, distinct)
+        }
+        "STDEV" => translate_aggregate_one_arg(params, Aggregate::stdev, args, name, distinct),
         "COALESCE" => {
             let exprs = args
                 .into_iter()
-                .map(translate_expr)
+                .map(|expr| translate_expr_with_params(expr, params))
                 .collect::<Result<Vec<_>>>()?;
             Ok(Expr::Function(Box::new(Function::Coalesce(exprs))))
         }
         "CONCAT" => {
             let exprs = args
                 .into_iter()
-                .map(translate_expr)
+                .map(|expr| translate_expr_with_params(expr, params))
                 .collect::<Result<Vec<_>>>()?;
             Ok(Expr::Function(Box::new(Function::Concat(exprs))))
         }
         "CONCAT_WS" => {
             check_len_min(name, args.len(), 2)?;
-            let separator = translate_expr(args[0])?;
+            let separator = translate_expr_with_params(args[0], params)?;
             let exprs = args
                 .into_iter()
                 .skip(1)
-                .map(translate_expr)
+                .map(|expr| translate_expr_with_params(expr, params))
                 .collect::<Result<Vec<_>>>()?;
             Ok(Expr::Function(Box::new(Function::ConcatWs {
                 separator,
@@ -278,10 +298,10 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "FIND_IDX" => {
             check_len_range(name, args.len(), 2, 3)?;
 
-            let from_expr = translate_expr(args[0])?;
-            let sub_expr = translate_expr(args[1])?;
+            let from_expr = translate_expr_with_params(args[0], params)?;
+            let sub_expr = translate_expr_with_params(args[1], params)?;
             let start = (args.len() > 2)
-                .then(|| translate_expr(args[2]))
+                .then(|| translate_expr_with_params(args[2], params))
                 .transpose()?;
 
             Ok(Expr::Function(Box::new(Function::FindIdx {
@@ -290,41 +310,41 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
                 start,
             })))
         }
-        "LOWER" => translate_function_one_arg(Function::Lower, args, name),
-        "INITCAP" => translate_function_one_arg(Function::Initcap, args, name),
-        "UPPER" => translate_function_one_arg(Function::Upper, args, name),
+        "LOWER" => translate_function_one_arg(params, Function::Lower, args, name),
+        "INITCAP" => translate_function_one_arg(params, Function::Initcap, args, name),
+        "UPPER" => translate_function_one_arg(params, Function::Upper, args, name),
         "LEFT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Left { expr, size })))
         }
         "IFNULL" => {
             check_len(name, args.len(), 2)?;
-            let expr = translate_expr(args[0])?;
-            let then = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let then = translate_expr_with_params(args[1], params)?;
             Ok(Expr::Function(Box::new(Function::IfNull { expr, then })))
         }
         "NULLIF" => {
             check_len(name, args.len(), 2)?;
-            let expr1 = translate_expr(args[0])?;
-            let expr2 = translate_expr(args[1])?;
+            let expr1 = translate_expr_with_params(args[0], params)?;
+            let expr2 = translate_expr_with_params(args[1], params)?;
             Ok(Expr::Function(Box::new(Function::NullIf { expr1, expr2 })))
         }
         "RIGHT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Right { expr, size })))
         }
         "SQRT" => {
             check_len(name, args.len(), 1)?;
 
-            translate_expr(args[0])
+            translate_expr_with_params(args[0], params)
                 .map(Function::Sqrt)
                 .map(Box::new)
                 .map(Expr::Function)
@@ -332,20 +352,20 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "POWER" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let power = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let power = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Power { expr, power })))
         }
         "LPAD" => {
             check_len_range(name, args.len(), 2, 3)?;
 
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
             let fill = if args.len() == 2 {
                 None
             } else {
-                Some(translate_expr(args[2])?)
+                Some(translate_expr_with_params(args[2], params)?)
             };
 
             Ok(Expr::Function(Box::new(Function::Lpad {
@@ -357,12 +377,12 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "RPAD" => {
             check_len_range(name, args.len(), 2, 3)?;
 
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
             let fill = if args.len() == 2 {
                 None
             } else {
-                Some(translate_expr(args[2])?)
+                Some(translate_expr_with_params(args[2], params)?)
             };
 
             Ok(Expr::Function(Box::new(Function::Rpad {
@@ -376,32 +396,32 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             let v = if args.is_empty() {
                 None
             } else {
-                Some(translate_expr(args[0])?)
+                Some(translate_expr_with_params(args[0], params)?)
             };
             Ok(Expr::Function(Box::new(Function::Rand(v))))
         }
-        "ROUND" => translate_function_one_arg(Function::Round, args, name),
-        "TRUNC" => translate_function_one_arg(Function::Trunc, args, name),
-        "EXP" => translate_function_one_arg(Function::Exp, args, name),
-        "LN" => translate_function_one_arg(Function::Ln, args, name),
+        "ROUND" => translate_function_one_arg(params, Function::Round, args, name),
+        "TRUNC" => translate_function_one_arg(params, Function::Trunc, args, name),
+        "EXP" => translate_function_one_arg(params, Function::Exp, args, name),
+        "LN" => translate_function_one_arg(params, Function::Ln, args, name),
         "LOG" => {
             check_len(name, args.len(), 2)?;
 
-            let antilog = translate_expr(args[0])?;
-            let base = translate_expr(args[1])?;
+            let antilog = translate_expr_with_params(args[0], params)?;
+            let base = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Log { antilog, base })))
         }
-        "LOG2" => translate_function_one_arg(Function::Log2, args, name),
-        "LOG10" => translate_function_one_arg(Function::Log10, args, name),
-        "SIN" => translate_function_one_arg(Function::Sin, args, name),
-        "COS" => translate_function_one_arg(Function::Cos, args, name),
-        "TAN" => translate_function_one_arg(Function::Tan, args, name),
-        "ASIN" => translate_function_one_arg(Function::Asin, args, name),
-        "ACOS" => translate_function_one_arg(Function::Acos, args, name),
-        "ATAN" => translate_function_one_arg(Function::Atan, args, name),
-        "RADIANS" => translate_function_one_arg(Function::Radians, args, name),
-        "DEGREES" => translate_function_one_arg(Function::Degrees, args, name),
+        "LOG2" => translate_function_one_arg(params, Function::Log2, args, name),
+        "LOG10" => translate_function_one_arg(params, Function::Log10, args, name),
+        "SIN" => translate_function_one_arg(params, Function::Sin, args, name),
+        "COS" => translate_function_one_arg(params, Function::Cos, args, name),
+        "TAN" => translate_function_one_arg(params, Function::Tan, args, name),
+        "ASIN" => translate_function_one_arg(params, Function::Asin, args, name),
+        "ACOS" => translate_function_one_arg(params, Function::Acos, args, name),
+        "ATAN" => translate_function_one_arg(params, Function::Atan, args, name),
+        "RADIANS" => translate_function_one_arg(params, Function::Radians, args, name),
+        "DEGREES" => translate_function_one_arg(params, Function::Degrees, args, name),
         "PI" => translate_function_zero_arg(Function::Pi(), args, name),
         "NOW" => translate_function_zero_arg(Function::Now(), args, name),
         "CURRENT_DATE" => translate_function_zero_arg(Function::CurrentDate(), args, name),
@@ -412,37 +432,43 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "GCD" => {
             check_len(name, args.len(), 2)?;
 
-            let left = translate_expr(args[0])?;
-            let right = translate_expr(args[1])?;
+            let left = translate_expr_with_params(args[0], params)?;
+            let right = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Gcd { left, right })))
         }
         "LAST_DAY" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
 
             Ok(Expr::Function(Box::new(Function::LastDay(expr))))
         }
         "LCM" => {
             check_len(name, args.len(), 2)?;
 
-            let left = translate_expr(args[0])?;
-            let right = translate_expr(args[1])?;
+            let left = translate_expr_with_params(args[0], params)?;
+            let right = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Lcm { left, right })))
         }
-        "LTRIM" => {
-            translate_function_trim(|expr, chars| Function::Ltrim { expr, chars }, args, name)
-        }
-        "RTRIM" => {
-            translate_function_trim(|expr, chars| Function::Rtrim { expr, chars }, args, name)
-        }
+        "LTRIM" => translate_function_trim(
+            params,
+            |expr, chars| Function::Ltrim { expr, chars },
+            args,
+            name,
+        ),
+        "RTRIM" => translate_function_trim(
+            params,
+            |expr, chars| Function::Rtrim { expr, chars },
+            args,
+            name,
+        ),
         "DIV" => {
             check_len(name, args.len(), 2)?;
 
-            let dividend = translate_expr(args[0])?;
-            let divisor = translate_expr(args[1])?;
+            let dividend = translate_expr_with_params(args[0], params)?;
+            let divisor = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Div {
                 dividend,
@@ -452,20 +478,20 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "MOD" => {
             check_len(name, args.len(), 2)?;
 
-            let dividend = translate_expr(args[0])?;
-            let divisor = translate_expr(args[1])?;
+            let dividend = translate_expr_with_params(args[0], params)?;
+            let divisor = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Mod {
                 dividend,
                 divisor,
             })))
         }
-        "REVERSE" => translate_function_one_arg(Function::Reverse, args, name),
+        "REVERSE" => translate_function_one_arg(params, Function::Reverse, args, name),
         "REPLACE" => {
             check_len(name, args.len(), 3)?;
-            let expr = translate_expr(args[0])?;
-            let old = translate_expr(args[1])?;
-            let new = translate_expr(args[2])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let old = translate_expr_with_params(args[1], params)?;
+            let new = translate_expr_with_params(args[2], params)?;
 
             Ok(Expr::Function(Box::new(Function::Replace {
                 expr,
@@ -476,18 +502,18 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "REPEAT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let num = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let num = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Repeat { expr, num })))
         }
         "SUBSTR" => {
             check_len_range(name, args.len(), 2, 3)?;
 
-            let expr = translate_expr(args[0])?;
-            let start = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let start = translate_expr_with_params(args[1], params)?;
             let count = (args.len() > 2)
-                .then(|| translate_expr(args[2]))
+                .then(|| translate_expr_with_params(args[2], params))
                 .transpose()?;
 
             Ok(Expr::Function(Box::new(Function::Substr {
@@ -499,30 +525,30 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "UNWRAP" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let selector = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let selector = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Unwrap {
                 expr,
                 selector,
             })))
         }
-        "ABS" => translate_function_one_arg(Function::Abs, args, name),
-        "SIGN" => translate_function_one_arg(Function::Sign, args, name),
+        "ABS" => translate_function_one_arg(params, Function::Abs, args, name),
+        "SIGN" => translate_function_one_arg(params, Function::Sign, args, name),
         "GENERATE_UUID" => translate_function_zero_arg(Function::GenerateUuid(), args, name),
         "FORMAT" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let format = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let format = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Format { expr, format })))
         }
         "TO_DATE" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let format = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let format = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::ToDate { expr, format })))
         }
@@ -530,8 +556,8 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "TO_TIMESTAMP" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let format = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let format = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::ToTimestamp {
                 expr,
@@ -541,109 +567,109 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "TO_TIME" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let format = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let format = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::ToTime { expr, format })))
         }
         "ADD_MONTH" => {
             check_len(name, args.len(), 2)?;
 
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::AddMonth { expr, size })))
         }
         "ASCII" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Ascii(expr))))
         }
         "CHR" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Chr(expr))))
         }
         "MD5" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Md5(expr))))
         }
         "HEX" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Hex(expr))))
         }
         "LENGTH" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Length(expr))))
         }
         "APPEND" => {
             check_len(name, args.len(), 2)?;
-            let expr = translate_expr(args[0])?;
-            let value = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let value = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Append { expr, value })))
         }
         "PREPEND" => {
             check_len(name, args.len(), 2)?;
-            let expr = translate_expr(args[0])?;
-            let value = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let value = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Prepend { expr, value })))
         }
         "SKIP" => {
             check_len(name, args.len(), 2)?;
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Skip { expr, size })))
         }
         "SORT" => {
             check_len_range(name, args.len(), 1, 2)?;
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             let order = (args.len() > 1)
-                .then(|| translate_expr(args[1]))
+                .then(|| translate_expr_with_params(args[1], params))
                 .transpose()?;
 
             Ok(Expr::Function(Box::new(Function::Sort { expr, order })))
         }
         "TAKE" => {
             check_len(name, args.len(), 2)?;
-            let expr = translate_expr(args[0])?;
-            let size = translate_expr(args[1])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let size = translate_expr_with_params(args[1], params)?;
 
             Ok(Expr::Function(Box::new(Function::Take { expr, size })))
         }
         "POINT" => {
             check_len(name, args.len(), 2)?;
-            let x = translate_expr(args[0])?;
-            let y = translate_expr(args[1])?;
+            let x = translate_expr_with_params(args[0], params)?;
+            let y = translate_expr_with_params(args[1], params)?;
             Ok(Expr::Function(Box::new(Function::Point { x, y })))
         }
         "GET_X" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::GetX(expr))))
         }
         "GET_Y" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::GetY(expr))))
         }
         "CALC_DISTANCE" => {
             check_len(name, args.len(), 2)?;
 
-            let geometry1 = translate_expr(args[0])?;
-            let geometry2 = translate_expr(args[1])?;
+            let geometry1 = translate_expr_with_params(args[0], params)?;
+            let geometry2 = translate_expr_with_params(args[1], params)?;
             Ok(Expr::Function(Box::new(Function::CalcDistance {
                 geometry1,
                 geometry2,
@@ -652,14 +678,14 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         "IS_EMPTY" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::IsEmpty(expr))))
         }
         "SLICE" => {
             check_len(name, args.len(), 3)?;
-            let expr = translate_expr(args[0])?;
-            let start = translate_expr(args[1])?;
-            let length = translate_expr(args[2])?;
+            let expr = translate_expr_with_params(args[0], params)?;
+            let start = translate_expr_with_params(args[1], params)?;
+            let length = translate_expr_with_params(args[2], params)?;
 
             Ok(Expr::Function(Box::new(Function::Slice {
                 expr,
@@ -671,35 +697,35 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
             check_len_min(name, args.len(), 2)?;
             let exprs = args
                 .into_iter()
-                .map(translate_expr)
+                .map(|expr| translate_expr_with_params(expr, params))
                 .collect::<Result<Vec<_>>>()?;
             Ok(Expr::Function(Box::new(Function::Greatest(exprs))))
         }
         "ENTRIES" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Entries(expr))))
         }
         "KEYS" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Keys(expr))))
         }
         "VALUES" => {
             check_len(name, args.len(), 1)?;
 
-            let expr = translate_expr(args[0])?;
+            let expr = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Values(expr))))
         }
         "SPLICE" => {
             check_len_range(name, args.len(), 3, 4)?;
-            let list_data = translate_expr(args[0])?;
-            let begin_index = translate_expr(args[1])?;
-            let end_index = translate_expr(args[2])?;
+            let list_data = translate_expr_with_params(args[0], params)?;
+            let begin_index = translate_expr_with_params(args[1], params)?;
+            let end_index = translate_expr_with_params(args[2], params)?;
             let values = if args.len() == 4 {
-                Some(translate_expr(args[3])?)
+                Some(translate_expr_with_params(args[3], params)?)
             } else {
                 None
             };
@@ -712,24 +738,68 @@ pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
         }
         "DEDUP" => {
             check_len(name, args.len(), 1)?;
-            let list = translate_expr(args[0])?;
+            let list = translate_expr_with_params(args[0], params)?;
             Ok(Expr::Function(Box::new(Function::Dedup(list))))
         }
         _ => {
             let exprs = args
                 .into_iter()
-                .map(translate_expr)
+                .map(|expr| translate_expr_with_params(expr, params))
                 .collect::<Result<Vec<_>>>()?;
             Ok(Expr::Function(Box::new(Function::Custom { name, exprs })))
         }
     }
 }
 
+#[allow(dead_code)]
+pub fn translate_trim(
+    expr: &SqlExpr,
+    trim_where: &Option<SqlTrimWhereField>,
+    trim_what: &Option<Box<SqlExpr>>,
+) -> Result<Expr> {
+    translate_trim_with_params(&[], expr, trim_where, trim_what)
+}
+
+#[allow(dead_code)]
+pub fn translate_floor(expr: &SqlExpr) -> Result<Expr> {
+    translate_floor_with_params(&[], expr)
+}
+
+#[allow(dead_code)]
+pub fn translate_ceil(expr: &SqlExpr) -> Result<Expr> {
+    translate_ceil_with_params(&[], expr)
+}
+
+#[allow(dead_code)]
+pub fn translate_position(sub_expr: &SqlExpr, from_expr: &SqlExpr) -> Result<Expr> {
+    translate_position_with_params(&[], sub_expr, from_expr)
+}
+
+#[allow(dead_code)]
+pub fn translate_cast(
+    kind: &SqlCastKind,
+    expr: &SqlExpr,
+    data_type: &SqlDataType,
+    format: Option<&SqlCastFormat>,
+) -> Result<Expr> {
+    translate_cast_with_params(&[], kind, expr, data_type, format)
+}
+
+#[allow(dead_code)]
+pub fn translate_extract(field: &SqlDateTimeField, expr: &SqlExpr) -> Result<Expr> {
+    translate_extract_with_params(&[], field, expr)
+}
+
+#[allow(dead_code)]
+pub fn translate_function(sql_function: &SqlFunction) -> Result<Expr> {
+    translate_function_with_params(&[], sql_function)
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
-        crate::{ast::DataType, parse_sql::parse_expr},
+        crate::{ast::DataType, parse_sql::parse_expr, translate::translate_expr},
     };
 
     #[test]

--- a/core/src/translate/param.rs
+++ b/core/src/translate/param.rs
@@ -1,0 +1,281 @@
+use {
+    crate::{
+        ast::{AstLiteral, DataType, DateTimeField, Expr},
+        data::{Interval, Point},
+    },
+    bigdecimal::BigDecimal,
+    chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc},
+    rust_decimal::Decimal,
+    std::net::IpAddr,
+    uuid::Uuid,
+};
+
+#[derive(Debug, Clone)]
+pub enum ParamLiteral {
+    Literal(AstLiteral),
+    TypedString {
+        data_type: DataType,
+        value: String,
+    },
+    Interval {
+        expr: Box<ParamLiteral>,
+        leading_field: Option<DateTimeField>,
+        last_field: Option<DateTimeField>,
+    },
+}
+
+impl ParamLiteral {
+    pub const fn null() -> Self {
+        Self::Literal(AstLiteral::Null)
+    }
+
+    pub(crate) fn into_expr_for_placeholder(self, _index: usize) -> crate::result::Result<Expr> {
+        Ok(self.into_expr())
+    }
+
+    pub fn into_expr(self) -> Expr {
+        match self {
+            ParamLiteral::Literal(literal) => Expr::Literal(literal),
+            ParamLiteral::TypedString { data_type, value } => {
+                Expr::TypedString { data_type, value }
+            }
+            ParamLiteral::Interval {
+                expr,
+                leading_field,
+                last_field,
+            } => Expr::Interval {
+                expr: Box::new(expr.into_expr()),
+                leading_field,
+                last_field,
+            },
+        }
+    }
+}
+
+fn into_number_literal(value: impl ToString) -> AstLiteral {
+    let number = value
+        .to_string()
+        .parse::<BigDecimal>()
+        .expect("failed to convert number into BigDecimal");
+
+    AstLiteral::Number(number)
+}
+
+impl From<bool> for ParamLiteral {
+    fn from(value: bool) -> Self {
+        ParamLiteral::Literal(AstLiteral::Boolean(value))
+    }
+}
+
+macro_rules! impl_from_integer {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl From<$ty> for ParamLiteral {
+                fn from(value: $ty) -> Self {
+                    ParamLiteral::Literal(into_number_literal(value))
+                }
+            }
+        )+
+    };
+}
+
+impl_from_integer!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
+
+impl From<f32> for ParamLiteral {
+    fn from(value: f32) -> Self {
+        ParamLiteral::Literal(into_number_literal(value))
+    }
+}
+
+impl From<f64> for ParamLiteral {
+    fn from(value: f64) -> Self {
+        ParamLiteral::Literal(into_number_literal(value))
+    }
+}
+
+impl From<Decimal> for ParamLiteral {
+    fn from(value: Decimal) -> Self {
+        ParamLiteral::Literal(into_number_literal(value))
+    }
+}
+
+impl From<String> for ParamLiteral {
+    fn from(value: String) -> Self {
+        ParamLiteral::Literal(AstLiteral::QuotedString(value))
+    }
+}
+
+impl From<&str> for ParamLiteral {
+    fn from(value: &str) -> Self {
+        ParamLiteral::Literal(AstLiteral::QuotedString(value.to_owned()))
+    }
+}
+
+impl From<Vec<u8>> for ParamLiteral {
+    fn from(value: Vec<u8>) -> Self {
+        ParamLiteral::Literal(AstLiteral::HexString(hex::encode(value)))
+    }
+}
+
+impl From<&[u8]> for ParamLiteral {
+    fn from(value: &[u8]) -> Self {
+        ParamLiteral::Literal(AstLiteral::HexString(hex::encode(value)))
+    }
+}
+
+impl From<IpAddr> for ParamLiteral {
+    fn from(value: IpAddr) -> Self {
+        ParamLiteral::Literal(AstLiteral::QuotedString(value.to_string()))
+    }
+}
+
+impl From<NaiveDate> for ParamLiteral {
+    fn from(value: NaiveDate) -> Self {
+        ParamLiteral::TypedString {
+            data_type: DataType::Date,
+            value: value.to_string(),
+        }
+    }
+}
+
+impl From<NaiveTime> for ParamLiteral {
+    fn from(value: NaiveTime) -> Self {
+        ParamLiteral::TypedString {
+            data_type: DataType::Time,
+            value: value.to_string(),
+        }
+    }
+}
+
+impl From<NaiveDateTime> for ParamLiteral {
+    fn from(value: NaiveDateTime) -> Self {
+        ParamLiteral::TypedString {
+            data_type: DataType::Timestamp,
+            value: Utc.from_utc_datetime(&value).to_string(),
+        }
+    }
+}
+
+impl From<Uuid> for ParamLiteral {
+    fn from(value: Uuid) -> Self {
+        ParamLiteral::Literal(AstLiteral::QuotedString(value.hyphenated().to_string()))
+    }
+}
+
+impl From<Point> for ParamLiteral {
+    fn from(value: Point) -> Self {
+        ParamLiteral::Literal(AstLiteral::QuotedString(value.to_string()))
+    }
+}
+
+impl From<Interval> for ParamLiteral {
+    fn from(value: Interval) -> Self {
+        match value {
+            Interval::Month(months) => ParamLiteral::Interval {
+                expr: Box::new(ParamLiteral::Literal(into_number_literal(months))),
+                leading_field: Some(DateTimeField::Month),
+                last_field: None,
+            },
+            Interval::Microsecond(micros) => ParamLiteral::Interval {
+                expr: Box::new(ParamLiteral::Literal(into_number_literal(
+                    micros / 1_000_000,
+                ))),
+                leading_field: Some(DateTimeField::Second),
+                last_field: None,
+            },
+        }
+    }
+}
+
+impl<T> From<Option<T>> for ParamLiteral
+where
+    T: Into<ParamLiteral>,
+{
+    fn from(value: Option<T>) -> Self {
+        value.map(Into::into).unwrap_or_else(ParamLiteral::null)
+    }
+}
+
+#[macro_export]
+macro_rules! params {
+    ($($expr:expr),* $(,)?) => {
+        vec![
+            $(
+                $crate::translate::ParamLiteral::from($expr)
+            ),*
+        ]
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::ast::{AstLiteral, Expr},
+    };
+
+    #[test]
+    fn converts_basic_literals() {
+        let literal = ParamLiteral::from(true).into_expr();
+        assert_eq!(literal, Expr::Literal(AstLiteral::Boolean(true)));
+
+        let literal = ParamLiteral::from(42_i64).into_expr();
+        assert_eq!(literal, Expr::Literal(AstLiteral::Number(42.into())));
+
+        let literal = ParamLiteral::from("glue").into_expr();
+        assert_eq!(
+            literal,
+            Expr::Literal(AstLiteral::QuotedString("glue".to_owned()))
+        );
+    }
+
+    #[test]
+    fn converts_typed_literals() {
+        let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        let expr = ParamLiteral::from(date).into_expr();
+        assert_eq!(
+            expr,
+            Expr::TypedString {
+                data_type: DataType::Date,
+                value: "2024-01-15".to_owned(),
+            }
+        );
+
+        let timestamp = NaiveDate::from_ymd_opt(2024, 1, 15)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let expr = ParamLiteral::from(timestamp).into_expr();
+        assert_eq!(
+            expr,
+            Expr::TypedString {
+                data_type: DataType::Timestamp,
+                value: "2024-01-15 12:00:00 UTC".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn converts_interval() {
+        let expr = ParamLiteral::from(Interval::Month(2)).into_expr();
+        assert_eq!(
+            expr,
+            Expr::Interval {
+                expr: Box::new(Expr::Literal(AstLiteral::Number(2.into()))),
+                leading_field: Some(DateTimeField::Month),
+                last_field: None,
+            }
+        );
+    }
+
+    #[test]
+    fn converts_option() {
+        let expr = ParamLiteral::from(Some(1_i32)).into_expr();
+        assert_eq!(expr, Expr::Literal(AstLiteral::Number(1.into())));
+
+        let expr = ParamLiteral::from(None::<i32>).into_expr();
+        assert_eq!(expr, Expr::Literal(AstLiteral::Null));
+    }
+}

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -1,7 +1,8 @@
 use {
     super::{
-        TranslateError, function::translate_function_arg_exprs, translate_expr, translate_idents,
-        translate_object_name, translate_order_by_expr,
+        ParamLiteral, TranslateError, function::translate_function_arg_exprs,
+        translate_expr_with_params, translate_idents, translate_object_name,
+        translate_order_by_expr_with_params,
     },
     crate::{
         ast::{
@@ -20,7 +21,10 @@ use {
     },
 };
 
-pub fn translate_query(sql_query: &SqlQuery) -> Result<Query> {
+pub(crate) fn translate_query_with_params(
+    sql_query: &SqlQuery,
+    params: &[ParamLiteral],
+) -> Result<Query> {
     let SqlQuery {
         with,
         body,
@@ -46,31 +50,51 @@ pub fn translate_query(sql_query: &SqlQuery) -> Result<Query> {
         return Err(TranslateError::UnsupportedQueryOption(reason).into());
     }
 
-    let body = translate_set_expr(body)?;
-    let order_by = order_by
-        .iter()
-        .flat_map(|order_by| order_by.exprs.iter().map(translate_order_by_expr))
-        .collect::<Result<_>>()?;
-    let limit = limit.as_ref().map(translate_expr).transpose()?;
+    let body = translate_set_expr_with_params(params, body)?;
+    let mut order_by_exprs = Vec::new();
+    for clause in order_by.iter() {
+        for expr in clause.exprs.iter() {
+            order_by_exprs.push(translate_order_by_expr_with_params(expr, params)?);
+        }
+    }
+    let limit = limit
+        .as_ref()
+        .map(|limit| translate_expr_with_params(limit, params))
+        .transpose()?;
     let offset = offset
         .as_ref()
-        .map(|offset| translate_expr(&offset.value))
+        .map(|offset| translate_expr_with_params(&offset.value, params))
         .transpose()?;
 
     Ok(Query {
         body,
-        order_by,
+        order_by: order_by_exprs,
         limit,
         offset,
     })
 }
 
-fn translate_set_expr(sql_set_expr: &SqlSetExpr) -> Result<SetExpr> {
+pub fn translate_query(sql_query: &SqlQuery) -> Result<Query> {
+    const NO_PARAMS: [ParamLiteral; 0] = [];
+    translate_query_with_params(sql_query, &NO_PARAMS)
+}
+
+fn translate_set_expr_with_params(
+    params: &[ParamLiteral],
+    sql_set_expr: &SqlSetExpr,
+) -> Result<SetExpr> {
     match sql_set_expr {
-        SqlSetExpr::Select(select) => translate_select(select).map(Box::new).map(SetExpr::Select),
+        SqlSetExpr::Select(select) => translate_select_with_params(params, select)
+            .map(Box::new)
+            .map(SetExpr::Select),
         SqlSetExpr::Values(sqlparser::ast::Values { rows, .. }) => rows
             .iter()
-            .map(|items| items.iter().map(translate_expr).collect::<Result<_>>())
+            .map(|items| {
+                items
+                    .iter()
+                    .map(|expr| translate_expr_with_params(expr, params))
+                    .collect::<Result<_>>()
+            })
             .collect::<Result<_>>()
             .map(Values)
             .map(SetExpr::Values),
@@ -78,7 +102,7 @@ fn translate_set_expr(sql_set_expr: &SqlSetExpr) -> Result<SetExpr> {
     }
 }
 
-fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
+fn translate_select_with_params(params: &[ParamLiteral], sql_select: &SqlSelect) -> Result<Select> {
     let SqlSelect {
         projection,
         from,
@@ -110,7 +134,7 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
     };
 
     let from = match from.first() {
-        Some(sql_table_with_joins) => translate_table_with_joins(sql_table_with_joins)?,
+        Some(sql_table_with_joins) => translate_table_with_joins(params, sql_table_with_joins)?,
         None => TableWithJoins {
             relation: TableFactor::Series {
                 alias: TableAlias {
@@ -134,16 +158,28 @@ fn translate_select(sql_select: &SqlSelect) -> Result<Select> {
         distinct,
         projection: projection
             .iter()
-            .map(translate_select_item)
+            .map(|item| translate_select_item_with_params(params, item))
             .collect::<Result<_>>()?,
         from,
-        selection: selection.as_ref().map(translate_expr).transpose()?,
-        group_by: group_by.iter().map(translate_expr).collect::<Result<_>>()?,
-        having: having.as_ref().map(translate_expr).transpose()?,
+        selection: selection
+            .as_ref()
+            .map(|expr| translate_expr_with_params(expr, params))
+            .transpose()?,
+        group_by: group_by
+            .iter()
+            .map(|expr| translate_expr_with_params(expr, params))
+            .collect::<Result<_>>()?,
+        having: having
+            .as_ref()
+            .map(|expr| translate_expr_with_params(expr, params))
+            .transpose()?,
     })
 }
 
-pub fn translate_select_item(sql_select_item: &SqlSelectItem) -> Result<SelectItem> {
+pub(crate) fn translate_select_item_with_params(
+    params: &[ParamLiteral],
+    sql_select_item: &SqlSelectItem,
+) -> Result<SelectItem> {
     match sql_select_item {
         SqlSelectItem::UnnamedExpr(expr) => {
             let label = match expr {
@@ -155,16 +191,15 @@ pub fn translate_select_item(sql_select_item: &SqlSelectItem) -> Result<SelectIt
             };
 
             Ok(SelectItem::Expr {
-                expr: translate_expr(expr)?,
+                expr: translate_expr_with_params(expr, params)?,
                 label,
             })
         }
-        SqlSelectItem::ExprWithAlias { expr, alias } => {
-            translate_expr(expr).map(|expr| SelectItem::Expr {
+        SqlSelectItem::ExprWithAlias { expr, alias } => translate_expr_with_params(expr, params)
+            .map(|expr| SelectItem::Expr {
                 expr,
                 label: alias.value.to_owned(),
-            })
-        }
+            }),
         SqlSelectItem::QualifiedWildcard(object_name, _) => Ok(SelectItem::QualifiedWildcard(
             translate_object_name(object_name)?,
         )),
@@ -172,12 +207,23 @@ pub fn translate_select_item(sql_select_item: &SqlSelectItem) -> Result<SelectIt
     }
 }
 
-fn translate_table_with_joins(sql_table_with_joins: &SqlTableWithJoins) -> Result<TableWithJoins> {
+pub fn translate_select_item(sql_select_item: &SqlSelectItem) -> Result<SelectItem> {
+    const NO_PARAMS: [ParamLiteral; 0] = [];
+    translate_select_item_with_params(&NO_PARAMS, sql_select_item)
+}
+
+fn translate_table_with_joins(
+    params: &[ParamLiteral],
+    sql_table_with_joins: &SqlTableWithJoins,
+) -> Result<TableWithJoins> {
     let SqlTableWithJoins { relation, joins } = sql_table_with_joins;
 
     Ok(TableWithJoins {
-        relation: translate_table_factor(relation)?,
-        joins: joins.iter().map(translate_join).collect::<Result<_>>()?,
+        relation: translate_table_factor(params, relation)?,
+        joins: joins
+            .iter()
+            .map(|join| translate_join(params, join))
+            .collect::<Result<_>>()?,
     })
 }
 
@@ -190,7 +236,10 @@ fn translate_table_alias(alias: &Option<SqlTableAlias>) -> Option<TableAlias> {
         })
 }
 
-fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFactor> {
+fn translate_table_factor(
+    params: &[ParamLiteral],
+    sql_table_factor: &SqlTableFactor,
+) -> Result<TableFactor> {
     let translate_table_args = |args: &Vec<SqlFunctionArg>| -> Result<Expr> {
         let function_arg_exprs = args
             .iter()
@@ -203,7 +252,7 @@ fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFact
             .collect::<Result<Vec<_>>>()?;
 
         match translate_function_arg_exprs(function_arg_exprs)?.first() {
-            Some(expr) => Ok(translate_expr(expr)?),
+            Some(expr) => Ok(translate_expr_with_params(expr, params)?),
             None => Err(TranslateError::LackOfArgs.into()),
         }
     };
@@ -250,7 +299,7 @@ fn translate_table_factor(sql_table_factor: &SqlTableFactor) -> Result<TableFact
         } => {
             if let Some(alias) = alias {
                 Ok(TableFactor::Derived {
-                    subquery: translate_query(subquery)?,
+                    subquery: translate_query_with_params(subquery, params)?,
                     alias: TableAlias {
                         name: alias.name.value.to_owned(),
                         columns: translate_idents(&alias.columns),
@@ -271,7 +320,7 @@ pub fn alias_or_name(alias: Option<TableAlias>, name: String) -> TableAlias {
     })
 }
 
-fn translate_join(sql_join: &SqlJoin) -> Result<Join> {
+fn translate_join(params: &[ParamLiteral], sql_join: &SqlJoin) -> Result<Join> {
     let SqlJoin {
         relation,
         join_operator: sql_join_operator,
@@ -279,7 +328,9 @@ fn translate_join(sql_join: &SqlJoin) -> Result<Join> {
     } = sql_join;
 
     let translate_constraint = |sql_join_constraint: &SqlJoinConstraint| match sql_join_constraint {
-        SqlJoinConstraint::On(expr) => translate_expr(expr).map(JoinConstraint::On),
+        SqlJoinConstraint::On(expr) => {
+            translate_expr_with_params(expr, params).map(JoinConstraint::On)
+        }
         SqlJoinConstraint::None => Ok(JoinConstraint::None),
         SqlJoinConstraint::Using(_) => {
             Err(TranslateError::UnsupportedJoinConstraint("USING".to_owned()).into())
@@ -300,7 +351,7 @@ fn translate_join(sql_join: &SqlJoin) -> Result<Join> {
     }?;
 
     Ok(Join {
-        relation: translate_table_factor(relation)?,
+        relation: translate_table_factor(params, relation)?,
         join_operator,
         join_executor: JoinExecutor::NestedLoop,
     })

--- a/pkg/rust/examples/parameter_binding.rs
+++ b/pkg/rust/examples/parameter_binding.rs
@@ -1,0 +1,46 @@
+#[cfg(feature = "gluesql_memory_storage")]
+mod parameter_binding_example {
+    use gluesql::{
+        gluesql_memory_storage::MemoryStorage,
+        prelude::{Glue, Result},
+    };
+
+    pub async fn run() -> Result<()> {
+        let storage = MemoryStorage::default();
+        let mut glue = Glue::new(storage);
+
+        glue.execute("DROP TABLE IF EXISTS bind_example").await?;
+
+        glue.execute(
+            "CREATE TABLE bind_example (
+                id INTEGER,
+                name TEXT
+            )",
+        )
+        .await?;
+
+        let first = gluesql::params![1_i64, "Alice"];
+        glue.execute_with_params("INSERT INTO bind_example (id, name) VALUES ($1, $2)", first)
+            .await?;
+
+        let rows = glue
+            .execute_with_params(
+                "SELECT name FROM bind_example WHERE id = $1",
+                gluesql::params![2_i64],
+            )
+            .await?;
+
+        println!("query result: {rows:?}");
+
+        Ok(())
+    }
+}
+
+fn main() {
+    #[cfg(feature = "gluesql_memory_storage")]
+    {
+        if let Err(error) = futures::executor::block_on(parameter_binding_example::run()) {
+            eprintln!("error: {error}");
+        }
+    }
+}

--- a/pkg/rust/src/lib.rs
+++ b/pkg/rust/src/lib.rs
@@ -9,6 +9,8 @@ pub mod core {
     pub use gluesql_core::*;
 }
 
+pub use gluesql_core::params;
+
 // Re-export the derive macro so users can `use gluesql::FromGlueRow`.
 pub use gluesql_macros::FromGlueRow;
 


### PR DESCRIPTION
## Summary
- remove question-mark placeholder normalization and require indexed forms
- introduce ParamLiteral conversions and tighten translation pipeline
- add example and unit tests for parameter binding and placeholder indexing

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -p gluesql-core
- cargo test -p gluesql_memory_storage