### PR TITLE
Fix ambiguous column resolution across query scopes

### DIFF
--- a/core/src/executor/context.rs
+++ b/core/src/executor/context.rs
@@ -3,5 +3,5 @@ mod row_context;
 
 pub use {
     aggregate_context::{AggregateContext, AggregateValues},
-    row_context::RowContext,
+    row_context::{RowContext, ValueLookup},
 };

--- a/core/src/executor/context/row_context.rs
+++ b/core/src/executor/context/row_context.rs
@@ -124,32 +124,37 @@ impl<'a> RowContext<'a> {
 
     pub fn get_alias_value(&'a self, target_table_alias: &str, target: &str) -> Option<&'a Value> {
         match self.lookup_alias_value(target_table_alias, target) {
-            AliasLookup::Bound(value) => value,
-            AliasLookup::Unbound => None,
+            ValueLookup::Found(value) => Some(value),
+            ValueLookup::Unbound | ValueLookup::Missing | ValueLookup::Ambiguous => None,
         }
     }
 
-    fn lookup_alias_value(
+    pub fn lookup_alias_value(&'a self, target_table_alias: &str, target: &str) -> ValueLookup<'a> {
+        match self.lookup_bound_alias_value(target_table_alias, target) {
+            AliasLookup::Bound(value) => value,
+            AliasLookup::Unbound => ValueLookup::Unbound,
+        }
+    }
+
+    fn lookup_bound_alias_value(
         &'a self,
         target_table_alias: &str,
         target: &str,
-    ) -> AliasLookup<Option<&'a Value>> {
+    ) -> AliasLookup<ValueLookup<'a>> {
         match self {
             Self::Data {
                 table_alias, row, ..
             } if *table_alias == target_table_alias => {
-                let value = match lookup_row_value(row, target) {
-                    ValueLookup::Found(value) => Some(value),
-                    ValueLookup::Unbound | ValueLookup::Missing | ValueLookup::Ambiguous => None,
-                };
-                AliasLookup::Bound(value)
+                AliasLookup::Bound(lookup_row_value(row, target))
             }
             Self::Data {
                 next: Some(next), ..
-            } => next.lookup_alias_value(target_table_alias, target),
+            } => next.lookup_bound_alias_value(target_table_alias, target),
             Self::Bridge { left, right } => {
-                match left.lookup_alias_value(target_table_alias, target) {
-                    AliasLookup::Unbound => right.lookup_alias_value(target_table_alias, target),
+                match left.lookup_bound_alias_value(target_table_alias, target) {
+                    AliasLookup::Unbound => {
+                        right.lookup_bound_alias_value(target_table_alias, target)
+                    }
                     bound @ AliasLookup::Bound(_) => bound,
                 }
             }
@@ -304,6 +309,20 @@ mod tests {
         assert!(matches!(
             scope.lookup_value("id"),
             ValueLookup::Found(Value::I64(0))
+        ));
+    }
+
+    #[test]
+    fn qualified_lookup_preserves_missing_document_key() {
+        let context = document_context("A", &[], None);
+
+        assert!(matches!(
+            context.lookup_alias_value("A", "id"),
+            ValueLookup::Missing
+        ));
+        assert!(matches!(
+            context.lookup_alias_value("B", "id"),
+            ValueLookup::Unbound
         ));
     }
 

--- a/core/src/executor/context/row_context.rs
+++ b/core/src/executor/context/row_context.rs
@@ -1,5 +1,5 @@
 use {
-    crate::data::{Row, Value},
+    crate::data::{Row, SCHEMALESS_DOC_COLUMN, Value},
     std::{borrow::Cow, fmt::Debug, rc::Rc},
 };
 
@@ -20,6 +20,60 @@ pub enum RowContext<'a> {
     },
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ValueLookup<'a> {
+    Unbound,
+    Missing,
+    Found(&'a Value),
+    Ambiguous,
+}
+
+impl ValueLookup<'_> {
+    fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Ambiguous, _) | (_, Self::Ambiguous) | (Self::Found(_), Self::Found(_)) => {
+                Self::Ambiguous
+            }
+            (found @ Self::Found(_), Self::Unbound | Self::Missing)
+            | (Self::Unbound | Self::Missing, found @ Self::Found(_)) => found,
+            (Self::Missing, Self::Missing | Self::Unbound) | (Self::Unbound, Self::Missing) => {
+                Self::Missing
+            }
+            (Self::Unbound, Self::Unbound) => Self::Unbound,
+        }
+    }
+
+    fn or_else(self, other: impl FnOnce() -> Self) -> Self {
+        match self {
+            Self::Unbound => other(),
+            Self::Missing => match other() {
+                Self::Unbound => Self::Missing,
+                found => found,
+            },
+            found => found,
+        }
+    }
+}
+
+enum AliasLookup<T> {
+    Unbound,
+    Bound(T),
+}
+
+fn lookup_row_value<'a>(row: &'a Row, target: &str) -> ValueLookup<'a> {
+    if let Some(value) = row.get_value(target) {
+        return ValueLookup::Found(value);
+    }
+
+    let Some(Value::Map(document)) = row.get_value(SCHEMALESS_DOC_COLUMN) else {
+        return ValueLookup::Unbound;
+    };
+
+    document
+        .get(target)
+        .map_or(ValueLookup::Missing, ValueLookup::Found)
+}
+
 impl<'a> RowContext<'a> {
     pub fn new(table_alias: &'a str, row: Cow<'a, Row>, next: Option<Rc<RowContext<'a>>>) -> Self {
         Self::Data {
@@ -34,48 +88,72 @@ impl<'a> RowContext<'a> {
     }
 
     pub fn get_value(&'a self, target: &str) -> Option<&'a Value> {
+        match self.lookup_value(target) {
+            ValueLookup::Found(value) => Some(value),
+            ValueLookup::Unbound | ValueLookup::Missing | ValueLookup::Ambiguous => None,
+        }
+    }
+
+    pub fn lookup_value(&'a self, target: &str) -> ValueLookup<'a> {
         match self {
-            Self::Data {
-                row, next: None, ..
-            } => row.get_value(target),
-            Self::Data {
-                row,
-                next: Some(next),
-                ..
-            } => row.get_value(target).or_else(|| next.get_value(target)),
-            Self::Bridge { left, right } => {
-                left.get_value(target).or_else(|| right.get_value(target))
+            Self::Data { row, next, .. } => {
+                let current = lookup_row_value(row, target);
+
+                let Some(next) = next else {
+                    return current;
+                };
+
+                match next.as_ref() {
+                    Self::Bridge { left, right } => {
+                        let current = current.combine(left.lookup_value(target));
+                        current.or_else(|| right.lookup_value(target))
+                    }
+                    next => current.combine(next.lookup_value(target)),
+                }
             }
+            Self::Bridge { left, right } => left
+                .lookup_value(target)
+                .or_else(|| right.lookup_value(target)),
             Self::RefVecData { columns, values } => columns
                 .iter()
                 .position(|column| column == target)
-                .and_then(|index| values.get(index)),
+                .and_then(|index| values.get(index))
+                .map_or(ValueLookup::Unbound, ValueLookup::Found),
         }
     }
 
     pub fn get_alias_value(&'a self, target_table_alias: &str, target: &str) -> Option<&'a Value> {
+        match self.lookup_alias_value(target_table_alias, target) {
+            AliasLookup::Bound(value) => value,
+            AliasLookup::Unbound => None,
+        }
+    }
+
+    fn lookup_alias_value(
+        &'a self,
+        target_table_alias: &str,
+        target: &str,
+    ) -> AliasLookup<Option<&'a Value>> {
         match self {
             Self::Data {
-                table_alias,
-                row,
-                next,
+                table_alias, row, ..
             } if *table_alias == target_table_alias => {
-                let value = row.get_value(target);
-
-                if value.is_some() {
-                    value
-                } else {
-                    next.as_ref()
-                        .and_then(|context| context.get_alias_value(target_table_alias, target))
-                }
+                let value = match lookup_row_value(row, target) {
+                    ValueLookup::Found(value) => Some(value),
+                    ValueLookup::Unbound | ValueLookup::Missing | ValueLookup::Ambiguous => None,
+                };
+                AliasLookup::Bound(value)
             }
             Self::Data {
                 next: Some(next), ..
-            } => next.get_alias_value(target_table_alias, target),
-            Self::Bridge { left, right } => left
-                .get_alias_value(target_table_alias, target)
-                .or_else(|| right.get_alias_value(target_table_alias, target)),
-            _ => None,
+            } => next.lookup_alias_value(target_table_alias, target),
+            Self::Bridge { left, right } => {
+                match left.lookup_alias_value(target_table_alias, target) {
+                    AliasLookup::Unbound => right.lookup_alias_value(target_table_alias, target),
+                    bound @ AliasLookup::Bound(_) => bound,
+                }
+            }
+            _ => AliasLookup::Unbound,
         }
     }
 
@@ -113,5 +191,102 @@ impl<'a> RowContext<'a> {
             }
             _ => vec![],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{RowContext, ValueLookup},
+        crate::data::{Row, SCHEMALESS_DOC_COLUMN, Value},
+        std::{borrow::Cow, collections::BTreeMap, rc::Rc},
+    };
+
+    fn context(
+        alias: &'static str,
+        columns: &[&str],
+        next: Option<Rc<RowContext<'static>>>,
+    ) -> Rc<RowContext<'static>> {
+        let row = Row {
+            columns: columns
+                .iter()
+                .map(|column| (*column).to_owned())
+                .collect::<Vec<_>>()
+                .into(),
+            values: (0..columns.len())
+                .map(|index| Value::I64(index as i64))
+                .collect(),
+        };
+
+        Rc::new(RowContext::new(alias, Cow::Owned(row), next))
+    }
+
+    fn document_context(
+        alias: &'static str,
+        entries: &[(&str, Value)],
+        next: Option<Rc<RowContext<'static>>>,
+    ) -> Rc<RowContext<'static>> {
+        let document = entries
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), value.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let row = Row {
+            columns: vec![SCHEMALESS_DOC_COLUMN.to_owned()].into(),
+            values: vec![Value::Map(document)],
+        };
+
+        Rc::new(RowContext::new(alias, Cow::Owned(row), next))
+    }
+
+    #[test]
+    fn qualified_alias_shadows_outer_scope_even_when_column_is_missing() {
+        let outer = context("A", &["name"], None);
+        let inner = context("A", &["id"], None);
+        let scope = RowContext::concat(inner, outer);
+
+        assert_eq!(scope.get_alias_value("A", "name"), None);
+    }
+
+    #[test]
+    fn qualified_alias_falls_back_only_when_unbound() {
+        let outer = context("A", &["name"], None);
+        let inner = context("B", &["id"], None);
+        let scope = RowContext::concat(inner, outer);
+
+        assert_eq!(scope.get_alias_value("A", "name"), Some(&Value::I64(0)));
+    }
+
+    #[test]
+    fn unqualified_lookup_detects_same_scope_ambiguity() {
+        let left = context("A", &["id"], None);
+        let joined = context("B", &["id"], Some(left));
+
+        assert!(matches!(joined.lookup_value("id"), ValueLookup::Ambiguous));
+    }
+
+    #[test]
+    fn unqualified_lookup_prefers_current_scope() {
+        let outer = context("A", &["id"], None);
+        let inner = context("B", &["id"], None);
+        let scope = RowContext::concat(inner, outer);
+
+        assert!(matches!(
+            scope.lookup_value("id"),
+            ValueLookup::Found(Value::I64(0))
+        ));
+    }
+
+    #[test]
+    fn schemaless_lookup_counts_actual_document_keys() {
+        let left = document_context("A", &[("id", Value::I64(1))], None);
+        let joined = document_context("B", &[("name", Value::Str("B".to_owned()))], Some(left));
+        assert!(matches!(
+            joined.lookup_value("id"),
+            ValueLookup::Found(Value::I64(1))
+        ));
+
+        let left = document_context("A", &[("id", Value::I64(1))], None);
+        let joined = document_context("B", &[("id", Value::I64(2))], Some(left));
+        assert!(matches!(joined.lookup_value("id"), ValueLookup::Ambiguous));
     }
 }

