### PR TITLE
Replace custom ControlFlowMap with ControlFlow::map_continue

### DIFF
--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -60,7 +60,6 @@ impl BreakIfNull<Value> for Result<Value> {
     }
 }
 
-
 trait ControlFlowMapErr<T, F> {
     fn map_err(self, f: F) -> ControlFlow<T>
     where


### PR DESCRIPTION
###  Description
Replace custom `ControlFlowMap` trait with Rust's standard library `map_continue()` method.