### PR TITLE
Apply `clippy::assigning_clones` clippy rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ utils = { package = "gluesql-utils", path = "./utils", version = "0.18.0" }
 [workspace.lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 too_many_lines = "allow"  # It's a clippy::pedantic rule, but it should still be allowed for cohesion.
-assigning_clones = "allow"
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_precision_loss = "allow"


### PR DESCRIPTION
Apply `clippy::assigning_clones` pedantic rule

This PR removes the `assigning_clones = "allow"` from workspace.lints.clippy and fixes all occurrences by using `clone_into()` instead of `.to_owned()` assignments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized in-place string handling for rename operations to improve internal performance and maintainability.
* **Chores**
  * Removed a previously allowed lint rule in workspace configuration, enforcing stricter lint checks in CI.

No user-facing functionality changed; these updates affect internal behavior, performance characteristics, and developer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->