### PR TITLE
Relax lifetime constraint on TableNameNode::delete

### DIFF
--- a/core/src/ast_builder/table_name.rs
+++ b/core/src/ast_builder/table_name.rs
@@ -20,7 +20,7 @@ impl<'a> TableNameNode {
         SelectNode::new(table_factor)
     }
 
-    pub fn delete(self) -> DeleteNode<'static> {
+    pub fn delete(self) -> DeleteNode<'a> {
         DeleteNode::new(self.table_name)
     }
 


### PR DESCRIPTION
This commit relaxes the lifetime constraint on the value returned by TableNameNode::delete -- prior to this change, the return value was bound to `'static`, which makes using it very challenging/unergonomic.

After this change, the lifetime is bound to `'a`, similar to its peer functions.

This fixes #1861 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structure handling to improve memory management and type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->