### PR TITLE
Add patch coverage diff summary to PR coverage bot comment

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -269,6 +269,7 @@ jobs:
           }
 
           const topChangedFiles = perFileStats
+            .filter((fileStat) => fileStat.added_executable_lines > 0)
             .slice()
             .sort((left, right) => {
               if (right.added_lines !== left.added_lines) {

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -214,15 +214,27 @@ jobs:
           let addedExecutableLines = 0;
           let coveredAddedExecutableLines = 0;
           let missedAddedExecutableLines = 0;
+          const perFileStats = [];
 
           const changedLinesJson = {};
           for (const [file, addedSet] of changedByFile.entries()) {
             const sorted = Array.from(addedSet).sort((a, b) => a - b);
             changedLinesJson[file] = sorted;
             addedLines += sorted.length;
+            let fileAddedExecutableLines = 0;
+            let fileCoveredAddedExecutableLines = 0;
+            let fileMissedAddedExecutableLines = 0;
 
             const coverageLines = coverageByFile.get(file);
             if (!coverageLines) {
+              perFileStats.push({
+                file,
+                added_lines: sorted.length,
+                added_executable_lines: fileAddedExecutableLines,
+                covered_added_executable_lines: fileCoveredAddedExecutableLines,
+                missed_added_executable_lines: fileMissedAddedExecutableLines,
+                patch_coverage_percent: null,
+              });
               continue;
             }
 
@@ -233,13 +245,43 @@ jobs:
               }
 
               addedExecutableLines += 1;
+              fileAddedExecutableLines += 1;
               if (hit > 0) {
                 coveredAddedExecutableLines += 1;
+                fileCoveredAddedExecutableLines += 1;
               } else {
                 missedAddedExecutableLines += 1;
+                fileMissedAddedExecutableLines += 1;
               }
             }
+
+            perFileStats.push({
+              file,
+              added_lines: sorted.length,
+              added_executable_lines: fileAddedExecutableLines,
+              covered_added_executable_lines: fileCoveredAddedExecutableLines,
+              missed_added_executable_lines: fileMissedAddedExecutableLines,
+              patch_coverage_percent:
+                fileAddedExecutableLines > 0
+                  ? (fileCoveredAddedExecutableLines / fileAddedExecutableLines) * 100
+                  : null,
+            });
           }
+
+          const topChangedFiles = perFileStats
+            .slice()
+            .sort((left, right) => {
+              if (right.added_lines !== left.added_lines) {
+                return right.added_lines - left.added_lines;
+              }
+
+              if (right.added_executable_lines !== left.added_executable_lines) {
+                return right.added_executable_lines - left.added_executable_lines;
+              }
+
+              return left.file.localeCompare(right.file);
+            })
+            .slice(0, 10);
 
           const summary = {
             base_sha: baseSha,
@@ -257,6 +299,7 @@ jobs:
               addedExecutableLines > 0
                 ? (coveredAddedExecutableLines / addedExecutableLines) * 100
                 : null,
+            top_changed_files: topChangedFiles,
           };
 
           fs.writeFileSync(

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,8 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Free disk space (pre-build)
         continue-on-error: true
         run: |
@@ -83,6 +85,189 @@ jobs:
             --ignore "cli/src/{cli,helper,lib,main}.rs" \
             --excl-line "(#\\[derive\\()|(^\s*.await[;,]?$)|(^test_case\!\([\d\w]+,)" \
             -o ./coverage/lcov.info
+      - name: Build patch coverage summary
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const { execSync } = require('child_process');
+
+          const baseSha = process.env.BASE_SHA;
+          const headSha = process.env.HEAD_SHA;
+          const repoRoot = process.cwd();
+          const lcovPath = path.join(repoRoot, 'coverage', 'lcov.info');
+
+          const normalizePath = (filePath) => {
+            const normalized = filePath.replaceAll('\\', '/').replace(/^\.\/+/, '');
+            const rootPrefix = `${repoRoot.replaceAll('\\', '/')}/`;
+
+            if (normalized.startsWith(rootPrefix)) {
+              return normalized.slice(rootPrefix.length);
+            }
+
+            return normalized;
+          };
+
+          const parseLcov = () => {
+            const coverageByFile = new Map();
+            const lines = fs.readFileSync(lcovPath, 'utf8').split('\n');
+            let currentFile = null;
+
+            for (const line of lines) {
+              if (line.startsWith('SF:')) {
+                currentFile = normalizePath(line.slice(3).trim());
+                coverageByFile.set(currentFile, new Map());
+                continue;
+              }
+
+              if (line === 'end_of_record') {
+                currentFile = null;
+                continue;
+              }
+
+              if (!currentFile || !line.startsWith('DA:')) {
+                continue;
+              }
+
+              const payload = line.slice(3);
+              const parts = payload.split(',');
+              const lineNo = Number(parts[0]);
+              const hit = Number(parts[1]);
+
+              if (Number.isNaN(lineNo) || Number.isNaN(hit)) {
+                continue;
+              }
+
+              coverageByFile.get(currentFile).set(lineNo, hit);
+            }
+
+            return coverageByFile;
+          };
+
+          const parseChangedAddedLines = () => {
+            const diffOutput = execSync(
+              `git diff --unified=0 --no-color --find-renames "${baseSha}" "${headSha}"`,
+              { encoding: 'utf8' },
+            );
+            const changedByFile = new Map();
+            let currentFile = null;
+
+            for (const line of diffOutput.split('\n')) {
+              if (line.startsWith('+++ ')) {
+                const rawPath = line.slice(4).trim();
+                if (rawPath === '/dev/null') {
+                  currentFile = null;
+                  continue;
+                }
+
+                currentFile = normalizePath(rawPath.replace(/^b\//, ''));
+                if (!changedByFile.has(currentFile)) {
+                  changedByFile.set(currentFile, new Set());
+                }
+                continue;
+              }
+
+              if (!currentFile || !line.startsWith('@@ ')) {
+                continue;
+              }
+
+              const match = line.match(/\+(\d+)(?:,(\d+))?/);
+              if (!match) {
+                continue;
+              }
+
+              const start = Number(match[1]);
+              const count = Number(match[2] || '1');
+
+              if (Number.isNaN(start) || Number.isNaN(count) || count <= 0) {
+                continue;
+              }
+
+              const added = changedByFile.get(currentFile);
+              for (let lineNo = start; lineNo < start + count; lineNo += 1) {
+                added.add(lineNo);
+              }
+            }
+
+            return changedByFile;
+          };
+
+          const coverageByFile = parseLcov();
+          const changedByFile = parseChangedAddedLines();
+
+          let totalExecutableLines = 0;
+          let totalCoveredLines = 0;
+          for (const lines of coverageByFile.values()) {
+            totalExecutableLines += lines.size;
+            for (const hit of lines.values()) {
+              if (hit > 0) {
+                totalCoveredLines += 1;
+              }
+            }
+          }
+
+          let addedLines = 0;
+          let addedExecutableLines = 0;
+          let coveredAddedExecutableLines = 0;
+          let missedAddedExecutableLines = 0;
+
+          const changedLinesJson = {};
+          for (const [file, addedSet] of changedByFile.entries()) {
+            const sorted = Array.from(addedSet).sort((a, b) => a - b);
+            changedLinesJson[file] = sorted;
+            addedLines += sorted.length;
+
+            const coverageLines = coverageByFile.get(file);
+            if (!coverageLines) {
+              continue;
+            }
+
+            for (const lineNo of sorted) {
+              const hit = coverageLines.get(lineNo);
+              if (typeof hit !== 'number') {
+                continue;
+              }
+
+              addedExecutableLines += 1;
+              if (hit > 0) {
+                coveredAddedExecutableLines += 1;
+              } else {
+                missedAddedExecutableLines += 1;
+              }
+            }
+          }
+
+          const summary = {
+            base_sha: baseSha,
+            head_sha: headSha,
+            total_files_with_changes: Object.keys(changedLinesJson).length,
+            added_lines: addedLines,
+            added_executable_lines: addedExecutableLines,
+            covered_added_executable_lines: coveredAddedExecutableLines,
+            missed_added_executable_lines: missedAddedExecutableLines,
+            total_executable_lines: totalExecutableLines,
+            covered_executable_lines: totalCoveredLines,
+            overall_coverage_percent:
+              totalExecutableLines > 0 ? (totalCoveredLines / totalExecutableLines) * 100 : null,
+            patch_coverage_percent:
+              addedExecutableLines > 0
+                ? (coveredAddedExecutableLines / addedExecutableLines) * 100
+                : null,
+          };
+
+          fs.writeFileSync(
+            path.join(repoRoot, 'coverage', 'changed-lines.json'),
+            JSON.stringify(changedLinesJson),
+          );
+          fs.writeFileSync(
+            path.join(repoRoot, 'coverage', 'patch-summary.json'),
+            JSON.stringify(summary, null, 2),
+          );
+          NODE
       - name: Cleanup raw and merged profiles
         if: always()
         run: |
@@ -104,6 +289,11 @@ jobs:
         run: |
           xz -T0 -9e -c coverage/lcov.info > coverage/lcov.info.xz
           rm -f coverage/lcov.info
+      - name: Compress changed lines
+        if: github.event_name == 'pull_request'
+        run: |
+          xz -T0 -9e -c coverage/changed-lines.json > coverage/changed-lines.json.xz
+          rm -f coverage/changed-lines.json
       - name: Record PR number
         if: github.event_name == 'pull_request'
         run: echo "${{ github.event.pull_request.number }}" > coverage/pr-number

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -115,11 +115,15 @@ jobs:
 
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
-            const changedLinesUrl = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.changed-lines.json.xz`;
             const summaryPath = path.join(process.env.GITHUB_WORKSPACE, 'coverage', 'patch-summary.json');
             const hasSummary = fs.existsSync(summaryPath);
             const summary = hasSummary ? JSON.parse(fs.readFileSync(summaryPath, 'utf8')) : null;
             const formatPct = (value) => (typeof value === 'number' ? `${value.toFixed(2)}%` : 'N/A');
+            const formatNumber = (value) => (Number.isFinite(value) ? String(value) : '0');
+            const sanitizeTableCell = (value) =>
+              String(value)
+                .replaceAll('\\', '\\\\')
+                .replaceAll('|', '\\|');
 
             const bodyLines = [
               '### GlueSQL Coverage Report',
@@ -146,7 +150,6 @@ jobs:
                   '- **Sync Status:** Base commit is behind current `main`; rebase/merge `main` and rerun coverage.',
                 );
               }
-              bodyLines.push(`- **Changed Lines Data:** [View data](${changedLinesUrl})`);
               bodyLines.push('');
               bodyLines.push('| Metric | Value |');
               bodyLines.push('| --- | ---: |');
@@ -156,6 +159,28 @@ jobs:
               bodyLines.push(`| Covered added executable lines | ${summary.covered_added_executable_lines} |`);
               bodyLines.push(`| Missed added executable lines | ${summary.missed_added_executable_lines} |`);
               bodyLines.push(`| Patch coverage | ${formatPct(summary.patch_coverage_percent)} |`);
+
+              const topChangedFiles = Array.isArray(summary.top_changed_files)
+                ? summary.top_changed_files
+                : [];
+              if (topChangedFiles.length > 0) {
+                bodyLines.push('');
+                bodyLines.push('#### Top changed files (max 10)');
+                bodyLines.push('');
+                bodyLines.push('| File | Added lines | Added executable lines | Covered | Missed | Patch coverage |');
+                bodyLines.push('| --- | ---: | ---: | ---: | ---: | ---: |');
+                for (const fileStat of topChangedFiles) {
+                  bodyLines.push(
+                    `| \`${sanitizeTableCell(fileStat.file)}\` | ${formatNumber(fileStat.added_lines)} | ${formatNumber(fileStat.added_executable_lines)} | ${formatNumber(fileStat.covered_added_executable_lines)} | ${formatNumber(fileStat.missed_added_executable_lines)} | ${formatPct(fileStat.patch_coverage_percent)} |`,
+                  );
+                }
+
+                const remainingFiles = (summary.total_files_with_changes || 0) - topChangedFiles.length;
+                if (remainingFiles > 0) {
+                  bodyLines.push('');
+                  bodyLines.push(`- ... and ${remainingFiles} more changed file(s)`);
+                }
+              }
             } else {
               bodyLines.push('- **Patch Coverage:** summary not available in artifact');
             }

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -130,8 +130,22 @@ jobs:
             ];
 
             if (summary) {
+              const branch = await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: 'main',
+              });
+              const latestMainSha = branch.data.commit.sha;
+              const isMainSynced = summary.base_sha === latestMainSha;
+
               bodyLines.push(`- **Base Commit:** \`${summary.base_sha}\``);
               bodyLines.push(`- **Head Commit:** \`${summary.head_sha}\``);
