### PR TITLE
Reject multi-column IN subqueries

### DIFF
--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -7,7 +7,7 @@ use {
     self::function::BreakCase,
     super::{
         context::{AggregateValues, RowContext},
-        select::select,
+        select::{select, select_with_labels},
     },
     crate::{
         data::{CustomFunction, Interval, Row, Value},
@@ -175,9 +175,14 @@ where
                 return Err(EvaluateError::SchemalessProjectionForInSubQuery.into());
             }
             let target = eval(target_expr)?;
+            let (labels, rows) = select_with_labels(storage, subquery, context.cloned())?;
+
+            if labels.len() > 1 {
+                return Err(EvaluateError::MoreThanOneColumnReturned.into());
+            }
 
             let mut matched = false;
-            for row in select(storage, subquery, context.cloned())? {
+            for row in rows {
                 let value = row?.into_values().into_iter().next().unwrap_or(Value::Null);
                 let evaluated = Evaluated::Value(Cow::Owned(value));
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -178,7 +178,7 @@ where
             let (labels, rows) = select_with_labels(storage, subquery, context.cloned())?;
 
             if labels.len() > 1 {
-                return Err(EvaluateError::MoreThanOneColumnReturned.into());
+                return Err(EvaluateError::InSubqueryMustReturnOneColumn.into());
             }
 
             let mut matched = false;

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -127,6 +127,9 @@ pub enum EvaluateError {
     #[error("subquery returns more than one column")]
     MoreThanOneColumnReturned,
 
+    #[error("IN (subquery) must return one column")]
+    InSubqueryMustReturnOneColumn,
+
     #[error("schemaless projection is not allowed for IN (subquery)")]
     SchemalessProjectionForInSubQuery,
 

--- a/test-suite/src/index/nested.rs
+++ b/test-suite/src/index/nested.rs
@@ -2,7 +2,6 @@ use {
     crate::*,
     gluesql_core::{
         ast::IndexOperator::*,
-        executor::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };
@@ -69,9 +68,13 @@ CREATE TABLE User (
         "
         SELECT * FROM User u1
         WHERE id IN (
-            SELECT * FROM User WHERE id = 1
+            SELECT id FROM User WHERE id = 1
         )",
-        Err(EvaluateError::MoreThanOneColumnReturned.into()),
+        Ok(select!(
+            id  | num | name
+            I64 | I64 | Str;
+            1     2     "Hello".to_owned()
+        )),
         idx!(idx_id, Eq, "1"),
     );
 });

--- a/test-suite/src/index/nested.rs
+++ b/test-suite/src/index/nested.rs
@@ -2,6 +2,7 @@ use {
     crate::*,
     gluesql_core::{
         ast::IndexOperator::*,
+        executor::EvaluateError,
         prelude::{Payload, Value::*},
     },
 };
@@ -70,11 +71,7 @@ CREATE TABLE User (
         WHERE id IN (
             SELECT * FROM User WHERE id = 1
         )",
-        Ok(select!(
-            id  | num | name
-            I64 | I64 | Str;
-            1     2     "Hello".to_owned()
-        )),
+        Err(EvaluateError::MoreThanOneColumnReturned.into()),
         idx!(idx_id, Eq, "1"),
     );
 });

--- a/test-suite/src/nested_select.rs
+++ b/test-suite/src/nested_select.rs
@@ -1,6 +1,9 @@
 use {
     crate::*,
-    gluesql_core::{executor::Payload, prelude::Value},
+    gluesql_core::{
+        executor::{EvaluateError, Payload},
+        prelude::Value,
+    },
 };
 
 test_case!(nested_select, {
@@ -110,5 +113,14 @@ test_case!(nested_select, {
 
     for (sql, expected) in test_cases {
         g.test(sql, expected);
+    }
+
+    let error_cases = [
+        "SELECT id FROM Player WHERE id IN (SELECT id, name FROM Player)",
+        "SELECT id FROM Player WHERE id IN (SELECT id, name FROM Player WHERE id = 0)",
+    ];
+
+    for sql in error_cases {
+        g.test(sql, Err(EvaluateError::MoreThanOneColumnReturned.into()));
     }
 });

--- a/test-suite/src/nested_select.rs
+++ b/test-suite/src/nested_select.rs
@@ -121,6 +121,9 @@ test_case!(nested_select, {
     ];
 
     for sql in error_cases {
-        g.test(sql, Err(EvaluateError::MoreThanOneColumnReturned.into()));
+        g.test(
+            sql,
+            Err(EvaluateError::InSubqueryMustReturnOneColumn.into()),
+        );
     }
 });


### PR DESCRIPTION
## Summary

  `IN (subquery)` now rejects subqueries that return more than one column instead of
  silently comparing only the first column.

  This matches existing scalar subquery behavior by returning `MoreThanOneColumnReturned`.

  ## Problem

  `IN (subquery)` previously accepted multi-column subquery results.

  ```sql
  CREATE TABLE T (id INTEGER, name TEXT);

  SELECT id FROM T WHERE id IN (SELECT id, name FROM T);
  ```

  The subquery returns both `id` and `name`, but GlueSQL only used the first column and
  ignored the rest.

  ## Changes

  - Use `select_with_labels` in `ExprPlan::InSubquery` evaluation to inspect the projected
  subquery column count.
  - Return `EvaluateError::MoreThanOneColumnReturned` when an `IN` subquery projects more
  than one column.
  - Reuse the selected row iterator from `select_with_labels` for the actual `IN`
  comparison.
  - Add regression coverage for multi-column `IN` subqueries.

  ## Test coverage

  ```sql
  -- Before: silently compares only the first column
  SELECT id FROM Player WHERE id IN (SELECT id, name FROM Player);

  -- After: returns MoreThanOneColumnReturned
  ```

  New tests verify:

  - Multi-column `IN` subqueries with returned rows are rejected
  - Multi-column `IN` subqueries with empty result sets are also rejected

  Fixes #1880

  ## Testing

  ```sh
  cargo fmt --all
  cargo test -p gluesql_memory_storage nested_select --verbose
  cargo clippy --all-targets -- -D warnings
  ```

 result : All passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation of nested `IN (subquery)` queries by validating the subquery’s projected columns before performing membership checks.
  * Subqueries that don’t return exactly one column now fail with a clear, dedicated error: “IN (subquery) must return one column”.
* **Tests**
  * Added coverage for invalid nested-select cases to confirm the new error is returned.
  * Updated nested `IN` test queries to select only the required single column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->