### PR TITLE
Include gluesql-macros in publish workflow

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -47,6 +47,7 @@ jobs:
               "gluesql-git-storage"
               "gluesql-composite-storage"
               "gluesql-cli"
+              "gluesql-macros"
               "gluesql"
             )
             for package in "${packages[@]}"; do


### PR DESCRIPTION
## Summary
- add gluesql-macros to the list of crates published by the rust workflow

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d63ddca418832a9fc1dce74f83a960