--- a/core/src/executor/context/row_context.rs
+++ b/core/src/executor/context/row_context.rs
@@ -277,6 +277,37 @@ mod tests {
     }
 
     #[test]
+    fn unqualified_lookup_handles_unbound_and_bridge_chains() {
+        let outer_left = context("A", &["name"], None);
+        let outer_right = context("B", &["id"], None);
+        let outer = Rc::new(RowContext::concat(outer_left, outer_right));
+        let current = context("C", &["quantity"], Some(outer));
+
+        assert!(matches!(
+            current.lookup_value("id"),
+            ValueLookup::Found(Value::I64(0))
+        ));
+        assert_eq!(current.get_value("missing"), None);
+        assert_eq!(current.get_alias_value("missing", "id"), None);
+    }
+
+    #[test]
+    fn missing_document_key_falls_back_only_to_a_bound_value() {
+        let missing = document_context("A", &[], None);
+        let unbound = context("B", &["name"], None);
+        let scope = RowContext::concat(missing, unbound);
+        assert!(matches!(scope.lookup_value("id"), ValueLookup::Missing));
+
+        let missing = document_context("A", &[], None);
+        let found = context("B", &["id"], None);
+        let scope = RowContext::concat(missing, found);
+        assert!(matches!(
+            scope.lookup_value("id"),
+            ValueLookup::Found(Value::I64(0))
+        ));
+    }
+
+    #[test]
     fn schemaless_lookup_counts_actual_document_keys() {
         let left = document_context("A", &[("id", Value::I64(1))], None);
         let joined = document_context("B", &[("name", Value::Str("B".to_owned()))], Some(left));

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -6,7 +6,7 @@ mod function;
 use {
     self::function::BreakCase,
     super::{
-        context::{AggregateValues, RowContext},
+        context::{AggregateValues, RowContext, ValueLookup},
         select::{select, select_with_labels},
     },
     crate::{
@@ -65,9 +65,15 @@ where
             let context = context
                 .ok_or_else(|| EvaluateError::IdentifierRequiresRowContext(ident.to_owned()))?;
 
-            match context.get_value(ident) {
-                Some(value) => Ok(Evaluated::Value(Cow::Owned(value.clone()))),
-                None => Err(EvaluateError::IdentifierNotFound(ident.to_owned()).into()),
+            match context.lookup_value(ident) {
+                ValueLookup::Found(value) => Ok(Evaluated::Value(Cow::Owned(value.clone()))),
+                ValueLookup::Unbound => {
+                    Err(EvaluateError::IdentifierNotFound(ident.to_owned()).into())
+                }
+                ValueLookup::Missing => Ok(Evaluated::Value(Cow::Owned(Value::Null))),
+                ValueLookup::Ambiguous => {
+                    Err(EvaluateError::IdentifierAmbiguous(ident.to_owned()).into())
+                }
             }
         }
         ExprPlan::Nested(expr) => eval(expr),

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -777,6 +777,42 @@ mod tests {
     }
 
     #[test]
+    fn qualified_identifier_evaluation_boundaries() {
+        let expr = ExprPlan::CompoundIdentifier {
+            alias: "Item".to_owned(),
+            ident: "id".to_owned(),
+        };
+        let row = Row {
+            columns: vec!["id".to_owned()].into(),
+            values: vec![Value::I64(1)],
+        };
+
+        assert_eq!(
+            evaluate_stateless(
+                Some(RowContext::new("Item", Cow::Owned(row.clone()), None)),
+                &expr
+            ),
+            Ok(Evaluated::Value(Cow::Owned(Value::I64(1))))
+        );
+        assert_eq!(
+            evaluate_stateless(None, &expr),
+            Err(Error::from(
+                EvaluateError::CompoundIdentifierRequiresRowContext {
+                    alias: "Item".to_owned(),
+                    ident: "id".to_owned(),
+                }
+            ))
+        );
+        assert_eq!(
+            evaluate_stateless(Some(RowContext::new("Other", Cow::Owned(row), None)), &expr),
+            Err(Error::from(EvaluateError::CompoundIdentifierNotFound {
+                table_alias: "Item".to_owned(),
+                column_name: "id".to_owned(),
+            }))
+        );
+    }
+
+    #[test]
     fn aggregate_requires_planner_binding() {
         let sql = "SELECT COUNT(*) FROM Item";
         let parsed = parse(sql)

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -84,13 +84,16 @@ where
                     ident: ident.to_owned(),
                 })?;
 
-            match context.get_alias_value(alias, ident) {
-                Some(value) => Ok(Evaluated::Value(Cow::Owned(value.clone()))),
-                None => Err(EvaluateError::CompoundIdentifierNotFound {
-                    table_alias: alias.to_owned(),
-                    column_name: ident.to_owned(),
+            match context.lookup_alias_value(alias, ident) {
+                ValueLookup::Found(value) => Ok(Evaluated::Value(Cow::Owned(value.clone()))),
+                ValueLookup::Missing => Ok(Evaluated::Value(Cow::Owned(Value::Null))),
+                ValueLookup::Unbound | ValueLookup::Ambiguous => {
+                    Err(EvaluateError::CompoundIdentifierNotFound {
+                        table_alias: alias.to_owned(),
+                        column_name: ident.to_owned(),
+                    }
+                    .into())
                 }
-                .into()),
             }
         }
         ExprPlan::Subquery(query) => {
@@ -741,18 +744,37 @@ fn evaluate_function<'a, 'b: 'a, T: GStore>(
 #[cfg(test)]
 mod tests {
     use {
-        super::{EvaluateError, evaluate, evaluate_stateless},
+        super::{EvaluateError, Evaluated, evaluate, evaluate_stateless},
         crate::{
             ast::{Expr, Projection, SelectItem, SetExpr, Statement},
-            executor::context::AggregateValues,
+            data::{Row, SCHEMALESS_DOC_COLUMN, Value},
+            executor::context::{AggregateValues, RowContext},
             mock::MockStorage,
             parse_sql::parse,
             plan::{AggregateFunctionPlan, AggregatePlan, CountArgExprPlan, ExprPlan},
             result::Error,
             translate::translate,
         },
-        std::rc::Rc,
+        std::{borrow::Cow, collections::BTreeMap, rc::Rc},
     };
+
+    #[test]
+    fn missing_qualified_schemaless_key_evaluates_to_null() {
+        let row = Row {
+            columns: vec![SCHEMALESS_DOC_COLUMN.to_owned()].into(),
+            values: vec![Value::Map(BTreeMap::new())],
+        };
+        let context = RowContext::new("Item", Cow::Owned(row), None);
+        let expr = ExprPlan::CompoundIdentifier {
+            alias: "Item".to_owned(),
+            ident: "missing".to_owned(),
+        };
+
+        assert_eq!(
+            evaluate_stateless(Some(context), &expr),
+            Ok(Evaluated::Value(Cow::Owned(Value::Null)))
+        );
+    }
 
     #[test]
     fn aggregate_requires_planner_binding() {

--- a/core/src/executor/evaluate/error.rs
+++ b/core/src/executor/evaluate/error.rs
@@ -58,6 +58,9 @@ pub enum EvaluateError {
     #[error("identifier not found: {0}")]
     IdentifierNotFound(String),
 
+    #[error("column reference {0} is ambiguous, please specify the table name")]
+    IdentifierAmbiguous(String),
+
     #[error("identifier not found: {table_alias}.{column_name}")]
     CompoundIdentifierNotFound {
         table_alias: String,

--- a/core/src/executor/sort.rs
+++ b/core/src/executor/sort.rs
@@ -97,7 +97,7 @@ impl<'a, T: GStore> Sort<'a, T> {
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            let filter_context = match (&next, &self.context) {
+            let input_context = match (&next, &self.context) {
                 (Some(next), Some(context)) => Some(Rc::new(RowContext::concat(
                     Rc::clone(next),
                     Rc::clone(context),
@@ -109,12 +109,19 @@ impl<'a, T: GStore> Sort<'a, T> {
 
             let context = RowContext::new(table_alias, Cow::Borrowed(&row), None);
             let label_context = Rc::new(context);
-            let filter_context = match filter_context {
-                Some(filter_context) => Some(Rc::new(RowContext::concat(
-                    filter_context,
+            let input_first_context = match input_context.as_ref() {
+                Some(input_context) => Some(Rc::new(RowContext::concat(
+                    Rc::clone(input_context),
                     Rc::clone(&label_context),
                 ))),
                 None => Some(Rc::clone(&label_context)),
+            };
+            let output_first_context = match input_context {
+                Some(input_context) => Some(Rc::new(RowContext::concat(
+                    Rc::clone(&label_context),
+                    input_context,
+                ))),
+                None => Some(label_context),
             };
 
             let keys = order_by
@@ -122,13 +129,14 @@ impl<'a, T: GStore> Sort<'a, T> {
                 .map(|(sort_type, asc)| {
                     match sort_type {
                         SortType::Value(value) => Ok(value),
-                        SortType::Expr(expr) => evaluate(
-                            self.storage,
-                            filter_context.as_ref(),
-                            aggregated.as_ref(),
-                            expr,
-                        )?
-                        .try_into(),
+                        SortType::Expr(expr) => {
+                            let context = if matches!(expr, ExprPlan::Identifier(_)) {
+                                output_first_context.as_ref()
+                            } else {
+                                input_first_context.as_ref()
+                            };
+                            evaluate(self.storage, context, aggregated.as_ref(), expr)?.try_into()
+                        }
                     }?
                     .try_into()
                     .map(|key| (key, asc))
@@ -162,4 +170,48 @@ pub fn sort_by(keys_a: &[(Key, Option<bool>)], keys_b: &[(Key, Option<bool>)]) -
     }
 
     Ordering::Equal
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::Sort,
+        crate::{
+            data::{Row, Value},
+            mock::MockStorage,
+            plan::{ExprPlan, OrderByExprPlan},
+            result::Result,
+        },
+        std::rc::Rc,
+    };
+
+    #[test]
+    fn sorts_output_alias_without_input_context() {
+        let storage = MockStorage::default();
+        let order_by = [OrderByExprPlan {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            asc: None,
+        }];
+        let rows = [2, 1].into_iter().map(|value| {
+            Ok((
+                None,
+                None,
+                Row {
+                    columns: Rc::from(["value".to_owned()]),
+                    values: vec![Value::I64(value)],
+                },
+            ))
+        });
+
+        let values = Sort::new(&storage, None, &order_by)
+            .apply(rows, "")
+            .unwrap()
+            .collect::<Result<Vec<_>>>()
+            .unwrap()
+            .into_iter()
+            .flat_map(Row::into_values)
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, vec![Value::I64(1), Value::I64(2)]);
+    }
 }

--- a/core/src/plan/context.rs
+++ b/core/src/plan/context.rs
@@ -160,4 +160,17 @@ mod tests {
 
         assert!(!joined.contains_column("id"));
     }
+
+    #[test]
+    fn unqualified_column_resolves_data_before_bridge_outer_scope() {
+        let outer_left = Rc::new(Context::new("A".to_owned(), vec!["name"], None));
+        let outer_right = Rc::new(Context::new("B".to_owned(), vec!["id"], None));
+        let outer = Context::concat(Some(outer_left), Some(outer_right)).unwrap();
+
+        let current = Context::new("C".to_owned(), vec!["quantity"], Some(Rc::clone(&outer)));
+        assert!(current.contains_column("id"));
+
+        let current = Context::new("C".to_owned(), vec!["id"], Some(outer));
+        assert!(current.contains_column("id"));
+    }
 }

--- a/core/src/plan/context.rs
+++ b/core/src/plan/context.rs
@@ -1,5 +1,30 @@
 use std::rc::Rc;
 
+enum Lookup<T> {
+    Unbound,
+    Found(T),
+    Ambiguous,
+}
+
+impl<T> Lookup<T> {
+    fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Ambiguous, _) | (_, Self::Ambiguous) | (Self::Found(_), Self::Found(_)) => {
+                Self::Ambiguous
+            }
+            (found @ Self::Found(_), Self::Unbound) | (Self::Unbound, found @ Self::Found(_)) => {
+                found
+            }
+            (Self::Unbound, Self::Unbound) => Self::Unbound,
+        }
+    }
+}
+
+enum AliasLookup {
+    Unbound,
+    Bound(bool),
+}
+
 pub enum Context<'a> {
     Data {
         alias: String,
@@ -45,29 +70,94 @@ impl<'a> Context<'a> {
     }
 
     pub fn contains_column(&self, target: &str) -> bool {
+        matches!(self.lookup_column(target), Lookup::Found(()))
+    }
+
+    fn lookup_column(&self, target: &str) -> Lookup<()> {
         match self {
-            Self::Data { columns, .. } if columns.iter().any(|column| column == &target) => true,
-            Self::Data { next, .. } => next
-                .as_ref()
-                .is_some_and(|next| next.contains_column(target)),
-            Self::Bridge { left, right } => {
-                left.contains_column(target) || right.contains_column(target)
+            Self::Data { columns, next, .. } => {
+                let current = if columns.iter().any(|column| column == &target) {
+                    Lookup::Found(())
+                } else {
+                    Lookup::Unbound
+                };
+
+                let Some(next) = next else {
+                    return current;
+                };
+
+                match next.as_ref() {
+                    Self::Bridge { left, right } => {
+                        let current = current.combine(left.lookup_column(target));
+                        match current {
+                            Lookup::Unbound => right.lookup_column(target),
+                            found => found,
+                        }
+                    }
+                    next @ Self::Data { .. } => current.combine(next.lookup_column(target)),
+                }
             }
+            Self::Bridge { left, right } => match left.lookup_column(target) {
+                Lookup::Unbound => right.lookup_column(target),
+                found => found,
+            },
         }
     }
 
     pub fn contains_aliased_column(&self, target_alias: &str, target_column: &str) -> bool {
+        matches!(
+            self.lookup_aliased_column(target_alias, target_column),
+            AliasLookup::Bound(true)
+        )
+    }
+
+    fn lookup_aliased_column(&self, target_alias: &str, target_column: &str) -> AliasLookup {
         match self {
             Self::Data { alias, columns, .. } if alias == target_alias => {
-                columns.iter().any(|column| column == &target_column)
+                AliasLookup::Bound(columns.iter().any(|column| column == &target_column))
             }
-            Self::Data { next, .. } => next
-                .as_ref()
-                .is_some_and(|next| next.contains_aliased_column(target_alias, target_column)),
+            Self::Data { next, .. } => next.as_ref().map_or(AliasLookup::Unbound, |next| {
+                next.lookup_aliased_column(target_alias, target_column)
+            }),
             Self::Bridge { left, right } => {
-                left.contains_aliased_column(target_alias, target_column)
-                    || right.contains_aliased_column(target_alias, target_column)
+                match left.lookup_aliased_column(target_alias, target_column) {
+                    AliasLookup::Unbound => {
+                        right.lookup_aliased_column(target_alias, target_column)
+                    }
+                    bound @ AliasLookup::Bound(_) => bound,
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::Context, std::rc::Rc};
+
+    #[test]
+    fn aliased_column_does_not_fall_back_past_bound_alias() {
+        let outer = Rc::new(Context::new("A".to_owned(), vec!["name"], None));
+        let inner = Rc::new(Context::new("A".to_owned(), vec!["id"], None));
+        let scope = Context::concat(Some(inner), Some(outer)).unwrap();
+
+        assert!(!scope.contains_aliased_column("A", "name"));
+    }
+
+    #[test]
+    fn unqualified_column_is_not_ambiguous_across_scopes() {
+        let outer = Rc::new(Context::new("A".to_owned(), vec!["id"], None));
+        let inner = Rc::new(Context::new("B".to_owned(), vec!["id"], None));
+        let scope = Context::concat(Some(inner), Some(outer)).unwrap();
+
+        assert!(scope.contains_column("id"));
+    }
+
+    #[test]
+    fn unqualified_column_is_ambiguous_within_scope() {
+        let left = Rc::new(Context::new("A".to_owned(), vec!["id"], None));
+        let joined = Context::new("B".to_owned(), vec!["id"], Some(left));
+
+        assert!(!joined.contains_column("id"));
     }
 }

--- a/core/src/plan/error.rs
+++ b/core/src/plan/error.rs
@@ -7,6 +7,9 @@ pub enum PlanError {
     #[error("column reference {0} is ambiguous, please specify the table name")]
     ColumnReferenceAmbiguous(String),
 
+    #[error("relation identifier {0} is specified more than once")]
+    DuplicateRelationIdentifier(String),
+
     #[error(
         "SELECT * is not allowed for joins mixing schemaful and schemaless tables; use qualified wildcard or explicit columns"
     )]

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -4,8 +4,8 @@ use {
         ast::{BinaryOperator, IndexOperator},
         data::{Schema, SchemaIndex, SchemaIndexOrd, Value},
         plan::{
-            ExprPlan, IndexItemPlan, OrderByExprPlan, QueryPlan, SelectPlan, SetExprPlan,
-            StatementPlan, TableFactorPlan,
+            ExprPlan, IndexItemPlan, OrderByExprPlan, ProjectionPlan, QueryPlan, SelectItemPlan,
+            SelectPlan, SetExprPlan, StatementPlan, TableFactorPlan,
             expr::{deterministic::is_deterministic, nullability::may_return_null},
             plan_scalar_expr,
         },
@@ -86,6 +86,7 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
         if let (Some(indexes), Some(order_expr)) = (indexes.as_ref(), order_by.last())
             && let TableFactorPlan::Table { index, .. } = &mut from.relation
             && index.is_none()
+            && !is_output_alias(&projection, &order_expr.expr)
             && let Some(index_name) = indexes.find_ordered(order_expr)
         {
             *index = Some(IndexItemPlan::NonClustered {
@@ -381,6 +382,22 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
     }
 }
 
+fn is_output_alias(projection: &ProjectionPlan, expr: &ExprPlan) -> bool {
+    let ExprPlan::Identifier(identifier) = expr else {
+        return false;
+    };
+    let ProjectionPlan::SelectItems(items) = projection else {
+        return false;
+    };
+
+    items.iter().any(|item| {
+        matches!(
+            item,
+            SelectItemPlan::Expr { label, .. } if label == identifier
+        )
+    })
+}
+
 struct PlannedSchemaIndex<'a> {
     expr: ExprPlan,
     index: &'a SchemaIndex,
@@ -440,11 +457,12 @@ enum Planned {
 #[cfg(test)]
 mod tests {
     use {
-        super::plan,
+        super::{is_output_alias, plan},
         crate::{
+            ast::Literal,
             mock::{MockStorage, run},
             parse_sql::parse,
-            plan::{StatementPlan, fetch_schema_map},
+            plan::{ExprPlan, ProjectionPlan, SelectItemPlan, StatementPlan, fetch_schema_map},
             query_builder::{
                 Build, col, exists, nested, non_clustered, null, num, primary_key, table, text,
             },
@@ -572,6 +590,36 @@ CREATE INDEX idx_name ON Test (name);
             actual, expected,
             "keeps existing access path instead of clobbering it with a secondary index"
         );
+    }
+
+    #[test]
+    fn index_planning_does_not_consume_output_alias_ordering() {
+        let storage = storage_with_indexes();
+        let sql = "SELECT name AS id FROM Test ORDER BY id";
+        let actual = plan_index(&storage, sql);
+        let mut parsed = parse(sql).unwrap();
+        let expected = Ok(StatementPlan::from(translate(&parsed.remove(0)).unwrap()));
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn output_alias_detection_boundaries() {
+        let identifier = ExprPlan::Identifier("id".to_owned());
+        let projection = ProjectionPlan::SelectItems(vec![SelectItemPlan::Expr {
+            expr: ExprPlan::Identifier("name".to_owned()),
+            label: "name".to_owned(),
+        }]);
+
+        assert!(!is_output_alias(
+            &projection,
+            &ExprPlan::Literal(Literal::QuotedString("id".to_owned()))
+        ));
+        assert!(!is_output_alias(
+            &ProjectionPlan::SchemalessMap,
+            &identifier
+        ));
+        assert!(!is_output_alias(&projection, &identifier));
     }
 
     #[test]

--- a/core/src/plan/index.rs
+++ b/core/src/plan/index.rs
@@ -393,7 +393,14 @@ fn is_output_alias(projection: &ProjectionPlan, expr: &ExprPlan) -> bool {
     items.iter().any(|item| {
         matches!(
             item,
-            SelectItemPlan::Expr { label, .. } if label == identifier
+            SelectItemPlan::Expr {
+                expr: output_expr,
+                label,
+            } if label == identifier
+                && !matches!(
+                    output_expr,
+                    ExprPlan::Identifier(output_identifier) if output_identifier == identifier
+                )
         )
     })
 }
@@ -532,6 +539,15 @@ CREATE INDEX idx_name ON Test (name);
             .build();
         assert_eq!(actual, expected, "applies order by index:\n{sql}");
 
+        let sql = "SELECT id FROM Test ORDER BY id";
+        let actual = plan_index(&storage, sql);
+        let expected = table("Test")
+            .index_by(non_clustered("idx_id".to_owned()))
+            .select()
+            .project("id")
+            .build();
+        assert_eq!(actual, expected, "applies order by index:\n{sql}");
+
         let sql = "SELECT * FROM Test WHERE flag IS NULL";
         let actual = plan_index(&storage, sql);
         let expected = table("Test")
@@ -620,6 +636,18 @@ CREATE INDEX idx_name ON Test (name);
             &identifier
         ));
         assert!(!is_output_alias(&projection, &identifier));
+
+        let identity_projection = ProjectionPlan::SelectItems(vec![SelectItemPlan::Expr {
+            expr: identifier.clone(),
+            label: "id".to_owned(),
+        }]);
+        assert!(!is_output_alias(&identity_projection, &identifier));
+
+        let renamed_projection = ProjectionPlan::SelectItems(vec![SelectItemPlan::Expr {
+            expr: ExprPlan::Identifier("name".to_owned()),
+            label: "id".to_owned(),
+        }]);
+        assert!(is_output_alias(&renamed_projection, &identifier));
     }
 
     #[test]

--- a/core/src/plan/schemaless/query.rs
+++ b/core/src/plan/schemaless/query.rs
@@ -29,7 +29,7 @@ pub(super) fn transform_query<S: BuildHasher>(
             let rewrite_unqualified_identifiers = matches!(
                 &select.from.relation,
                 TableFactorPlan::Table { name, .. } if is_schemaless_table(schema_map, name)
-            );
+            ) && select.from.joins.is_empty();
             let schemaless_aliases = collect_schemaless_aliases(schema_map, &select.from);
             let state = QueryRewriteState {
                 rewrite_unqualified_identifiers,

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -3,187 +3,406 @@ use {
     crate::{
         data::Schema,
         plan::{
-            ExprPlan, JoinPlan, ProjectionPlan, QueryPlan, SelectItemPlan, SetExprPlan,
-            StatementPlan, TableFactorPlan, TableWithJoinsPlan,
+            ExprPlan, JoinConstraintPlan, JoinOperatorPlan, ProjectionPlan, QueryPlan,
+            SelectItemPlan, SelectPlan, SetExprPlan, StatementPlan, TableAliasPlan,
+            TableFactorPlan, expr::try_visit_expr,
         },
         result::Result,
     },
-    std::{collections::HashMap, rc::Rc},
+    std::{
+        collections::{HashMap, HashSet},
+        rc::Rc,
+    },
 };
 
 type SchemaMap = HashMap<String, Schema>;
-/// Validate user select column should not be ambiguous
+type ValidateResult<T = ()> = std::result::Result<T, PlanError>;
+
+#[derive(Clone)]
+struct RelationBinding {
+    columns: Option<HashSet<String>>,
+}
+
+struct Scope {
+    relations: Vec<RelationBinding>,
+    outer: Option<Rc<Scope>>,
+}
+
+impl Scope {
+    fn validate_unqualified_column(&self, column_name: &str) -> ValidateResult {
+        let mut scope = Some(self);
+
+        while let Some(current) = scope {
+            let mut matches = 0;
+            let mut has_unknown = false;
+
+            for relation in &current.relations {
+                match &relation.columns {
+                    Some(columns) if columns.contains(column_name) => matches += 1,
+                    Some(_) => {}
+                    None => has_unknown = true,
+                }
+            }
+
+            if matches > 1 {
+                return Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()));
+            }
+
+            if matches == 1 || has_unknown {
+                return Ok(());
+            }
+
+            scope = current.outer.as_deref();
+        }
+
+        Ok(())
+    }
+}
+
 pub fn validate(schema_map: &SchemaMap, statement: &StatementPlan) -> Result<()> {
-    let query = match statement {
-        StatementPlan::Query(query) => Some(query),
-        StatementPlan::Insert { source, .. } => Some(source),
-        StatementPlan::CreateTable { source, .. } => source.as_deref(),
-        _ => None,
+    validate_statement(schema_map, statement).map_err(Into::into)
+}
+
+fn validate_statement(schema_map: &SchemaMap, statement: &StatementPlan) -> ValidateResult {
+    match statement {
+        StatementPlan::Query(query) => validate_query(schema_map, query, None).map(|_| ()),
+        StatementPlan::Insert { source, .. } => {
+            validate_query(schema_map, source, None).map(|_| ())
+        }
+        StatementPlan::CreateTable { source, .. } => source.as_deref().map_or(Ok(()), |query| {
+            validate_query(schema_map, query, None).map(|_| ())
+        }),
+        StatementPlan::Update {
+            table_name,
+            assignments,
+            selection,
+        } => {
+            let scope = single_table_scope(schema_map, table_name);
+            for assignment in assignments {
+                validate_expr(schema_map, &assignment.value, scope.as_ref())?;
+            }
+            selection.as_ref().map_or(Ok(()), |expr| {
+                validate_expr(schema_map, expr, scope.as_ref())
+            })
+        }
+        StatementPlan::Delete {
+            table_name,
+            selection,
+        } => {
+            let scope = single_table_scope(schema_map, table_name);
+            selection.as_ref().map_or(Ok(()), |expr| {
+                validate_expr(schema_map, expr, scope.as_ref())
+            })
+        }
+        _ => Ok(()),
+    }
+}
+
+fn validate_query(
+    schema_map: &SchemaMap,
+    query: &QueryPlan,
+    outer: Option<Rc<Scope>>,
+) -> ValidateResult<Option<Rc<Scope>>> {
+    let scope = match &query.body {
+        SetExprPlan::Select(select) => validate_select(schema_map, select, outer)?,
+        SetExprPlan::Values(values) => {
+            for expr in values.0.iter().flatten() {
+                validate_expr(schema_map, expr, outer.as_ref())?;
+            }
+            outer
+        }
     };
 
-    if let Some(query) = query
-        && let QueryPlan {
-            body: SetExprPlan::Select(select),
-            ..
-        } = query
-    {
-        let ProjectionPlan::SelectItems(projection) = &select.projection else {
-            return Ok(());
-        };
+    for order_by in &query.order_by {
+        validate_expr(schema_map, &order_by.expr, scope.as_ref())?;
+    }
+    if let Some(limit) = &query.limit {
+        validate_expr(schema_map, limit, scope.as_ref())?;
+    }
+    if let Some(offset) = &query.offset {
+        validate_expr(schema_map, offset, scope.as_ref())?;
+    }
 
-        for select_item in projection {
-            if let SelectItemPlan::Expr {
-                expr: ExprPlan::Identifier(ident),
-                ..
-            } = select_item
-                && let Some(context) = contextualize_query(schema_map, query)
-            {
-                context.validate_duplicated(ident)?;
+    Ok(scope)
+}
+
+fn validate_select(
+    schema_map: &SchemaMap,
+    select: &SelectPlan,
+    outer: Option<Rc<Scope>>,
+) -> ValidateResult<Option<Rc<Scope>>> {
+    let mut relations = Vec::with_capacity(select.from.joins.len() + 1);
+    let mut identifiers = HashSet::new();
+
+    validate_table_factor(schema_map, &select.from.relation, outer.as_ref())?;
+    push_relation(
+        schema_map,
+        &select.from.relation,
+        &mut relations,
+        &mut identifiers,
+    )?;
+
+    for join in &select.from.joins {
+        validate_table_factor(schema_map, &join.relation, outer.as_ref())?;
+        push_relation(schema_map, &join.relation, &mut relations, &mut identifiers)?;
+
+        let join_scope = Rc::new(Scope {
+            relations: relations.clone(),
+            outer: outer.as_ref().map(Rc::clone),
+        });
+        match &join.join_operator {
+            JoinOperatorPlan::Inner(JoinConstraintPlan::On(expr))
+            | JoinOperatorPlan::LeftOuter(JoinConstraintPlan::On(expr)) => {
+                validate_expr(schema_map, expr, Some(&join_scope))?;
             }
+            JoinOperatorPlan::Inner(JoinConstraintPlan::None)
+            | JoinOperatorPlan::LeftOuter(JoinConstraintPlan::None) => {}
         }
     }
 
+    let scope = Rc::new(Scope { relations, outer });
+
+    if let ProjectionPlan::SelectItems(projection) = &select.projection {
+        for item in projection {
+            if let SelectItemPlan::Expr { expr, .. } = item {
+                validate_expr(schema_map, expr, Some(&scope))?;
+            }
+        }
+    }
+    if let Some(selection) = &select.selection {
+        validate_expr(schema_map, selection, Some(&scope))?;
+    }
+    for group_by in &select.group_by {
+        validate_expr(schema_map, group_by, Some(&scope))?;
+    }
+    if let Some(having) = &select.having {
+        validate_expr(schema_map, having, Some(&scope))?;
+    }
+
+    Ok(Some(scope))
+}
+
+fn validate_table_factor(
+    schema_map: &SchemaMap,
+    table_factor: &TableFactorPlan,
+    outer: Option<&Rc<Scope>>,
+) -> ValidateResult {
+    match table_factor {
+        TableFactorPlan::Derived { subquery, .. } => {
+            validate_query(schema_map, subquery, outer.cloned()).map(|_| ())
+        }
+        TableFactorPlan::Series { size, .. } => validate_expr(schema_map, size, outer),
+        TableFactorPlan::Table { .. } | TableFactorPlan::Dictionary { .. } => Ok(()),
+    }
+}
+
+fn push_relation(
+    schema_map: &SchemaMap,
+    table_factor: &TableFactorPlan,
+    relations: &mut Vec<RelationBinding>,
+    identifiers: &mut HashSet<String>,
+) -> ValidateResult {
+    let identifier = table_factor.alias_name().to_owned();
+    if !identifiers.insert(identifier.clone()) {
+        return Err(PlanError::DuplicateRelationIdentifier(identifier));
+    }
+
+    relations.push(RelationBinding {
+        columns: relation_columns(schema_map, table_factor),
+    });
     Ok(())
 }
 
-enum Context<'a> {
-    Data {
-        labels: Option<Vec<&'a str>>,
-        next: Option<Rc<Context<'a>>>,
-    },
-    Bridge {
-        left: Rc<Context<'a>>,
-        right: Rc<Context<'a>>,
-    },
-}
-
-impl<'a> Context<'a> {
-    fn new(labels: Option<Vec<&'a str>>, next: Option<Rc<Context<'a>>>) -> Self {
-        Self::Data { labels, next }
-    }
-
-    fn concat(left: Option<Rc<Context<'a>>>, right: Option<Rc<Context<'a>>>) -> Option<Rc<Self>> {
-        match (left, right) {
-            (Some(left), Some(right)) => Some(Rc::new(Self::Bridge { left, right })),
-            (context @ Some(_), None) | (None, context @ Some(_)) => context,
-            (None, None) => None,
-        }
-    }
-
-    fn validate_duplicated(&self, column_name: &str) -> Result<()> {
-        fn validate(context: &Context, column_name: &str) -> Result<bool> {
-            let (left, right) = match context {
-                Context::Data { labels, next, .. } => {
-                    let current = labels
-                        .as_ref()
-                        .is_some_and(|labels| labels.contains(&column_name));
-
-                    let next = next
-                        .as_ref()
-                        .map_or(Ok(false), |next| validate(next, column_name))?;
-
-                    (current, next)
-                }
-                Context::Bridge { left, right } => {
-                    let left = validate(left, column_name)?;
-                    let right = validate(right, column_name)?;
-
-                    (left, right)
-                }
-            };
-
-            if left && right {
-                Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()).into())
-            } else {
-                Ok(left || right)
-            }
-        }
-
-        validate(self, column_name).map(|_| ())
-    }
-}
-
-fn get_labels(schema: &Schema) -> Option<Vec<&str>> {
-    schema.column_defs.as_ref().map(|column_defs| {
-        column_defs
-            .iter()
-            .map(|column_def| column_def.name.as_str())
-            .collect::<Vec<_>>()
-    })
-}
-
-fn contextualize_query<'a>(
-    schema_map: &'a SchemaMap,
-    query: &'a QueryPlan,
-) -> Option<Rc<Context<'a>>> {
-    let QueryPlan { body, .. } = query;
-    match body {
-        SetExprPlan::Select(select) => {
-            let TableWithJoinsPlan { relation, joins } = &select.from;
-            let by_table = contextualize_table_factor(schema_map, relation);
-            let by_joins = joins
+fn relation_columns(
+    schema_map: &SchemaMap,
+    table_factor: &TableFactorPlan,
+) -> Option<HashSet<String>> {
+    let columns = match table_factor {
+        TableFactorPlan::Table { name, alias, .. } => {
+            let columns = schema_map
+                .get(name)?
+                .column_defs
+                .as_ref()?
                 .iter()
-                .map(|JoinPlan { relation, .. }| contextualize_table_factor(schema_map, relation))
-                .fold(None, Context::concat);
-
-            Context::concat(by_table, by_joins)
+                .map(|column| column.name.clone())
+                .collect::<Vec<_>>();
+            apply_column_aliases(columns, alias.as_ref())
         }
+        TableFactorPlan::Derived { subquery, alias } => {
+            let columns = query_output_columns(subquery)?;
+            apply_column_aliases(columns, Some(alias))
+        }
+        TableFactorPlan::Series { alias, .. } => {
+            apply_column_aliases(vec!["N".to_owned()], Some(alias))
+        }
+        TableFactorPlan::Dictionary { .. } => return None,
+    };
+
+    Some(columns.into_iter().collect())
+}
+
+fn apply_column_aliases(columns: Vec<String>, alias: Option<&TableAliasPlan>) -> Vec<String> {
+    let Some(alias) = alias else {
+        return columns;
+    };
+
+    alias
+        .columns
+        .iter()
+        .cloned()
+        .chain(columns.into_iter().skip(alias.columns.len()))
+        .collect()
+}
+
+fn query_output_columns(query: &QueryPlan) -> Option<Vec<String>> {
+    match &query.body {
+        SetExprPlan::Select(select) => match &select.projection {
+            ProjectionPlan::SelectItems(items) => items
+                .iter()
+                .map(|item| match item {
+                    SelectItemPlan::Expr { label, .. } => Some(label.clone()),
+                    SelectItemPlan::QualifiedWildcard(_) | SelectItemPlan::Wildcard => None,
+                })
+                .collect(),
+            ProjectionPlan::SchemalessMap => None,
+        },
         SetExprPlan::Values(_) => None,
     }
 }
 
-fn contextualize_table_factor<'a>(
-    schema_map: &'a SchemaMap,
-    table_factor: &'a TableFactorPlan,
-) -> Option<Rc<Context<'a>>> {
-    match table_factor {
-        TableFactorPlan::Table { name, .. } => {
-            let schema = schema_map.get(name);
-            schema.map(|schema| Rc::from(Context::new(get_labels(schema), None)))
+fn single_table_scope(schema_map: &SchemaMap, table_name: &str) -> Option<Rc<Scope>> {
+    let columns = schema_map
+        .get(table_name)?
+        .column_defs
+        .as_ref()?
+        .iter()
+        .map(|column| column.name.clone())
+        .collect::<HashSet<_>>();
+
+    Some(Rc::new(Scope {
+        relations: vec![RelationBinding {
+            columns: Some(columns),
+        }],
+        outer: None,
+    }))
+}
+
+fn validate_expr(
+    schema_map: &SchemaMap,
+    expr: &ExprPlan,
+    scope: Option<&Rc<Scope>>,
+) -> ValidateResult {
+    try_visit_expr(expr, &mut |expr| match expr {
+        ExprPlan::Identifier(ident) => {
+            scope.map_or(Ok(()), |scope| scope.validate_unqualified_column(ident))
         }
-        TableFactorPlan::Derived { subquery, .. } => contextualize_query(schema_map, subquery),
-        TableFactorPlan::Series { .. } | TableFactorPlan::Dictionary { .. } => None,
-    }
+        ExprPlan::Subquery(subquery)
+        | ExprPlan::Exists { subquery, .. }
+        | ExprPlan::InSubquery { subquery, .. } => {
+            validate_query(schema_map, subquery, scope.cloned()).map(|_| ())
+        }
+        _ => Ok(()),
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        mock::run,
-        plan::{fetch_schema_map, validate},
-        prelude::{parse, translate},
+    use {
+        super::validate,
+        crate::{
+            mock::{MockStorage, run},
+            parse_sql::parse,
+            plan::{PlanError, StatementPlan, fetch_schema_map},
+            translate::translate,
+        },
     };
 
-    #[test]
-    fn validate_test() {
-        let storage = run("
+    fn setup_storage() -> MockStorage {
+        run("
             CREATE TABLE Users (
                 id INTEGER,
                 name TEXT
             );
-        ");
+            CREATE TABLE Items (
+                id INTEGER,
+                quantity INTEGER
+            );
+        ")
+    }
 
+    fn validate_sql(storage: &MockStorage, sql: &str) -> crate::result::Result<()> {
+        let parsed = parse(sql).expect(sql).into_iter().next().unwrap();
+        let statement = StatementPlan::from(translate(&parsed).unwrap());
+        let schema_map = fetch_schema_map(storage, &statement).unwrap();
+
+        validate(&schema_map, &statement)
+    }
+
+    fn assert_plan_error(storage: &MockStorage, sql: &str, expected: PlanError) {
+        assert_eq!(validate_sql(storage, sql), Err(expected.into()), "{sql}");
+    }
+
+    fn assert_plan_ok(storage: &MockStorage, sql: &str) {
+        assert!(validate_sql(storage, sql).is_ok(), "{sql}");
+    }
+
+    #[test]
+    fn rejects_unqualified_ambiguity_in_query_expressions() {
+        let storage = setup_storage();
         let cases = [
-            ("SELECT * FROM (SELECT * FROM Users) AS Sub", true),
-            ("SELECT * FROM SERIES(3)", true),
-            ("SELECT id FROM Users A JOIN Users B on A.id = B.id", false),
-            (
-                "INSERT INTO Users SELECT id FROM Users A JOIN Users B on A.id = B.id",
-                false,
-            ),
-            (
-                "CREATE TABLE Ids AS SELECT id FROM Users A JOIN Users B on A.id = B.id",
-                false,
-            ),
+            "SELECT id FROM Users U JOIN Items I ON U.id = I.id",
+            "SELECT id + 1 FROM Users U JOIN Items I ON U.id = I.id",
+            "SELECT COALESCE(id, 0) FROM Users U JOIN Items I ON U.id = I.id",
+            "SELECT U.name FROM Users U JOIN Items I ON U.id = I.id WHERE id > 0",
+            "SELECT U.name FROM Users U JOIN Items I ON id = I.id",
+            "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id GROUP BY id",
+            "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id HAVING id > 0",
+            "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id ORDER BY id",
         ];
 
-        for (sql, expected) in cases {
-            let parsed = parse(sql).expect(sql).into_iter().next().unwrap();
-            let statement = translate(&parsed).unwrap().into();
-            let schema_map = fetch_schema_map(&storage, &statement).unwrap();
-            let actual = validate(&schema_map, &statement).is_ok();
+        for sql in cases {
+            assert_plan_error(
+                &storage,
+                sql,
+                PlanError::ColumnReferenceAmbiguous("id".to_owned()),
+            );
+        }
+    }
 
-            assert_eq!(actual, expected);
+    #[test]
+    fn rejects_duplicate_relation_identifiers() {
+        let storage = setup_storage();
+        let cases = [
+            "SELECT A.id FROM Users A JOIN Items A ON A.id = A.id",
+            "SELECT Users.id FROM Users JOIN Users ON Users.id = Users.id",
+        ];
+
+        for sql in cases {
+            let identifier = if sql.contains("Items A") {
+                "A"
+            } else {
+                "Users"
+            };
+            assert_plan_error(
+                &storage,
+                sql,
+                PlanError::DuplicateRelationIdentifier(identifier.to_owned()),
+            );
+        }
+    }
+
+    #[test]
+    fn allows_unambiguous_and_correlated_references() {
+        let storage = setup_storage();
+        let cases = [
+            "SELECT U.name FROM Users U JOIN Items I ON U.id = I.id",
+            "SELECT name FROM Users U JOIN Items I ON U.id = I.id",
+            "SELECT U.name FROM Users U WHERE EXISTS (SELECT 1 FROM Items I WHERE I.id = U.id)",
+            "SELECT U.name FROM Users U WHERE EXISTS (SELECT 1 FROM Items U WHERE U.id = 1)",
+        ];
+
+        for sql in cases {
+            assert_plan_ok(&storage, sql);
         }
     }
 }

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -20,7 +20,8 @@ type ValidateResult<T = ()> = std::result::Result<T, PlanError>;
 
 #[derive(Clone)]
 struct RelationBinding {
-    columns: Option<HashSet<String>>,
+    identifier: String,
+    columns: Option<Vec<String>>,
 }
 
 struct Scope {
@@ -38,8 +39,12 @@ impl Scope {
 
             for relation in &current.relations {
                 match &relation.columns {
-                    Some(columns) if columns.contains(column_name) => matches += 1,
-                    Some(_) => {}
+                    Some(columns) => {
+                        matches += columns
+                            .iter()
+                            .filter(|column| column == &column_name)
+                            .count();
+                    }
                     None => has_unknown = true,
                 }
             }
@@ -49,6 +54,34 @@ impl Scope {
             }
 
             if matches == 1 || has_unknown {
+                return Ok(());
+            }
+
+            scope = current.outer.as_deref();
+        }
+
+        Ok(())
+    }
+
+    fn validate_qualified_column(&self, identifier: &str, column_name: &str) -> ValidateResult {
+        let mut scope = Some(self);
+
+        while let Some(current) = scope {
+            if let Some(relation) = current
+                .relations
+                .iter()
+                .find(|relation| relation.identifier == identifier)
+            {
+                if relation.columns.as_ref().is_some_and(|columns| {
+                    columns
+                        .iter()
+                        .filter(|column| column == &column_name)
+                        .count()
+                        > 1
+                }) {
+                    return Err(PlanError::ColumnReferenceAmbiguous(column_name.to_owned()));
+                }
+
                 return Ok(());
             }
 
@@ -113,8 +146,14 @@ fn validate_query(
         }
     };
 
+    let output_columns = query_output_columns(schema_map, query);
     for order_by in &query.order_by {
-        validate_expr(schema_map, &order_by.expr, scope.as_ref())?;
+        validate_order_by(
+            schema_map,
+            &order_by.expr,
+            scope.as_ref(),
+            output_columns.as_deref(),
+        )?;
     }
     if let Some(limit) = &query.limit {
         validate_expr(schema_map, limit, scope.as_ref())?;
@@ -135,8 +174,10 @@ fn validate_select(
     let mut identifiers = HashSet::new();
 
     validate_table_factor(schema_map, &select.from.relation, outer.as_ref())?;
-    identifiers.insert(select.from.relation.alias_name().to_owned());
+    let identifier = select.from.relation.alias_name().to_owned();
+    identifiers.insert(identifier.clone());
     relations.push(RelationBinding {
+        identifier,
         columns: relation_columns(schema_map, &select.from.relation),
     });
 
@@ -206,15 +247,13 @@ fn push_relation(
     }
 
     relations.push(RelationBinding {
+        identifier,
         columns: relation_columns(schema_map, table_factor),
     });
     Ok(())
 }
 
-fn relation_columns(
-    schema_map: &SchemaMap,
-    table_factor: &TableFactorPlan,
-) -> Option<HashSet<String>> {
+fn relation_columns(schema_map: &SchemaMap, table_factor: &TableFactorPlan) -> Option<Vec<String>> {
     let columns = match table_factor {
         TableFactorPlan::Table { name, alias, .. } => {
             let columns = schema_map
@@ -227,7 +266,7 @@ fn relation_columns(
             apply_column_aliases(columns, alias.as_ref())
         }
         TableFactorPlan::Derived { subquery, alias } => {
-            let columns = query_output_columns(subquery)?;
+            let columns = query_output_columns(schema_map, subquery)?;
             apply_column_aliases(columns, Some(alias))
         }
         TableFactorPlan::Series { alias, .. } => {
@@ -236,7 +275,7 @@ fn relation_columns(
         TableFactorPlan::Dictionary { .. } => return None,
     };
 
-    Some(columns.into_iter().collect())
+    Some(columns)
 }
 
 fn apply_column_aliases(columns: Vec<String>, alias: Option<&TableAliasPlan>) -> Vec<String> {
@@ -252,19 +291,38 @@ fn apply_column_aliases(columns: Vec<String>, alias: Option<&TableAliasPlan>) ->
         .collect()
 }
 
-fn query_output_columns(query: &QueryPlan) -> Option<Vec<String>> {
+fn query_output_columns(schema_map: &SchemaMap, query: &QueryPlan) -> Option<Vec<String>> {
     match &query.body {
         SetExprPlan::Select(select) => match &select.projection {
-            ProjectionPlan::SelectItems(items) => items
-                .iter()
-                .map(|item| match item {
-                    SelectItemPlan::Expr { label, .. } => Some(label.clone()),
-                    SelectItemPlan::QualifiedWildcard(_) | SelectItemPlan::Wildcard => None,
-                })
-                .collect(),
+            ProjectionPlan::SelectItems(items) => {
+                let mut output = Vec::new();
+                for item in items {
+                    match item {
+                        SelectItemPlan::Expr { label, .. } => output.push(label.clone()),
+                        SelectItemPlan::QualifiedWildcard(identifier) => {
+                            let relation = std::iter::once(&select.from.relation)
+                                .chain(select.from.joins.iter().map(|join| &join.relation))
+                                .find(|relation| relation.alias_name() == identifier)?;
+                            output.extend(relation_columns(schema_map, relation)?);
+                        }
+                        SelectItemPlan::Wildcard => {
+                            for relation in std::iter::once(&select.from.relation)
+                                .chain(select.from.joins.iter().map(|join| &join.relation))
+                            {
+                                output.extend(relation_columns(schema_map, relation)?);
+                            }
+                        }
+                    }
+                }
+                Some(output)
+            }
             ProjectionPlan::SchemalessMap => None,
         },
-        SetExprPlan::Values(_) => None,
+        SetExprPlan::Values(values) => values.0.first().map(|row| {
+            (1..=row.len())
+                .map(|index| format!("column{index}"))
+                .collect()
+        }),
     }
 }
 
@@ -275,10 +333,11 @@ fn single_table_scope(schema_map: &SchemaMap, table_name: &str) -> Option<Rc<Sco
         .as_ref()?
         .iter()
         .map(|column| column.name.clone())
-        .collect::<HashSet<_>>();
+        .collect::<Vec<_>>();
 
     Some(Rc::new(Scope {
         relations: vec![RelationBinding {
+            identifier: table_name.to_owned(),
             columns: Some(columns),
         }],
         outer: None,
@@ -294,6 +353,9 @@ fn validate_expr(
         ExprPlan::Identifier(ident) => {
             scope.map_or(Ok(()), |scope| scope.validate_unqualified_column(ident))
         }
+        ExprPlan::CompoundIdentifier { alias, ident } => scope.map_or(Ok(()), |scope| {
+            scope.validate_qualified_column(alias, ident)
+        }),
         ExprPlan::Subquery(subquery)
         | ExprPlan::Exists { subquery, .. }
         | ExprPlan::InSubquery { subquery, .. } => {
@@ -301,6 +363,27 @@ fn validate_expr(
         }
         _ => Ok(()),
     })
+}
+
+fn validate_order_by(
+    schema_map: &SchemaMap,
+    expr: &ExprPlan,
+    scope: Option<&Rc<Scope>>,
+    output_columns: Option<&[String]>,
+) -> ValidateResult {
+    if let (ExprPlan::Identifier(identifier), Some(output_columns)) = (expr, output_columns) {
+        match output_columns
+            .iter()
+            .filter(|column| column == &identifier)
+            .count()
+        {
+            0 => {}
+            1 => return Ok(()),
+            _ => return Err(PlanError::ColumnReferenceAmbiguous(identifier.clone())),
+        }
+    }
+
+    validate_expr(schema_map, expr, scope)
 }
 
 #[cfg(test)]
@@ -358,7 +441,7 @@ mod tests {
             "SELECT U.name FROM Users U JOIN Items I ON id = I.id",
             "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id GROUP BY id",
             "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id HAVING id > 0",
-            "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id ORDER BY id",
+            "SELECT U.id AS id FROM Users U JOIN Items I ON U.id = I.id ORDER BY id + 0",
         ];
 
         for sql in cases {
@@ -393,6 +476,33 @@ mod tests {
     }
 
     #[test]
+    fn rejects_duplicate_columns_within_relation() {
+        let storage = setup_storage();
+        let cases = [
+            "SELECT D.id FROM (SELECT U.id AS id, I.id AS id FROM Users U JOIN Items I ON U.id = I.id) D",
+            "SELECT D.id FROM (SELECT * FROM Users U JOIN Items I ON U.id = I.id) D",
+            "SELECT id FROM Users U(id, id)",
+            "SELECT D.id FROM (SELECT U.id, I.id FROM Users U JOIN Items I ON U.id = I.id) D(id, id)",
+            "SELECT U.id AS value, I.id AS value FROM Users U JOIN Items I ON U.id = I.id ORDER BY value",
+        ];
+
+        for sql in cases {
+            assert_plan_error(
+                &storage,
+                sql,
+                PlanError::ColumnReferenceAmbiguous(
+                    if sql.contains("ORDER BY value") {
+                        "value"
+                    } else {
+                        "id"
+                    }
+                    .to_owned(),
+                ),
+            );
+        }
+    }
+
+    #[test]
     fn allows_unambiguous_and_correlated_references() {
         let storage = setup_storage();
         let cases = [
@@ -400,11 +510,21 @@ mod tests {
             "SELECT name FROM Users U JOIN Items I ON U.id = I.id",
             "SELECT U.name FROM Users U WHERE EXISTS (SELECT 1 FROM Items I WHERE I.id = U.id)",
             "SELECT U.name FROM Users U WHERE EXISTS (SELECT 1 FROM Items U WHERE U.id = 1)",
+            "SELECT U.id FROM Users U JOIN Items I ON U.id = I.id ORDER BY id",
+            "SELECT U.name AS quantity FROM Users U JOIN Items I ON U.id = I.id ORDER BY quantity",
+            "SELECT U.name AS title FROM Users U JOIN Items I ON U.id = I.id ORDER BY quantity",
         ];
 
         for sql in cases {
             assert_plan_ok(&storage, sql);
         }
+    }
+
+    #[test]
+    fn defers_unknown_qualified_references() {
+        let storage = setup_storage();
+
+        assert_plan_ok(&storage, "SELECT Missing.id FROM Users U");
     }
 
     #[test]

--- a/core/src/plan/validate.rs
+++ b/core/src/plan/validate.rs
@@ -135,12 +135,10 @@ fn validate_select(
     let mut identifiers = HashSet::new();
 
     validate_table_factor(schema_map, &select.from.relation, outer.as_ref())?;
-    push_relation(
-        schema_map,
-        &select.from.relation,
-        &mut relations,
-        &mut identifiers,
-    )?;
+    identifiers.insert(select.from.relation.alias_name().to_owned());
+    relations.push(RelationBinding {
+        columns: relation_columns(schema_map, &select.from.relation),
+    });
 
     for join in &select.from.joins {
         validate_table_factor(schema_map, &join.relation, outer.as_ref())?;
@@ -312,7 +310,10 @@ mod tests {
         crate::{
             mock::{MockStorage, run},
             parse_sql::parse,
-            plan::{PlanError, StatementPlan, fetch_schema_map},
+            plan::{
+                PlanError, ProjectionPlan, QueryPlan, SelectPlan, SetExprPlan, StatementPlan,
+                TableAliasPlan, TableFactorPlan, TableWithJoinsPlan, fetch_schema_map,
+            },
             translate::translate,
         },
     };
@@ -404,5 +405,42 @@ mod tests {
         for sql in cases {
             assert_plan_ok(&storage, sql);
         }
+    }
+
+    #[test]
+    fn allows_schemaless_map_projections() {
+        let storage = setup_storage();
+        let query = |relation| QueryPlan {
+            body: SetExprPlan::Select(Box::new(SelectPlan {
+                distinct: false,
+                projection: ProjectionPlan::SchemalessMap,
+                from: TableWithJoinsPlan {
+                    relation,
+                    joins: Vec::new(),
+                },
+                selection: None,
+                group_by: Vec::new(),
+                having: None,
+                aggregate_slots: None,
+            })),
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+        };
+        let derived = query(TableFactorPlan::Table {
+            name: "Users".to_owned(),
+            alias: None,
+            index: None,
+        });
+        let statement = StatementPlan::Query(query(TableFactorPlan::Derived {
+            subquery: derived,
+            alias: TableAliasPlan {
+                name: "D".to_owned(),
+                columns: Vec::new(),
+            },
+        }));
+
+        let schema_map = fetch_schema_map(&storage, &statement).unwrap();
+        assert!(validate(&schema_map, &statement).is_ok());
     }
 }

--- a/test-suite/fixtures/index/order_by.sql
+++ b/test-suite/fixtures/index/order_by.sql
@@ -16,6 +16,9 @@ VALUES
 CREATE INDEX idx_name ON Test (name);
 -- @expect: payload CreateIndex
 
+CREATE INDEX idx_id ON Test (id);
+-- @expect: payload CreateIndex
+
 CREATE INDEX idx_id_num_asc ON Test (id + num ASC);
 -- @expect: payload CreateIndex
 
@@ -31,6 +34,16 @@ SELECT * FROM Test ORDER BY name;
 -- | I64(4) | I64(7) | Str("Monday") |
 -- | I64(1) | I64(9) | Str("Wild")   |
 -- | I64(3) | NULL   | Str("World")  |
+
+SELECT name AS id FROM Test ORDER BY id;
+-- @expect-index: none
+-- @expect:
+-- | id            |
+-- | ------------- |
+-- | Str("Hello")  |
+-- | Str("Monday") |
+-- | Str("Wild")   |
+-- | Str("World")  |
 
 SELECT * FROM Test ORDER BY id + num;
 -- @expect-index: idx_id_num_asc

--- a/test-suite/fixtures/join.sql
+++ b/test-suite/fixtures/join.sql
@@ -29,6 +29,59 @@ CREATE TABLE AliasScopeBar (
 );
 -- @expect: ok
 
+INSERT INTO AliasScopeFoo VALUES
+    (1, 'Zulu'),
+    (2, 'Alpha');
+-- @expect: ok
+
+INSERT INTO AliasScopeBar VALUES
+    (1, 'A'),
+    (2, 'Z');
+-- @expect: ok
+
+SELECT F.name AS title
+FROM AliasScopeFoo AS F
+JOIN AliasScopeBar AS B ON F.id = B.id
+ORDER BY title;
+-- @expect:
+-- | title: Str |
+-- | ---------- |
+-- | "Alpha"    |
+-- | "Zulu"     |
+
+-- ORDER BY expressions keep input-column resolution.
+SELECT F.name AS title
+FROM AliasScopeFoo AS F
+JOIN AliasScopeBar AS B ON F.id = B.id
+ORDER BY F.id + 0;
+-- @expect:
+-- | title: Str |
+-- | ---------- |
+-- | "Zulu"     |
+-- | "Alpha"    |
+
+SELECT D.id
+FROM (
+    SELECT F.id AS id, B.id AS id
+    FROM AliasScopeFoo AS F
+    JOIN AliasScopeBar AS B ON F.id = B.id
+) AS D;
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
+SELECT D.id
+FROM (
+    SELECT *
+    FROM AliasScopeFoo AS F
+    JOIN AliasScopeBar AS B ON F.id = B.id
+) AS D;
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
+SELECT id FROM AliasScopeFoo AS F(id, id);
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
 SELECT A.id
 FROM AliasScopeFoo AS A
 JOIN AliasScopeBar AS A ON A.id = A.id;

--- a/test-suite/fixtures/join.sql
+++ b/test-suite/fixtures/join.sql
@@ -17,6 +17,49 @@ DELETE FROM Player
 DELETE FROM Item
 -- @expect: ok
 
+CREATE TABLE AliasScopeFoo (
+    id INTEGER,
+    name TEXT
+);
+-- @expect: ok
+
+CREATE TABLE AliasScopeBar (
+    id INTEGER,
+    title TEXT
+);
+-- @expect: ok
+
+SELECT A.id
+FROM AliasScopeFoo AS A
+JOIN AliasScopeBar AS A ON A.id = A.id;
+-- @expect: error Plan.DuplicateRelationIdentifier
+-- @json: "A"
+
+SELECT AliasScopeFoo.id
+FROM AliasScopeFoo
+JOIN AliasScopeFoo ON AliasScopeFoo.id = AliasScopeFoo.id;
+-- @expect: error Plan.DuplicateRelationIdentifier
+-- @json: "AliasScopeFoo"
+
+SELECT id + 1
+FROM AliasScopeFoo AS F
+JOIN AliasScopeBar AS B ON F.id = B.id;
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
+SELECT F.name
+FROM AliasScopeFoo AS F
+JOIN AliasScopeBar AS B ON F.id = B.id
+WHERE id > 0;
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
+SELECT F.name
+FROM AliasScopeFoo AS F
+JOIN AliasScopeBar AS B ON id = B.id;
+-- @expect: error Plan.ColumnReferenceAmbiguous
+-- @json: "id"
+
 INSERT INTO Player (id, name) VALUES
     (1, 'Taehoon'),
     (2,    'Mike'),

--- a/test-suite/fixtures/nested_select.sql
+++ b/test-suite/fixtures/nested_select.sql
@@ -77,3 +77,26 @@ SELECT id FROM Player WHERE id IN (SELECT id, name FROM Player)
 
 SELECT id FROM Player WHERE id IN (SELECT id, name FROM Player WHERE id = 0)
 -- @expect: error Evaluate.InSubqueryMustReturnOneColumn
+
+SELECT P.name
+FROM Player AS P
+WHERE EXISTS (
+    SELECT 1
+    FROM Request AS P
+    WHERE P.name = 'Taehoon'
+);
+-- @expect: error Evaluate.CompoundIdentifierNotFound
+-- @json:
+-- {
+--   "table_alias": "P",
+--   "column_name": "name"
+-- }
+
+SELECT P.name
+FROM Player AS P
+WHERE EXISTS (
+    SELECT 1
+    FROM Request AS R
+    WHERE R.user_id = P.id
+);
+-- @expect: count 4

--- a/test-suite/fixtures/schemaless/error.sql
+++ b/test-suite/fixtures/schemaless/error.sql
@@ -54,3 +54,14 @@ SELECT id FROM Item WHERE id = (SELECT * FROM Item LIMIT 1)
 
 SELECT id FROM Item WHERE id = (SELECT * FROM Item AS I LIMIT 1)
 -- @expect: error Evaluate.SchemalessProjectionForSubQuery
+
+SELECT id FROM Item JOIN Player;
+-- @expect: error Evaluate.IdentifierAmbiguous
+-- @json: "id"
+
+SELECT dex FROM Item JOIN Player;
+-- @expect:
+-- | dex: I64 |
+-- | -------- |
+-- | 324      |
+-- | 324      |


### PR DESCRIPTION
## Summary

- detect ambiguous unqualified column references within the same query scope
- reject duplicate relation identifiers in joins
- preserve duplicate output column names from derived tables and positional aliases
- enforce alias shadowing and correlated subquery scope resolution
- resolve simple `ORDER BY` names against output aliases first
- retain input-column resolution for `ORDER BY` expressions
- prevent index ordering optimization from consuming output-alias ordering
- detect schemaless column ambiguity at runtime

## Testing

- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all`
- `cargo test -p gluesql-core --lib`
- `cargo test -p gluesql_memory_storage --test memory_storage sql_join`
- `cargo test -p gluesql_sled_storage --test sled_storage sql_index`
- `cargo test -p gluesql_sled_storage --test sled_storage sql_join`
- changed-line coverage: 100%
- changed-branch coverage: 100%

Closes #1965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced SQL identifier/alias resolution for joins, nested queries, and schemaless data.
  * Added clearer errors for ambiguous identifiers and duplicate relation identifiers.
* **Bug Fixes**
  * Correct handling of missing vs ambiguous columns (including better NULL vs “not found/ambiguous” behavior).
  * Fixed `ORDER BY` behavior when ordering by projected output aliases, including preventing incorrect index selection.
  * Improved sorting behavior and correlated subquery alias scoping.
* **Tests**
  * Expanded coverage for ambiguity, alias shadowing, and schemaless JOIN scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->