### PR TITLE
Support generics and where clauses in ToGlueRow derive

### DIFF
--- a/macros/src/to_glue_row.rs
+++ b/macros/src/to_glue_row.rs
@@ -66,9 +66,10 @@ pub(crate) fn expand_to_glue_row(
     }
 
     let columns_len = column_names.len();
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let expanded = quote! {
-        impl #gluesql_crate::row_conversion::ToGlueRow for #ident {
+        impl #impl_generics #gluesql_crate::row_conversion::ToGlueRow for #ident #ty_generics #where_clause {
             fn glue_columns() -> &'static [&'static str] {
                 static COLUMNS: [&str; #columns_len] = [ #(#column_names),* ];
                 &COLUMNS
@@ -146,5 +147,22 @@ mod tests {
             err.to_string()
                 .contains("expected string literal for rename")
         );
+    }
+
+    #[test]
+    fn generics_and_lifetimes_preserved() {
+        let di: syn::DeriveInput = parse_quote! {
+            struct Record<'a, T>
+            where
+                T: Clone + crate::translate::IntoParamLiteral,
+            {
+                name: &'a str,
+                value: T,
+            }
+        };
+        let ts = expand_to_glue_row(di).expect("expand ok").to_string();
+        assert!(ts.contains("impl < 'a , T >"));
+        assert!(ts.contains("ToGlueRow for Record < 'a , T >"));
+        assert!(ts.contains("where T : Clone + crate :: translate :: IntoParamLiteral"));
     }
 }

--- a/macros/tests/compile-fail/to_glue_row_missing_bounds.rs
+++ b/macros/tests/compile-fail/to_glue_row_missing_bounds.rs
@@ -1,0 +1,18 @@
+use {
+    gluesql_core::row_conversion::ToGlueRow as _,
+    gluesql_macros::ToGlueRow,
+};
+
+struct NotConvertible;
+
+#[derive(ToGlueRow)]
+struct Record<T> {
+    value: T,
+}
+
+fn main() {
+    let rec = Record {
+        value: NotConvertible,
+    };
+    let _ = rec.to_glue_row();
+}

--- a/macros/tests/compile-fail/to_glue_row_missing_bounds.stderr
+++ b/macros/tests/compile-fail/to_glue_row_missing_bounds.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `T: Clone` is not satisfied
+ --> tests/compile-fail/to_glue_row_missing_bounds.rs:8:10
+  |
+8 | #[derive(ToGlueRow)]
+  |          ^^^^^^^^^ the trait `Clone` is not implemented for `T`
+  |
+  = note: this error originates in the derive macro `ToGlueRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T` with trait `Clone`
+  |
+9 | struct Record<T: std::clone::Clone> {
+  |                +++++++++++++++++++
+
+error[E0277]: the trait bound `T: IntoParamLiteral` is not satisfied
+ --> tests/compile-fail/to_glue_row_missing_bounds.rs:8:10
+  |
+8 | #[derive(ToGlueRow)]
+  |          ^^^^^^^^^ the trait `IntoParamLiteral` is not implemented for `T`
+  |
+  = note: this error originates in the derive macro `ToGlueRow` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T` with trait `IntoParamLiteral`
+  |
+9 | struct Record<T: gluesql_core::translate::IntoParamLiteral> {
+  |                +++++++++++++++++++++++++++++++++++++++++++

--- a/macros/tests/runtime_ok_to_glue_row.rs
+++ b/macros/tests/runtime_ok_to_glue_row.rs
@@ -116,3 +116,66 @@ fn values_from_round_trip_with_memory_storage() {
 
     assert_eq!(fetched, users);
 }
+
+#[derive(ToGlueRow)]
+struct GenericRecord<'a, T>
+where
+    T: Clone + gluesql_core::translate::IntoParamLiteral,
+{
+    name: &'a str,
+    value: T,
+}
+
+#[test]
+fn to_glue_row_supports_generics_and_lifetimes() {
+    let rec = GenericRecord {
+        name: "test",
+        value: 42_i64,
+    };
+    assert_eq!(GenericRecord::<i64>::glue_columns(), &["name", "value"]);
+    let exprs = rec
+        .to_glue_row()
+        .into_iter()
+        .map(ParamLiteral::into_expr)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        exprs,
+        vec![
+            Expr::Value(Value::Str("test".to_owned())),
+            Expr::Value(Value::I64(42)),
+        ]
+    );
+}
+
+#[derive(ToGlueRow)]
+struct ConstGenericRecord<T, const N: usize>
+where
+    T: Clone + gluesql_core::translate::IntoParamLiteral,
+{
+    tag: String,
+    payload: T,
+}
+
+#[test]
+fn to_glue_row_supports_const_generics() {
+    let rec = ConstGenericRecord::<i64, 10> {
+        tag: "const_tag".to_owned(),
+        payload: 99_i64,
+    };
+    assert_eq!(
+        ConstGenericRecord::<i64, 10>::glue_columns(),
+        &["tag", "payload"]
+    );
+    let exprs = rec
+        .to_glue_row()
+        .into_iter()
+        .map(ParamLiteral::into_expr)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        exprs,
+        vec![
+            Expr::Value(Value::Str("const_tag".to_owned())),
+            Expr::Value(Value::I64(99)),
+        ]
+    );
+}


### PR DESCRIPTION
Preserves `impl` generics, type generics, and `where` clauses when generating `ToGlueRow` derive implementations using `syn::Generics::split_for_impl`.

Field conversion bounds (`Clone + IntoParamLiteral`) are left to be supplied by the user on their struct definition, ensuring clean compile-time diagnostics when conversion bounds are not met.

Includes runtime compile-pass tests for lifetime/type/const generics and compile-fail diagnostic coverage.

Closes #1951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `ToGlueRow` and `FromGlueRow` derives to correctly preserve generic parameters, lifetimes, `where` clauses, and const generics in generated implementations.
  - Improved compile-time feedback by reporting clearer errors when generic types are missing required conversion/cloning bounds.
  - Updated unsupported reference-type diagnostics for `FromGlueRow`.

- **Tests**
  - Added runtime test coverage for generic, lifetime-carrying, and const-generic records/rows.
  - Added compile-fail tests to verify missing trait bounds and updated expected stderr output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->