### PR TITLE
ci: run coverage on docs-only pushes to main (#1949)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Coverage
 on:
   push:
     branches: [main, release-*]
-    paths-ignore:
-      - "docs/**"
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Description
Removes `paths-ignore` (`docs/**`) from the `on.push` trigger in `.github/workflows/coverage.yml` while retaining it under `on.pull_request`.

This ensures that docs-only pushes to `main` trigger the Coverage workflow so that main coverage reporting remains up to date, while docs-only pull requests targeting `main` continue to skip coverage tests during PR checks.

Closes #1949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Coverage checks now run for pushes that include documentation changes. Pull request behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->