### PR TITLE
Ensure sled migration tests create tmp directory

### DIFF
--- a/storages/sled-storage/tests/migration_v1_to_v2.rs
+++ b/storages/sled-storage/tests/migration_v1_to_v2.rs
@@ -12,7 +12,7 @@ use {
     sled::Db,
     std::{
         collections::BTreeMap,
-        fs::{remove_dir_all, remove_file, write},
+        fs::{create_dir_all, remove_dir_all, remove_file, write},
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     },
@@ -65,7 +65,10 @@ fn test_path(name: &str) -> PathBuf {
         .expect("system time")
         .as_nanos();
 
-    PathBuf::from(format!("./tmp/{name}-{suffix}"))
+    let path = PathBuf::from("./tmp");
+    create_dir_all(&path).expect("create tmp directory");
+
+    path.join(format!("{name}-{suffix}"))
 }
 
 fn data_key(table_name: &str, key: Vec<u8>) -> Vec<u8> {


### PR DESCRIPTION
## Summary

- Ensure sled migration tests create their shared `tmp` directory before using generated test paths.
- Remove the test-order dependency where another sled test had to create `tmp` first.

## Context

`migration_v1_to_v2.rs` generated paths under `./tmp`, but the helper did not create the parent directory. In a clean checkout, running `migrate_rejects_file_path` in isolation fails if no earlier test has created `tmp`.

The full sled storage test suite can still pass when another test happens to create `tmp` first, which makes this kind of issue appear order-dependent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved migration test reliability by ensuring temporary storage directories are properly created during test initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gluesql/gluesql/pull/1914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->