### PR TITLE
Check table factor fields for evaluability

### DIFF
--- a/core/src/plan/expr/evaluable.rs
+++ b/core/src/plan/expr/evaluable.rs
@@ -133,16 +133,25 @@ fn check_select(context: Option<&Rc<Context<'_>>>, select: &SelectPlan) -> bool 
 }
 
 fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFactorPlan) -> bool {
+    let Some(context) = context else {
+        return false;
+    };
+
     let alias = match table_factor {
         TableFactorPlan::Table { name, alias, .. } => alias
             .as_ref()
             .map_or_else(|| name, |TableAliasPlan { name, .. }| name),
-        TableFactorPlan::Derived { alias, .. }
-        | TableFactorPlan::Series { alias, .. }
-        | TableFactorPlan::Dictionary { alias, .. } => &alias.name,
+        TableFactorPlan::Derived { subquery, alias } => {
+            return context.contains_alias(&alias.name) && check_query(Some(&context), subquery);
+        }
+        TableFactorPlan::Series { alias, size } => {
+            return context.contains_alias(&alias.name)
+                && check_expr(Some(Rc::clone(&context)), size);
+        }
+        TableFactorPlan::Dictionary { alias, .. } => &alias.name,
     };
 
-    context.is_some_and(|context| context.contains_alias(alias))
+    context.contains_alias(alias)
 }
 
 #[cfg(test)]
@@ -273,6 +282,10 @@ mod tests {
         test!("(SELECT id FROM Carry)", false);
         test!("(SELECT id FROM Carry AS Foo)", true);
         test!("(SELECT T.id FROM Carry AS Bar)", false);
+        test!("(SELECT * FROM (SELECT id FROM Foo) AS Bar)", true);
+        test!("(SELECT * FROM (SELECT id FROM Berry) AS Bar)", false);
+        test!("(SELECT * FROM SERIES(id) AS Bar)", true);
+        test!("(SELECT * FROM SERIES(unknown) AS Bar)", false);
 
         // PlanExpr::QueryAndExpr
         test!(

--- a/core/src/plan/expr/evaluable.rs
+++ b/core/src/plan/expr/evaluable.rs
@@ -98,7 +98,7 @@ fn check_select(context: Option<&Rc<Context<'_>>>, select: &SelectPlan) -> bool 
 
     let TableWithJoinsPlan { relation, joins } = from;
 
-    if !check_table_factor(context.map(Rc::clone), relation) {
+    if !check_table_factor(context, relation) {
         return false;
     }
 
@@ -109,7 +109,7 @@ fn check_select(context: Option<&Rc<Context<'_>>>, select: &SelectPlan) -> bool 
             ..
         } = join;
 
-        if !check_table_factor(context.map(Rc::clone), relation) {
+        if !check_table_factor(context, relation) {
             return false;
         }
 
@@ -132,26 +132,25 @@ fn check_select(context: Option<&Rc<Context<'_>>>, select: &SelectPlan) -> bool 
         .all(|expr| check_expr(context.map(Rc::clone), expr))
 }
 
-fn check_table_factor(context: Option<Rc<Context<'_>>>, table_factor: &TableFactorPlan) -> bool {
-    let Some(context) = context else {
-        return false;
-    };
+fn check_table_factor(context: Option<&Rc<Context<'_>>>, table_factor: &TableFactorPlan) -> bool {
+    let contains_alias = |alias: &str| context.is_some_and(|context| context.contains_alias(alias));
 
-    let alias = match table_factor {
-        TableFactorPlan::Table { name, alias, .. } => alias
-            .as_ref()
-            .map_or_else(|| name, |TableAliasPlan { name, .. }| name),
+    match table_factor {
+        TableFactorPlan::Table { name, alias, .. } => {
+            let alias = alias
+                .as_ref()
+                .map_or_else(|| name, |TableAliasPlan { name, .. }| name);
+
+            contains_alias(alias)
+        }
         TableFactorPlan::Derived { subquery, alias } => {
-            return context.contains_alias(&alias.name) && check_query(Some(&context), subquery);
+            contains_alias(&alias.name) && check_query(context, subquery)
         }
         TableFactorPlan::Series { alias, size } => {
-            return context.contains_alias(&alias.name)
-                && check_expr(Some(Rc::clone(&context)), size);
+            contains_alias(&alias.name) && check_expr(context.map(Rc::clone), size)
         }
-        TableFactorPlan::Dictionary { alias, .. } => &alias.name,
-    };
-
-    context.contains_alias(alias)
+        TableFactorPlan::Dictionary { alias, .. } => contains_alias(&alias.name),
+    }
 }
 
 #[cfg(test)]
@@ -284,8 +283,11 @@ mod tests {
         test!("(SELECT T.id FROM Carry AS Bar)", false);
         test!("(SELECT * FROM (SELECT id FROM Foo) AS Bar)", true);
         test!("(SELECT * FROM (SELECT id FROM Berry) AS Bar)", false);
+        test!("(SELECT * FROM (SELECT id FROM Foo) AS Unknown)", false);
         test!("(SELECT * FROM SERIES(id) AS Bar)", true);
         test!("(SELECT * FROM SERIES(unknown) AS Bar)", false);
+        test!("(SELECT * FROM SERIES(id) AS Unknown)", false);
+        test!("(SELECT * FROM GLUE_TABLES AS Bar)", true);
 
         // PlanExpr::QueryAndExpr
         test!(


### PR DESCRIPTION
## Summary

- check derived table subqueries when determining expression evaluability
- check `SERIES` size expressions
- add regression tests for evaluable and non-evaluable table factors

## Why

`check_table_factor` previously checked only whether a table factor's alias existed in the given context.

As a result, derived table subqueries and `SERIES` size expressions could be considered evaluable without checking their nested references.

This change recursively checks those fields using the existing query and expression evaluability logic.

## Tests

- `cargo test -p gluesql-core plan::expr::evaluable::tests::evaluable`
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` with allowances for unrelated Rust 1.96 lints already present on `main`

Closes #1407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for derived tables and `SERIES` expressions.
  * Added checks for missing or invalid aliases in nested queries and `GLUE_TABLES` expressions.
  * Expanded coverage for query validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->