### PR TITLE
Add runtime Value support to Expr

### DIFF
--- a/core/src/ast/expr.rs
+++ b/core/src/ast/expr.rs
@@ -3,6 +3,7 @@ use {
         Aggregate, AstLiteral, BinaryOperator, DataType, DateTimeField, Function, Query, ToSql,
         ToSqlUnquoted, UnaryOperator,
     },
+    crate::data::Value,
     serde::{Deserialize, Serialize},
 };
 
@@ -52,6 +53,7 @@ pub enum Expr {
     },
     Nested(Box<Expr>),
     Literal(AstLiteral),
+    Value(Value),
     TypedString {
         data_type: DataType,
         value: String,
@@ -181,6 +183,7 @@ impl Expr {
             },
             Expr::Nested(expr) => format!("({})", expr.to_sql_with(quoted)),
             Expr::Literal(s) => s.to_sql(),
+            Expr::Value(value) => value.to_sql(),
             Expr::TypedString { data_type, value } => format!("{data_type} '{value}'"),
             Expr::Case {
                 operand,

--- a/core/src/data/value.rs
+++ b/core/src/data/value.rs
@@ -29,6 +29,7 @@ mod expr;
 mod json;
 mod literal;
 mod selector;
+mod to_sql;
 mod uuid;
 
 pub use {

--- a/core/src/data/value/to_sql.rs
+++ b/core/src/data/value/to_sql.rs
@@ -1,0 +1,129 @@
+use {
+    super::Value,
+    crate::{
+        ast::ToSql,
+        chrono::{TimeZone, Utc},
+    },
+    bigdecimal::{BigDecimal, FromPrimitive},
+    serde_json::Value as JsonValue,
+    uuid::Uuid,
+};
+
+impl ToSql for Value {
+    fn to_sql(&self) -> String {
+        match self {
+            Value::Bool(value) => match value {
+                true => "TRUE".to_owned(),
+                false => "FALSE".to_owned(),
+            },
+            Value::I8(value) => value.to_string(),
+            Value::I16(value) => value.to_string(),
+            Value::I32(value) => value.to_string(),
+            Value::I64(value) => value.to_string(),
+            Value::I128(value) => value.to_string(),
+            Value::U8(value) => value.to_string(),
+            Value::U16(value) => value.to_string(),
+            Value::U32(value) => value.to_string(),
+            Value::U64(value) => value.to_string(),
+            Value::U128(value) => value.to_string(),
+            Value::F32(value) => format_float(BigDecimal::from_f32(*value), *value as f64),
+            Value::F64(value) => format_float(BigDecimal::from_f64(*value), *value),
+            Value::Decimal(value) => value.to_string(),
+            Value::Str(value) => quote(value),
+            Value::Bytea(bytes) => quote(&hex::encode(bytes)),
+            Value::Inet(addr) => quote(&addr.to_string()),
+            Value::Date(value) => format!("DATE {}", quote(&value.to_string())),
+            Value::Timestamp(value) => format!(
+                "TIMESTAMP {}",
+                quote(&Utc.from_utc_datetime(value).to_string())
+            ),
+            Value::Time(value) => format!("TIME {}", quote(&value.to_string())),
+            Value::Interval(interval) => format!("INTERVAL {}", interval.to_sql_str()),
+            Value::Uuid(value) => quote(&Uuid::from_u128(*value).hyphenated().to_string()),
+            Value::Map(map) => quote(&json_from_value(Value::Map(map.clone()), "{}")),
+            Value::List(list) => quote(&json_from_value(Value::List(list.clone()), "[]")),
+            Value::Point(point) => quote(&point.to_string()),
+            Value::Null => "NULL".to_owned(),
+        }
+    }
+}
+
+fn quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn format_float(from_big_decimal: Option<BigDecimal>, fallback: f64) -> String {
+    match from_big_decimal {
+        Some(decimal) => decimal.to_string(),
+        None => fallback.to_string(),
+    }
+}
+
+fn json_from_value(value: Value, default: &str) -> String {
+    JsonValue::try_from(value)
+        .map(|json| json.to_string())
+        .unwrap_or_else(|_| default.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::data::{Interval, Value, point::Point, value::uuid::parse_uuid},
+        chrono::{NaiveDate, NaiveDateTime, NaiveTime},
+        std::collections::BTreeMap,
+    };
+
+    #[test]
+    fn scalar_values_to_sql() {
+        assert_eq!(Value::Bool(true).to_sql(), "TRUE");
+        assert_eq!(Value::I32(-42).to_sql(), "-42");
+        assert_eq!(Value::F64(3.5).to_sql(), "3.5");
+        assert_eq!(Value::Str("can't".into()).to_sql(), "'can''t'");
+        assert_eq!(Value::Bytea(vec![0xde, 0xad]).to_sql(), "'dead'");
+
+        let uuid = parse_uuid("b6631ba6-9329-4e9d-b5ba-9b405df82d47").unwrap();
+        assert_eq!(
+            Value::Uuid(uuid).to_sql(),
+            "'b6631ba6-9329-4e9d-b5ba-9b405df82d47'"
+        );
+
+        assert_eq!(
+            Value::Date(NaiveDate::from_ymd_opt(2024, 1, 30).unwrap()).to_sql(),
+            "DATE '2024-01-30'"
+        );
+        assert_eq!(
+            Value::Timestamp(NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(2024, 1, 30).unwrap(),
+                NaiveTime::from_hms_opt(12, 5, 10).unwrap(),
+            ),)
+            .to_sql(),
+            "TIMESTAMP '2024-01-30 12:05:10 UTC'"
+        );
+        assert_eq!(
+            Value::Time(NaiveTime::from_hms_opt(23, 59, 59).unwrap()).to_sql(),
+            "TIME '23:59:59'"
+        );
+    }
+
+    #[test]
+    fn complex_values_to_sql() {
+        assert_eq!(
+            Value::Interval(Interval::Month(15)).to_sql(),
+            "INTERVAL '1-3' YEAR TO MONTH"
+        );
+
+        let mut map = BTreeMap::new();
+        map.insert("flag".to_owned(), Value::Bool(true));
+        assert_eq!(Value::Map(map).to_sql(), "'{\"flag\":true}'");
+
+        let list = vec![Value::I32(1), Value::I32(2)];
+        assert_eq!(Value::List(list).to_sql(), "'[1,2]'");
+
+        assert_eq!(
+            Value::Point(Point::new(1.1, 2.2)).to_sql(),
+            "'POINT(1.1 2.2)'"
+        );
+        assert_eq!(Value::Null.to_sql(), "NULL");
+    }
+}

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -70,6 +70,7 @@ where
 
     match expr {
         Expr::Literal(ast_literal) => expr::literal(ast_literal),
+        Expr::Value(value) => Ok(Evaluated::Value(value.clone())),
         Expr::TypedString { data_type, value } => {
             expr::typed_string(data_type, Cow::Borrowed(value))
         }

--- a/core/src/plan/expr.rs
+++ b/core/src/plan/expr.rs
@@ -22,7 +22,7 @@ pub enum PlanExpr<'a> {
 impl<'a> From<&'a Expr> for PlanExpr<'a> {
     fn from(expr: &'a Expr) -> Self {
         match expr {
-            Expr::Literal(_) | Expr::TypedString { .. } => PlanExpr::None,
+            Expr::Literal(_) | Expr::TypedString { .. } | Expr::Value(_) => PlanExpr::None,
             Expr::Identifier(ident) => PlanExpr::Identifier(ident),
             Expr::CompoundIdentifier { alias, ident } => {
                 PlanExpr::CompoundIdentifier { alias, ident }

--- a/core/src/plan/planner.rs
+++ b/core/src/plan/planner.rs
@@ -17,7 +17,8 @@ pub trait Planner<'a> {
             Expr::Identifier(_)
             | Expr::CompoundIdentifier { .. }
             | Expr::Literal(_)
-            | Expr::TypedString { .. } => expr,
+            | Expr::TypedString { .. }
+            | Expr::Value(_) => expr,
             Expr::IsNull(expr) => Expr::IsNull(Box::new(self.subquery_expr(outer_context, *expr))),
             Expr::IsNotNull(expr) => {
                 Expr::IsNotNull(Box::new(self.subquery_expr(outer_context, *expr)))


### PR DESCRIPTION
* Introduce `Expr::Value` so planner and runtime can carry values without literal conversions
* Add `Value::to_sql()` helper and reuse it in CLI dump output
* Cover the new serialization pathways with focused unit tests

## Testing
- cargo test --package gluesql-core scalar_values_to_sql
- cargo test --package gluesql-core complex_values_to_sql
- cargo test --package gluesql-cli format_dump_row_values
- cargo test
- cargo clippy --package gluesql-core --package gluesql-cli --all-targets -- -D warnings
