### PR TITLE
Add null cases to literal bitwise_and tests

### DIFF
--- a/core/src/data/literal.rs
+++ b/core/src/data/literal.rs
@@ -671,6 +671,9 @@ mod tests {
         }
 
         ok!(num(11), num(12), num(8));
+        ok!(Null, num(12), Null);
+        ok!(num(11), Null, Null);
+        ok!(Null, Null, Null);
         err!(text("11"), num(12));
         err!(num(11), text("12"));
         err!(text("11"), text("12"));


### PR DESCRIPTION
## Summary
- add assertions covering null operands in `Literal::bitwise_and` tests to exercise null-handling branches

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -p gluesql-core bitwise_and

------
https://chatgpt.com/codex/tasks/task_e_68daafca2d14832aaa36e82a53899b29