### PR TITLE
Stream Parquet rows instead of loading them all at once

### DIFF
--- a/storages/parquet-storage/src/lib.rs
+++ b/storages/parquet-storage/src/lib.rs
@@ -8,8 +8,8 @@ use {
         store::{Metadata, Planner, Store},
     },
     parquet::{
-        file::{reader::FileReader, serialized_reader::SerializedFileReader},
-        record::Row,
+        file::serialized_reader::SerializedFileReader,
+        record::{Row, reader::RowIter as ParquetRowIter},
     },
     std::{
         collections::BTreeMap,
@@ -68,53 +68,72 @@ impl ParquetStorage {
         let file = File::open(self.data_path(table_name)).map_storage_err()?;
 
         let parquet_reader = SerializedFileReader::new(file).map_storage_err()?;
-        let row_iter = parquet_reader.get_row_iter(None).map_storage_err()?;
+        let row_iter = ParquetRowIter::from_file_into(Box::new(parquet_reader));
+        let scan_schema = fetched_schema.clone();
+        let primary_key_index = scan_schema.column_defs.as_ref().and_then(|column_defs| {
+            column_defs.iter().position(|column_def| {
+                column_def.unique == Some(ColumnUniqueOption { is_primary: true })
+            })
+        });
 
-        let mut rows = Vec::new();
-        let mut key_counter: u64 = 0;
+        let rows: RowIter = if scan_schema.column_defs.is_some() {
+            let mut key_counter = 0_u64;
 
-        if let Some(column_defs) = &fetched_schema.column_defs {
-            for record in row_iter {
-                let record: Row = record.map_storage_err()?;
-                let mut row = Vec::new();
-                let mut key = None;
+            Box::new(row_iter.map(move |record| {
+                record.map_storage_err().and_then(|record: Row| {
+                    let mut row = Vec::new();
+                    let mut key = None;
 
-                for (idx, (_, field)) in record.get_column_iter().enumerate() {
-                    let value = ParquetField(field.clone()).to_value(&fetched_schema, idx)?;
-                    row.push(value.clone());
+                    for (idx, (_, field)) in record.get_column_iter().enumerate() {
+                        let value = ParquetField(field.clone()).to_value(&scan_schema, idx)?;
 
-                    if column_defs[idx].unique == Some(ColumnUniqueOption { is_primary: true }) {
-                        key = Key::try_from(&value).ok();
+                        if primary_key_index == Some(idx) {
+                            key = Key::try_from(&value).ok();
+                        }
+
+                        row.push(value);
                     }
-                }
 
-                let generated_key = key.unwrap_or_else(|| {
-                    let generated = Key::U64(key_counter);
-                    key_counter += 1;
-                    generated
-                });
-                rows.push(Ok((generated_key, row)));
-            }
+                    let generated_key = key.unwrap_or_else(|| {
+                        let generated = Key::U64(key_counter);
+                        key_counter += 1;
+                        generated
+                    });
+
+                    Ok((generated_key, row))
+                })
+            }))
         } else {
             let tmp_schema = Self::generate_temp_schema();
-            for record in row_iter {
-                let record: Row = record.map_storage_err()?;
-                let mut data_map = BTreeMap::new();
+            let mut key_counter = 0_u64;
 
-                for (_, field) in record.get_column_iter() {
-                    let value = ParquetField(field.clone()).to_value(&tmp_schema, 0)?;
-                    let generated_key = Key::U64(key_counter);
-                    key_counter += 1;
-                    if let Value::Map(inner_map) = value {
-                        data_map = inner_map;
+            Box::new(row_iter.flat_map(move |record| {
+                let rows = record.map_storage_err().and_then(|record: Row| {
+                    let mut data_map = BTreeMap::new();
+                    let mut rows = Vec::new();
+
+                    for (_, field) in record.get_column_iter() {
+                        let value = ParquetField(field.clone()).to_value(&tmp_schema, 0)?;
+                        let generated_key = Key::U64(key_counter);
+                        key_counter += 1;
+                        if let Value::Map(inner_map) = value {
+                            data_map = inner_map;
+                        }
+
+                        rows.push((generated_key, vec![Value::Map(data_map.clone())]));
                     }
 
-                    rows.push(Ok((generated_key, vec![Value::Map(data_map.clone())])));
-                }
-            }
-        }
+                    Ok(rows)
+                });
 
-        Ok((Box::new(rows.into_iter()), fetched_schema))
+                match rows {
+                    Ok(rows) => rows.into_iter().map(Ok).collect::<Vec<_>>().into_iter(),
+                    Err(error) => vec![Err(error)].into_iter(),
+                }
+            }))
+        };
+
+        Ok((rows, fetched_schema))
     }
 
     fn generate_temp_schema() -> Schema {

--- a/storages/parquet-storage/src/lib.rs
+++ b/storages/parquet-storage/src/lib.rs
@@ -157,3 +157,79 @@ impl ParquetStorage {
 
 impl Metadata for ParquetStorage {}
 impl Planner for ParquetStorage {}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        gluesql_core::prelude::Error,
+        parquet::{
+            basic::{Repetition, Type},
+            column::writer::ColumnWriter,
+            data_type::ByteArray,
+            file::{properties::WriterProperties, writer::SerializedFileWriter},
+            format::KeyValue,
+            schema::types::Type as SchemaType,
+        },
+        std::{
+            fs::{File, remove_dir_all},
+            sync::Arc,
+        },
+        uuid::Uuid,
+    };
+
+    #[test]
+    fn scan_data_returns_schemaless_value_conversion_errors() {
+        let path = std::env::temp_dir().join(format!("parquet-storage-{}", Uuid::new_v4()));
+        let storage = ParquetStorage::new(&path).expect("create parquet storage");
+        let field = SchemaType::primitive_type_builder("schemaless", Type::BYTE_ARRAY)
+            .with_repetition(Repetition::OPTIONAL)
+            .build()
+            .expect("build parquet field");
+        let schema = SchemaType::group_type_builder("schema")
+            .with_fields(&mut vec![Arc::new(field)])
+            .build()
+            .map(Arc::new)
+            .expect("build parquet schema");
+        let properties = Arc::new(
+            WriterProperties::builder()
+                .set_key_value_metadata(Some(vec![KeyValue {
+                    key: "schemaless".to_owned(),
+                    value: Some("true".to_owned()),
+                }]))
+                .build(),
+        );
+        let file = File::create(storage.data_path("Foo")).expect("create parquet file");
+        let mut file_writer =
+            SerializedFileWriter::new(file, schema, properties).expect("create parquet writer");
+
+        {
+            let mut row_group = file_writer.next_row_group().expect("create row group");
+            let mut column = row_group
+                .next_column()
+                .expect("read column")
+                .expect("expected column");
+
+            match column.untyped() {
+                ColumnWriter::ByteArrayColumnWriter(writer) => writer
+                    .write_batch(&[ByteArray::from(vec![0_u8])], Some(&[1]), None)
+                    .expect("write invalid serialized map"),
+                _ => panic!("expected byte array column"),
+            };
+
+            column.close().expect("close column");
+            row_group.close().expect("close row group");
+        }
+
+        file_writer.close().expect("close parquet writer");
+
+        let (mut rows, _) = storage.scan_data("Foo").expect("scan data");
+        let error = rows
+            .next()
+            .expect("conversion error row")
+            .expect_err("invalid schemaless map should fail to deserialize");
+
+        assert!(matches!(error, Error::StorageMsg(_)));
+        remove_dir_all(path).expect("remove temporary storage");
+    }
+}


### PR DESCRIPTION
## Summary

- Stream Parquet records directly into GlueSQL's `RowIter` instead of materializing the full table in a `Vec`.
- Keep the Parquet reader alive for the iterator lifetime with the owning Parquet row iterator API.
- Determine the primary-key column once per scan and avoid the previous extra `Value` clone.

This preserves structured and schemaless scan behavior while allowing consumers to stop reading early.

Closes #1967

## Benchmark

Release-mode warm-cache measurements used a 250,000-row, 5.8 MiB Parquet file. Each result is the median of repeated queries that open storage and execute the query.

| Query | Before | After | Change |
| --- | ---: | ---: | ---: |
| `SELECT * FROM Foo LIMIT 10` | 71.0 ms | 1.11 ms | 64.0x faster |
| `SELECT * FROM Foo WHERE id = 1` | 71.0 ms | 1.14 ms | 62.3x faster |
| `SELECT COUNT(*) FROM Foo` | 83.9 ms | 74.9 ms | 10.7% faster |
| `SELECT * FROM Foo WHERE id = 249999` | 71.3 ms | 60.0 ms | 15.9% faster |

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-parquet-storage`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Parquet data scanning to process records incrementally, avoiding upfront loading of all rows into memory.
  * Reduced memory usage for large datasets.

* **Bug Fixes**
  * Improved row and key handling when a primary-key column is present.
  * Ensured consistent scanning behavior for data without predefined column definitions.

* **Tests**
  * Added coverage to verify that schemaless value conversion issues are surfaced correctly during scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->