### PR TITLE
ci: run coverage workflow on docs-only push to configured branches (#1949)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Coverage
 on:
   push:
     branches: [main, release-*]
-    paths-ignore:
-      - "docs/**"
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Change
Removed `paths-ignore: docs/**` from the `push` trigger in `.github/workflows/coverage.yml`. The `pull_request` trigger keeps this filter unchanged.

## Why
A docs-only merge to `main` (which triggers a `push` event) would skip the Coverage workflow, leaving the published coverage report out of sync with the actual HEAD of `main`. Pushes to `main`/`release-*` should always publish an up-to-date report.

Closes  #1949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Coverage checks now run for pushes that modify documentation files.
  * Pull request behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->