### PR TITLE
Bump Rust toolchain to 1.94

### DIFF
--- a/core/src/executor/aggregate/state.rs
+++ b/core/src/executor/aggregate/state.rs
@@ -253,17 +253,8 @@ impl AggrValue {
                 sum,
                 count,
                 distinct_values,
-            } => {
-                if !Self::track_distinct(distinct_values, new_value) {
-                    return Ok(false);
-                }
-
-                *sum_square = sum_square.add(&new_value.multiply(new_value)?)?;
-                *sum = sum.add(new_value)?;
-                *count += 1;
-                Ok(true)
             }
-            Self::Stdev {
+            | Self::Stdev {
                 sum_square,
                 sum,
                 count,

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -359,7 +359,7 @@ async fn evaluate_function<'a, 'b: 'a, T: GStore>(
                 .ok_or(EvaluateError::UnsupportedCustomFunction)?
                 .fetch_function(name)
                 .await?
-                .ok_or_else(|| EvaluateError::UnsupportedFunction(name.to_string()))?;
+                .ok_or_else(|| EvaluateError::UnsupportedFunction(name.clone()))?;
 
             let min = args.iter().filter(|arg| arg.default.is_none()).count();
             let max = args.len();

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -146,7 +146,7 @@ pub async fn fetch_relation_rows<'a, T: GStore>(
                             .as_ref()
                             .and_then(|column_defs| {
                                 column_defs.iter().find(|column_def| {
-                                    column_def.unique.map(|u| u.is_primary) == Some(true)
+                                    column_def.unique.is_some_and(|u| u.is_primary)
                                 })
                             })
                             .ok_or(FetchError::Unreachable)?;
@@ -396,7 +396,7 @@ where
                 None => Ok(columns),
                 Some(alias) if alias.columns.len() > columns.len() => {
                     Err(FetchError::TooManyColumnAliases(
-                        name.to_string(),
+                        name.clone(),
                         columns.len(),
                         alias.columns.len(),
                     )
@@ -458,7 +458,7 @@ where
                     Ok(labels)
                 } else if alias_columns.len() > labels.len() {
                     Err(FetchError::TooManyColumnAliases(
-                        name.to_string(),
+                        name.clone(),
                         labels.len(),
                         alias_columns.len(),
                     )

--- a/core/src/translate/ddl.rs
+++ b/core/src/translate/ddl.rs
@@ -89,7 +89,7 @@ pub fn translate_column_def(
                     Ok((nullable, default, unique, comment))
                 }
                 SqlColumnOption::Comment(comment) => {
-                    Ok((nullable, default, unique, Some(comment.to_string())))
+                    Ok((nullable, default, unique, Some(comment.clone())))
                 }
                 _ => Err(TranslateError::UnsupportedColumnOption(option.to_string()).into()),
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89"
+channel = "1.94"
 components = ["rustfmt", "clippy"]

--- a/storages/sled-storage/src/lock.rs
+++ b/storages/sled-storage/src/lock.rs
@@ -79,7 +79,7 @@ pub fn fetch(
         .map_err(err_into)?
         .as_millis();
 
-    if tx_timeout.map(|tx_timeout| now >= tx_timeout + created_at) == Some(true) {
+    if tx_timeout.is_some_and(|tx_timeout| now >= tx_timeout + created_at) {
         return Err(Error::StorageMsg(
             "fetch failed - expired transaction has used (timeout)".to_owned(),
         ));
@@ -133,7 +133,7 @@ pub fn acquire(
         .map_err(ConflictableTransactionError::Abort)?
         .as_millis();
 
-    if tx_timeout.map(|tx_timeout| now >= tx_timeout + created_at) == Some(true) {
+    if tx_timeout.is_some_and(|tx_timeout| now >= tx_timeout + created_at) {
         return Err(ConflictableTransactionError::Abort(Error::StorageMsg(
             "acquire failed - expired transaction has used (timeout)".to_owned(),
         )));
@@ -144,7 +144,7 @@ pub fn acquire(
     }
 
     let txid = if let Some(lock_txid) = lock_txid {
-        if tx_timeout.map(|tx_timeout| now >= tx_timeout + lock_created_at) == Some(true) {
+        if tx_timeout.is_some_and(|tx_timeout| now >= tx_timeout + lock_created_at) {
             return Ok(LockAcquired::RollbackAndRetry { lock_txid });
         } else if txid != lock_txid {
             return Err(ConflictableTransactionError::Abort(Error::StorageMsg(


### PR DESCRIPTION
## Summary

Bump the repository Rust toolchain from 1.89 to 1.94.

The motivation is to keep GlueSQL ready for newer dependency versions. Recent SQLx development has moved its Rust requirement up to 1.94, and using 1.94 gives us that compatibility headroom without jumping to the latest stable edge.

This PR intentionally only updates the toolchain pin and the Clippy fixes required by that update. It does not add a `rust-version` MSRV declaration to Cargo manifests; that can stay as a separate policy decision if we want to formalize MSRV later.

## Changes

- Update `rust-toolchain.toml` from `1.89` to `1.94`
- Adjust code for Clippy 1.94 lints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Rust toolchain to version 1.94

* **Refactor**
  * Improved code efficiency in aggregate value accumulation through pattern consolidation
  * Simplified error handling logic in function evaluation and fetch operations
  * Optimized transaction and lock expiration verification checks
  * Enhanced code maintainability across multiple core modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->