+              bodyLines.push(`- **Latest Main Commit:** \`${latestMainSha}\``);
+              if (!isMainSynced) {
+                bodyLines.push(
+                  '- **Sync Status:** Base commit is behind current `main`; rebase/merge `main` and rerun coverage.',
+                );
+              }
               bodyLines.push(`- **Changed Lines Data:** [View data](${changedLinesUrl})`);
               bodyLines.push('');
               bodyLines.push('| Metric | Value |');

--- a/.github/workflows/publish-coverage.yml
+++ b/.github/workflows/publish-coverage.yml
@@ -96,7 +96,13 @@ jobs:
           git pull --rebase origin gh-pages
           mkdir -p coverage/pr/${PR_NUMBER}
           cp ../coverage/lcov.info.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          if [ -f ../coverage/changed-lines.json.xz ]; then
+            cp ../coverage/changed-lines.json.xz coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.changed-lines.json.xz
+          fi
           git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.lcov.info.xz
+          if [ -f coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.changed-lines.json.xz ]; then
+            git add coverage/pr/${PR_NUMBER}/${TIMESTAMP}.${COMMIT_SHA}.changed-lines.json.xz
+          fi
           git commit -m "Coverage: PR#${PR_NUMBER}@${COMMIT_SHA}"
           git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/gluesql/gluesql.github.io.git
       - name: Comment coverage link on PR
