### PR TITLE
Fix retired macos-13 runner in publish-python workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [gluesql]
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15]
         architecture: [x86-64, aarch64]
 
     steps:
@@ -99,7 +99,7 @@ jobs:
         if: matrix.architecture == 'aarch64'
         id: target
         run: |
-          TARGET=${{ matrix.os == 'macos-13' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu'}}
+          TARGET=${{ matrix.os == 'macos-15' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu'}}
           echo "target=$TARGET" >> $GITHUB_OUTPUT
 
       - name: Build wheel


### PR DESCRIPTION
- [ ] [PyPI] Trusted Publisher for project gluesql can be made more secure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to use newer macOS runner targets for improved build infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->