### PR TITLE
Fix CompositeStorage rollback delegation

### DIFF
--- a/storages/composite-storage/src/transaction.rs
+++ b/storages/composite-storage/src/transaction.rs
@@ -23,7 +23,7 @@ impl Transaction for CompositeStorage {
 
     fn rollback(&mut self) -> Result<()> {
         for storage in self.storages.values_mut() {
-            storage.commit()?;
+            storage.rollback()?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Delegate `CompositeStorage::rollback()` to `rollback()` on each inner storage instead of `commit()`.

Closes #1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction rollback so underlying storage operations are correctly rolled back instead of committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->