### PR TITLE
Apply `clippy::bool_to_int_with_if` clippy rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ utils = { package = "gluesql-utils", path = "./utils", version = "0.18.0" }
 pedantic = { level = "deny", priority = -1 }
 too_many_lines = "allow"  # It's a clippy::pedantic rule, but it should still be allowed for cohesion.
 assigning_clones = "allow"
-bool_to_int_with_if = "allow"
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_precision_loss = "allow"

--- a/utils/src/or_stream.rs
+++ b/utils/src/or_stream.rs
@@ -81,7 +81,7 @@ where
                 } else if s1_low > 0 {
                     (s1_low, s1_high)
                 } else {
-                    let low = if s2_low > 0 { 1 } else { 0 };
+                    let low = usize::from(s2_low > 0);
                     let high = match (s1_high, s2_high) {
                         (Some(h1), Some(h2)) => Some(max(h1, h2)),
                         _ => None,


### PR DESCRIPTION
## Summary

This PR applies the `clippy::bool_to_int_with_if` clippy rule to enforce more idiomatic Rust code for boolean-to-integer conversions.

## Changes

- Removed `bool_to_int_with_if = "allow"` from workspace lints in `Cargo.toml`
- Fixed 1 violation in `utils/src/or_stream.rs:84`: replaced `if s2_low > 0 { 1 } else { 0 }` with `usize::from(s2_low > 0)`

## Test plan

- All clippy checks pass with `cargo clippy --all-targets -q`
- Code formatted with `cargo fmt --all -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified an internal size hint calculation for stream iteration; behavior and public API unchanged.

* **Chores**
  * Tightened lint configuration by removing an allow rule to enforce stricter checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->