### PR TITLE
Update Rust getting started version and storage features

### DIFF
--- a/docs/docs/getting-started/rust.md
+++ b/docs/docs/getting-started/rust.md
@@ -8,7 +8,7 @@ To install and use GlueSQL in your Rust project, you'll first need to add it as 
 
 ```toml
 [dependencies]
-gluesql = "0.16"
+gluesql = "0.19.0"
 ```
 
 By default, all available storage features are included with GlueSQL. Here's a list of the available features:
@@ -18,13 +18,19 @@ By default, all available storage features are included with GlueSQL. Here's a l
 - `gluesql_memory_storage` - Simple in-memory storage
 - `gluesql-shared-memory-storage` - A wrapper around memory-storage for easy use in multi-threaded environments
 - `gluesql-json-storage` - Storage that allows you to analyze and modify JSON or JSONL files using SQL
+- `gluesql-parquet-storage` - Storage for querying Parquet files
+- `gluesql-csv-storage` - Storage for querying CSV files
 - `gluesql-composite-storage` - A storage feature that enables joining and processing data from multiple storage types simultaneously
+- `gluesql-mongo-storage` - Storage backed by MongoDB
+- `gluesql-redis-storage` - Storage backed by Redis
+- `gluesql-file-storage` - Storage backed by files on the local filesystem
+- `gluesql-git-storage` - Git-backed storage with version history
 
 If you don't need all the default storage features, you can disable them and select only the ones you require. To do this, update your `Cargo.toml` file with the following lines:
 
 ```toml
 [dependencies.gluesql]
-version = "0.16"
+version = "0.19.0"
 default-features = false
 features = ["gluesql_memory_storage", "gluesql-json-storage"]
 ```


### PR DESCRIPTION
## Summary

- update both Rust dependency examples from GlueSQL 0.16 to the current 0.19.0 release
- add the six missing default storage features to the getting-started list
- preserve each published feature's underscore or hyphen spelling and follow the order in `pkg/rust/Cargo.toml`

This keeps the installation examples usable and makes the documented default storage set match the crate manifest.

Fixes #1939.

## Validation

- `uvx --from zensical==0.0.43 zensical build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust installation examples to use GlueSQL version 0.19.0.
  * Expanded the list of available storage features, including Parquet, CSV, MongoDB, Redis, file-system, Git, and composite storage options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->