### PR TITLE
Pass PR number via coverage artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -104,6 +104,9 @@ jobs:
         run: |
           xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
           rm -f coverage/lcov.info
+      - name: Record PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > coverage/pr-number
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV
       - name: Create GitHub App token
@@ -131,4 +134,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage/lcov.info.xz
+          path: coverage

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           echo "RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
           echo "COMMIT_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
-          echo "PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=coverage" >> $GITHUB_ENV
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
@@ -72,6 +71,20 @@ jobs:
           run-id: ${{ env.RUN_ID }}
           path: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Load PR number from artifact
+        if: github.event_name == 'workflow_run'
+        run: |
+          pr_file="coverage/pr-number"
+          if [ ! -f "${pr_file}" ]; then
+            echo "PR number file not found in artifact: ${pr_file}" >&2
+            exit 1
+          fi
+          pr_number=$(cat "${pr_file}" | tr -d '\n\r ')
+          if [ -z "${pr_number}" ]; then
+            echo "PR number file is empty: ${pr_file}" >&2
+            exit 1
+          fi
+          echo "PR_NUMBER=${pr_number}" >> $GITHUB_ENV
       # No normalization needed: file will be at ./coverage/lcov.info.xz
       - name: Set timestamp
         run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H%M%SZ')" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Fork-originated Coverage runs expose an empty `pull_requests` array in the `workflow_run` payload, so Publish Coverage could not recover the PR number and failed when writing artifacts and comments. Persist the PR number inside the coverage artifact and let the publish job read it back so the workflow succeeds regardless of where the PR branch lives.

- record the pull request number in the coverage artifact when the Coverage workflow runs for PRs
- have the Publish Coverage workflow read that value from the downloaded artifact instead of assuming the payload contains PR metadata

## Testing
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coverage reporting pipeline in CI by recording the pull request number during PR runs and attaching it to the coverage artifact.
  * Updated the publish step to read the PR number from the artifact for workflow_run events, ensuring accurate association with the correct PR.
  * Now uploads the entire coverage directory as an artifact, enhancing reliability and diagnostics for coverage publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
