### PR TITLE
Hide chrono::ParseError from EvaluateError::FormatParseError

### DIFF
--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -1,15 +1,14 @@
 use {
     crate::ast::{Aggregate, BinaryOperator, DataType, Expr, ToSql},
-    serde::{Serialize, Serializer},
+    serde::Serialize,
     std::fmt::Debug,
     thiserror::Error,
 };
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
 pub enum EvaluateError {
-    #[error(transparent)]
-    #[serde(serialize_with = "error_serialize")]
-    FormatParseError(#[from] chrono::format::ParseError),
+    #[error("{0}")]
+    FormatParseError(String),
 
     #[error("literal add on non-numeric")]
     LiteralAddOnNonNumeric,
@@ -224,13 +223,4 @@ pub enum EvaluateError {
         literal: String,
         data_type: DataType,
     },
-}
-
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn error_serialize<S>(error: &chrono::format::ParseError, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let display = format!("{error}");
-    serializer.serialize_str(&display)
 }

--- a/core/src/executor/evaluate/function.rs
+++ b/core/src/executor/evaluate/function.rs
@@ -817,10 +817,7 @@ pub fn to_date<'a>(
             chrono::NaiveDate::parse_from_str(&expr, &format)
                 .map(Value::Date)
                 .map(|v| Evaluated::Value(Cow::Owned(v)))
-                .map_err(|err| {
-                    let err: EvaluateError = err.into();
-                    err.into()
-                })
+                .map_err(|err| EvaluateError::FormatParseError(err.to_string()).into())
         }
         _ => Err(EvaluateError::FunctionRequiresStringValue(name.to_owned()).into()),
     }
@@ -839,10 +836,7 @@ pub fn to_timestamp<'a>(
             chrono::NaiveDateTime::parse_from_str(&expr, &format)
                 .map(Value::Timestamp)
                 .map(|v| Evaluated::Value(Cow::Owned(v)))
-                .map_err(|err| {
-                    let err: EvaluateError = err.into();
-                    err.into()
-                })
+                .map_err(|err| EvaluateError::FormatParseError(err.to_string()).into())
         }
         _ => Err(EvaluateError::FunctionRequiresStringValue(name.to_owned()).into()),
     }
@@ -857,7 +851,7 @@ pub fn add_month<'a>(
     let size = eval_to_int(name, size)?;
     let expr = eval_to_str(name, expr)?;
     let expr = chrono::NaiveDate::parse_from_str(&expr, "%Y-%m-%d")
-        .map_err(EvaluateError::from)
+        .map_err(|err| EvaluateError::FormatParseError(err.to_string()))
         .map_err(Error::from)
         .into_control_flow()?;
     let date = {
@@ -890,10 +884,7 @@ pub fn to_time<'a>(
             chrono::NaiveTime::parse_from_str(&expr, &format)
                 .map(Value::Time)
                 .map(|v| Evaluated::Value(Cow::Owned(v)))
-                .map_err(|err| {
-                    let err: EvaluateError = err.into();
-                    err.into()
-                })
+                .map_err(|err| EvaluateError::FormatParseError(err.to_string()).into())
         }
         _ => Err(EvaluateError::FunctionRequiresStringValue(name.to_owned()).into()),
     }