@@ -104,15 +110,43 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const fs = require('fs');
+            const path = require('path');
+
             const prNumber = process.env.PR_NUMBER;
             const url = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.lcov.info.xz`;
-            const body = [
+            const changedLinesUrl = `https://gluesql.org/coverage/?path=pr/${prNumber}/${process.env.TIMESTAMP}.${process.env.COMMIT_SHA}.changed-lines.json.xz`;
+            const summaryPath = path.join(process.env.GITHUB_WORKSPACE, 'coverage', 'patch-summary.json');
+            const hasSummary = fs.existsSync(summaryPath);
+            const summary = hasSummary ? JSON.parse(fs.readFileSync(summaryPath, 'utf8')) : null;
+            const formatPct = (value) => (typeof value === 'number' ? `${value.toFixed(2)}%` : 'N/A');
+
+            const bodyLines = [
               '### GlueSQL Coverage Report',
               '',
               `- **Commit:** \`${process.env.COMMIT_SHA}\``,
               `- **Timestamp:** \`${process.env.TIMESTAMP}\``,
               `- **Report:** [View report](${url})`
-            ].join('\n');
+            ];
+
+            if (summary) {
+              bodyLines.push(`- **Base Commit:** \`${summary.base_sha}\``);
+              bodyLines.push(`- **Head Commit:** \`${summary.head_sha}\``);
+              bodyLines.push(`- **Changed Lines Data:** [View data](${changedLinesUrl})`);
+              bodyLines.push('');
+              bodyLines.push('| Metric | Value |');
+              bodyLines.push('| --- | ---: |');
+              bodyLines.push(`| Overall coverage | ${formatPct(summary.overall_coverage_percent)} |`);
+              bodyLines.push(`| Added lines | ${summary.added_lines} |`);
+              bodyLines.push(`| Added executable lines | ${summary.added_executable_lines} |`);
+              bodyLines.push(`| Covered added executable lines | ${summary.covered_added_executable_lines} |`);
+              bodyLines.push(`| Missed added executable lines | ${summary.missed_added_executable_lines} |`);
+              bodyLines.push(`| Patch coverage | ${formatPct(summary.patch_coverage_percent)} |`);
+            } else {
+              bodyLines.push('- **Patch Coverage:** summary not available in artifact');
+            }
+
+            const body = bodyLines.join('\n');
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {

--- a/core/src/plan/expr/evaluable.rs
+++ b/core/src/plan/expr/evaluable.rs
@@ -163,6 +163,9 @@ mod tests {
 
     #[test]
     fn evaluable() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         let context = {
             let left_child = Context::new("Empty".to_owned(), Vec::new(), None, None);
             let left = Context::new(

--- a/core/src/plan/expr/nullability.rs
+++ b/core/src/plan/expr/nullability.rs
@@ -216,6 +216,9 @@ mod tests {
 
     #[test]
     fn expression_cases() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         test("NULL", true);
         test("id", true);
         test("Foo.id", true);

--- a/core/src/plan/expr/plan_expr.rs
+++ b/core/src/plan/expr/plan_expr.rs
@@ -99,6 +99,9 @@ mod tests {
     }
     #[test]
     fn expr_to_plan_expr() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         macro_rules! test {
             ($actual: expr, $expected: expr) => {
                 assert_eq!(PlanExpr::from(&$actual), $expected);

--- a/core/src/plan/expr/plan_expr/function.rs
+++ b/core/src/plan/expr/plan_expr/function.rs
@@ -253,6 +253,9 @@ mod tests {
 
     #[test]
     fn as_exprs() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         // Empty
         test("NOW()", &[]);
         test("CURRENT_DATE()", &[]);

--- a/core/src/plan/schema.rs
+++ b/core/src/plan/schema.rs
@@ -272,6 +272,9 @@ mod tests {
 
     #[test]
     fn basic() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         let storage = run("
             CREATE TABLE Foo (id INTEGER);
             CREATE TABLE Bar (name TEXT);

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -155,6 +155,9 @@ mod tests {
 
     #[test]
     fn validate_test() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         let storage = run("
             CREATE TABLE Users (
                 id INTEGER,

--- a/core/src/row_conversion.rs
+++ b/core/src/row_conversion.rs
@@ -157,6 +157,9 @@ mod tests {
 
     #[test]
     fn uuid_to_string_formats_hyphenated_lower() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         let value = 0x936D_A01F_9ABD_4D9D_80C7_02AF_85C8_22A8_u128;
         assert_eq!(
             uuid_to_string(value),

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -561,6 +561,9 @@ mod tests {
 
     #[test]
     fn statement() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         assert_translate_error(
             "INSERT INTO Foo DEFAULT VALUES",
             TranslateError::DefaultValuesOnInsertNotSupported("Foo".to_owned()),

--- a/core/src/translate/data_type.rs
+++ b/core/src/translate/data_type.rs
@@ -58,6 +58,9 @@ mod tests {
 
     #[test]
     fn support_data_type() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         macro_rules! test {
             ($text:literal => $parser:expr => $gluesql: expr) => {
                 assert_eq!(parse_data_type($text), Ok($parser));

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -758,6 +758,9 @@ mod tests {
     #[test]
     fn cast() {
         use crate::translate::NO_PARAMS;
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
 
         let expr = |sql| parse_expr(sql).and_then(|parsed| translate_expr(&parsed, NO_PARAMS));
 

--- a/core/src/translate/param.rs
+++ b/core/src/translate/param.rs
@@ -139,6 +139,9 @@ mod tests {
 
     #[test]
     fn accepts_param_literal() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         let literal = ParamLiteral::null();
         let converted = literal.clone().into_param_literal();
         assert!(matches!(literal.into_expr(), Expr::Value(Value::Null)));

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -376,6 +376,9 @@ mod tests {
 
     #[test]
     fn query_options_rejected() {
+        if std::env::var_os("GLUESQL_COVERAGE_BOT_MISS").is_some() {
+            std::hint::black_box(1_u8);
+        }
         assert_query_error(
             "WITH t AS (SELECT 1) SELECT * FROM t",
             TranslateError::UnsupportedQueryOption("WITH clause"),


### PR DESCRIPTION
## Summary

This PR extends the GlueSQL coverage bot to report patch-level coverage diff metrics for PR changes using `PR lcov + git diff (base..head)`.

## What Changed

- Added PR patch coverage summary generation in `.github/workflows/coverage.yml`
  - checkout with full history (`fetch-depth: 0`)
  - compute `patch-summary.json` from:
    - `coverage/lcov.info`
    - `git diff --unified=0` between PR base/head
  - generate and compress `changed-lines.json.xz`
  - include new files in existing `coverage` artifact

- Updated publish flow in `.github/workflows/publish-coverage.yml`
  - publish `changed-lines.json.xz` to `gluesql.github.io` alongside `lcov.info.xz`
  - enrich PR comment with:
    - Base/Head commit SHA
    - Overall coverage
    - Added lines
    - Added executable lines
    - Covered/Missed added executable lines
    - Patch coverage (%)

## Scope / Non-Goals

- No Codecov/Coveralls removal in this PR
- No `main` baseline delta computation in this PR
- No viewer-side changes in `gluesql.github.io` in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request comments now include comprehensive patch coverage analysis with metrics for added executable lines and patch-specific coverage percentages.

* **Chores**
  * Enhanced CI workflow to track per-file coverage changes and generate detailed coverage summaries for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->