### PR TITLE
Disallow Float32 primary keys

### DIFF
--- a/core/src/executor/alter/validate.rs
+++ b/core/src/executor/alter/validate.rs
@@ -17,8 +17,10 @@ pub async fn validate(column_def: &ColumnDef) -> Result<()> {
     } = column_def;
 
     // unique + data type
-    if matches!(data_type, DataType::Float | DataType::Map)
-        && matches!(unique, Some(ColumnUniqueOption { .. }))
+    if matches!(
+        data_type,
+        DataType::Float | DataType::Float32 | DataType::Map
+    ) && matches!(unique, Some(ColumnUniqueOption { .. }))
     {
         return Err(AlterError::UnsupportedDataTypeForUniqueColumn(
             name.to_owned(),

--- a/test-suite/src/alter/create_table.rs
+++ b/test-suite/src/alter/create_table.rs
@@ -78,6 +78,18 @@ test_case!(create_table, {
             .into()),
         ),
         (
+            "
+        CREATE TABLE CreateTableFloat32 (
+            id INTEGER,
+            ratio FLOAT32 PRIMARY KEY
+        )",
+            Err(AlterError::UnsupportedDataTypeForUniqueColumn(
+                "ratio".to_owned(),
+                gluesql_core::ast::DataType::Float32,
+            )
+            .into()),
+        ),
+        (
             "CREATE TABLE Gluery (id INTEGER DEFAULT (SELECT id FROM Wow))",
             Err(
                 EvaluateError::UnsupportedStatelessExpr(Box::new(expr("(SELECT id FROM Wow)")))


### PR DESCRIPTION
## Summary
- extend unique/primary key guard to include FLOAT32 columns
- add regression test covering FLOAT32 primary key rejection as unsupported

## Verification
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all
- cargo test -p gluesql_memory_storage create_table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation logic to consistently reject FLOAT32 data types when used with unique constraints, aligning with existing restrictions on FLOAT and Map types.

* **Tests**
  * Added test case to verify that FLOAT32 columns marked as UNIQUE properly trigger validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->