### PR TITLE
Wait for sled lock release when opening storage

### DIFF
--- a/storages/sled-storage/src/lib.rs
+++ b/storages/sled-storage/src/lib.rs
@@ -9,6 +9,7 @@ mod index_sync;
 mod key;
 mod lock;
 mod migration;
+mod open;
 mod planner;
 mod snapshot;
 mod store;
@@ -25,6 +26,7 @@ use {
             ensure_storage_format_version_supported, initialize_storage_format_version,
             prepare_import_destination,
         },
+        open::open_with_lock_wait,
         snapshot::Snapshot,
     },
     error::{err_into, tx_err_into},
@@ -69,7 +71,8 @@ impl SledStorage {
     pub fn new<P: AsRef<std::path::Path>>(filename: P) -> Result<Self> {
         let path = filename.as_ref();
         let path_exists = path.exists();
-        let tree = sled::open(path).map_err(err_into)?;
+        let config = Config::new().path(path);
+        let tree = open_with_lock_wait(&config)?;
         if path_exists {
             ensure_storage_format_version_supported(&tree)?;
         } else {
@@ -124,7 +127,7 @@ impl TryFrom<Config> for SledStorage {
 
     fn try_from(config: Config) -> Result<Self> {
         let path_exists = config.get_path().exists();
-        let tree = config.open().map_err(err_into)?;
+        let tree = open_with_lock_wait(&config)?;
         if path_exists {
             ensure_storage_format_version_supported(&tree)?;
         } else {

--- a/storages/sled-storage/src/migration.rs
+++ b/storages/sled-storage/src/migration.rs
@@ -1,7 +1,7 @@
 mod v1_to_v2;
 
 use {
-    crate::{Snapshot, err_into},
+    crate::{Snapshot, err_into, open::open_with_lock_wait},
     gluesql_core::{
         data::Schema,
         error::{Error, Result},
@@ -84,11 +84,8 @@ pub fn migrate_to_latest<P: AsRef<Path>>(path: P) -> Result<MigrationReport> {
         )));
     }
 
-    let tree = sled::Config::new()
-        .path(path)
-        .flush_every_ms(None)
-        .open()
-        .map_err(err_into)?;
+    let config = sled::Config::new().path(path).flush_every_ms(None);
+    let tree = open_with_lock_wait(&config)?;
     migrate_tree_to_latest(&tree)
 }
 

--- a/storages/sled-storage/src/open.rs
+++ b/storages/sled-storage/src/open.rs
@@ -13,38 +13,37 @@ const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
 const LOCK_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 pub(crate) fn open_with_lock_wait(config: &Config) -> Result<Db> {
-    let started_at = Instant::now();
-
     open_with_lock_wait_by(
         || config.open(),
-        || {
-            let remaining = LOCK_WAIT_TIMEOUT.saturating_sub(started_at.elapsed());
-            if remaining.is_zero() {
-                return false;
-            }
-
-            thread::sleep(LOCK_WAIT_INTERVAL.min(remaining));
-            true
-        },
+        Instant::now,
+        thread::sleep,
         LOCK_WAIT_TIMEOUT,
+        LOCK_WAIT_INTERVAL,
     )
 }
 
 fn open_with_lock_wait_by<T>(
     mut open: impl FnMut() -> sled::Result<T>,
-    mut wait: impl FnMut() -> bool,
+    mut now: impl FnMut() -> Instant,
+    mut sleep: impl FnMut(Duration),
     timeout: Duration,
+    interval: Duration,
 ) -> Result<T> {
+    let started_at = now();
+
     loop {
         match open() {
             Ok(tree) => return Ok(tree),
             Err(error) if is_lock_unavailable(&error) => {
-                if !wait() {
+                let remaining = timeout.saturating_sub(now().duration_since(started_at));
+                if remaining.is_zero() {
                     return Err(Error::StorageMsg(format!(
                         "[SledStorage] timed out after {} ms waiting for the database lock: {error}",
                         timeout.as_millis(),
                     )));
                 }
+
+                sleep(interval.min(remaining));
             }
             Err(error) => return Err(err_into(error)),
         }
@@ -80,7 +79,9 @@ mod tests {
     #[test]
     fn retries_after_waiting_for_lock() {
         let mut attempts = 0;
-        let mut waits = 0;
+        let started_at = Instant::now();
+        let mut now = [started_at, started_at].into_iter();
+        let mut sleeps = Vec::new();
 
         open_with_lock_wait_by(
             || {
@@ -91,32 +92,37 @@ mod tests {
                     Ok(())
                 }
             },
-            || {
-                waits += 1;
-                true
-            },
+            || now.next().expect("current time"),
+            |duration| sleeps.push(duration),
             Duration::from_secs(1),
+            Duration::from_millis(10),
         )
         .expect("open after waiting");
 
         assert_eq!(attempts, 2);
-        assert_eq!(waits, 1);
+        assert_eq!(sleeps, [Duration::from_millis(10)]);
     }
 
     #[test]
-    fn returns_timeout_without_another_attempt() {
+    fn caps_wait_at_timeout_and_stops_retrying() {
         let mut attempts = 0;
-        let mut waits = 0;
+        let started_at = Instant::now();
+        let mut now = [
+            started_at,
+            started_at + Duration::from_millis(15),
+            started_at + Duration::from_millis(20),
+        ]
+        .into_iter();
+        let mut sleeps = Vec::new();
         let actual: Result<()> = open_with_lock_wait_by(
             || {
                 attempts += 1;
                 Err(lock_error())
             },
-            || {
-                waits += 1;
-                false
-            },
+            || now.next().expect("current time"),
+            |duration| sleeps.push(duration),
             Duration::from_millis(20),
+            Duration::from_millis(10),
         );
         assert!(matches!(
             actual,
@@ -125,24 +131,27 @@ mod tests {
                     "[SledStorage] timed out after 20 ms waiting for the database lock:"
                 )
         ));
-        assert_eq!(attempts, 1);
-        assert_eq!(waits, 1);
+        assert_eq!(attempts, 2);
+        assert_eq!(sleeps, [Duration::from_millis(5)]);
     }
 
     #[test]
     fn returns_non_lock_error_without_waiting() {
-        let mut waits = 0;
+        let mut attempts = 0;
+        let now = Instant::now();
         let actual: Result<()> = open_with_lock_wait_by(
-            || Err(sled::Error::Unsupported("invalid config".to_owned())),
             || {
-                waits += 1;
-                true
+                attempts += 1;
+                Err(sled::Error::Unsupported("invalid config".to_owned()))
             },
+            || now,
+            thread::sleep,
             Duration::from_secs(1),
+            Duration::from_millis(10),
         );
 
         assert!(matches!(actual, Err(Error::StorageMsg(_))));
-        assert_eq!(waits, 0);
+        assert_eq!(attempts, 1);
     }
 
     #[test]

--- a/storages/sled-storage/src/open.rs
+++ b/storages/sled-storage/src/open.rs
@@ -1,0 +1,159 @@
+use {
+    crate::error::err_into,
+    gluesql_core::error::{Error, Result},
+    sled::{Config, Db},
+    std::{
+        io::ErrorKind,
+        thread,
+        time::{Duration, Instant},
+    },
+};
+
+const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+const LOCK_WAIT_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(crate) fn open_with_lock_wait(config: &Config) -> Result<Db> {
+    let started_at = Instant::now();
+
+    open_with_lock_wait_by(
+        || config.open(),
+        || {
+            let remaining = LOCK_WAIT_TIMEOUT.saturating_sub(started_at.elapsed());
+            if remaining.is_zero() {
+                return false;
+            }
+
+            thread::sleep(LOCK_WAIT_INTERVAL.min(remaining));
+            true
+        },
+        LOCK_WAIT_TIMEOUT,
+    )
+}
+
+fn open_with_lock_wait_by<T>(
+    mut open: impl FnMut() -> sled::Result<T>,
+    mut wait: impl FnMut() -> bool,
+    timeout: Duration,
+) -> Result<T> {
+    loop {
+        match open() {
+            Ok(tree) => return Ok(tree),
+            Err(error) if is_lock_unavailable(&error) => {
+                if !wait() {
+                    return Err(Error::StorageMsg(format!(
+                        "[SledStorage] timed out after {} ms waiting for the database lock: {error}",
+                        timeout.as_millis(),
+                    )));
+                }
+            }
+            Err(error) => return Err(err_into(error)),
+        }
+    }
+}
+
+fn is_lock_unavailable(error: &sled::Error) -> bool {
+    matches!(
+        error,
+        sled::Error::Io(error)
+            if error.kind() == ErrorKind::Other
+                && error.to_string().starts_with("could not acquire lock on ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::io};
+
+    fn configs_for_same_temporary_path() -> (Config, Config) {
+        let owner = Config::new().temporary(true).flush_every_ms(None);
+        let contender = Config::new().path(owner.get_path()).flush_every_ms(None);
+
+        (owner, contender)
+    }
+
+    fn lock_error() -> sled::Error {
+        sled::Error::Io(io::Error::other(
+            "could not acquire lock on \"db\": Resource temporarily unavailable",
+        ))
+    }
+
+    #[test]
+    fn retries_after_waiting_for_lock() {
+        let mut attempts = 0;
+        let mut waits = 0;
+
+        open_with_lock_wait_by(
+            || {
+                attempts += 1;
+                if attempts == 1 {
+                    Err(lock_error())
+                } else {
+                    Ok(())
+                }
+            },
+            || {
+                waits += 1;
+                true
+            },
+            Duration::from_secs(1),
+        )
+        .expect("open after waiting");
+
+        assert_eq!(attempts, 2);
+        assert_eq!(waits, 1);
+    }
+
+    #[test]
+    fn returns_timeout_without_another_attempt() {
+        let mut attempts = 0;
+        let mut waits = 0;
+        let actual: Result<()> = open_with_lock_wait_by(
+            || {
+                attempts += 1;
+                Err(lock_error())
+            },
+            || {
+                waits += 1;
+                false
+            },
+            Duration::from_millis(20),
+        );
+        assert!(matches!(
+            actual,
+            Err(Error::StorageMsg(message))
+                if message.starts_with(
+                    "[SledStorage] timed out after 20 ms waiting for the database lock:"
+                )
+        ));
+        assert_eq!(attempts, 1);
+        assert_eq!(waits, 1);
+    }
+
+    #[test]
+    fn returns_non_lock_error_without_waiting() {
+        let mut waits = 0;
+        let actual: Result<()> = open_with_lock_wait_by(
+            || Err(sled::Error::Unsupported("invalid config".to_owned())),
+            || {
+                waits += 1;
+                true
+            },
+            Duration::from_secs(1),
+        );
+
+        assert!(matches!(actual, Err(Error::StorageMsg(_))));
+        assert_eq!(waits, 0);
+    }
+
+    #[test]
+    fn recognizes_lock_error_from_sled() {
+        let (owner_config, contender_config) = configs_for_same_temporary_path();
+        let owner = owner_config.open().expect("open lock owner");
+        let actual = contender_config
+            .open()
+            .expect_err("second open should be locked");
+
+        assert!(is_lock_unavailable(&actual));
+        drop(owner);
+    }
+}

--- a/storages/sled-storage/tests/migration_v1_to_v2.rs
+++ b/storages/sled-storage/tests/migration_v1_to_v2.rs
@@ -13,12 +13,16 @@ use {
     std::{
         collections::BTreeMap,
         fs::{create_dir_all, remove_dir_all, remove_file, write},
+        io::ErrorKind,
         path::{Path, PathBuf},
-        time::{SystemTime, UNIX_EPOCH},
+        thread,
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     },
 };
 
 const STORAGE_FORMAT_VERSION_KEY: &str = "__GLUESQL_STORAGE_FORMAT_VERSION__";
+const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+const LOCK_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct V1SnapshotItem<T> {
@@ -80,11 +84,23 @@ fn data_key(table_name: &str, key: Vec<u8>) -> Vec<u8> {
 }
 
 fn open_sled(path: &Path) -> Db {
-    sled::Config::new()
-        .path(path)
-        .flush_every_ms(None)
-        .open()
-        .expect("open sled")
+    let config = sled::Config::new().path(path).flush_every_ms(None);
+    let started_at = Instant::now();
+
+    loop {
+        match config.open() {
+            Ok(tree) => return tree,
+            Err(sled::Error::Io(error))
+                if error.kind() == ErrorKind::Other
+                    && error.to_string().starts_with("could not acquire lock on ") =>
+            {
+                let remaining = LOCK_WAIT_TIMEOUT.saturating_sub(started_at.elapsed());
+                assert!(!remaining.is_zero(), "open sled: {error}");
+                thread::sleep(LOCK_WAIT_INTERVAL.min(remaining));
+            }
+            Err(error) => panic!("open sled: {error}"),
+        }
+    }
 }
 
 fn write_schema_snapshot(tree: &Db, schema: Schema) {
@@ -184,8 +200,7 @@ fn setup_v1_storage(path: &Path) -> BTreeMap<String, Value> {
     log_row
 }
 
-fn read_storage_format_version(path: &Path) -> u32 {
-    let tree = open_sled(path);
+fn read_storage_format_version(tree: &Db) -> u32 {
     let value = tree
         .get(STORAGE_FORMAT_VERSION_KEY)
         .expect("read storage format version key")
@@ -195,8 +210,7 @@ fn read_storage_format_version(path: &Path) -> u32 {
     u32::from_be_bytes(bytes)
 }
 
-fn read_row_snapshot(path: &Path, table_name: &str, key: Vec<u8>) -> Vec<Value> {
-    let tree = open_sled(path);
+fn read_row_snapshot(tree: &Db, table_name: &str, key: Vec<u8>) -> Vec<Value> {
     let key = data_key(table_name, key);
     let value = tree
         .get(key)
@@ -238,12 +252,13 @@ fn migrate_v1_to_v2_rewrites_rows_and_sets_version() {
         }
     );
 
+    let tree = open_sled(&path);
     assert_eq!(
-        read_storage_format_version(&path),
+        read_storage_format_version(&tree),
         SLED_STORAGE_FORMAT_VERSION
     );
     let user_row = read_row_snapshot(
-        &path,
+        &tree,
         "User",
         Key::I64(1).to_cmp_be_bytes().expect("user key"),
     );
@@ -252,8 +267,9 @@ fn migrate_v1_to_v2_rewrites_rows_and_sets_version() {
         vec![Value::I64(1), Value::Str("Alice".to_owned())]
     );
 
-    let logs_row = read_row_snapshot(&path, "Logs", vec![0, 0, 0, 0, 0, 0, 0, 1]);
+    let logs_row = read_row_snapshot(&tree, "Logs", vec![0, 0, 0, 0, 0, 0, 0, 1]);
     assert_eq!(logs_row, vec![Value::Map(expected_log_row)]);
+    drop(tree);
 
     let report = migrate_to_latest(&path).expect("idempotent migration");
     assert_eq!(
@@ -436,9 +452,10 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
         }
     );
 
+    let tree = open_sled(&path);
     assert_eq!(
         read_row_snapshot(
-            &path,
+            &tree,
             "Mixed",
             Key::I64(1).to_cmp_be_bytes().expect("key 1")
         ),
@@ -446,7 +463,7 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
     );
     assert_eq!(
         read_row_snapshot(
-            &path,
+            &tree,
             "Mixed",
             Key::I64(2).to_cmp_be_bytes().expect("key 2")
         ),
@@ -454,7 +471,7 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
     );
     assert_eq!(
         read_row_snapshot(
-            &path,
+            &tree,
             "Mixed",
             Key::I64(3).to_cmp_be_bytes().expect("key 3")
         ),
@@ -462,7 +479,7 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
     );
     assert_eq!(
         read_row_snapshot(
-            &path,
+            &tree,
             "Mixed",
             Key::I64(4).to_cmp_be_bytes().expect("key 4")
         ),
@@ -470,12 +487,13 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
     );
     assert_eq!(
         read_row_snapshot(
-            &path,
+            &tree,
             "Mixed",
             Key::I64(5).to_cmp_be_bytes().expect("key 5")
         ),
         vec![Value::I64(5)]
     );
+    drop(tree);
 
     remove_dir_all(path).expect("cleanup");
 }
@@ -516,10 +534,12 @@ fn migrate_v1_storage_without_data_rows() {
             rewritten_rows: 0,
         }
     );
+    let tree = open_sled(&path);
     assert_eq!(
-        read_storage_format_version(&path),
+        read_storage_format_version(&tree),
         SLED_STORAGE_FORMAT_VERSION
     );
+    drop(tree);
 
     remove_dir_all(path).expect("cleanup");
 }

--- a/storages/sled-storage/tests/migration_v1_to_v2.rs
+++ b/storages/sled-storage/tests/migration_v1_to_v2.rs
@@ -13,16 +13,12 @@ use {
     std::{
         collections::BTreeMap,
         fs::{create_dir_all, remove_dir_all, remove_file, write},
-        io::{self, ErrorKind},
         path::{Path, PathBuf},
-        thread,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+        time::{SystemTime, UNIX_EPOCH},
     },
 };
 
 const STORAGE_FORMAT_VERSION_KEY: &str = "__GLUESQL_STORAGE_FORMAT_VERSION__";
-const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
-const LOCK_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct V1SnapshotItem<T> {
@@ -83,107 +79,20 @@ fn data_key(table_name: &str, key: Vec<u8>) -> Vec<u8> {
         .collect()
 }
 
-fn open_sled(path: &Path) -> Db {
+fn create_sled(path: &Path) -> Db {
+    sled::Config::new()
+        .path(path)
+        .flush_every_ms(None)
+        .open()
+        .expect("create sled")
+}
+
+fn open_migrated_sled(path: &Path) -> Db {
     let config = sled::Config::new().path(path).flush_every_ms(None);
 
-    open_sled_with_lock_wait_by(
-        || config.open(),
-        Instant::now,
-        thread::sleep,
-        LOCK_WAIT_TIMEOUT,
-        LOCK_WAIT_INTERVAL,
-    )
-}
-
-fn open_sled_with_lock_wait_by<T>(
-    mut open: impl FnMut() -> sled::Result<T>,
-    mut now: impl FnMut() -> Instant,
-    mut sleep: impl FnMut(Duration),
-    timeout: Duration,
-    interval: Duration,
-) -> T {
-    let started_at = now();
-
-    loop {
-        match open() {
-            Ok(tree) => return tree,
-            Err(sled::Error::Io(error))
-                if error.kind() == ErrorKind::Other
-                    && error.to_string().starts_with("could not acquire lock on ") =>
-            {
-                let remaining = timeout.saturating_sub(now().duration_since(started_at));
-                assert!(
-                    !remaining.is_zero(),
-                    "open sled: timed out after {} ms waiting for the database lock: {error}",
-                    timeout.as_millis(),
-                );
-                sleep(interval.min(remaining));
-            }
-            Err(error) => panic!("open sled: {error}"),
-        }
-    }
-}
-
-fn lock_error() -> sled::Error {
-    sled::Error::Io(io::Error::other(
-        "could not acquire lock on \"db\": Resource temporarily unavailable",
-    ))
-}
-
-#[test]
-fn open_sled_waits_for_lock_release() {
-    let mut attempts = 0;
-    let started_at = Instant::now();
-    let mut now = [started_at, started_at].into_iter();
-    let mut sleeps = Vec::new();
-
-    let actual = open_sled_with_lock_wait_by(
-        || {
-            attempts += 1;
-            if attempts == 1 {
-                Err(lock_error())
-            } else {
-                Ok(7)
-            }
-        },
-        || now.next().expect("current time"),
-        |duration| sleeps.push(duration),
-        Duration::from_secs(1),
-        Duration::from_millis(10),
-    );
-
-    assert_eq!(actual, 7);
-    assert_eq!(attempts, 2);
-    assert_eq!(sleeps, [Duration::from_millis(10)]);
-}
-
-#[test]
-#[should_panic(expected = "timed out after 20 ms waiting for the database lock")]
-fn open_sled_panics_after_lock_timeout() {
-    let started_at = Instant::now();
-    let mut now = [started_at, started_at + Duration::from_millis(20)].into_iter();
-
-    open_sled_with_lock_wait_by(
-        || Err::<(), _>(lock_error()),
-        || now.next().expect("current time"),
-        thread::sleep,
-        Duration::from_millis(20),
-        Duration::from_millis(10),
-    );
-}
-
-#[test]
-#[should_panic(expected = "open sled: Unsupported: invalid config")]
-fn open_sled_panics_on_non_lock_error() {
-    let now = Instant::now();
-
-    open_sled_with_lock_wait_by(
-        || Err::<(), _>(sled::Error::Unsupported("invalid config".to_owned())),
-        || now,
-        thread::sleep,
-        Duration::from_secs(1),
-        Duration::from_millis(10),
-    );
+    SledStorage::try_from(config)
+        .expect("open migrated sled")
+        .tree
 }
 
 fn write_schema_snapshot(tree: &Db, schema: Schema) {
@@ -213,7 +122,7 @@ fn write_v2_data_snapshot(tree: &Db, table_name: &str, key: Vec<u8>, row: Vec<Va
 }
 
 fn write_storage_format_version(path: &Path, version_bytes: &[u8]) {
-    let tree = open_sled(path);
+    let tree = create_sled(path);
     tree.insert(STORAGE_FORMAT_VERSION_KEY, version_bytes)
         .expect("insert version");
     tree.flush().expect("flush version");
@@ -221,7 +130,7 @@ fn write_storage_format_version(path: &Path, version_bytes: &[u8]) {
 
 fn setup_v1_storage(path: &Path) -> BTreeMap<String, Value> {
     let _ = remove_dir_all(path);
-    let tree = open_sled(path);
+    let tree = create_sled(path);
 
     let user_schema = Schema {
         table_name: "User".to_owned(),
@@ -335,7 +244,7 @@ fn migrate_v1_to_v2_rewrites_rows_and_sets_version() {
         }
     );
 
-    let tree = open_sled(&path);
+    let tree = open_migrated_sled(&path);
     assert_eq!(
         read_storage_format_version(&tree),
         SLED_STORAGE_FORMAT_VERSION
@@ -474,7 +383,7 @@ fn migrate_rejects_file_path() {
 fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
     let path = test_path("sled-migration-v1-shapes");
     let _ = remove_dir_all(&path);
-    let tree = open_sled(&path);
+    let tree = create_sled(&path);
 
     write_schema_snapshot(
         &tree,
@@ -535,7 +444,7 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
         }
     );
 
-    let tree = open_sled(&path);
+    let tree = open_migrated_sled(&path);
     assert_eq!(
         read_row_snapshot(
             &tree,
@@ -585,7 +494,7 @@ fn migrate_v1_to_v2_supports_all_v1_snapshot_shapes() {
 fn migrate_v1_storage_without_data_rows() {
     let path = test_path("sled-migration-without-data-rows");
     let _ = remove_dir_all(&path);
-    let tree = open_sled(&path);
+    let tree = create_sled(&path);
 
     write_schema_snapshot(
         &tree,
@@ -617,7 +526,7 @@ fn migrate_v1_storage_without_data_rows() {
             rewritten_rows: 0,
         }
     );
-    let tree = open_sled(&path);
+    let tree = open_migrated_sled(&path);
     assert_eq!(
         read_storage_format_version(&tree),
         SLED_STORAGE_FORMAT_VERSION
@@ -631,7 +540,7 @@ fn migrate_v1_storage_without_data_rows() {
 fn migrate_rejects_invalid_v1_row_snapshot_payload() {
     let path = test_path("sled-migration-invalid-v1-row-snapshot");
     let _ = remove_dir_all(&path);
-    let tree = open_sled(&path);
+    let tree = create_sled(&path);
     write_schema_snapshot(
         &tree,
         Schema {
@@ -664,7 +573,7 @@ fn migrate_rejects_invalid_v1_row_snapshot_payload() {
 fn migrate_v2_storage_with_invalid_schema_snapshot_is_rejected() {
     let path = test_path("sled-v2-invalid-schema-snapshot");
     let _ = remove_dir_all(&path);
-    let tree = open_sled(&path);
+    let tree = create_sled(&path);
 
     tree.insert(
         STORAGE_FORMAT_VERSION_KEY,

--- a/storages/sled-storage/tests/migration_v1_to_v2.rs
+++ b/storages/sled-storage/tests/migration_v1_to_v2.rs
@@ -13,7 +13,7 @@ use {
     std::{
         collections::BTreeMap,
         fs::{create_dir_all, remove_dir_all, remove_file, write},
-        io::ErrorKind,
+        io::{self, ErrorKind},
         path::{Path, PathBuf},
         thread,
         time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -85,22 +85,105 @@ fn data_key(table_name: &str, key: Vec<u8>) -> Vec<u8> {
 
 fn open_sled(path: &Path) -> Db {
     let config = sled::Config::new().path(path).flush_every_ms(None);
-    let started_at = Instant::now();
+
+    open_sled_with_lock_wait_by(
+        || config.open(),
+        Instant::now,
+        thread::sleep,
+        LOCK_WAIT_TIMEOUT,
+        LOCK_WAIT_INTERVAL,
+    )
+}
+
+fn open_sled_with_lock_wait_by<T>(
+    mut open: impl FnMut() -> sled::Result<T>,
+    mut now: impl FnMut() -> Instant,
+    mut sleep: impl FnMut(Duration),
+    timeout: Duration,
+    interval: Duration,
+) -> T {
+    let started_at = now();
 
     loop {
-        match config.open() {
+        match open() {
             Ok(tree) => return tree,
             Err(sled::Error::Io(error))
                 if error.kind() == ErrorKind::Other
                     && error.to_string().starts_with("could not acquire lock on ") =>
             {
-                let remaining = LOCK_WAIT_TIMEOUT.saturating_sub(started_at.elapsed());
-                assert!(!remaining.is_zero(), "open sled: {error}");
-                thread::sleep(LOCK_WAIT_INTERVAL.min(remaining));
+                let remaining = timeout.saturating_sub(now().duration_since(started_at));
+                assert!(
+                    !remaining.is_zero(),
+                    "open sled: timed out after {} ms waiting for the database lock: {error}",
+                    timeout.as_millis(),
+                );
+                sleep(interval.min(remaining));
             }
             Err(error) => panic!("open sled: {error}"),
         }
     }
+}
+
+fn lock_error() -> sled::Error {
+    sled::Error::Io(io::Error::other(
+        "could not acquire lock on \"db\": Resource temporarily unavailable",
+    ))
+}
+
+#[test]
+fn open_sled_waits_for_lock_release() {
+    let mut attempts = 0;
+    let started_at = Instant::now();
+    let mut now = [started_at, started_at].into_iter();
+    let mut sleeps = Vec::new();
+
+    let actual = open_sled_with_lock_wait_by(
+        || {
+            attempts += 1;
+            if attempts == 1 {
+                Err(lock_error())
+            } else {
+                Ok(7)
+            }
+        },
+        || now.next().expect("current time"),
+        |duration| sleeps.push(duration),
+        Duration::from_secs(1),
+        Duration::from_millis(10),
+    );
+
+    assert_eq!(actual, 7);
+    assert_eq!(attempts, 2);
+    assert_eq!(sleeps, [Duration::from_millis(10)]);
+}
+
+#[test]
+#[should_panic(expected = "timed out after 20 ms waiting for the database lock")]
+fn open_sled_panics_after_lock_timeout() {
+    let started_at = Instant::now();
+    let mut now = [started_at, started_at + Duration::from_millis(20)].into_iter();
+
+    open_sled_with_lock_wait_by(
+        || Err::<(), _>(lock_error()),
+        || now.next().expect("current time"),
+        thread::sleep,
+        Duration::from_millis(20),
+        Duration::from_millis(10),
+    );
+}
+
+#[test]
+#[should_panic(expected = "open sled: Unsupported: invalid config")]
+fn open_sled_panics_on_non_lock_error() {
+    let now = Instant::now();
+
+    open_sled_with_lock_wait_by(
+        || Err::<(), _>(sled::Error::Unsupported("invalid config".to_owned())),
+        || now,
+        thread::sleep,
+        Duration::from_secs(1),
+        Duration::from_millis(10),
+    );
 }
 
 fn write_schema_snapshot(tree: &Db, schema: Schema) {


### PR DESCRIPTION
Sled may keep the database file locked briefly after a flush while its I/O worker finishes. Wait up to one second for the lock to clear instead of failing immediate reopen operations.

Apply the same behavior to regular and migration opens, reduce repeated opens in migration tests, and cover lock release, timeout, and unrelated errors deterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup reliability by adding lock-aware retries when the storage is temporarily locked.
  * Migration now uses the same lock-aware database opening behavior for consistent results.
* **Tests**
  * Expanded coverage for lock contention, retry timing, timeout behavior (including capped waiting), and ensuring non-lock errors fail immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->