### PR TITLE
Add `ToGlueRow` derive macro and `values_from` insert builder

### DIFF
--- a/core/src/query_builder/error.rs
+++ b/core/src/query_builder/error.rs
@@ -15,4 +15,7 @@ pub enum QueryBuilderError {
         "projection expression label cannot be derived from a plan-only expression; use an explicit alias"
     )]
     ProjectionLabelRequiresAlias,
+
+    #[error("values_from requires at least one row")]
+    ValuesFromRequiresRows,
 }

--- a/core/src/query_builder/error.rs
+++ b/core/src/query_builder/error.rs
@@ -18,4 +18,7 @@ pub enum QueryBuilderError {
 
     #[error("values_from requires at least one row")]
     ValuesFromRequiresRows,
+
+    #[error("values_from row has {found} values but {expected} columns are declared")]
+    ValuesFromColumnCountMismatch { expected: usize, found: usize },
 }

--- a/core/src/query_builder/insert.rs
+++ b/core/src/query_builder/insert.rs
@@ -51,13 +51,22 @@ impl InsertNode {
         let values = rows
             .iter()
             .map(|row| {
-                row.to_glue_row()
+                let literals = row.to_glue_row();
+                if literals.len() != columns.len() {
+                    return Err(QueryBuilderError::ValuesFromColumnCountMismatch {
+                        expected: columns.len(),
+                        found: literals.len(),
+                    }
+                    .into());
+                }
+
+                Ok(literals
                     .into_iter()
                     .map(|literal| ExprNode::Expr(Cow::Owned(literal.into_expr())))
                     .collect::<Vec<_>>()
-                    .into()
+                    .into())
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
         Ok(InsertSourceNode {
             insert_node: self.columns(columns),
@@ -211,6 +220,34 @@ mod tests {
         let actual = table("Foo").insert().values_from::<Item>(&[]).map(|_| ());
         let expected = Err(Error::QueryBuilder(
             QueryBuilderError::ValuesFromRequiresRows,
+        ));
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn insert_values_from_rejects_column_count_mismatch() {
+        struct Mismatched;
+
+        impl ToGlueRow for Mismatched {
+            fn glue_columns() -> &'static [&'static str] {
+                static COLUMNS: [&str; 2] = ["id", "name"];
+                &COLUMNS
+            }
+
+            fn to_glue_row(&self) -> Vec<ParamLiteral> {
+                vec![1_i64.into_param_literal()]
+            }
+        }
+
+        let actual = table("Foo")
+            .insert()
+            .values_from(&[Mismatched])
+            .map(|_| ());
+        let expected = Err(Error::QueryBuilder(
+            QueryBuilderError::ValuesFromColumnCountMismatch {
+                expected: 2,
+                found: 1,
+            },
         ));
         pretty_assertions::assert_eq!(actual, expected);
     }

--- a/core/src/query_builder/insert.rs
+++ b/core/src/query_builder/insert.rs
@@ -1,6 +1,7 @@
 use {
-    super::{Build, ColumnList, ExprList, QueryNode},
-    crate::{plan::StatementPlan, result::Result},
+    super::{Build, ColumnList, ExprList, ExprNode, QueryBuilderError, QueryNode},
+    crate::{plan::StatementPlan, result::Result, row_conversion::ToGlueRow},
+    std::borrow::Cow,
 };
 
 #[derive(Clone, Debug)]
@@ -38,6 +39,31 @@ impl InsertNode {
             source: query.into(),
         }
     }
+
+    /// Builds VALUES rows from [`ToGlueRow`] structs. Columns are always set
+    /// from the struct metadata, replacing any set beforehand.
+    pub fn values_from<'a, T: ToGlueRow>(self, rows: &[T]) -> Result<InsertSourceNode<'a>> {
+        if rows.is_empty() {
+            return Err(QueryBuilderError::ValuesFromRequiresRows.into());
+        }
+
+        let columns = T::glue_columns().to_vec();
+        let values = rows
+            .iter()
+            .map(|row| {
+                row.to_glue_row()
+                    .into_iter()
+                    .map(|literal| ExprNode::Expr(Cow::Owned(literal.into_expr())))
+                    .collect::<Vec<_>>()
+                    .into()
+            })
+            .collect();
+
+        Ok(InsertSourceNode {
+            insert_node: self.columns(columns),
+            source: QueryNode::Values(values),
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -63,7 +89,13 @@ impl Build for InsertSourceNode<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::query_builder::{Build, num, table, test};
+    use crate::{
+        data::Value,
+        query_builder::{Build, QueryBuilderError, num, table, test, value},
+        result::Error,
+        row_conversion::ToGlueRow,
+        translate::{IntoParamLiteral, ParamLiteral},
+    };
 
     #[test]
     fn insert() {
@@ -93,5 +125,93 @@ mod tests {
             .build();
         let expected = r"INSERT INTO Foo SELECT id, name FROM Bar LIMIT 10";
         test(&actual, expected);
+    }
+
+    struct Item {
+        id: i64,
+        name: String,
+        in_stock: Option<bool>,
+    }
+
+    impl ToGlueRow for Item {
+        fn glue_columns() -> &'static [&'static str] {
+            static COLUMNS: [&str; 3] = ["id", "title", "in_stock"];
+            &COLUMNS
+        }
+
+        fn to_glue_row(&self) -> Vec<ParamLiteral> {
+            vec![
+                self.id.into_param_literal(),
+                self.name.clone().into_param_literal(),
+                self.in_stock.into_param_literal(),
+            ]
+        }
+    }
+
+    #[test]
+    fn insert_values_from() {
+        let items = vec![
+            Item {
+                id: 1,
+                name: "glue".to_owned(),
+                in_stock: Some(true),
+            },
+            Item {
+                id: 2,
+                name: "sql".to_owned(),
+                in_stock: None,
+            },
+        ];
+
+        let actual = table("Foo")
+            .insert()
+            .values_from(&items)
+            .and_then(Build::build);
+        let expected = table("Foo")
+            .insert()
+            .columns(vec!["id", "title", "in_stock"])
+            .values(vec![
+                vec![
+                    value(Value::I64(1)),
+                    value(Value::Str("glue".to_owned())),
+                    value(Value::Bool(true)),
+                ],
+                vec![
+                    value(Value::I64(2)),
+                    value(Value::Str("sql".to_owned())),
+                    value(Value::Null),
+                ],
+            ])
+            .build();
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn insert_values_from_replaces_columns() {
+        let items = vec![Item {
+            id: 7,
+            name: "hi".to_owned(),
+            in_stock: None,
+        }];
+
+        let actual = table("Foo")
+            .insert()
+            .columns("ignored, also_ignored")
+            .values_from(&items)
+            .and_then(Build::build);
+        let expected = table("Foo")
+            .insert()
+            .values_from(&items)
+            .and_then(Build::build);
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn insert_values_from_requires_rows() {
+        let actual = table("Foo").insert().values_from::<Item>(&[]).map(|_| ());
+        let expected = Err(Error::QueryBuilder(
+            QueryBuilderError::ValuesFromRequiresRows,
+        ));
+        pretty_assertions::assert_eq!(actual, expected);
     }
 }

--- a/core/src/query_builder/insert.rs
+++ b/core/src/query_builder/insert.rs
@@ -239,10 +239,7 @@ mod tests {
             }
         }
 
-        let actual = table("Foo")
-            .insert()
-            .values_from(&[Mismatched])
-            .map(|_| ());
+        let actual = table("Foo").insert().values_from(&[Mismatched]).map(|_| ());
         let expected = Err(Error::QueryBuilder(
             QueryBuilderError::ValuesFromColumnCountMismatch {
                 expected: 2,

--- a/core/src/row_conversion.rs
+++ b/core/src/row_conversion.rs
@@ -51,6 +51,11 @@ pub trait FromGlueRow: Sized {
     ) -> Result<Self, RowConversionError>;
 }
 
+pub trait ToGlueRow {
+    fn glue_columns() -> &'static [&'static str];
+    fn to_glue_row(&self) -> Vec<crate::translate::ParamLiteral>;
+}
+
 pub trait SelectExt {
     fn rows_as<T: FromGlueRow>(self) -> Result<Vec<T>, RowConversionError>;
     fn one_as<T: FromGlueRow>(self) -> Result<T, RowConversionError>;

--- a/docs/docs/query-builder/statements/data-manipulation/inserting-data.md
+++ b/docs/docs/query-builder/statements/data-manipulation/inserting-data.md
@@ -51,3 +51,33 @@ test(actual, expected);
 ```
 
 This code inserts data into the table `Bar` using the `SELECT` statement on the table `Foo`. The `project` method is used to specify the columns `id` and `name` as the source data.
+
+## Insert from Structs
+
+If you derive `ToGlueRow` on a struct, you can insert struct values directly with the `values_from` method — no manual field-to-expression mapping required. Columns are set automatically from the struct fields, and `#[glue(rename = "...")]` lets a field map to a different column name. `Option` fields convert `None` to `NULL`.
+
+```rust
+use gluesql::ToGlueRow;
+
+#[derive(ToGlueRow)]
+struct Item {
+    id: i64,
+    #[glue(rename = "name")]
+    title: String,
+    rate: Option<f64>, // None -> NULL
+}
+
+let items = vec![
+    Item { id: 4, title: "Fish".to_owned(), rate: Some(0.2) },
+    Item { id: 5, title: "Bread".to_owned(), rate: None },
+];
+
+let actual = table("Foo")
+    .insert()
+    .values_from(&items)?
+    .execute(glue);
+let expected = Ok(Payload::Insert(2));
+test(actual, expected);
+```
+
+`values_from` returns an error if the given slice is empty, and it always sets the insert columns from the struct metadata so the columns stay aligned with the generated values.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -976,8 +976,55 @@ fn match_expected(
 
 #[cfg(test)]
 mod tests {
-    use super::expand_from_glue_row;
+    use super::{expand_from_glue_row, expand_to_glue_row};
     use syn::parse_quote;
+
+    #[test]
+    fn to_glue_row_non_struct_input_returns_error() {
+        let di: syn::DeriveInput = parse_quote! {
+            enum E { A }
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ToGlueRow can only be derived for structs")
+        );
+    }
+
+    #[test]
+    fn to_glue_row_non_named_fields_struct_returns_error() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct T(i32);
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ToGlueRow supports only named fields")
+        );
+    }
+
+    #[test]
+    fn to_glue_row_glue_rename_ok_some_and_ok_none() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct S {
+                #[glue(rename = "col")] a: i64,
+                #[glue(other = "x")] b: String,
+            }
+        };
+        let _ = expand_to_glue_row(di).expect("expand ok");
+    }
+
+    #[test]
+    fn to_glue_row_glue_rename_wrong_literal_type() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct S { #[glue(rename = 123)] a: i64 }
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected string literal for rename")
+        );
+    }
 
     #[test]
     fn non_struct_input_returns_error() {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -191,6 +191,84 @@ pub fn derive_from_glue_row(input: TokenStream) -> TokenStream {
     }
 }
 
+fn expand_to_glue_row(input: DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let input_span = input.span();
+
+    let gluesql_crate_path = resolve_gluesql_crate()?;
+    let gluesql_crate = quote! { #gluesql_crate_path };
+
+    let ident = input.ident.clone();
+    let Data::Struct(data) = input.data else {
+        return Err(syn::Error::new(
+            input_span,
+            "ToGlueRow can only be derived for structs",
+        ));
+    };
+
+    let fields = match data.fields {
+        Fields::Named(f) => f.named,
+        _ => {
+            return Err(syn::Error::new(
+                input_span,
+                "ToGlueRow supports only named fields",
+            ));
+        }
+    };
+
+    let mut column_names = Vec::new();
+    let mut field_literals = Vec::new();
+
+    for field in &fields {
+        let field_ident = field.ident.clone().expect("named field");
+        let field_name_literal = field_ident.to_string();
+
+        let mut rename: Option<String> = None;
+        for attr in &field.attrs {
+            if let Some(res) = parse_glue_rename(attr) {
+                match res {
+                    Ok(Some(name)) => rename = Some(name),
+                    Ok(None) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        let column_name = rename.unwrap_or_else(|| field_name_literal.clone());
+        column_names.push(quote! { #column_name });
+
+        field_literals.push(quote! {
+            #gluesql_crate::translate::IntoParamLiteral::into_param_literal(
+                ::core::clone::Clone::clone(&self.#field_ident)
+            )
+        });
+    }
+
+    let columns_len = column_names.len();
+
+    let expanded = quote! {
+        impl #gluesql_crate::row_conversion::ToGlueRow for #ident {
+            fn glue_columns() -> &'static [&'static str] {
+                static COLUMNS: [&str; #columns_len] = [ #(#column_names),* ];
+                &COLUMNS
+            }
+
+            fn to_glue_row(&self) -> ::std::vec::Vec<#gluesql_crate::translate::ParamLiteral> {
+                ::std::vec![ #(#field_literals),* ]
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+#[proc_macro_derive(ToGlueRow, attributes(glue))]
+pub fn derive_to_glue_row(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand_to_glue_row(input) {
+        Ok(ts) => TokenStream::from(ts),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
 fn parse_glue_rename(attr: &Attribute) -> Option<Result<Option<String>, syn::Error>> {
     if !attr.path().is_ident("glue") {
         return None;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,6 +8,8 @@ use {
     },
 };
 
+mod to_glue_row;
+
 fn resolve_gluesql_crate() -> Result<syn::Path, syn::Error> {
     if std::env::var("CARGO_PKG_NAME")
         .map(|name| name == "gluesql")
@@ -191,79 +193,10 @@ pub fn derive_from_glue_row(input: TokenStream) -> TokenStream {
     }
 }
 
-fn expand_to_glue_row(input: DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
-    let input_span = input.span();
-
-    let gluesql_crate_path = resolve_gluesql_crate()?;
-    let gluesql_crate = quote! { #gluesql_crate_path };
-
-    let ident = input.ident.clone();
-    let Data::Struct(data) = input.data else {
-        return Err(syn::Error::new(
-            input_span,
-            "ToGlueRow can only be derived for structs",
-        ));
-    };
-
-    let fields = match data.fields {
-        Fields::Named(f) => f.named,
-        _ => {
-            return Err(syn::Error::new(
-                input_span,
-                "ToGlueRow supports only named fields",
-            ));
-        }
-    };
-
-    let mut column_names = Vec::new();
-    let mut field_literals = Vec::new();
-
-    for field in &fields {
-        let field_ident = field.ident.clone().expect("named field");
-        let field_name_literal = field_ident.to_string();
-
-        let mut rename: Option<String> = None;
-        for attr in &field.attrs {
-            if let Some(res) = parse_glue_rename(attr) {
-                match res {
-                    Ok(Some(name)) => rename = Some(name),
-                    Ok(None) => {}
-                    Err(e) => return Err(e),
-                }
-            }
-        }
-        let column_name = rename.unwrap_or_else(|| field_name_literal.clone());
-        column_names.push(quote! { #column_name });
-
-        field_literals.push(quote! {
-            #gluesql_crate::translate::IntoParamLiteral::into_param_literal(
-                ::core::clone::Clone::clone(&self.#field_ident)
-            )
-        });
-    }
-
-    let columns_len = column_names.len();
-
-    let expanded = quote! {
-        impl #gluesql_crate::row_conversion::ToGlueRow for #ident {
-            fn glue_columns() -> &'static [&'static str] {
-                static COLUMNS: [&str; #columns_len] = [ #(#column_names),* ];
-                &COLUMNS
-            }
-
-            fn to_glue_row(&self) -> ::std::vec::Vec<#gluesql_crate::translate::ParamLiteral> {
-                ::std::vec![ #(#field_literals),* ]
-            }
-        }
-    };
-
-    Ok(expanded)
-}
-
 #[proc_macro_derive(ToGlueRow, attributes(glue))]
 pub fn derive_to_glue_row(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    match expand_to_glue_row(input) {
+    match to_glue_row::expand_to_glue_row(input) {
         Ok(ts) => TokenStream::from(ts),
         Err(e) => e.to_compile_error().into(),
     }
@@ -976,55 +909,8 @@ fn match_expected(
 
 #[cfg(test)]
 mod tests {
-    use super::{expand_from_glue_row, expand_to_glue_row};
+    use super::expand_from_glue_row;
     use syn::parse_quote;
-
-    #[test]
-    fn to_glue_row_non_struct_input_returns_error() {
-        let di: syn::DeriveInput = parse_quote! {
-            enum E { A }
-        };
-        let err = expand_to_glue_row(di).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("ToGlueRow can only be derived for structs")
-        );
-    }
-
-    #[test]
-    fn to_glue_row_non_named_fields_struct_returns_error() {
-        let di: syn::DeriveInput = parse_quote! {
-            struct T(i32);
-        };
-        let err = expand_to_glue_row(di).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("ToGlueRow supports only named fields")
-        );
-    }
-
-    #[test]
-    fn to_glue_row_glue_rename_ok_some_and_ok_none() {
-        let di: syn::DeriveInput = parse_quote! {
-            struct S {
-                #[glue(rename = "col")] a: i64,
-                #[glue(other = "x")] b: String,
-            }
-        };
-        let _ = expand_to_glue_row(di).expect("expand ok");
-    }
-
-    #[test]
-    fn to_glue_row_glue_rename_wrong_literal_type() {
-        let di: syn::DeriveInput = parse_quote! {
-            struct S { #[glue(rename = 123)] a: i64 }
-        };
-        let err = expand_to_glue_row(di).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("expected string literal for rename")
-        );
-    }
 
     #[test]
     fn non_struct_input_returns_error() {

--- a/macros/src/to_glue_row.rs
+++ b/macros/src/to_glue_row.rs
@@ -30,6 +30,7 @@ pub(crate) fn expand_to_glue_row(
         }
     };
 
+    let mut seen_columns: Vec<String> = Vec::new();
     let mut column_names = Vec::new();
     let mut field_literals = Vec::new();
 
@@ -48,6 +49,13 @@ pub(crate) fn expand_to_glue_row(
             }
         }
         let column_name = rename.unwrap_or_else(|| field_name_literal.clone());
+        if seen_columns.contains(&column_name) {
+            return Err(syn::Error::new(
+                field.span(),
+                format!("duplicate column name `{column_name}`"),
+            ));
+        }
+        seen_columns.push(column_name.clone());
         column_names.push(quote! { #column_name });
 
         field_literals.push(quote! {
@@ -113,6 +121,19 @@ mod tests {
             }
         };
         let _ = expand_to_glue_row(di).expect("expand ok");
+    }
+
+    #[test]
+    fn duplicate_column_name_returns_error() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct S {
+                value: i64,
+                #[glue(rename = "value")]
+                previous_value: i64,
+            }
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(err.to_string().contains("duplicate column name `value`"));
     }
 
     #[test]

--- a/macros/src/to_glue_row.rs
+++ b/macros/src/to_glue_row.rs
@@ -1,0 +1,129 @@
+use {
+    crate::{parse_glue_rename, resolve_gluesql_crate},
+    quote::quote,
+    syn::{Data, DeriveInput, Fields, spanned::Spanned},
+};
+
+pub(crate) fn expand_to_glue_row(
+    input: DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let input_span = input.span();
+
+    let gluesql_crate_path = resolve_gluesql_crate()?;
+    let gluesql_crate = quote! { #gluesql_crate_path };
+
+    let ident = input.ident.clone();
+    let Data::Struct(data) = input.data else {
+        return Err(syn::Error::new(
+            input_span,
+            "ToGlueRow can only be derived for structs",
+        ));
+    };
+
+    let fields = match data.fields {
+        Fields::Named(f) => f.named,
+        _ => {
+            return Err(syn::Error::new(
+                input_span,
+                "ToGlueRow supports only named fields",
+            ));
+        }
+    };
+
+    let mut column_names = Vec::new();
+    let mut field_literals = Vec::new();
+
+    for field in &fields {
+        let field_ident = field.ident.clone().expect("named field");
+        let field_name_literal = field_ident.to_string();
+
+        let mut rename: Option<String> = None;
+        for attr in &field.attrs {
+            if let Some(res) = parse_glue_rename(attr) {
+                match res {
+                    Ok(Some(name)) => rename = Some(name),
+                    Ok(None) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        let column_name = rename.unwrap_or_else(|| field_name_literal.clone());
+        column_names.push(quote! { #column_name });
+
+        field_literals.push(quote! {
+            #gluesql_crate::translate::IntoParamLiteral::into_param_literal(
+                ::core::clone::Clone::clone(&self.#field_ident)
+            )
+        });
+    }
+
+    let columns_len = column_names.len();
+
+    let expanded = quote! {
+        impl #gluesql_crate::row_conversion::ToGlueRow for #ident {
+            fn glue_columns() -> &'static [&'static str] {
+                static COLUMNS: [&str; #columns_len] = [ #(#column_names),* ];
+                &COLUMNS
+            }
+
+            fn to_glue_row(&self) -> ::std::vec::Vec<#gluesql_crate::translate::ParamLiteral> {
+                ::std::vec![ #(#field_literals),* ]
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_to_glue_row;
+    use syn::parse_quote;
+
+    #[test]
+    fn non_struct_input_returns_error() {
+        let di: syn::DeriveInput = parse_quote! {
+            enum E { A }
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ToGlueRow can only be derived for structs")
+        );
+    }
+
+    #[test]
+    fn non_named_fields_struct_returns_error() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct T(i32);
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ToGlueRow supports only named fields")
+        );
+    }
+
+    #[test]
+    fn glue_rename_ok_some_and_ok_none() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct S {
+                #[glue(rename = "col")] a: i64,
+                #[glue(other = "x")] b: String,
+            }
+        };
+        let _ = expand_to_glue_row(di).expect("expand ok");
+    }
+
+    #[test]
+    fn glue_rename_wrong_literal_type() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct S { #[glue(rename = 123)] a: i64 }
+        };
+        let err = expand_to_glue_row(di).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected string literal for rename")
+        );
+    }
+}

--- a/macros/tests/compile-fail/to_glue_row_duplicate_column.rs
+++ b/macros/tests/compile-fail/to_glue_row_duplicate_column.rs
@@ -1,0 +1,8 @@
+use gluesql_macros::ToGlueRow;
+
+#[derive(ToGlueRow)]
+struct T {
+    value: i64,
+    #[glue(rename = "value")]
+    previous_value: i64,
+}

--- a/macros/tests/compile-fail/to_glue_row_duplicate_column.stderr
+++ b/macros/tests/compile-fail/to_glue_row_duplicate_column.stderr
@@ -1,0 +1,11 @@
+error: duplicate column name `value`
+ --> tests/compile-fail/to_glue_row_duplicate_column.rs:6:5
+  |
+6 |     #[glue(rename = "value")]
+  |     ^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile-fail/to_glue_row_duplicate_column.rs:8:2
+  |
+8 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile-fail/to_glue_row_duplicate_column.rs`

--- a/macros/tests/compile-fail/to_glue_row_on_enum.rs
+++ b/macros/tests/compile-fail/to_glue_row_on_enum.rs
@@ -1,0 +1,6 @@
+use gluesql_macros::ToGlueRow;
+
+#[derive(ToGlueRow)]
+enum E {
+    A,
+}

--- a/macros/tests/compile-fail/to_glue_row_on_enum.stderr
+++ b/macros/tests/compile-fail/to_glue_row_on_enum.stderr
@@ -1,0 +1,11 @@
+error: ToGlueRow can only be derived for structs
+ --> tests/compile-fail/to_glue_row_on_enum.rs:4:1
+  |
+4 | enum E {
+  | ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile-fail/to_glue_row_on_enum.rs:6:2
+  |
+6 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile-fail/to_glue_row_on_enum.rs`

--- a/macros/tests/compile-fail/to_glue_row_tuple_struct.rs
+++ b/macros/tests/compile-fail/to_glue_row_tuple_struct.rs
@@ -1,0 +1,4 @@
+use gluesql_macros::ToGlueRow;
+
+#[derive(ToGlueRow)]
+struct T(i32);

--- a/macros/tests/compile-fail/to_glue_row_tuple_struct.stderr
+++ b/macros/tests/compile-fail/to_glue_row_tuple_struct.stderr
@@ -1,0 +1,11 @@
+error: ToGlueRow supports only named fields
+ --> tests/compile-fail/to_glue_row_tuple_struct.rs:4:1
+  |
+4 | struct T(i32);
+  | ^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile-fail/to_glue_row_tuple_struct.rs:4:15
+  |
+4 | struct T(i32);
+  |               ^ consider adding a `main` function to `$DIR/tests/compile-fail/to_glue_row_tuple_struct.rs`

--- a/macros/tests/runtime_ok_to_glue_row.rs
+++ b/macros/tests/runtime_ok_to_glue_row.rs
@@ -1,0 +1,118 @@
+use {
+    gluesql_core::{ast::Expr, data::Value, row_conversion::ToGlueRow, translate::ParamLiteral},
+    gluesql_macros::{FromGlueRow, ToGlueRow},
+};
+
+#[derive(ToGlueRow)]
+struct Item {
+    id: i64,
+    #[glue(rename = "title")]
+    name: String,
+    price_cents: i64,
+    in_stock: Option<bool>,
+}
+
+#[test]
+fn glue_columns_honors_rename() {
+    assert_eq!(
+        Item::glue_columns(),
+        &["id", "title", "price_cents", "in_stock"]
+    );
+}
+
+#[test]
+fn to_glue_row_converts_values() {
+    let item = Item {
+        id: 1,
+        name: "glue".to_owned(),
+        price_cents: 100,
+        in_stock: Some(true),
+    };
+
+    let exprs = item
+        .to_glue_row()
+        .into_iter()
+        .map(ParamLiteral::into_expr)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        exprs,
+        vec![
+            Expr::Value(Value::I64(1)),
+            Expr::Value(Value::Str("glue".to_owned())),
+            Expr::Value(Value::I64(100)),
+            Expr::Value(Value::Bool(true)),
+        ]
+    );
+}
+
+#[test]
+fn to_glue_row_none_becomes_null() {
+    let item = Item {
+        id: 2,
+        name: "sql".to_owned(),
+        price_cents: 200,
+        in_stock: None,
+    };
+
+    let exprs = item
+        .to_glue_row()
+        .into_iter()
+        .map(ParamLiteral::into_expr)
+        .collect::<Vec<_>>();
+
+    assert_eq!(exprs[3], Expr::Value(Value::Null));
+}
+
+#[derive(Debug, PartialEq, FromGlueRow, ToGlueRow)]
+struct User {
+    id: i64,
+    #[glue(rename = "full_name")]
+    name: String,
+    email: Option<String>,
+}
+
+#[test]
+fn values_from_round_trip_with_memory_storage() {
+    use {
+        gluesql_core::{
+            prelude::Glue,
+            query_builder::{Execute, table},
+            row_conversion::SelectResultExt,
+        },
+        gluesql_memory_storage::MemoryStorage,
+    };
+
+    let storage = MemoryStorage::default();
+    let mut glue = Glue::new(storage);
+
+    glue.execute("CREATE TABLE users (id INTEGER, full_name TEXT, email TEXT);")
+        .unwrap();
+
+    let users = vec![
+        User {
+            id: 1,
+            name: "A".to_owned(),
+            email: None,
+        },
+        User {
+            id: 2,
+            name: "B".to_owned(),
+            email: Some("b@x.com".to_owned()),
+        },
+    ];
+
+    table("users")
+        .insert()
+        .values_from(&users)
+        .unwrap()
+        .execute(&mut glue)
+        .unwrap();
+
+    let fetched: Vec<User> = glue
+        .execute("SELECT id, full_name, email FROM users ORDER BY id;")
+        .rows_as::<User>()
+        .unwrap();
+
+    assert_eq!(fetched, users);
+}

--- a/pkg/rust/src/lib.rs
+++ b/pkg/rust/src/lib.rs
@@ -11,8 +11,8 @@ pub mod core {
 
 pub use gluesql_core::params;
 
-// Re-export the derive macro so users can `use gluesql::FromGlueRow`.
-pub use gluesql_macros::FromGlueRow;
+// Re-export the derive macros so users can `use gluesql::{FromGlueRow, ToGlueRow}`.
+pub use gluesql_macros::{FromGlueRow, ToGlueRow};
 
 #[cfg(feature = "gluesql_memory_storage")]
 pub use gluesql_memory_storage;


### PR DESCRIPTION
Define `ToGlueRow` to derive column metadata and row conversion from structs. Add `values_from` to support struct-based insertion in the query builder, replacing column expressions. Update error handling to enforce non-empty `values_from` inputs. Expand tests to validate struct-based insertion via `values_from`. Document struct-based insertion support and field renaming.

Closes #1849 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a `ToGlueRow` derive to convert Rust structs into insertable row values, including renamed columns.
  - Added `values_from` to insert multiple rows from structs with automatic column/value alignment.
  - Re-exported the `ToGlueRow` derive from the Rust package.

- **Bug Fixes**
  - `values_from` now returns a clear error when given no rows, and when row field counts don’t match.

- **Documentation**
  - Added an “Insert from Structs” section with examples.

- **Tests**
  - Added compile-fail and runtime coverage, including invalid derive targets and duplicate column detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->