### PR TITLE
Return transaction unsupported errors for COMMIT and ROLLBACK in MemoryStorage

### DIFF
--- a/storages/memory-storage/src/transaction.rs
+++ b/storages/memory-storage/src/transaction.rs
@@ -18,10 +18,14 @@ impl Transaction for MemoryStorage {
     }
 
     fn rollback(&mut self) -> Result<()> {
-        Ok(())
+        Err(Error::StorageMsg(
+            "[MemoryStorage] transaction is not supported".to_owned(),
+        ))
     }
 
     fn commit(&mut self) -> Result<()> {
-        Ok(())
+        Err(Error::StorageMsg(
+            "[MemoryStorage] transaction is not supported".to_owned(),
+        ))
     }
 }

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -79,15 +79,15 @@ fn memory_storage_index() {
 
 #[test]
 fn memory_storage_transaction() {
-    use gluesql_core::prelude::{Error, Glue, Payload};
+    use gluesql_core::prelude::{Error, Glue};
 
     let storage = MemoryStorage::default();
     let mut glue = Glue::new(storage);
 
     exec!(glue "CREATE TABLE TxTest (id INTEGER);");
     test!(glue "BEGIN", Err(Error::StorageMsg("[MemoryStorage] transaction is not supported".to_owned())));
-    test!(glue "COMMIT", Ok(vec![Payload::Commit]));
-    test!(glue "ROLLBACK", Ok(vec![Payload::Rollback]));
+    test!(glue "COMMIT", Err(Error::StorageMsg("[MemoryStorage] transaction is not supported".to_owned())));
+    test!(glue "ROLLBACK", Err(Error::StorageMsg("[MemoryStorage] transaction is not supported".to_owned())));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Return transaction unsupported errors for explicit `COMMIT` and `ROLLBACK` statements in `MemoryStorage`.
- Update the transaction test to verify the unsupported operation errors.

Closes #1959 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction commands now clearly report that transactions are unsupported by memory storage instead of indicating success.
  * Updated transaction behavior checks to reflect the correct error responses for `BEGIN`, `COMMIT`, and `ROLLBACK`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->