--- a/test-suite/src/function/add_month.rs
+++ b/test-suite/src/function/add_month.rs
@@ -1,6 +1,5 @@
 use {
     crate::*,
-    chrono::format::ParseErrorKind,
     gluesql_core::{
         error::EvaluateError,
         prelude::{Error, Value},
@@ -13,13 +12,11 @@ test_case!(add_month, {
             $date.parse().unwrap()
         };
     }
-    fn assert_chrono_error_kind_eq(error: &Error, kind: ParseErrorKind) {
-        match error {
-            Error::Evaluate(EvaluateError::FormatParseError(err)) => {
-                assert_eq!(err.kind(), kind);
-            }
-            _ => panic!("invalid error: {error}"),
-        }
+    fn assert_format_parse_error(error: &Error) {
+        assert!(
+            matches!(error, Error::Evaluate(EvaluateError::FormatParseError(_))),
+            "expected FormatParseError, got: {error}"
+        );
     }
     let g = get_tester!();
 
@@ -92,22 +89,13 @@ test_case!(add_month, {
     )
     .await;
     let error_cases = [
-        (
-            g.run_err("SELECT ADD_MONTH('2017-01-31-10',0) AS test;")
-                .await,
-            chrono::format::ParseErrorKind::TooLong,
-        ),
-        (
-            g.run_err("SELECT ADD_MONTH('2017-01',0) AS test;").await,
-            chrono::format::ParseErrorKind::TooShort,
-        ),
-        (
-            g.run_err("SELECT ADD_MONTH('2015-14-05',1) AS test").await,
-            chrono::format::ParseErrorKind::OutOfRange,
-        ),
+        g.run_err("SELECT ADD_MONTH('2017-01-31-10',0) AS test;")
+            .await,
+        g.run_err("SELECT ADD_MONTH('2017-01',0) AS test;").await,
+        g.run_err("SELECT ADD_MONTH('2015-14-05',1) AS test").await,
     ];
 
-    for (error, kind) in error_cases {
-        assert_chrono_error_kind_eq(&error, kind);
+    for error in &error_cases {
+        assert_format_parse_error(error);
     }
 });

--- a/test-suite/src/function/to_date.rs
+++ b/test-suite/src/function/to_date.rs
@@ -1,6 +1,6 @@
 use {
     crate::*,
-    chrono::{NaiveDate, NaiveTime, format::ParseErrorKind},
+    chrono::{NaiveDate, NaiveTime},
     gluesql_core::{
         error::EvaluateError,
         prelude::{Error, Value::*},
@@ -8,13 +8,11 @@ use {
 };
 
 test_case!(to_date, {
-    fn assert_chrono_error_kind_eq(error: &Error, kind: ParseErrorKind) {
-        match error {
-            Error::Evaluate(EvaluateError::FormatParseError(err)) => {
-                assert_eq!(err.kind(), kind);
-            }
-            _ => panic!("invalid error: {error}"),
-        }
+    fn assert_format_parse_error(error: &Error) {
+        assert!(
+            matches!(error, Error::Evaluate(EvaluateError::FormatParseError(_))),
+            "expected FormatParseError, got: {error}"
+        );
     }
 
     let g = get_tester!();
@@ -95,59 +93,25 @@ test_case!(to_date, {
     }
 
     let error_cases = [
-        (
-            g.run_err("SELECT TO_DATE('2015-09-05', '%Y-%m') AS date")
-                .await,
-            chrono::format::ParseErrorKind::TooLong,
-        ),
-        (
-            g.run_err("SELECT TO_TIME('23:56', '%H:%M:%S') AS time")
-                .await,
-            chrono::format::ParseErrorKind::TooShort,
-        ),
-        (
-            g.run_err("SELECT TO_TIMESTAMP('2015-05 23', '%Y-%d %H') AS timestamp")
-                .await,
-            chrono::format::ParseErrorKind::NotEnough,
-        ),
-        (
-            g.run_err(
-                "SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%S') AS timestamp",
-            )
+        g.run_err("SELECT TO_DATE('2015-09-05', '%Y-%m') AS date")
             .await,
-            chrono::format::ParseErrorKind::OutOfRange,
-        ),
-        (
-            g.run_err(
-                "SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%S') AS timestamp",
-            )
+        g.run_err("SELECT TO_TIME('23:56', '%H:%M:%S') AS time")
             .await,
-            chrono::format::ParseErrorKind::OutOfRange,
-        ),
-        (
-            g.run_err(
-                "SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%%S') AS timestamp;",
-            )
+        g.run_err("SELECT TO_TIMESTAMP('2015-05 23', '%Y-%d %H') AS timestamp")
             .await,
-            chrono::format::ParseErrorKind::OutOfRange,
-        ),
-        (
-            g.run_err(
-                "SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%M') AS timestamp",
-            )
+        g.run_err("SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%S') AS timestamp")
             .await,
-            chrono::format::ParseErrorKind::Impossible,
-        ),
-        (
-            g.run_err(
-                "SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%') AS timestamp",
-            )
+        g.run_err("SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%S') AS timestamp")
             .await,
-            chrono::format::ParseErrorKind::BadFormat,
-        ),
+        g.run_err("SELECT TO_TIMESTAMP('2015-14-05 23:56:12','%Y-%m-%d %H:%M:%%S') AS timestamp;")
+            .await,
+        g.run_err("SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%M') AS timestamp")
+            .await,
+        g.run_err("SELECT TO_TIMESTAMP('2015-09-05 23:56:04', '%Y-%m-%d %H:%M:%') AS timestamp")
+            .await,
     ];
 
-    for (error, kind) in error_cases {
-        assert_chrono_error_kind_eq(&error, kind);
+    for error in &error_cases {
+        assert_format_parse_error(error);
     }
 });


### PR DESCRIPTION
## Summary
- Replace `FormatParseError(chrono::format::ParseError)` with `FormatParseError(String)` and `#[error("{0}")]`, removing chrono from the public error surface.
- Drop the bespoke `error_serialize` helper and the `#[allow(clippy::trivially_copy_pass_by_ref)]` that were introduced alongside the variant.
- Update construction sites in `core/src/executor/evaluate/function.rs` to call `EvaluateError::FormatParseError(err.to_string())`.
- Relax tests in `test-suite/src/function/{to_date,add_month}.rs` to assert on the `FormatParseError` variant instead of matching `chrono::format::ParseErrorKind` (the `.kind()` checks were effectively testing chrono's parser rather than gluesql).

Net: +37 / -104 across 4 files.

Closes #1839

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` (workspace)
- [x] `cargo fmt --all`
- [x] `cargo test -p gluesql-core` (482 passed)
- [x] `cargo test -p gluesql_memory_storage --test memory_storage -- to_date add_month`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified error handling for date and time parsing operations to provide more consistent error reporting across date, timestamp, and time-related functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gluesql/gluesql/pull/1913)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->