### PR TITLE
Add optional tracing-based query execution observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "bigdecimal",
  "cfg-if",
  "chrono",
+ "gluesql-macros",
  "hex",
  "im",
  "iter-enum",
@@ -1560,6 +1561,7 @@ dependencies = [
  "rust_decimal",
  "syn 2.0.119",
  "tracing",
+ "tracing-subscriber",
  "trybuild",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -36,7 +36,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
@@ -394,7 +394,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -446,6 +446,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
@@ -548,7 +554,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
  "syn_derive",
 ]
 
@@ -584,10 +590,10 @@ dependencies = [
  "bitvec",
  "chrono",
  "hex",
- "indexmap 2.3.0",
+ "indexmap 2.14.0",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -637,9 +643,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -660,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -780,7 +786,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -955,6 +961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +999,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -995,7 +1010,7 @@ checksum = "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1218,6 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1276,7 +1292,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1300,6 +1316,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1314,6 +1331,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags 2.6.0",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1337,6 +1368,18 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1400,11 +1443,17 @@ dependencies = [
  "gluesql-redb-storage",
  "gluesql_memory_storage",
  "gluesql_sled_storage",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rustyline",
  "rustyline-derive",
  "strum_macros 0.25.3",
  "tabled",
  "thiserror 1.0.63",
+ "tracing-flame",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1432,7 +1481,7 @@ dependencies = [
  "md-5",
  "ordered-float 4.2.2",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rust_decimal",
  "serde",
@@ -1440,6 +1489,8 @@ dependencies = [
  "sqlparser",
  "strum_macros 0.25.3",
  "thiserror 1.0.63",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1507,7 +1558,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust_decimal",
- "syn 2.0.89",
+ "syn 2.0.119",
+ "tracing",
  "trybuild",
 ]
 
@@ -1550,11 +1602,17 @@ name = "gluesql-redb-storage"
 version = "0.20.0"
 dependencies = [
  "bincode",
+ "fxprof-processed-profile",
  "gluesql-core",
+ "gluesql-macros",
  "gluesql-test-suite",
+ "libc",
  "redb",
  "serde",
- "thiserror 2.0.3",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1654,6 +1712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1786,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -1816,12 +1962,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2041,11 +2187,10 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2092,6 +2237,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -2171,7 +2325,7 @@ dependencies = [
  "md-5",
  "pbkdf2",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rustc_version_runtime",
  "rustls",
  "rustls-pemfile",
@@ -2214,6 +2368,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2307,15 +2470,84 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2333,7 +2565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -2378,7 +2610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2397,15 +2629,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2549,6 +2781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2854,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,9 +2940,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2685,7 +2962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2694,8 +2981,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2704,7 +3000,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2776,7 +3072,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.63",
 ]
@@ -2820,6 +3116,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,7 +3164,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2894,7 +3221,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2915,6 +3242,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3142,7 +3475,7 @@ checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3151,7 +3484,7 @@ version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3224,6 +3557,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3393,7 +3735,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3406,7 +3748,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3428,9 +3770,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3446,7 +3799,16 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3539,11 +3901,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3554,18 +3916,27 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3668,7 +4039,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3713,7 +4084,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -3746,7 +4117,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.8",
  "winnow 0.5.40",
 ]
@@ -3757,7 +4128,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.7",
  "toml_datetime 0.6.8",
@@ -3780,13 +4151,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3794,6 +4222,64 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "trust-dns-proto"
@@ -3812,7 +4298,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "thiserror 1.0.63",
  "tinyvec",
@@ -3839,6 +4325,12 @@ dependencies = [
  "tokio",
  "trust-dns-proto",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
@@ -3950,10 +4442,16 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -3984,10 +4482,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4012,7 +4528,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -4047,7 +4563,7 @@ checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4066,6 +4582,16 @@ name = "web-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4134,6 +4660,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -4318,6 +4850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,7 +4888,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,21 @@ license.workspace = true
 repository.workspace = true
 documentation.workspace = true
 
+[features]
+tracing = [
+  "gluesql-core/tracing",
+  "gluesql-redb-storage/tracing",
+  "dep:tracing-subscriber",
+]
+tracing-flame = ["tracing", "dep:tracing-flame"]
+opentelemetry = [
+  "tracing",
+  "dep:opentelemetry",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry_sdk",
+  "dep:tracing-opentelemetry",
+]
+
 [dependencies]
 gluesql-core.workspace = true
 gluesql_sled_storage.workspace = true
@@ -25,6 +40,20 @@ thiserror = "1.0"
 edit = "0.1.4"
 anyhow = "1.0"
 strum_macros = "0.25"
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt"] }
+tracing-flame = { version = "0.2", optional = true }
+opentelemetry = { version = "0.32", optional = true, default-features = false, features = [
+  "trace",
+] }
+opentelemetry-otlp = { version = "0.32", optional = true, default-features = false, features = [
+  "http-proto",
+  "reqwest-blocking-client",
+  "trace",
+] }
+opentelemetry_sdk = { version = "0.32", optional = true, default-features = false, features = [
+  "trace",
+] }
+tracing-opentelemetry = { version = "0.33", optional = true, default-features = false }
 
 [lints]
 workspace = true

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -71,6 +71,75 @@ enum Storage {
     File,
 }
 
+#[cfg(feature = "tracing")]
+struct TracingGuard {
+    #[cfg(feature = "tracing-flame")]
+    _flame: tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>,
+    #[cfg(feature = "opentelemetry")]
+    provider: opentelemetry_sdk::trace::SdkTracerProvider,
+}
+
+#[cfg(all(feature = "tracing", feature = "opentelemetry"))]
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.provider.shutdown() {
+            eprintln!("[tracing] failed to shut down OpenTelemetry exporter: {error}");
+        }
+    }
+}
+
+#[cfg(feature = "tracing")]
+fn init_tracing() -> Result<TracingGuard> {
+    use tracing_subscriber::{
+        EnvFilter,
+        fmt::{self, format::FmtSpan},
+        layer::SubscriberExt,
+        util::SubscriberInitExt,
+    };
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+    let fmt_layer = fmt::layer()
+        .with_span_events(FmtSpan::CLOSE)
+        .with_writer(std::io::stderr);
+
+    #[cfg(feature = "tracing-flame")]
+    let (flame_layer, flame_guard) = {
+        let path =
+            std::env::var_os("GLUESQL_FLAMEGRAPH_PATH").unwrap_or_else(|| "tracing.folded".into());
+        let (layer, guard) = tracing_flame::FlameLayer::with_file(path)?;
+
+        (layer.with_empty_samples(false), guard)
+    };
+
+    #[cfg(feature = "opentelemetry")]
+    let (otel_layer, provider) = {
+        use opentelemetry::trace::TracerProvider as _;
+
+        let exporter = opentelemetry_otlp::SpanExporter::builder().build()?;
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("gluesql-cli");
+
+        (tracing_opentelemetry::layer().with_tracer(tracer), provider)
+    };
+
+    let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+    #[cfg(feature = "tracing-flame")]
+    let subscriber = subscriber.with(flame_layer);
+    #[cfg(feature = "opentelemetry")]
+    let subscriber = subscriber.with(otel_layer);
+    subscriber.try_init()?;
+
+    Ok(TracingGuard {
+        #[cfg(feature = "tracing-flame")]
+        _flame: flame_guard,
+        #[cfg(feature = "opentelemetry")]
+        provider,
+    })
+}
+
 pub fn run() -> Result<()> {
     fn run<T: GStore + GStoreMut + Planner>(storage: T, input: Option<PathBuf>) {
         let output = std::io::stdout();
@@ -86,6 +155,9 @@ pub fn run() -> Result<()> {
             eprintln!("{e}");
         }
     }
+
+    #[cfg(feature = "tracing")]
+    let _tracing_guard = init_tracing()?;
 
     let Args {
         execute,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 documentation.workspace = true
 
+[features]
+tracing = ["dep:tracing", "dep:tracing-subscriber"]
+
 [dependencies]
 regex = "1"
 cfg-if = "1"
@@ -25,6 +28,12 @@ hex = "0.4"
 rand = "0.8"
 ordered-float = { version = "4", features = ["serde"] }
 md-5 = "0.10.5"
+tracing = { version = "0.1", optional = true, default-features = false, features = ["attributes", "std"] }
+tracing-subscriber = { version = "0.3", optional = true, default-features = false, features = [
+  "env-filter",
+  "fmt",
+  "std",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.uuid]
 version = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,10 +8,11 @@ repository.workspace = true
 documentation.workspace = true
 
 [features]
-tracing = ["dep:tracing", "dep:tracing-subscriber"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:gluesql-macros"]
 
 [dependencies]
 regex = "1"
+gluesql-macros = { path = "../macros", version = "0.20.0", optional = true }
 cfg-if = "1"
 chrono = { version = "0.4.38", features = ["serde", "wasmbind"] }
 rust_decimal = { version = "1", features = ["serde-str"] }

--- a/core/src/__private.rs
+++ b/core/src/__private.rs
@@ -1,0 +1,92 @@
+use {
+    std::{fmt::Debug, sync::OnceLock},
+    tracing::{Span, trace},
+    tracing_subscriber::{EnvFilter, fmt::format::FmtSpan},
+};
+
+static DEFAULT_SUBSCRIBER: OnceLock<()> = OnceLock::new();
+
+pub fn ensure_default_subscriber() {
+    DEFAULT_SUBSCRIBER.get_or_init(|| {
+        if tracing::dispatcher::has_been_set() {
+            return;
+        }
+
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_writer(std::io::stderr)
+            .try_init();
+    });
+}
+
+pub struct TracedResultIterator<I> {
+    inner: I,
+    span: Span,
+    row_count: usize,
+    error_count: usize,
+    completed: bool,
+}
+
+impl<I> TracedResultIterator<I> {
+    pub fn new(inner: I, span: Span) -> Self {
+        Self {
+            inner,
+            span,
+            row_count: 0,
+            error_count: 0,
+            completed: false,
+        }
+    }
+}
+
+impl<I, T, E> Iterator for TracedResultIterator<I>
+where
+    I: Iterator<Item = Result<T, E>>,
+    T: Debug,
+    E: Debug,
+{
+    type Item = Result<T, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let span = self.span.clone();
+        span.in_scope(|| {
+            let item = self.inner.next();
+
+            match &item {
+                Some(Ok(row)) => {
+                    self.row_count += 1;
+                    trace!(target: "gluesql", row = ?row, "storage iterator yielded a row");
+                }
+                Some(Err(error)) => {
+                    self.error_count += 1;
+                    trace!(target: "gluesql", error = ?error, "storage iterator yielded an error");
+                }
+                None => self.completed = true,
+            }
+
+            item
+        })
+    }
+}
+
+impl<I> Drop for TracedResultIterator<I> {
+    fn drop(&mut self) {
+        self.span.record("row_count", self.row_count);
+        self.span.record("error_count", self.error_count);
+        self.span.record("completed", self.completed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn installs_default_subscriber_once() {
+        super::ensure_default_subscriber();
+        super::ensure_default_subscriber();
+
+        assert!(tracing::dispatcher::has_been_set());
+    }
+}

--- a/core/src/executor/delete.rs
+++ b/core/src/executor/delete.rs
@@ -39,6 +39,16 @@ pub fn delete<T: GStore + GStoreMut>(
         })
         .collect::<Result<Vec<_>>>()?;
 
+    #[cfg(feature = "tracing")]
+    let collect_span = tracing::debug_span!(
+        target: "gluesql",
+        "gluesql.mutation.collect",
+        operation = "delete",
+        buffered_rows = tracing::field::Empty
+    );
+    #[cfg(feature = "tracing")]
+    let collect_entered = collect_span.enter();
+
     let mut keys = Vec::new();
     for item in fetch(storage, table_name, columns, selection)? {
         let (key, row) = item?;
@@ -85,6 +95,12 @@ pub fn delete<T: GStore + GStoreMut>(
         keys.push(key);
     }
     let num_keys = keys.len();
+
+    #[cfg(feature = "tracing")]
+    {
+        collect_span.record("buffered_rows", num_keys);
+        drop(collect_entered);
+    }
 
     storage
         .delete_data(table_name, keys)

--- a/core/src/executor/delete.rs
+++ b/core/src/executor/delete.rs
@@ -23,6 +23,16 @@ pub enum DeleteError {
     ValueNotFound(String),
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.mutation.collect",
+        fields(operation = "delete"),
+        start = before_let(keys),
+        end = after_let(num_keys),
+        record(buffered_rows = num_keys)
+    )
+)]
 pub fn delete<T: GStore + GStoreMut>(
     storage: &mut T,
     table_name: &str,
@@ -38,16 +48,6 @@ pub fn delete<T: GStore + GStoreMut>(
                 .map(|columns| (referencing, columns))
         })
         .collect::<Result<Vec<_>>>()?;
-
-    #[cfg(feature = "tracing")]
-    let collect_span = tracing::debug_span!(
-        target: "gluesql",
-        "gluesql.mutation.collect",
-        operation = "delete",
-        buffered_rows = tracing::field::Empty
-    );
-    #[cfg(feature = "tracing")]
-    let collect_entered = collect_span.enter();
 
     let mut keys = Vec::new();
     for item in fetch(storage, table_name, columns, selection)? {
@@ -95,12 +95,6 @@ pub fn delete<T: GStore + GStoreMut>(
         keys.push(key);
     }
     let num_keys = keys.len();
-
-    #[cfg(feature = "tracing")]
-    {
-        collect_span.record("buffered_rows", num_keys);
-        drop(collect_entered);
-    }
 
     storage
         .delete_data(table_name, keys)

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -343,12 +343,13 @@ fn evaluate_function<'a, 'b: 'a, T: GStore>(
             f::concat(exprs)
         }
         FunctionExprPlan::Custom { name, exprs } => {
+            let custom_function_storage =
+                storage.ok_or(EvaluateError::UnsupportedCustomFunction)?;
             let CustomFunction {
                 func_name,
                 args,
                 body,
-            } = storage
-                .ok_or(EvaluateError::UnsupportedCustomFunction)?
+            } = custom_function_storage
                 .fetch_function(name)?
                 .ok_or_else(|| EvaluateError::UnsupportedFunction(name.clone()))?;
 

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -343,13 +343,12 @@ fn evaluate_function<'a, 'b: 'a, T: GStore>(
             f::concat(exprs)
         }
         FunctionExprPlan::Custom { name, exprs } => {
-            let custom_function_storage =
-                storage.ok_or(EvaluateError::UnsupportedCustomFunction)?;
             let CustomFunction {
                 func_name,
                 args,
                 body,
-            } = custom_function_storage
+            } = storage
+                .ok_or(EvaluateError::UnsupportedCustomFunction)?
                 .fetch_function(name)?
                 .ok_or_else(|| EvaluateError::UnsupportedFunction(name.clone()))?;
 

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -213,6 +213,16 @@ fn execute_inner<T: GStore + GStoreMut>(
 
             let foreign_keys = Rc::new(foreign_keys);
 
+            #[cfg(feature = "tracing")]
+            let collect_span = tracing::debug_span!(
+                target: "gluesql",
+                "gluesql.mutation.collect",
+                operation = "update",
+                buffered_rows = tracing::field::Empty
+            );
+            #[cfg(feature = "tracing")]
+            let collect_entered = collect_span.enter();
+
             let rows = fetch(storage, table_name, all_columns, selection.as_ref())?
                 .map(|item| {
                     let (key, row) = item?;
@@ -221,6 +231,12 @@ fn execute_inner<T: GStore + GStoreMut>(
                     Ok((key, row))
                 })
                 .collect::<Result<Vec<(Key, Row)>>>()?;
+
+            #[cfg(feature = "tracing")]
+            {
+                collect_span.record("buffered_rows", rows.len());
+                drop(collect_entered);
+            }
 
             if let Some(column_defs) = column_defs {
                 let column_validation =

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -132,6 +132,16 @@ pub fn execute<T: GStore + GStoreMut>(
     }
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.mutation.collect",
+        fields(operation = "update"),
+        start = before_let(rows, occurrence = 1),
+        end = after_let(rows, occurrence = 1),
+        record(buffered_rows = rows.len())
+    )
+)]
 fn execute_inner<T: GStore + GStoreMut>(
     storage: &mut T,
     statement: &StatementPlan,
@@ -213,16 +223,6 @@ fn execute_inner<T: GStore + GStoreMut>(
 
             let foreign_keys = Rc::new(foreign_keys);
 
-            #[cfg(feature = "tracing")]
-            let collect_span = tracing::debug_span!(
-                target: "gluesql",
-                "gluesql.mutation.collect",
-                operation = "update",
-                buffered_rows = tracing::field::Empty
-            );
-            #[cfg(feature = "tracing")]
-            let collect_entered = collect_span.enter();
-
             let rows = fetch(storage, table_name, all_columns, selection.as_ref())?
                 .map(|item| {
                     let (key, row) = item?;
@@ -231,12 +231,6 @@ fn execute_inner<T: GStore + GStoreMut>(
                     Ok((key, row))
                 })
                 .collect::<Result<Vec<(Key, Row)>>>()?;
-
-            #[cfg(feature = "tracing")]
-            {
-                collect_span.record("buffered_rows", rows.len());
-                drop(collect_entered);
-            }
 
             if let Some(column_defs) = column_defs {
                 let column_validation =

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -19,12 +19,20 @@ pub enum FetchError {
     TableNotFound(String),
 }
 
+pub(crate) fn trace_access_path(access_path: &'static str) {
+    #[cfg(feature = "tracing")]
+    tracing::debug!(target: "gluesql", access_path, "selected query access path");
+    #[cfg(not(feature = "tracing"))]
+    let _ = access_path;
+}
+
 pub fn fetch<'a, T: GStore>(
     storage: &'a T,
     table_name: &'a str,
     columns: Rc<[String]>,
     where_clause: Option<&'a ExprPlan>,
 ) -> Result<KeyedRows<'a>> {
+    trace_access_path("full_scan");
     let rows = storage.scan_data(table_name)?.filter_map(move |row| {
         let (key, values) = match row {
             Ok(row) => row,

--- a/core/src/executor/fetch.rs
+++ b/core/src/executor/fetch.rs
@@ -19,20 +19,16 @@ pub enum FetchError {
     TableNotFound(String),
 }
 
-pub(crate) fn trace_access_path(access_path: &'static str) {
-    #[cfg(feature = "tracing")]
-    tracing::debug!(target: "gluesql", access_path, "selected query access path");
-    #[cfg(not(feature = "tracing"))]
-    let _ = access_path;
-}
-
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(event("selected query access path", access_path = "full_scan"))
+)]
 pub fn fetch<'a, T: GStore>(
     storage: &'a T,
     table_name: &'a str,
     columns: Rc<[String]>,
     where_clause: Option<&'a ExprPlan>,
 ) -> Result<KeyedRows<'a>> {
-    trace_access_path("full_scan");
     let rows = storage.scan_data(table_name)?.filter_map(move |row| {
         let (key, values) = match row {
             Ok(row) => row,

--- a/core/src/executor/insert/schemaful.rs
+++ b/core/src/executor/insert/schemaful.rs
@@ -15,6 +15,16 @@ use {
     std::rc::Rc,
 };
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.insert.collect",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 pub(super) fn fetch_rows<T: GStore>(
     storage: &T,
     table_name: &str,
@@ -71,6 +81,9 @@ pub(super) fn fetch_rows<T: GStore>(
         Box::new(rows)
     };
     let rows = rows_iter.collect::<Result<Vec<Vec<Value>>>>()?;
+
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_rows", rows.len());
 
     validate_unique(
         storage,

--- a/core/src/executor/insert/schemaful.rs
+++ b/core/src/executor/insert/schemaful.rs
@@ -17,12 +17,11 @@ use {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.insert.collect",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        after_let(rows, occurrence = 3, record(buffered_rows = rows.len()))
     )
 )]
 pub(super) fn fetch_rows<T: GStore>(
@@ -81,9 +80,6 @@ pub(super) fn fetch_rows<T: GStore>(
         Box::new(rows)
     };
     let rows = rows_iter.collect::<Result<Vec<Vec<Value>>>>()?;
-
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_rows", rows.len());
 
     validate_unique(
         storage,

--- a/core/src/executor/insert/schemaless.rs
+++ b/core/src/executor/insert/schemaless.rs
@@ -13,6 +13,16 @@ use {
     std::collections::BTreeMap,
 };
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.insert.collect",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 pub(super) fn fetch_rows<T: GStore>(storage: &T, source: &QueryPlan) -> Result<Vec<Vec<Value>>> {
     let rows_iter: Box<dyn Iterator<Item = Result<Vec<Value>>> + '_> =
         if let Some(rows) = values::execute(source, values_rows)? {
@@ -26,6 +36,9 @@ pub(super) fn fetch_rows<T: GStore>(storage: &T, source: &QueryPlan) -> Result<V
             Box::new(rows)
         };
     let rows = rows_iter.collect::<Result<Vec<Vec<Value>>>>()?;
+
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_rows", rows.len());
 
     Ok(rows)
 }

--- a/core/src/executor/insert/schemaless.rs
+++ b/core/src/executor/insert/schemaless.rs
@@ -15,12 +15,11 @@ use {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.insert.collect",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        on_ok(rows, record(buffered_rows = rows.len()))
     )
 )]
 pub(super) fn fetch_rows<T: GStore>(storage: &T, source: &QueryPlan) -> Result<Vec<Vec<Value>>> {
@@ -36,9 +35,6 @@ pub(super) fn fetch_rows<T: GStore>(storage: &T, source: &QueryPlan) -> Result<V
             Box::new(rows)
         };
     let rows = rows_iter.collect::<Result<Vec<Vec<Value>>>>()?;
-
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_rows", rows.len());
 
     Ok(rows)
 }

--- a/core/src/executor/query/aggregation.rs
+++ b/core/src/executor/query/aggregation.rs
@@ -25,6 +25,16 @@ pub(super) struct AggregatedRows<'a> {
     pub(super) rows: Vec<AggregateContext<'a>>,
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.query.aggregate",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_groups = tracing::field::Empty)
+    )
+)]
 pub(super) fn execute<'a, T>(
     storage: &'a T,
     plan: &'a AggregationPlan,
@@ -71,6 +81,9 @@ where
     }
 
     let rows = state.export(aggregate_slots)?;
+
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_groups", rows.len());
 
     Ok(AggregatedRows { sources, rows })
 }

--- a/core/src/executor/query/aggregation.rs
+++ b/core/src/executor/query/aggregation.rs
@@ -27,12 +27,11 @@ pub(super) struct AggregatedRows<'a> {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.query.aggregate",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_groups = tracing::field::Empty)
+        after_let(rows, occurrence = 2, record(buffered_groups = rows.len()))
     )
 )]
 pub(super) fn execute<'a, T>(
@@ -81,9 +80,6 @@ where
     }
 
     let rows = state.export(aggregate_slots)?;
-
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_groups", rows.len());
 
     Ok(AggregatedRows { sources, rows })
 }

--- a/core/src/executor/query/distinct.rs
+++ b/core/src/executor/query/distinct.rs
@@ -9,6 +9,16 @@ use {
     std::{collections::HashSet, rc::Rc},
 };
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.query.distinct",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 pub(super) fn execute<'a, T>(
     storage: &'a T,
     plan: &'a DistinctPlan,
@@ -33,6 +43,9 @@ where
         }
     }?;
     let rows = rows.collect::<Result<Vec<_>>>()?;
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_rows", rows.len());
+
     let mut seen = HashSet::new();
     let rows = rows
         .into_iter()

--- a/core/src/executor/query/distinct.rs
+++ b/core/src/executor/query/distinct.rs
@@ -11,12 +11,11 @@ use {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.query.distinct",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        after_let(rows, occurrence = 4, record(buffered_rows = rows.len()))
     )
 )]
 pub(super) fn execute<'a, T>(
@@ -43,8 +42,6 @@ where
         }
     }?;
     let rows = rows.collect::<Result<Vec<_>>>()?;
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_rows", rows.len());
 
     let mut seen = HashSet::new();
     let rows = rows

--- a/core/src/executor/query/join/hash.rs
+++ b/core/src/executor/query/join/hash.rs
@@ -74,6 +74,16 @@ pub(super) fn execute<'a, T: GStore>(
     })
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.query.hash_join.build",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 fn build_rows<'a, T: GStore>(
     storage: &'a T,
     source: source::PreparedSource<'a>,
@@ -101,6 +111,9 @@ fn build_rows<'a, T: GStore>(
             rows.push((key, row));
         }
     }
+
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_rows", rows.len());
 
     Ok((rows.into_iter().into_group_map(), source.output))
 }

--- a/core/src/executor/query/join/hash.rs
+++ b/core/src/executor/query/join/hash.rs
@@ -76,12 +76,11 @@ pub(super) fn execute<'a, T: GStore>(
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.query.hash_join.build",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        after_loop(row, record(buffered_rows = rows.len()))
     )
 )]
 fn build_rows<'a, T: GStore>(
@@ -111,9 +110,6 @@ fn build_rows<'a, T: GStore>(
             rows.push((key, row));
         }
     }
-
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_rows", rows.len());
 
     Ok((rows.into_iter().into_group_map(), source.output))
 }

--- a/core/src/executor/query/order_by/select.rs
+++ b/core/src/executor/query/order_by/select.rs
@@ -41,6 +41,16 @@ where
     Ok(LabeledRows { labels, rows })
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.query.order_by",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 fn sort<'a, T>(
     storage: &'a T,
     context: Option<&Rc<RowContext<'a>>>,
@@ -57,6 +67,9 @@ where
     }
 
     let rows = rows.collect::<Result<Vec<_>>>()?;
+    #[cfg(feature = "tracing")]
+    tracing::Span::current().record("buffered_rows", rows.len());
+
     let mut keyed_rows = Vec::with_capacity(rows.len());
     for (aggregated, next, row) in rows {
         enum SortType<'a> {

--- a/core/src/executor/query/order_by/select.rs
+++ b/core/src/executor/query/order_by/select.rs
@@ -43,12 +43,11 @@ where
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.query.order_by",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        after_let(rows, occurrence = 1, record(buffered_rows = rows.len()))
     )
 )]
 fn sort<'a, T>(
@@ -67,8 +66,6 @@ where
     }
 
     let rows = rows.collect::<Result<Vec<_>>>()?;
-    #[cfg(feature = "tracing")]
-    tracing::Span::current().record("buffered_rows", rows.len());
 
     let mut keyed_rows = Vec::with_capacity(rows.len());
     for (aggregated, next, row) in rows {

--- a/core/src/executor/query/source/table.rs
+++ b/core/src/executor/query/source/table.rs
@@ -5,7 +5,11 @@ use {
     },
     crate::{
         data::{Key, Row},
-        executor::{context::RowContext, evaluate::evaluate, fetch::fetch_columns},
+        executor::{
+            context::RowContext,
+            evaluate::evaluate,
+            fetch::{fetch_columns, trace_access_path},
+        },
         plan::{TableAccessPlan, TableSourcePlan},
         result::Result,
         store::GStore,
@@ -71,6 +75,7 @@ fn rows<'a, T: GStore>(
     let columns = Rc::clone(&source.names);
     let rows = match &table.access {
         TableAccessPlan::FullScan => {
+            trace_access_path("full_scan");
             let rows = storage.scan_data(&table.name)?.map({
                 let columns = Rc::clone(&columns);
 
@@ -102,6 +107,7 @@ fn rows<'a, T: GStore>(
             let value = evaluated.try_into_value(&column_def.data_type, column_def.nullable)?;
             let key = Key::try_from(value)?;
 
+            trace_access_path("primary_key");
             match storage.fetch_data(&table.name, &key)? {
                 Some(values) => Box::new(iter::once(Ok(Row {
                     columns: Rc::clone(&columns),
@@ -123,6 +129,7 @@ fn rows<'a, T: GStore>(
                 }
                 None => None,
             };
+            trace_access_path("secondary_index");
             let rows = storage
                 .scan_indexed_data(&table.name, name, *asc, predicate)?
                 .map({

--- a/core/src/executor/query/source/table.rs
+++ b/core/src/executor/query/source/table.rs
@@ -5,11 +5,7 @@ use {
     },
     crate::{
         data::{Key, Row},
-        executor::{
-            context::RowContext,
-            evaluate::evaluate,
-            fetch::{fetch_columns, trace_access_path},
-        },
+        executor::{context::RowContext, evaluate::evaluate, fetch::fetch_columns},
         plan::{TableAccessPlan, TableSourcePlan},
         result::Result,
         store::GStore,
@@ -66,6 +62,21 @@ pub(super) fn execute<'a, T: GStore>(
     Ok(PreparedSource { output, rows })
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        before_let(
+            rows,
+            occurrence = 2,
+            event("selected query access path", access_path = "full_scan")
+        ),
+        after_let(key, event("selected query access path", access_path = "primary_key")),
+        after_let(
+            predicate,
+            event("selected query access path", access_path = "secondary_index")
+        )
+    )
+)]
 fn rows<'a, T: GStore>(
     storage: &'a T,
     table: &'a TableSourcePlan,
@@ -75,7 +86,6 @@ fn rows<'a, T: GStore>(
     let columns = Rc::clone(&source.names);
     let rows = match &table.access {
         TableAccessPlan::FullScan => {
-            trace_access_path("full_scan");
             let rows = storage.scan_data(&table.name)?.map({
                 let columns = Rc::clone(&columns);
 
@@ -107,7 +117,6 @@ fn rows<'a, T: GStore>(
             let value = evaluated.try_into_value(&column_def.data_type, column_def.nullable)?;
             let key = Key::try_from(value)?;
 
-            trace_access_path("primary_key");
             match storage.fetch_data(&table.name, &key)? {
                 Some(values) => Box::new(iter::once(Ok(Row {
                     columns: Rc::clone(&columns),
@@ -129,7 +138,6 @@ fn rows<'a, T: GStore>(
                 }
                 None => None,
             };
-            trace_access_path("secondary_index");
             let rows = storage
                 .scan_indexed_data(&table.name, name, *asc, predicate)?
                 .map({

--- a/core/src/executor/select.rs
+++ b/core/src/executor/select.rs
@@ -11,23 +11,41 @@ use {
     },
 };
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.result.materialize",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(buffered_rows = tracing::field::Empty)
+    )
+)]
 pub(super) fn execute<T: GStore>(storage: &T, query: &QueryPlan) -> Result<Payload> {
     let (labels, rows) = query::execute_with_labels(storage, query, None)?;
 
     if is_schemaless_map(query) {
-        rows.map(|row| {
-            let mut values = row?.into_values().into_iter();
-            match (values.next(), values.next()) {
-                (Some(Value::Map(map)), None) => Ok(map),
-                _ => Err(ExecuteError::ExpectedMapValueInDocColumn.into()),
-            }
-        })
-        .collect::<Result<Vec<_>>>()
-        .map(Payload::SelectMap)
+        let rows = rows
+            .map(|row| {
+                let mut values = row?.into_values().into_iter();
+                match (values.next(), values.next()) {
+                    (Some(Value::Map(map)), None) => Ok(map),
+                    _ => Err(ExecuteError::ExpectedMapValueInDocColumn.into()),
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("buffered_rows", rows.len());
+
+        Ok(Payload::SelectMap(rows))
     } else {
-        rows.map(|row| Ok(row?.into_values()))
-            .collect::<Result<Vec<_>>>()
-            .map(|rows| Payload::Select { labels, rows })
+        let rows = rows
+            .map(|row| Ok(row?.into_values()))
+            .collect::<Result<Vec<_>>>()?;
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("buffered_rows", rows.len());
+
+        Ok(Payload::Select { labels, rows })
     }
 }
 

--- a/core/src/executor/select.rs
+++ b/core/src/executor/select.rs
@@ -13,12 +13,12 @@ use {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.result.materialize",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(buffered_rows = tracing::field::Empty)
+        after_let(rows, occurrence = 2, record(buffered_rows = rows.len())),
+        after_let(rows, occurrence = 3, record(buffered_rows = rows.len()))
     )
 )]
 pub(super) fn execute<T: GStore>(storage: &T, query: &QueryPlan) -> Result<Payload> {
@@ -34,16 +34,12 @@ pub(super) fn execute<T: GStore>(storage: &T, query: &QueryPlan) -> Result<Paylo
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        #[cfg(feature = "tracing")]
-        tracing::Span::current().record("buffered_rows", rows.len());
 
         Ok(Payload::SelectMap(rows))
     } else {
         let rows = rows
             .map(|row| Ok(row?.into_values()))
             .collect::<Result<Vec<_>>>()?;
-        #[cfg(feature = "tracing")]
-        tracing::Span::current().record("buffered_rows", rows.len());
 
         Ok(Payload::Select { labels, rows })
     }

--- a/core/src/executor/select.rs
+++ b/core/src/executor/select.rs
@@ -17,31 +17,30 @@ use {
         name = "gluesql.result.materialize",
         target = "gluesql",
         level = "debug",
-        after_let(rows, occurrence = 2, record(buffered_rows = rows.len())),
-        after_let(rows, occurrence = 3, record(buffered_rows = rows.len()))
+        on_ok(payload, record(buffered_rows = match payload {
+            Payload::Select { rows, .. } => rows.len(),
+            Payload::SelectMap(rows) => rows.len(),
+            _ => unreachable!("select executor returned a non-select payload"),
+        }))
     )
 )]
 pub(super) fn execute<T: GStore>(storage: &T, query: &QueryPlan) -> Result<Payload> {
     let (labels, rows) = query::execute_with_labels(storage, query, None)?;
 
     if is_schemaless_map(query) {
-        let rows = rows
-            .map(|row| {
-                let mut values = row?.into_values().into_iter();
-                match (values.next(), values.next()) {
-                    (Some(Value::Map(map)), None) => Ok(map),
-                    _ => Err(ExecuteError::ExpectedMapValueInDocColumn.into()),
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(Payload::SelectMap(rows))
+        rows.map(|row| {
+            let mut values = row?.into_values().into_iter();
+            match (values.next(), values.next()) {
+                (Some(Value::Map(map)), None) => Ok(map),
+                _ => Err(ExecuteError::ExpectedMapValueInDocColumn.into()),
+            }
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Payload::SelectMap)
     } else {
-        let rows = rows
-            .map(|row| Ok(row?.into_values()))
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(Payload::Select { labels, rows })
+        rows.map(|row| Ok(row?.into_values()))
+            .collect::<Result<Vec<_>>>()
+            .map(|rows| Payload::Select { labels, rows })
     }
 }
 

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -76,6 +76,16 @@ impl UniqueConstraint {
     }
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.validate.unique",
+        target = "gluesql",
+        level = "debug",
+        skip_all,
+        fields(scanned_rows = tracing::field::Empty)
+    )
+)]
 pub fn validate_unique<'a, T: Store>(
     storage: &T,
     table_name: &str,
@@ -135,8 +145,14 @@ pub fn validate_unique<'a, T: Store>(
                 return Ok(());
             }
 
+            #[cfg(feature = "tracing")]
+            let mut scanned_rows = 0_usize;
             for row in storage.scan_data(table_name)? {
                 let (_, values) = row?;
+                #[cfg(feature = "tracing")]
+                {
+                    scanned_rows += 1;
+                }
                 for constraint in &unique_constraints {
                     let col_idx = constraint.column_index;
                     let val = values
@@ -146,6 +162,9 @@ pub fn validate_unique<'a, T: Store>(
                     constraint.check(val)?;
                 }
             }
+
+            #[cfg(feature = "tracing")]
+            tracing::Span::current().record("scanned_rows", scanned_rows);
 
             Ok(())
         }

--- a/core/src/executor/validate.rs
+++ b/core/src/executor/validate.rs
@@ -78,12 +78,11 @@ impl UniqueConstraint {
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
+    gluesql_macros::observe(
         name = "gluesql.validate.unique",
         target = "gluesql",
         level = "debug",
-        skip_all,
-        fields(scanned_rows = tracing::field::Empty)
+        count_loop(binding = row, increment = after_let(values), field = scanned_rows)
     )
 )]
 pub fn validate_unique<'a, T: Store>(
@@ -145,14 +144,8 @@ pub fn validate_unique<'a, T: Store>(
                 return Ok(());
             }
 
-            #[cfg(feature = "tracing")]
-            let mut scanned_rows = 0_usize;
             for row in storage.scan_data(table_name)? {
                 let (_, values) = row?;
-                #[cfg(feature = "tracing")]
-                {
-                    scanned_rows += 1;
-                }
                 for constraint in &unique_constraints {
                     let col_idx = constraint.column_index;
                     let val = values
@@ -162,9 +155,6 @@ pub fn validate_unique<'a, T: Store>(
                     constraint.check(val)?;
                 }
             }
-
-            #[cfg(feature = "tracing")]
-            tracing::Span::current().record("scanned_rows", scanned_rows);
 
             Ok(())
         }

--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -20,58 +20,40 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
         Self { storage }
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        gluesql_macros::observe(name = "gluesql.plan", target = "gluesql", level = "debug")
-    )]
-    fn plan_statement(&self, statement: StatementPlan) -> Result<StatementPlan> {
-        self.storage.plan(statement)
-    }
-
-    #[cfg_attr(
-        feature = "tracing",
-        gluesql_macros::observe(
-            name = "gluesql.plan_sql",
-            target = "gluesql",
-            level = "debug",
-            fields(
-                sql = %sql,
-                params = ?params
-            )
-        )
-    )]
-    fn plan_param_literals(
-        &self,
-        sql: &str,
-        params: &[ParamLiteral],
-    ) -> Result<Vec<StatementPlan>> {
-        parse(sql)?
-            .into_iter()
-            .map(|p| {
-                translate_with_params(&p, params)
-                    .and_then(|statement| self.plan_statement(statement.into()))
-            })
-            .collect()
-    }
-
     /// Plans all statements in the SQL string using the supplied parameters.
     ///
     /// # Errors
     ///
     /// Returns an error when parsing the SQL text fails or when building an execution plan for
     /// a statement fails.
+    #[cfg_attr(
+        feature = "tracing",
+        gluesql_macros::observe(
+            name = "gluesql.plan",
+            target = "gluesql",
+            level = "debug",
+            fields(sql = %sql.as_ref()),
+            after_let(params, record(params = ?params))
+        )
+    )]
     pub fn plan_with_params<Sql, I, P>(&mut self, sql: Sql, params: I) -> Result<Vec<StatementPlan>>
     where
         Sql: AsRef<str>,
         I: IntoIterator<Item = P>,
         P: IntoParamLiteral,
     {
+        let parsed = parse(sql)?;
         let params: Vec<ParamLiteral> = params
             .into_iter()
             .map(IntoParamLiteral::into_param_literal)
             .collect();
-
-        self.plan_param_literals(sql.as_ref(), &params)
+        parsed
+            .into_iter()
+            .map(|p| {
+                translate_with_params(&p, &params)
+                    .and_then(|statement| self.storage.plan(statement.into()))
+            })
+            .collect()
     }
 
     /// Plans all statements in the SQL string without parameters.
@@ -110,8 +92,7 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
             level = "info",
             fields(
                 sql = %sql.as_ref()
-            ),
-            after_let(params, record(params = ?params))
+            )
         )
     )]
     pub fn execute_with_params<Sql, I, P>(&mut self, sql: Sql, params: I) -> Result<Vec<Payload>>
@@ -120,11 +101,7 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
         I: IntoIterator<Item = P>,
         P: IntoParamLiteral,
     {
-        let params: Vec<ParamLiteral> = params
-            .into_iter()
-            .map(IntoParamLiteral::into_param_literal)
-            .collect();
-        let statements = self.plan_param_literals(sql.as_ref(), &params)?;
+        let statements = self.plan_with_params(sql, params)?;
         let mut payloads = Vec::<Payload>::new();
         for statement in &statements {
             let payload = self.execute_stmt(statement)?;

--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -14,7 +14,45 @@ pub struct Glue<T: GStore + GStoreMut + Planner> {
 
 impl<T: GStore + GStoreMut + Planner> Glue<T> {
     pub fn new(storage: T) -> Self {
+        #[cfg(feature = "tracing")]
+        crate::__private::ensure_default_subscriber();
+
         Self { storage }
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "gluesql.plan", target = "gluesql", level = "debug", skip_all)
+    )]
+    fn plan_statement(&self, statement: StatementPlan) -> Result<StatementPlan> {
+        self.storage.plan(statement)
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "gluesql.plan_sql",
+            target = "gluesql",
+            level = "debug",
+            skip_all,
+            fields(
+                sql = %sql,
+                params = ?params
+            )
+        )
+    )]
+    fn plan_param_literals(
+        &self,
+        sql: &str,
+        params: &[ParamLiteral],
+    ) -> Result<Vec<StatementPlan>> {
+        parse(sql)?
+            .into_iter()
+            .map(|p| {
+                translate_with_params(&p, params)
+                    .and_then(|statement| self.plan_statement(statement.into()))
+            })
+            .collect()
     }
 
     /// Plans all statements in the SQL string using the supplied parameters.
@@ -29,18 +67,12 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
         I: IntoIterator<Item = P>,
         P: IntoParamLiteral,
     {
-        let parsed = parse(sql)?;
         let params: Vec<ParamLiteral> = params
             .into_iter()
             .map(IntoParamLiteral::into_param_literal)
             .collect();
-        parsed
-            .into_iter()
-            .map(|p| {
-                translate_with_params(&p, &params)
-                    .and_then(|statement| self.storage.plan(statement.into()))
-            })
-            .collect()
+
+        self.plan_param_literals(sql.as_ref(), &params)
     }
 
     /// Plans all statements in the SQL string without parameters.
@@ -53,6 +85,15 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
         self.plan_with_params(sql, std::iter::empty::<ParamLiteral>())
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "gluesql.execute_statement",
+            target = "gluesql",
+            level = "debug",
+            skip_all
+        )
+    )]
     pub fn execute_stmt(&mut self, statement: &StatementPlan) -> Result<Payload> {
         execute(&mut self.storage, statement)
     }
@@ -63,13 +104,32 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
     ///
     /// Returns an error when parsing fails, planning fails, or executing a statement
     /// against the storage fails.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "gluesql.execute",
+            target = "gluesql",
+            level = "info",
+            skip_all,
+            fields(
+                sql = %sql.as_ref(),
+                params = tracing::field::Empty
+            )
+        )
+    )]
     pub fn execute_with_params<Sql, I, P>(&mut self, sql: Sql, params: I) -> Result<Vec<Payload>>
     where
         Sql: AsRef<str>,
         I: IntoIterator<Item = P>,
         P: IntoParamLiteral,
     {
-        let statements = self.plan_with_params(sql, params)?;
+        let params: Vec<ParamLiteral> = params
+            .into_iter()
+            .map(IntoParamLiteral::into_param_literal)
+            .collect();
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("params", tracing::field::debug(&params));
+        let statements = self.plan_param_literals(sql.as_ref(), &params)?;
         let mut payloads = Vec::<Payload>::new();
         for statement in &statements {
             let payload = self.execute_stmt(statement)?;

--- a/core/src/glue.rs
+++ b/core/src/glue.rs
@@ -22,7 +22,7 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "gluesql.plan", target = "gluesql", level = "debug", skip_all)
+        gluesql_macros::observe(name = "gluesql.plan", target = "gluesql", level = "debug")
     )]
     fn plan_statement(&self, statement: StatementPlan) -> Result<StatementPlan> {
         self.storage.plan(statement)
@@ -30,11 +30,10 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(
+        gluesql_macros::observe(
             name = "gluesql.plan_sql",
             target = "gluesql",
             level = "debug",
-            skip_all,
             fields(
                 sql = %sql,
                 params = ?params
@@ -87,11 +86,10 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(
+        gluesql_macros::observe(
             name = "gluesql.execute_statement",
             target = "gluesql",
             level = "debug",
-            skip_all
         )
     )]
     pub fn execute_stmt(&mut self, statement: &StatementPlan) -> Result<Payload> {
@@ -106,15 +104,14 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
     /// against the storage fails.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(
+        gluesql_macros::observe(
             name = "gluesql.execute",
             target = "gluesql",
             level = "info",
-            skip_all,
             fields(
-                sql = %sql.as_ref(),
-                params = tracing::field::Empty
-            )
+                sql = %sql.as_ref()
+            ),
+            after_let(params, record(params = ?params))
         )
     )]
     pub fn execute_with_params<Sql, I, P>(&mut self, sql: Sql, params: I) -> Result<Vec<Payload>>
@@ -127,8 +124,6 @@ impl<T: GStore + GStoreMut + Planner> Glue<T> {
             .into_iter()
             .map(IntoParamLiteral::into_param_literal)
             .collect();
-        #[cfg(feature = "tracing")]
-        tracing::Span::current().record("params", tracing::field::debug(&params));
         let statements = self.plan_param_literals(sql.as_ref(), &params)?;
         let mut payloads = Vec::<Payload>::new();
         for statement in &statements {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,6 +18,10 @@ pub mod row_conversion;
 pub mod store;
 pub mod translate;
 
+#[cfg(feature = "tracing")]
+#[doc(hidden)]
+pub mod __private;
+
 pub mod prelude {
     pub use crate::{
         ast::DataType,

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -14,6 +14,10 @@ use {
 
 const DIALECT: PostgreSqlDialect = PostgreSqlDialect {};
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(name = "gluesql.parse", target = "gluesql", level = "debug", skip_all)
+)]
 pub fn parse<Sql: AsRef<str>>(sql: Sql) -> Result<Vec<SqlStatement>> {
     Parser::parse_sql(&DIALECT, sql.as_ref()).map_err(|e| Error::Parser(format!("{e:#?}")))
 }

--- a/core/src/parse_sql.rs
+++ b/core/src/parse_sql.rs
@@ -16,7 +16,7 @@ const DIALECT: PostgreSqlDialect = PostgreSqlDialect {};
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(name = "gluesql.parse", target = "gluesql", level = "debug", skip_all)
+    gluesql_macros::observe(name = "gluesql.parse", target = "gluesql", level = "debug")
 )]
 pub fn parse<Sql: AsRef<str>>(sql: Sql) -> Result<Vec<SqlStatement>> {
     Parser::parse_sql(&DIALECT, sql.as_ref()).map_err(|e| Error::Parser(format!("{e:#?}")))

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -58,6 +58,15 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
 ///
 /// Returns an error when converting the provided parameters fails or when the SQL statement
 /// uses syntax `GlueSQL` does not support.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "gluesql.translate",
+        target = "gluesql",
+        level = "debug",
+        skip_all
+    )
+)]
 pub fn translate_with_params(
     sql_statement: &SqlStatement,
     params: &[ParamLiteral],

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -60,12 +60,7 @@ pub fn translate(sql_statement: &SqlStatement) -> Result<Statement> {
 /// uses syntax `GlueSQL` does not support.
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(
-        name = "gluesql.translate",
-        target = "gluesql",
-        level = "debug",
-        skip_all
-    )
+    gluesql_macros::observe(name = "gluesql.translate", target = "gluesql", level = "debug",)
 )]
 pub fn translate_with_params(
     sql_statement: &SqlStatement,

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -250,6 +250,76 @@ memory and these spans to locate the corresponding execution boundary.
 
 ## Declaring function observations
 
+### Run a complete example
+
+From the root of this GlueSQL checkout, copy and run:
+
+```sh
+cargo run -p gluesql-macros --example observe
+```
+
+This runs `macros/examples/observe.rs`; no database, external collector, or extra installation
+is needed beyond the repository's Rust build prerequisites. The example installs a console
+subscriber at DEBUG level and enables span-close events so that recorded fields are visible.
+It fixes the level in code, so `RUST_LOG` does not change this example's output.
+
+To save its logs in your home directory while leaving the check result on the terminal:
+
+```sh
+cargo run --quiet -p gluesql-macros --example observe 2> "$HOME/gluesql-observe-example.log"
+less "$HOME/gluesql-observe-example.log"
+```
+
+Cargo diagnostics also use stderr and may appear in that file. The program prints
+`All observation example checks passed.` on success. It exercises these three cases:
+
+| Call | Expected observation |
+| --- | --- |
+| `collect(&[1, 2, 3])` | `gluesql.example.collect` closes with `input_rows=3`, `buffered_rows=3`, `scanned_rows=3`, and `returned_rows=3`. |
+| `collect(&[1, -2, 3])` | An error event contains `negative row`; the span closes with `scanned_rows=2` and no recorded `returned_rows` value. |
+| `count_keys(&[1, 2, 3])` | `gluesql.example.collect_keys` closes with `buffered_rows=3`; work after `let num_keys` is outside this span. |
+
+The tracing output is:
+
+```text
+DEBUG gluesql.example.collect{input_rows=3 buffered_rows=3 scanned_rows=3 returned_rows=3}: gluesql: close
+ERROR gluesql.example.collect{input_rows=3 buffered_rows=3 scanned_rows=2}: gluesql: error="negative row"
+DEBUG gluesql.example.collect{input_rows=3 buffered_rows=3 scanned_rows=2}: gluesql: close
+DEBUG gluesql.example.collect_keys{buffered_rows=3}: gluesql: close
+```
+
+For example, the first function is fully defined as follows; its body contains no tracing calls:
+
+```rust
+#[gluesql_macros::observe(
+    name = "gluesql.example.collect",
+    fields(input_rows = input.len()),
+    after_let(rows, record(buffered_rows = rows.len())),
+    count_loop(binding = row, field = scanned_rows),
+    on_ok(rows, record(returned_rows = rows.len())),
+    err(Debug)
+)]
+fn collect(input: &[i32]) -> Result<Vec<i32>, &'static str> {
+    let rows = input.to_vec();
+    for row in &rows {
+        if *row < 0 {
+            return Err("negative row");
+        }
+    }
+    Ok(rows)
+}
+```
+
+`buffered_rows` counts items, not bytes or RSS. The failed call counts the second loop entry
+before returning the error; `on_ok` runs only for the successful call.
+
+This macro-crate example deliberately uses the attribute directly and the crate's existing
+development dependencies, so it needs no `--features tracing` flag. In a consuming crate,
+keep tracing optional using `cfg_attr` and optional dependencies as described below. The
+remaining snippets are integration patterns, not standalone programs.
+
+### Integrate with an existing function
+
 Use `gluesql_macros::observe` to keep instrumentation out of function bodies. The attribute
 supports non-const functions and methods. Synchronous functions support all selectors below;
 async functions support whole-function spans with `name`, `level`, `target`, `fields`, and

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -248,6 +248,184 @@ memory increase:
 The counts describe logical items rather than allocated bytes. Use the RSS counter for process
 memory and these spans to locate the corresponding execution boundary.
 
+## Declaring function observations
+
+Use `gluesql_macros::observe` to keep instrumentation out of function bodies. The attribute
+supports synchronous, non-const functions and methods. Enable optional `gluesql-macros` and
+`tracing` dependencies through the consuming crate's `tracing` feature, as in the storage setup
+above. Always use `cfg_attr`: without the feature, the original function is compiled without
+generated spans, counters, or field expressions.
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(name = "gluesql.evaluate", level = "trace")
+)]
+fn evaluate(/* existing arguments */) -> Result<Evaluated<'_>> {
+    // Existing implementation.
+}
+```
+
+`name` is required. `level` defaults to `debug` and accepts `trace`, `debug`, `info`, `warn`, or
+`error`; `target` defaults to `gluesql`. A function observation ends on normal return, early
+return, error propagation with `?`, or unwinding. It measures the function call, not subsequent
+consumption of a returned iterator. Continue using `trace_storage` for lazy storage iterators.
+The attribute does not install a subscriber.
+
+### Initial fields and local values
+
+Use `fields` for values available when the observation starts:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.storage.lookup",
+        fields(backend = "example", table = table_name, key = ?key)
+    )
+)]
+fn lookup(/* existing arguments */) -> Result<Option<DataRow>> {
+    // Existing implementation.
+}
+```
+
+`?value` records `Debug` formatting and `%value` records `Display` formatting. Expressions are
+borrowed, not consumed, and are evaluated only when the generated span is enabled.
+
+Use `after_let` for values available inside the function. The macro declares the recorded fields
+automatically and inserts the recording immediately after the selected initialization succeeds:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.query.aggregate",
+        after_let(rows, occurrence = 2, record(buffered_groups = rows.len()))
+    )
+)]
+fn execute(/* existing arguments */) -> Result<AggregatedRows<'_>> {
+    // Existing implementation, including the original `let rows` declarations.
+}
+```
+
+Selectors match bound identifiers, including tuple and struct destructuring. They search the
+function's blocks in source order, counting a declaration before its initializer's nested blocks.
+Parameters, separate item definitions, closure bodies, async blocks, and macro token bodies are
+not searched. A `let` must have an initializer; `if let` and `while let` conditions are not targets.
+
+- Omit `occurrence` when exactly one declaration matches.
+- Use `occurrence = N` to select a declaration, counting from 1.
+- Use `all` to record after every matching declaration, including declarations in separate branches.
+- Repeat `after_let(...)` to select multiple specific declarations or record different fields.
+
+Repeated writes to one span field retain its latest value; they are not time-series samples.
+If initialization returns through `?`, the subsequent record is not reached. If an initializer
+moves a value into an iterator, select an earlier point where the desired buffer still exists.
+
+Use `after_loop(row, record(buffered_rows = rows.len()))` to record after a `for row in ...` loop,
+as in the hash-join build. This selector also accepts `occurrence` or `all`. It records after
+normal completion or a local `break`, but not when the function returns from inside the loop.
+
+### Measuring a partial function interval
+
+Pair `start` and `end` to measure a region without extracting a new function. DELETE uses:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.mutation.collect",
+        fields(operation = "delete"),
+        start = before_let(keys),
+        end = after_let(num_keys),
+        record(buffered_rows = num_keys)
+    )
+)]
+fn delete(/* existing arguments */) -> Result<Payload> {
+    // Existing setup.
+    let mut keys = Vec::new();
+    // Existing key collection and foreign-key validation.
+    let num_keys = keys.len();
+    // Existing storage mutation.
+}
+```
+
+Both endpoints accept `before_let` or `after_let`, with an optional `occurrence`. They must select
+ordered positions in the same block. The span starts only if execution reaches the start point.
+The top-level `record` runs at the end point, before the span is exited and closed. On earlier
+return or unwinding, the span closes without that final record. The storage mutation stays
+outside the collection span.
+
+Range observations support `fields` and the final `record`; they cannot be combined with
+`after_let`, `after_loop`, `count_loop`, or `on_ok` in the same attribute.
+
+### Counting loop iterations
+
+`count_loop(binding = row, field = scanned_rows)` counts entries into a selected `for row in ...`
+body, including iterations that immediately propagate an error. Add an increment point to count
+only after a particular initialization succeeds:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.validate.unique",
+        count_loop(
+            binding = row,
+            increment = after_let(values),
+            field = scanned_rows
+        )
+    )
+)]
+fn validate_unique(/* existing arguments */) -> Result<()> {
+    for row in storage.scan_data(table_name)? {
+        let (_, values) = row?;
+        // Existing validation.
+    }
+    Ok(())
+}
+```
+
+Loop selection accepts `occurrence = N` when its binding is ambiguous. The optional increment
+selector is resolved within that loop body and must identify one declaration. The counter is
+recorded when leaving the loop's surrounding execution region, including error return and
+unwinding. Unlike the previous success-only validation record, errors retain the partial scan
+count. A loop that executes zero iterations records zero; an unreached loop records nothing.
+Instrumentation never pulls additional items from the iterator.
+
+### Recording successful return values
+
+`on_ok` binds a reference to the successful `Result` value and records without cloning or
+consuming it:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        name = "gluesql.insert.collect",
+        on_ok(rows, record(buffered_rows = rows.len()))
+    )
+)]
+fn fetch_rows(/* existing arguments */) -> Result<Vec<Vec<Value>>> {
+    // Existing implementation.
+}
+```
+
+Explicit successful `return` statements are included. Errors pass through unchanged without the
+success record. The return type must be written as `Result<...>` (optionally qualified); aliases
+with other names and opaque `impl Trait` return types are not supported by this option.
+
+### Validation when changing observed code
+
+Missing or ambiguous targets, invalid occurrence numbers, unsupported options, and invalid
+range boundaries produce macro errors. Rust checks expression types and visibility at each
+injected location. A refactor can change which declaration an occurrence selects even when it
+still compiles, so review the attribute alongside the body and verify the recorded values.
+
+Run checks with `tracing` enabled as well as disabled. Selectors are not checked when `cfg_attr`
+disables the macro. Runtime tests in `macros/tests/runtime_observe.rs` cover control flow, disabled
+field evaluation, and query-pipeline buffer counts.
+
 ## Resource benchmark profiles
 
 A resource benchmark groups one SQL workload, query spans, and resource measurements under a

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -144,11 +144,10 @@ not replace it.
 The initial instrumentation follows the query execution pipeline:
 
 ```text
-gluesql.execute { sql, params }
-├── gluesql.plan_sql { sql, params }
+gluesql.execute { sql }
+├── gluesql.plan { sql, params }
 │   ├── gluesql.parse
-│   ├── gluesql.translate
-│   └── gluesql.plan
+│   └── gluesql.translate
 └── gluesql.execute_statement
     ├── gluesql.redb.begin
     ├── gluesql.redb.fetch_data
@@ -885,7 +884,7 @@ profiler. Use `perf` or `cargo-flamegraph` when function-level CPU samples are r
 
 Full tracing deliberately records query and storage values that may contain sensitive data:
 
-- `gluesql.execute` and `gluesql.plan_sql` record SQL source text and bound parameters.
+- `gluesql.execute` records SQL source text, and `gluesql.plan` records the SQL and bound parameters.
 - `trace_storage(capture = "full")` records simple named method arguments, including keys,
   schemas, and rows, together with `Result` errors.
 - `trace_storage` emits an event for every yielded row or error from traced iterators.

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -366,7 +366,8 @@ can leave a span without a matching start or end. Put the condition on their enc
 function instead.
 
 Range observations support `fields` and the final `record`; they cannot be combined with
-`after_let`, `after_loop`, `count_loop`, or `on_ok` in the same attribute.
+`after_let`, `after_loop`, `count_loop`, `on_ok`, or `err(Debug)` in the same attribute. Invalid
+combinations produce a compile error rather than silently omitting error events.
 
 ### Counting loop iterations
 
@@ -422,7 +423,8 @@ fn fetch_rows(/* existing arguments */) -> Result<Vec<Vec<Value>>> {
 
 Explicit successful `return` statements are included. Errors pass through unchanged without the
 success record. The return type must be written as `Result<...>` (optionally qualified); aliases
-with other names and opaque `impl Trait` return types are not supported by this option.
+with other names are not supported. Mutable references and opaque success types such as
+`Result<impl Iterator<Item = Row>, Error>` retain their original return semantics.
 Add `err(Debug)` to emit an error event for a returned `Err`. `trace_storage` uses this same
 function observation generator for method spans, argument fields, and error events; its iterator
 wrapper continues to handle lazy consumption separately.

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -251,7 +251,9 @@ memory and these spans to locate the corresponding execution boundary.
 ## Declaring function observations
 
 Use `gluesql_macros::observe` to keep instrumentation out of function bodies. The attribute
-supports synchronous, non-const functions and methods. Enable optional `gluesql-macros` and
+supports non-const functions and methods. Synchronous functions support all selectors below;
+async functions support whole-function spans with `name`, `level`, `target`, `fields`, and
+`err(Debug)`, entering the span only while their future is polled. Enable optional `gluesql-macros` and
 `tracing` dependencies through the consuming crate's `tracing` feature, as in the storage setup
 above. Always use `cfg_attr`: without the feature, the original function is compiled without
 generated spans, counters, or field expressions.
@@ -266,7 +268,7 @@ fn evaluate(/* existing arguments */) -> Result<Evaluated<'_>> {
 }
 ```
 
-`name` is required. `level` defaults to `debug` and accepts `trace`, `debug`, `info`, `warn`, or
+`name` is required for spans; event-only observations omit it. `level` defaults to `debug` and accepts `trace`, `debug`, `info`, `warn`, or
 `error`; `target` defaults to `gluesql`. A function observation ends on normal return, early
 return, error propagation with `?`, or unwinding. It measures the function call, not subsequent
 consumption of a returned iterator. Continue using `trace_storage` for lazy storage iterators.
@@ -312,6 +314,10 @@ Selectors match bound identifiers, including tuple and struct destructuring. The
 function's blocks in source order, counting a declaration before its initializer's nested blocks.
 Parameters, separate item definitions, closure bodies, async blocks, and macro token bodies are
 not searched. A `let` must have an initializer; `if let` and `while let` conditions are not targets.
+Generated hooks inherit the selected statement's `cfg` and `cfg_attr` attributes. A declaration
+excluded from compilation does not leave a dangling field expression behind. Occurrence numbers
+still count declarations in source order, including conditionally excluded declarations.
+Raw field identifiers such as `r#type` are supported and recorded as `type`.
 
 - Omit `occurrence` when exactly one declaration matches.
 - Use `occurrence = N` to select a declaration, counting from 1.
@@ -355,6 +361,9 @@ ordered positions in the same block. The span starts only if execution reaches t
 The top-level `record` runs at the end point, before the span is exited and closed. On earlier
 return or unwinding, the span closes without that final record. The storage mutation stays
 outside the collection span.
+Endpoints with their own `cfg` or `cfg_attr` are rejected, since separately conditional endpoints
+can leave a span without a matching start or end. Put the condition on their enclosing block or
+function instead.
 
 Range observations support `fields` and the final `record`; they cannot be combined with
 `after_let`, `after_loop`, `count_loop`, or `on_ok` in the same attribute.
@@ -414,6 +423,46 @@ fn fetch_rows(/* existing arguments */) -> Result<Vec<Vec<Value>>> {
 Explicit successful `return` statements are included. Errors pass through unchanged without the
 success record. The return type must be written as `Result<...>` (optionally qualified); aliases
 with other names and opaque `impl Trait` return types are not supported by this option.
+Add `err(Debug)` to emit an error event for a returned `Err`. `trace_storage` uses this same
+function observation generator for method spans, argument fields, and error events; its iterator
+wrapper continues to handle lazy consumption separately.
+
+### Declaring events without a span
+
+Use `event` without `name` when only an event is needed. This preserves the current parent span
+and does not add a new span to the hierarchy:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        event("selected query access path", access_path = "full_scan")
+    )
+)]
+fn fetch(/* existing arguments */) -> Result<KeyedRows<'_>> {
+    // Existing implementation.
+}
+```
+
+Events can also be attached to precise statement boundaries:
+
+```rust
+#[cfg_attr(
+    feature = "tracing",
+    gluesql_macros::observe(
+        after_let(key, event("selected query access path", access_path = "primary_key"))
+    )
+)]
+fn rows(/* existing arguments */) -> Result<SourceRows<'_>> {
+    // Existing implementation.
+}
+```
+
+`before_let` emits before initialization; `after_let` emits after successful initialization;
+`after_loop` emits after loop completion. All accept the same occurrence selection rules as
+recording hooks. Entry events and hooks use the attribute's `level` and `target`. Event expressions
+are evaluated only when the event is enabled. Access-path events use these attributes and leave
+the SQL execution bodies free of logging calls.
 
 ### Validation when changing observed code
 

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -1,0 +1,597 @@
+---
+sidebar_position: 5
+---
+
+# Observability
+
+GlueSQL can emit structured spans and events for query execution when the optional `tracing`
+feature is enabled. The feature is disabled by default, so applications that do not use
+observability do not compile the instrumentation or its dependency.
+
+When `tracing` is enabled, `Glue::new` installs a formatted default subscriber if the process has
+not already configured one. Applications can install their own `tracing-subscriber`, OpenTelemetry,
+or `tracing-flame` subscriber before constructing `Glue`; GlueSQL detects and preserves it. The
+GlueSQL CLI configures its exporter layers before constructing `Glue`.
+
+## CLI logging
+
+Install or build the CLI with tracing enabled:
+
+```sh
+cargo install gluesql --features tracing
+```
+
+Set `RUST_LOG` to select the required detail:
+
+```sh
+RUST_LOG=gluesql=info gluesql
+RUST_LOG=gluesql=debug gluesql
+RUST_LOG=gluesql=trace gluesql
+```
+
+The levels have the following intended scope:
+
+| Level | Data |
+| --- | --- |
+| `info` | Total query execution time, SQL source text, and bound parameters |
+| `debug` | Parse, translate, plan, statement execution, and selected access path |
+| `trace` | Transaction, primary storage, and enabled backend call boundaries |
+
+The CLI reports span close events, including busy and idle durations.
+
+Optional CLI exporter features build on the same instrumentation:
+
+| Feature | Output |
+| --- | --- |
+| `tracing` | Formatted span close events on standard error |
+| `tracing-flame` | Formatted events and folded stack data |
+| `opentelemetry` | Formatted events and OTLP traces over HTTP/Protobuf |
+
+`tracing-flame` and `opentelemetry` both enable `tracing` and can be enabled together.
+
+### Try tracing locally
+
+From the repository root, build the CLI with tracing enabled:
+
+```sh
+cargo build -p gluesql-cli --features tracing
+```
+
+Start the CLI with its default in-memory storage and trace-level logging:
+
+```sh
+RUST_LOG=gluesql=trace \
+./target/debug/gluesql-cli
+```
+
+Run these statements at the `gluesql>` prompt:
+
+```sql
+CREATE TABLE Items (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+INSERT INTO Items VALUES
+    (1, 'apple'),
+    (2, 'banana'),
+    (3, 'cherry');
+
+SELECT * FROM Items WHERE id = 1;
+SELECT * FROM Items;
+```
+
+The query with the primary-key predicate emits an access-path event with
+`access_path="primary_key"`. The query without a predicate emits `access_path="full_scan"`.
+Storage method spans are emitted when that storage enables the optional integration described
+below; RedbStorage is the current reference implementation.
+
+Tracing output is written to standard error. Redirect it to a file while keeping query results in
+the terminal:
+
+```sh
+RUST_LOG=gluesql=trace \
+./target/debug/gluesql-cli 2> ~/gluesql-trace.log
+```
+
+Follow the trace from another terminal:
+
+```sh
+tail -f ~/gluesql-trace.log
+```
+
+## Library logging
+
+Enable GlueSQL instrumentation:
+
+```toml
+[dependencies]
+gluesql = { version = "0.19", features = ["tracing"] }
+```
+
+No initialization call is required. `Glue::new` reads `RUST_LOG` and installs a formatted
+subscriber with span-close events when no dispatcher has previously been set:
+
+```rust
+let mut glue = Glue::new(storage);
+glue.execute("SELECT * FROM Items")?;
+```
+
+To use a custom subscriber, install it before constructing `Glue`:
+
+```toml
+[dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+```
+
+```rust
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
+
+let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+
+tracing_subscriber::fmt()
+    .with_env_filter(filter)
+    .with_span_events(FmtSpan::CLOSE)
+    .init();
+```
+
+The existing subscriber then receives GlueSQL spans under the `gluesql` target, and GlueSQL does
+not replace it.
+
+## Span hierarchy
+
+The initial instrumentation follows the query execution pipeline:
+
+```text
+gluesql.execute { sql, params }
+├── gluesql.plan_sql { sql, params }
+│   ├── gluesql.parse
+│   ├── gluesql.translate
+│   └── gluesql.plan
+└── gluesql.execute_statement
+    ├── gluesql.redb.begin
+    ├── gluesql.redb.fetch_data
+    ├── gluesql.redb.scan_data
+    ├── gluesql.redb.scan_rows
+    └── gluesql.redb.commit
+```
+
+The `gluesql.redb.*` children appear only when RedbStorage's `tracing` feature is enabled. Core
+continues to call storage traits directly; storage implementations opt in to method-level spans.
+
+### Adding tracing support to a storage
+
+A storage opts in without changing its method bodies or any GlueSQL call sites. The procedural
+macro instruments the methods explicitly defined in each attributed `impl` block.
+
+Add the optional macro and tracing dependencies to the storage crate:
+
+```toml
+[features]
+tracing = ["dep:gluesql-macros", "dep:tracing", "gluesql-core/tracing"]
+
+[dependencies]
+gluesql-macros = { version = "0.19", optional = true }
+tracing = { version = "0.1", optional = true }
+```
+
+Apply the attribute to each implemented trait without changing the method bodies or call sites:
+
+```rust
+#[cfg_attr(feature = "tracing", gluesql_macros::trace_storage(name = "my_storage"))]
+impl Store for MyStorage {
+    // Existing implementation
+}
+```
+
+The default `capture = "full"` records every simple named argument with its `Debug`
+representation, records `row_count` for arguments named `rows` or `keys`, and records `Result`
+errors. Use `capture = "off"` to keep only timing. The generated span name follows
+`gluesql.<storage>.<method>`.
+
+`scan_data` and `scan_indexed_data` results are wrapped automatically. The wrapper emits each
+yielded row or error as an event and records `row_count`, `error_count`, and `completed` when
+dropped. For an iterator-returning method on any other trait, mark it inside the attributed
+implementation:
+
+```rust
+#[trace_iterator]
+fn stream(&self) -> Result<Box<dyn Iterator<Item = Result<Row>>>> {
+    // Existing implementation
+}
+```
+
+The attribute works on inherent implementations and external traits as well as GlueSQL storage
+traits. Iterator methods must return a `Result` whose success value is a boxed iterator of
+`Result` items. No subscriber setup is needed when calls begin through `Glue`; direct calls made
+before `Glue::new` use any subscriber already installed by the application.
+
+Access-path events use one of these stable values:
+
+```text
+primary_key
+secondary_index
+full_scan
+```
+
+`scan_data` and `scan_indexed_data` return lazy iterators. Their method spans measure iterator
+creation, while the generated iterator spans measure consumption.
+
+### Backend-specific spans
+
+The `trace_storage` naming and field conventions are the portable observability contract.
+RedbStorage is the first reference implementation: when its `tracing` feature is enabled, it emits
+`gluesql.redb.*` spans for database operations and
+`gluesql.redb.scan_rows{row_count=...}` for lazy iterator consumption. These Redb spans are an
+example, not a requirement for other storages.
+
+For `gluesql.redb.scan_rows`, the busy duration measures row reads and deserialization, the idle
+duration covers time spent by the consumer between reads, and `row_count` records the number of
+yielded items.
+
+When `tracing` is enabled, eager execution boundaries also expose the number of items retained for
+the operation. These fields can be aligned with RSS samples to identify which operation overlaps a
+memory increase:
+
+| Span | Field | Meaning |
+| --- | --- | --- |
+| `gluesql.validate.unique` | `scanned_rows` | Existing rows checked for a unique constraint |
+| `gluesql.query.hash_join.build` | `buffered_rows` | Rows retained on the hash-build side |
+| `gluesql.query.aggregate` | `buffered_groups` | Aggregate groups retained in memory |
+| `gluesql.query.order_by` | `buffered_rows` | Rows collected before sorting |
+| `gluesql.query.distinct` | `buffered_rows` | Rows collected before duplicate filtering |
+| `gluesql.mutation.collect` | `buffered_rows` | UPDATE rows or DELETE keys collected before mutation |
+| `gluesql.insert.collect` | `buffered_rows` | VALUES or query rows collected before insertion |
+| `gluesql.result.materialize` | `buffered_rows` | SELECT rows collected for the returned payload |
+
+The counts describe logical items rather than allocated bytes. Use the RSS counter for process
+memory and these spans to locate the corresponding execution boundary.
+
+## Resource benchmark profiles
+
+A resource benchmark groups one SQL workload, query spans, and resource measurements under a
+`gluesql.benchmark.run` span. The field names and Firefox Profiler representation below are shared
+across storage implementations. The current runnable reference is in the RedbStorage crate; it is
+not the definition of the generic storage tracing contract.
+
+Execute the SQL file once and use its filename without the extension as `benchmark.name`. The
+closing benchmark span uses these storage-independent fields:
+
+| Field | Meaning |
+| --- | --- |
+| `process.memory.peak_bytes` | Peak resident set size of the benchmark process |
+| `gluesql.database.size_bytes` | Storage-owned persistent data size after the workload, when measurable |
+| `process.executable.size_bytes` | Benchmark executable file size |
+
+At `debug` or `trace` level, a benchmark can also emit current RSS samples under the run span:
+
+```text
+gluesql.benchmark.memory_sample elapsed_ms=20 rss_bytes=18874368
+```
+
+### Run the RedbStorage reference
+
+The reference example is available only when its `tracing` feature is enabled.
+
+Run a SQL workload against a new Redb database path:
+
+```sh
+RUST_LOG=gluesql=trace \
+cargo run --release \
+  -p gluesql-redb-storage \
+  --example resource_benchmark \
+  --features tracing \
+  -- /tmp/gluesql-benchmark.redb \
+  storages/redb-storage/examples/resource_benchmark.sql
+```
+
+The default interval is 10 milliseconds. Set `GLUESQL_MEMORY_SAMPLE_MS` to use a different
+positive interval:
+
+```sh
+GLUESQL_MEMORY_SAMPLE_MS=50 \
+RUST_LOG=gluesql=debug \
+cargo run --release \
+  -p gluesql-redb-storage \
+  --example resource_benchmark \
+  --features tracing \
+  -- /tmp/gluesql-benchmark.redb \
+  storages/redb-storage/examples/resource_benchmark.sql
+```
+
+The example emits tracing data only; it does not select a graphing or storage format. Subscribers
+can consume `elapsed_ms` and `rss_bytes` to produce a step chart and align it with the existing
+query spans. At `info` level the sampler is not started, so only the final resource fields are
+recorded. RSS samples include the memory and scheduling overhead of the sampler thread itself.
+Current RSS sampling is supported on macOS and Linux.
+
+### Firefox Profiler output
+
+The optional `firefox-profile` feature keeps the formatted standard-error output and also writes
+GlueSQL spans, events, and RSS samples directly in the Firefox Profiler processed-profile JSON
+format. It uses a Rust library and does not require `protoc` or a separate trace converter.
+
+Generate a profile from one workload:
+
+```sh
+GLUESQL_FIREFOX_PROFILE_PATH=~/gluesql-benchmark-profile.json \
+GLUESQL_MEMORY_SAMPLE_MS=10 \
+RUST_LOG=gluesql=debug \
+cargo run --release \
+  -p gluesql-redb-storage \
+  --example resource_benchmark \
+  --features firefox-profile \
+  -- /tmp/gluesql-benchmark.redb \
+  storages/redb-storage/examples/resource_benchmark.sql
+```
+
+`GLUESQL_FIREFOX_PROFILE_PATH` defaults to `gluesql-benchmark-profile.json`. Open
+[Firefox Profiler](https://profiler.firefox.com/), select **Load a profile from file**, and choose
+the generated JSON file. Select the `process_rss` counter track to inspect RSS over time. GlueSQL
+spans and events appear as interval and instant markers on the same timeline. The profile remains
+local unless it is explicitly uploaded or shared; GlueSQL does not require a visualization
+service.
+
+Peak RSS is a process-lifetime high-water mark, so run each workload in a separate process and use
+a new database path when comparing results. Use the same build profile and target platform for
+executable-size comparisons. Peak RSS measurement is currently supported on Unix platforms.
+
+### Adding a benchmark for another storage
+
+The Redb example is currently the reference implementation rather than a shared benchmark harness.
+To add the same measurements to another storage crate, use these files as the starting point:
+
+```text
+storages/redb-storage/examples/resource_benchmark.rs
+storages/redb-storage/examples/resource_benchmark/firefox_profile.rs
+storages/redb-storage/examples/resource_benchmark.sql
+storages/redb-storage/Cargo.toml
+```
+
+First add a `tracing` feature to the target storage crate. It must enable the optional `tracing`
+and `gluesql-macros` dependencies together with `gluesql-core/tracing`. Register the example with
+`required-features = ["tracing"]` so its tracing and RSS dependencies are not compiled for normal
+storage users:
+
+```toml
+[features]
+tracing = ["dep:gluesql-macros", "dep:tracing", "gluesql-core/tracing"]
+
+[dependencies]
+gluesql-macros = { version = "0.19", optional = true }
+tracing = { version = "0.1", optional = true }
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
+[[example]]
+name = "resource_benchmark"
+required-features = ["tracing"]
+```
+
+Copy `resource_benchmark.rs` and adapt only the storage-specific parts:
+
+1. Import and construct the target storage instead of `RedbStorage`.
+2. Change `benchmark.storage` from `"redb"` to a stable storage name.
+3. Adjust the command-line arguments required to create or connect to the storage.
+4. Record the storage size only when it can be measured locally and consistently.
+5. Add a representative SQL file and pass the complete document to `Glue::execute(&sql)`.
+
+Keep the following names and behavior unchanged so profiles remain comparable across storage
+implementations:
+
+```text
+gluesql.benchmark.run
+gluesql.benchmark.memory_sample
+benchmark.name
+benchmark.storage
+process.memory.peak_bytes
+gluesql.database.size_bytes
+process.executable.size_bytes
+GLUESQL_MEMORY_SAMPLE_MS
+```
+
+Use the storage type to decide how `gluesql.database.size_bytes` is populated:
+
+| Storage type | Size measurement |
+| --- | --- |
+| Single local file | Read the database file metadata after the workload finishes |
+| Local directory | Sum only the files owned by that database after pending writes are flushed |
+| In-memory | Leave `gluesql.database.size_bytes` empty |
+| Remote service | Leave the local field empty; report a server-side metric separately if available |
+
+Apply `trace_storage` as described above when storage calls and their arguments must be visible.
+The macro uses one span for lazy iterator consumption, records its final row count, and emits row
+events rather than creating a span for every row.
+
+Firefox Profiler support is optional. To include it, copy the `firefox_profile.rs` support module
+without changing its marker and counter names, retain `GLUESQL_FIREFOX_PROFILE_PATH` as the output
+setting, and add these optional dependencies:
+
+```toml
+[features]
+firefox-profile = [
+  "tracing",
+  "dep:fxprof-processed-profile",
+  "dep:serde_json",
+]
+
+[dependencies]
+fxprof-processed-profile = { version = "0.8.1", optional = true }
+serde_json = { version = "1", optional = true }
+```
+
+Validate the new example in both modes:
+
+```sh
+cargo run --release \
+  -p <storage-package> \
+  --example resource_benchmark \
+  --features tracing \
+  -- <storage-arguments> <workload.sql>
+
+GLUESQL_FIREFOX_PROFILE_PATH=~/gluesql-benchmark-profile.json \
+RUST_LOG=gluesql=debug \
+cargo run --release \
+  -p <storage-package> \
+  --example resource_benchmark \
+  --features firefox-profile \
+  -- <storage-arguments> <workload.sql>
+```
+
+Confirm that the formatted trace contains `gluesql.benchmark.run`, the Firefox profile contains
+GlueSQL markers and a `process_rss` counter, and a tracing-disabled build of the storage remains
+unchanged. Run each comparison in a fresh process with an equivalent workload and build profile.
+
+## OpenTelemetry
+
+OpenTelemetry integration belongs to the host application rather than `gluesql-core`. Add the
+OpenTelemetry crates that match the application's chosen transport:
+
+### CLI OTLP export
+
+Build the CLI with the OpenTelemetry exporter:
+
+```sh
+cargo build -p gluesql-cli --features opentelemetry
+```
+
+Set the standard OpenTelemetry environment variables and run the CLI:
+
+```sh
+OTEL_SERVICE_NAME=gluesql-cli \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+RUST_LOG=gluesql=trace \
+./target/debug/gluesql-cli
+```
+
+The CLI exports completed spans to `/v1/traces` and flushes pending batches when it exits. The
+configured endpoint must accept OTLP over HTTP/Protobuf. A collector can forward those traces to
+Jaeger, Grafana Tempo, or another compatible backend.
+
+### Application integration
+
+```sh
+cargo add tracing-opentelemetry opentelemetry opentelemetry_sdk
+cargo add opentelemetry-otlp --features grpc-tonic
+```
+
+Create an OTLP exporter and attach the OpenTelemetry layer to the application's subscriber:
+
+```rust
+use {
+    opentelemetry::trace::TracerProvider as _,
+    opentelemetry_sdk::trace::SdkTracerProvider,
+    tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt},
+};
+
+let exporter = opentelemetry_otlp::SpanExporter::builder()
+    .with_tonic()
+    .build()?;
+let provider = SdkTracerProvider::builder()
+    .with_batch_exporter(exporter)
+    .build();
+let tracer = provider.tracer("gluesql");
+let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+
+tracing_subscriber::registry()
+    .with(filter)
+    .with(tracing_opentelemetry::layer().with_tracer(tracer))
+    .init();
+
+// Run GlueSQL queries here.
+
+provider.shutdown()?;
+```
+
+Configure the collector endpoint with the standard OpenTelemetry environment variables:
+
+```sh
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+The collector can forward traces to Jaeger, Grafana Tempo, or another OTLP-compatible backend. See
+the
+[`opentelemetry-otlp` exporter documentation](https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/)
+and
+[`tracing-opentelemetry` layer documentation](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/)
+for transport and SDK-specific configuration.
+
+## Flamegraphs
+
+`tracing-flame` can convert the same span hierarchy into folded stack data:
+
+### CLI flamegraph
+
+Build the CLI with the flame exporter:
+
+```sh
+cargo build -p gluesql-cli --features tracing-flame
+```
+
+Run a workload and choose the folded output path with `GLUESQL_FLAMEGRAPH_PATH`. The default path
+is `tracing.folded`.
+
+```sh
+GLUESQL_FLAMEGRAPH_PATH=~/gluesql.folded \
+RUST_LOG=gluesql=trace \
+./target/debug/gluesql-cli
+```
+
+After exiting the CLI, generate an SVG with Inferno:
+
+```sh
+cargo install inferno
+```
+
+```sh
+inferno-flamegraph < ~/gluesql.folded > ~/gluesql.svg
+```
+
+The CLI keeps empty samples out of the folded output so time waiting at the interactive prompt
+does not dominate the graph.
+
+### Application integration
+
+```rust
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+let (flame_layer, _guard) = tracing_flame::FlameLayer::with_file("tracing.folded")?;
+let filter = EnvFilter::try_from_default_env()
+    .unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+
+tracing_subscriber::registry()
+    .with(filter)
+    .with(flame_layer)
+    .init();
+```
+
+Keep the returned guard alive until tracing has finished so buffered output is flushed. Generate
+an SVG with Inferno:
+
+```sh
+inferno-flamegraph < tracing.folded > tracing.svg
+```
+
+`tracing-flame` measures elapsed time between instrumented span events; it is not a sampling CPU
+profiler. Use `perf` or `cargo-flamegraph` when function-level CPU samples are required.
+
+## Data handling
+
+Full tracing deliberately records query and storage values that may contain sensitive data:
+
+- `gluesql.execute` and `gluesql.plan_sql` record SQL source text and bound parameters.
+- `trace_storage(capture = "full")` records simple named method arguments, including keys,
+  schemas, and rows, together with `Result` errors.
+- `trace_storage` emits an event for every yielded row or error from traced iterators.
+
+Enable tracing only in environments where this data is acceptable. Use `capture = "off"` when a
+storage needs timing without argument and error values, and use an appropriate `RUST_LOG` filter
+to limit event volume. Applications are responsible for redaction, retention, and access-control
+policies in their selected subscriber or exporter.

--- a/docs/docs/getting-started/rust.md
+++ b/docs/docs/getting-started/rust.md
@@ -25,6 +25,7 @@ By default, all available storage features are included with GlueSQL. Here's a l
 - `gluesql-redis-storage` - Storage backed by Redis
 - `gluesql-file-storage` - Storage backed by files on the local filesystem
 - `gluesql-git-storage` - Git-backed storage with version history
+- `tracing` - Optional execution tracing for diagnostics and telemetry
 
 If you don't need all the default storage features, you can disable them and select only the ones you require. To do this, update your `Cargo.toml` file with the following lines:
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -12,6 +12,7 @@ nav = [
     "getting-started/javascript-web.md",
     "getting-started/nodejs.md",
     "getting-started/cli.md",
+    "getting-started/observability.md",
   ]},
   {"SQL Syntax" = [
     "sql-syntax/intro.md",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,10 +16,11 @@ syn = { version = "2", features = ["full"] }
 proc-macro-crate = "3"
 
 [dev-dependencies]
-gluesql-core.workspace = true
+gluesql-core = { workspace = true, features = ["tracing"] }
 gluesql_memory_storage.workspace = true
 chrono = "0.4"
 rust_decimal = "1"
+tracing = "0.1"
 trybuild = "1"
 
 [lints]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "visit-mut"] }
 proc-macro-crate = "3"
 
 [dev-dependencies]
@@ -21,6 +21,7 @@ gluesql_memory_storage.workspace = true
 chrono = "0.4"
 rust_decimal = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 trybuild = "1"
 
 [lints]

--- a/macros/examples/observe.rs
+++ b/macros/examples/observe.rs
@@ -1,0 +1,48 @@
+use {gluesql_macros::observe, tracing_subscriber::fmt::format::FmtSpan};
+
+#[observe(
+    name = "gluesql.example.collect",
+    fields(input_rows = input.len()),
+    after_let(rows, record(buffered_rows = rows.len())),
+    count_loop(binding = row, field = scanned_rows),
+    on_ok(rows, record(returned_rows = rows.len())),
+    err(Debug)
+)]
+fn collect(input: &[i32]) -> Result<Vec<i32>, &'static str> {
+    let rows = input.to_vec();
+    for row in &rows {
+        if *row < 0 {
+            return Err("negative row");
+        }
+    }
+    Ok(rows)
+}
+
+#[observe(
+    name = "gluesql.example.collect_keys",
+    start = before_let(keys),
+    end = after_let(num_keys),
+    record(buffered_rows = num_keys)
+)]
+fn count_keys(input: &[i32]) -> usize {
+    let keys = input.to_vec();
+    let num_keys = keys.len();
+    // This work is outside the collection span.
+    assert_eq!(num_keys, input.len());
+    num_keys
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(false)
+        .without_time()
+        .with_writer(std::io::stderr)
+        .init();
+
+    assert_eq!(collect(&[1, 2, 3]), Ok(vec![1, 2, 3]));
+    assert_eq!(collect(&[1, -2, 3]), Err("negative row"));
+    assert_eq!(count_keys(&[1, 2, 3]), 3);
+    println!("All observation example checks passed.");
+}

--- a/macros/src/instrument_storage.rs
+++ b/macros/src/instrument_storage.rs
@@ -1,0 +1,203 @@
+use {
+    crate::resolve_gluesql_crate,
+    proc_macro2::TokenStream,
+    quote::quote,
+    syn::{
+        Expr, ExprLit, FnArg, GenericArgument, ImplItem, ItemImpl, Lit, MetaNameValue, Pat,
+        PathArguments, ReturnType, Token, Type, parse::Parser, punctuated::Punctuated,
+    },
+};
+
+struct Args {
+    name: String,
+    capture_full: bool,
+}
+
+impl Args {
+    fn parse(tokens: TokenStream) -> Result<Self, syn::Error> {
+        let values = Punctuated::<MetaNameValue, Token![,]>::parse_terminated.parse2(tokens)?;
+        let mut name = None;
+        let mut capture_full = true;
+
+        for MetaNameValue { path, value, .. } in values {
+            let Expr::Lit(ExprLit {
+                lit: Lit::Str(value),
+                ..
+            }) = value
+            else {
+                return Err(syn::Error::new_spanned(value, "expected a string literal"));
+            };
+
+            if path.is_ident("name") {
+                name = Some(value.value());
+            } else if path.is_ident("capture") {
+                capture_full = parse_mode(&value, "capture")?;
+            } else {
+                return Err(syn::Error::new_spanned(path, "unsupported option"));
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| {
+                syn::Error::new(proc_macro2::Span::call_site(), "missing `name = \"...\"`")
+            })?,
+            capture_full,
+        })
+    }
+}
+
+fn parse_mode(value: &syn::LitStr, option: &str) -> Result<bool, syn::Error> {
+    match value.value().as_str() {
+        "full" => Ok(true),
+        "off" => Ok(false),
+        _ => Err(syn::Error::new(
+            value.span(),
+            format!("`{option}` must be `full` or `off`"),
+        )),
+    }
+}
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
+    let args = Args::parse(attr)?;
+    let mut implementation: ItemImpl = syn::parse2(item)?;
+    let gluesql = resolve_gluesql_crate()?;
+
+    for item in &mut implementation.items {
+        let ImplItem::Fn(method) = item else {
+            continue;
+        };
+
+        let method_name = method.sig.ident.to_string();
+        let span_name = format!("gluesql.{}.{method_name}", args.name);
+        let mut fields = Vec::new();
+
+        if args.capture_full {
+            for input in &method.sig.inputs {
+                let FnArg::Typed(input) = input else {
+                    continue;
+                };
+                let Pat::Ident(pattern) = input.pat.as_ref() else {
+                    continue;
+                };
+                let ident = &pattern.ident;
+                fields.push(quote!(#ident = ?#ident));
+
+                if ident == "rows" || ident == "keys" {
+                    fields.push(quote!(row_count = #ident.len()));
+                }
+            }
+        }
+
+        let fields = (!fields.is_empty()).then(|| quote!(fields(#(#fields),*),));
+        let error = (args.capture_full && result_ok_type(&method.sig.output).is_some())
+            .then(|| quote!(err(Debug),));
+        let attribute = quote!(
+            #[tracing::instrument(
+                target = "gluesql",
+                name = #span_name,
+                level = "trace",
+                skip_all,
+                #fields
+                #error
+            )]
+        );
+        let mut attribute = syn::Attribute::parse_outer.parse2(attribute)?;
+        method.attrs.append(&mut attribute);
+
+        let explicitly_traced = method
+            .attrs
+            .iter()
+            .any(|attribute| attribute.path().is_ident("trace_iterator"));
+        method
+            .attrs
+            .retain(|attribute| !attribute.path().is_ident("trace_iterator"));
+        let should_trace_iterator =
+            explicitly_traced || matches!(method_name.as_str(), "scan_data" | "scan_indexed_data");
+
+        if should_trace_iterator {
+            let ok_type = result_ok_type(&method.sig.output).ok_or_else(|| {
+                syn::Error::new_spanned(
+                    &method.sig.output,
+                    "traced iterator methods must return `Result<Box<dyn Iterator<...>>>`",
+                )
+            })?;
+            let iterator_operation = match method_name.as_str() {
+                "scan_data" => "scan_rows".to_owned(),
+                "scan_indexed_data" => "scan_indexed_rows".to_owned(),
+                _ => format!("{method_name}_rows"),
+            };
+            let iterator_span_name = format!("gluesql.{}.{iterator_operation}", args.name);
+            let block = &method.block;
+            method.block = syn::parse_quote!({
+                let __gluesql_result = (|| #block)();
+                __gluesql_result.map(|__gluesql_iterator| {
+                    let __gluesql_span = tracing::trace_span!(
+                        target: "gluesql",
+                        #iterator_span_name,
+                        row_count = tracing::field::Empty,
+                        error_count = tracing::field::Empty,
+                        completed = tracing::field::Empty
+                    );
+                    let __gluesql_iterator: #ok_type = Box::new(
+                        #gluesql::__private::TracedResultIterator::new(
+                            __gluesql_iterator,
+                            __gluesql_span,
+                        ),
+                    );
+                    __gluesql_iterator
+                })
+            });
+        }
+    }
+
+    Ok(quote!(#implementation))
+}
+
+fn result_ok_type(output: &ReturnType) -> Option<Type> {
+    let ReturnType::Type(_, output) = output else {
+        return None;
+    };
+    let Type::Path(output) = output.as_ref() else {
+        return None;
+    };
+    let result = output.path.segments.last()?;
+    if result.ident != "Result" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(arguments) = &result.arguments else {
+        return None;
+    };
+
+    arguments.args.iter().find_map(|argument| match argument {
+        GenericArgument::Type(ok_type) => Some(ok_type.clone()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::expand, quote::quote};
+
+    #[test]
+    fn capture_off_omits_error_recording() {
+        let implementation = quote! {
+            impl Storage {
+                fn operation(&self) -> Result<(), Error> {
+                    Ok(())
+                }
+            }
+        };
+        let capture_full = expand(
+            quote!(name = "test", capture = "full"),
+            implementation.clone(),
+        )
+        .expect("full instrumentation should expand")
+        .to_string();
+        let capture_off = expand(quote!(name = "test", capture = "off"), implementation)
+            .expect("timing-only instrumentation should expand")
+            .to_string();
+
+        assert!(capture_full.contains("err (Debug)"));
+        assert!(!capture_off.contains("err (Debug)"));
+    }
+}

--- a/macros/src/instrument_storage.rs
+++ b/macros/src/instrument_storage.rs
@@ -1,5 +1,5 @@
 use {
-    crate::resolve_gluesql_crate,
+    crate::{observe, resolve_gluesql_crate},
     proc_macro2::TokenStream,
     quote::quote,
     syn::{
@@ -91,19 +91,6 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::
         let fields = (!fields.is_empty()).then(|| quote!(fields(#(#fields),*),));
         let error = (args.capture_full && result_ok_type(&method.sig.output).is_some())
             .then(|| quote!(err(Debug),));
-        let attribute = quote!(
-            #[tracing::instrument(
-                target = "gluesql",
-                name = #span_name,
-                level = "trace",
-                skip_all,
-                #fields
-                #error
-            )]
-        );
-        let mut attribute = syn::Attribute::parse_outer.parse2(attribute)?;
-        method.attrs.append(&mut attribute);
-
         let explicitly_traced = method
             .attrs
             .iter()
@@ -148,6 +135,10 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::
                 })
             });
         }
+        *method = syn::parse2(observe::expand(
+            quote!(target = "gluesql", name = #span_name, level = "trace", #fields #error),
+            quote!(#method),
+        )?)?;
     }
 
     Ok(quote!(#implementation))
@@ -197,7 +188,7 @@ mod tests {
             .expect("timing-only instrumentation should expand")
             .to_string();
 
-        assert!(capture_full.contains("err (Debug)"));
-        assert!(!capture_off.contains("err (Debug)"));
+        assert!(capture_full.contains("tracing :: error !"));
+        assert!(!capture_off.contains("tracing :: error !"));
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,6 +9,7 @@ use {
 
 mod from_glue_row;
 mod instrument_storage;
+mod observe;
 mod to_glue_row;
 
 fn resolve_gluesql_crate() -> Result<syn::Path, syn::Error> {
@@ -67,6 +68,13 @@ pub fn derive_to_glue_row(input: TokenStream) -> TokenStream {
         Ok(ts) => TokenStream::from(ts),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro_attribute]
+pub fn observe(attr: TokenStream, item: TokenStream) -> TokenStream {
+    observe::expand(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 #[proc_macro_attribute]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,6 +8,7 @@ use {
 };
 
 mod from_glue_row;
+mod instrument_storage;
 mod to_glue_row;
 
 fn resolve_gluesql_crate() -> Result<syn::Path, syn::Error> {
@@ -66,6 +67,13 @@ pub fn derive_to_glue_row(input: TokenStream) -> TokenStream {
         Ok(ts) => TokenStream::from(ts),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+#[proc_macro_attribute]
+pub fn trace_storage(attr: TokenStream, item: TokenStream) -> TokenStream {
+    instrument_storage::expand(attr.into(), item.into())
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 fn parse_glue_rename(attr: &Attribute) -> Option<Result<Option<String>, syn::Error>> {

--- a/macros/src/observe.rs
+++ b/macros/src/observe.rs
@@ -3,7 +3,9 @@ use {
     quote::{format_ident, quote},
     std::collections::{BTreeMap, BTreeSet},
     syn::{
-        Block, Expr, Ident, ItemFn, LitInt, LitStr, Pat, Stmt, Token, parenthesized,
+        Attribute, Block, Expr, Ident, ItemFn, LitInt, LitStr, Pat, Stmt, Token,
+        ext::IdentExt,
+        parenthesized,
         parse::{Parse, ParseStream},
         parse_quote,
         visit_mut::{self, VisitMut},
@@ -63,6 +65,7 @@ struct Selector {
     occurrence: Option<usize>,
     all: bool,
     is_loop: bool,
+    reject_conditions: bool,
 }
 
 impl Selector {
@@ -72,6 +75,7 @@ impl Selector {
             occurrence: None,
             all: false,
             is_loop,
+            reject_conditions: false,
         }
     }
 
@@ -100,8 +104,15 @@ impl Selector {
             selector: self,
             block_id: 0,
             found: Vec::new(),
+            conditional: false,
         };
         search.visit_block_mut(block);
+        if self.reject_conditions && search.conditional {
+            return Err(syn::Error::new_spanned(
+                &self.binding,
+                "conditional range endpoints are not supported; put cfg on the enclosing block or function",
+            ));
+        }
         let found = search.found;
         if let Some(n) = self.occurrence {
             return found.get(n - 1).copied().map(|v| vec![v]).ok_or_else(|| {
@@ -124,7 +135,31 @@ impl Selector {
 
 struct Hook {
     selector: Selector,
+    after: bool,
     fields: Vec<Field>,
+    event: Option<Event>,
+}
+struct Event {
+    message: LitStr,
+    fields: Vec<Field>,
+}
+
+impl Parse for Event {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let message = input.parse()?;
+        let mut values = Vec::new();
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            values.push(input.parse()?);
+        }
+        Ok(Self {
+            message,
+            fields: values,
+        })
+    }
 }
 struct Point {
     selector: Selector,
@@ -179,6 +214,8 @@ struct Args {
     end: Option<Point>,
     record: Vec<Field>,
     on_ok: Option<(Ident, Vec<Field>)>,
+    event: Option<Event>,
+    err: bool,
 }
 
 impl Parse for Args {
@@ -188,8 +225,10 @@ impl Parse for Args {
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             let name = key.to_string();
-            if !matches!(name.as_str(), "after_let" | "after_loop" | "count_loop")
-                && !seen.insert(name.clone())
+            if !matches!(
+                name.as_str(),
+                "before_let" | "after_let" | "after_loop" | "count_loop"
+            ) && !seen.insert(name.clone())
             {
                 return Err(syn::Error::new_spanned(key, "duplicate observation option"));
             }
@@ -204,6 +243,20 @@ impl Parse for Args {
                     }
                 }
                 "fields" => args.fields = fields(input)?,
+                "event" => {
+                    let content;
+                    parenthesized!(content in input);
+                    args.event = Some(content.parse()?);
+                }
+                "err" => {
+                    let content;
+                    parenthesized!(content in input);
+                    let format: Ident = content.parse()?;
+                    if format != "Debug" || !content.is_empty() {
+                        return Err(syn::Error::new_spanned(format, "expected err(Debug)"));
+                    }
+                    args.err = true;
+                }
                 "record" => args.record = fields(input)?,
                 "start" | "end" => {
                     input.parse::<Token![=]>()?;
@@ -214,11 +267,12 @@ impl Parse for Args {
                         args.end = Some(value);
                     }
                 }
-                "after_let" | "after_loop" => {
+                "before_let" | "after_let" | "after_loop" => {
                     let content;
                     parenthesized!(content in input);
                     let mut selector = Selector::new(content.parse()?, name == "after_loop");
                     let mut record = None;
+                    let mut event = None;
                     while !content.is_empty() {
                         content.parse::<Token![,]>()?;
                         if content.is_empty() {
@@ -227,14 +281,25 @@ impl Parse for Args {
                         let key: Ident = content.parse()?;
                         if key == "record" && record.is_none() {
                             record = Some(fields(&content)?);
+                        } else if key == "event" && event.is_none() {
+                            let body;
+                            parenthesized!(body in content);
+                            event = Some(body.parse()?);
                         } else {
                             selector.option(&key, &content)?;
                         }
                     }
+                    if record.is_none() && event.is_none() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "missing record(...) or event(...)",
+                        ));
+                    }
                     args.hooks.push(Hook {
                         selector,
-                        fields: record
-                            .ok_or_else(|| syn::Error::new_spanned(key, "missing record(...)"))?,
+                        after: name != "before_let",
+                        fields: record.unwrap_or_default(),
+                        event,
                     });
                 }
                 "on_ok" => {
@@ -355,6 +420,7 @@ struct Search<'a> {
     selector: &'a Selector,
     block_id: usize,
     found: Vec<Location>,
+    conditional: bool,
 }
 
 impl VisitMut for Search<'_> {
@@ -375,6 +441,13 @@ impl VisitMut for Search<'_> {
                 _ => false,
             };
             if matched {
+                if self
+                    .selector
+                    .occurrence
+                    .is_none_or(|n| n == self.found.len() + 1)
+                {
+                    self.conditional |= !conditions(stmt).is_empty();
+                }
                 self.found.push(Location {
                     block: id,
                     statement: i,
@@ -415,40 +488,92 @@ impl VisitMut for Edits {
         let mut stmts = Vec::new();
         for (i, mut stmt) in std::mem::take(&mut block.stmts).into_iter().enumerate() {
             self.visit_stmt_mut(&mut stmt);
+            let conditions = conditions(&stmt);
             let location = Location {
                 block: id,
                 statement: i,
             };
-            stmts.extend(self.before.remove(&location).unwrap_or_default());
+            let conditional = |stmt: Stmt| -> Stmt { parse_quote!(#(#conditions)* #stmt) };
+            stmts.extend(
+                self.before
+                    .remove(&location)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(conditional),
+            );
             stmts.push(stmt);
-            stmts.extend(self.after.remove(&location).unwrap_or_default());
+            stmts.extend(
+                self.after
+                    .remove(&location)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(conditional),
+            );
         }
         block.stmts = stmts;
     }
 }
 
+fn conditions(stmt: &Stmt) -> Vec<Attribute> {
+    let attrs = match stmt {
+        Stmt::Local(local) => &local.attrs,
+        Stmt::Expr(Expr::ForLoop(expr), _) => &expr.attrs,
+        _ => return Vec::new(),
+    };
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+        .cloned()
+        .collect()
+}
+
 fn record(fields: &[Field], span: &Ident) -> TokenStream {
     let writes = fields.iter().map(|field| {
-        let name = field.name.to_string();
+        let name = field.name.unraw().to_string();
         let value = field.value();
         quote!(#span.record(#name, #value);)
     });
     quote!(if !#span.is_disabled() { #(#writes)* })
 }
 
+fn event(event: &Event, level: &Ident, target: &TokenStream) -> TokenStream {
+    let message = &event.message;
+    let values = event.fields.iter().map(|field| {
+        let name = &field.name;
+        let value = field.value();
+        quote!(#name = #value)
+    });
+    quote!(tracing::event!(target: #target, tracing::Level::#level, #(#values,)* #message);)
+}
+
 pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
     let args: Args = syn::parse2(attr)?;
     let mut function: ItemFn = syn::parse2(item)?;
-    if function.sig.asyncness.is_some() || function.sig.constness.is_some() {
+    if function.sig.constness.is_some() {
         return Err(syn::Error::new_spanned(
             &function.sig,
-            "observe currently supports synchronous, non-const functions",
+            "observe does not support const functions",
         ));
     }
-    let name = args
-        .name
-        .as_ref()
-        .ok_or_else(|| syn::Error::new(Span::call_site(), "missing name = \"...\""))?;
+    let has_span = args.name.is_some();
+    if !has_span
+        && (args.event.is_none() && args.hooks.is_empty()
+            || !args.fields.is_empty()
+            || !args.counters.is_empty()
+            || args.start.is_some()
+            || args.end.is_some()
+            || !args.record.is_empty()
+            || args.on_ok.is_some()
+            || args.err
+            || args.hooks.iter().any(|hook| !hook.fields.is_empty()))
+    {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "name is required for span observations; unnamed observations support only events",
+        ));
+    }
+    let fallback_name = LitStr::new("", Span::call_site());
+    let name = args.name.as_ref().unwrap_or(&fallback_name);
     let level = args
         .level
         .as_ref()
@@ -467,11 +592,41 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
         .target
         .as_ref()
         .map_or_else(|| quote!("gluesql"), |v| quote!(#v));
+    if function.sig.asyncness.is_some() {
+        if !has_span
+            || !args.hooks.is_empty()
+            || !args.counters.is_empty()
+            || args.start.is_some()
+            || args.end.is_some()
+            || !args.record.is_empty()
+            || args.on_ok.is_some()
+            || args.event.is_some()
+        {
+            return Err(syn::Error::new_spanned(
+                &function.sig,
+                "async observations support only name, level, target, fields, and err(Debug)",
+            ));
+        }
+        let fields = args.fields.iter().map(|field| {
+            let name = &field.name;
+            let value = field.value();
+            quote!(#name = #value)
+        });
+        let error = args.err.then(|| quote!(err(Debug),));
+        let level = level.to_string().to_lowercase();
+        return Ok(quote! {
+            #[tracing::instrument(name = #name, level = #level, target = #target, skip_all, fields(#(#fields),*), #error)]
+            #function
+        });
+    }
     let span = Ident::new("__gluesql_observe_span", Span::mixed_site());
     let entered = Ident::new("__gluesql_observe_entered", Span::mixed_site());
-    let mut names = BTreeSet::new();
+    let mut names = BTreeMap::new();
     for field in &args.fields {
-        if !names.insert(field.name.to_string()) {
+        if names
+            .insert(field.name.unraw().to_string(), &field.name)
+            .is_some()
+        {
             return Err(syn::Error::new_spanned(
                 &field.name,
                 "duplicate initial field",
@@ -485,20 +640,32 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
         .chain(&args.record)
         .chain(args.on_ok.iter().flat_map(|(_, f)| f))
     {
-        names.insert(field.name.to_string());
+        names.insert(field.name.unraw().to_string(), &field.name);
     }
     for counter in &args.counters {
-        names.insert(counter.field.to_string());
+        names.insert(counter.field.unraw().to_string(), &counter.field);
     }
-    let declarations = names.iter().map(|n| {
-        let ident = Ident::new(n, Span::call_site());
-        quote!(#ident = tracing::field::Empty)
+    let declarations = names.iter().map(|(name, ident)| {
+        if let Some(field) = args
+            .fields
+            .iter()
+            .find(|field| field.name.unraw() == name.as_str())
+        {
+            let value = field.value();
+            quote!(#ident = #value)
+        } else {
+            quote!(#ident = tracing::field::Empty)
+        }
     });
-    let initial = record(&args.fields, &span);
-    let start = quote! {
-        let #span = tracing::span!(target: #target, tracing::Level::#level, #name, #(#declarations),*);
-        #initial
-        let #entered = #span.enter();
+    let entry_event = args.event.as_ref().map(|e| event(e, &level, &target));
+    let start = if has_span {
+        quote! {
+            let #span = tracing::span!(target: #target, tracing::Level::#level, #name, #(#declarations),*);
+            let #entered = #span.enter();
+            #entry_event
+        }
+    } else {
+        quote!(#entry_event)
     };
     if args.start.is_some() != args.end.is_some() || (!args.record.is_empty() && args.end.is_none())
     {
@@ -517,8 +684,12 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
     }
     let mut edits = Edits::default();
     if let (Some(start_point), Some(end_point)) = (&args.start, &args.end) {
-        let a = start_point.selector.locations(&mut function.block)?[0];
-        let b = end_point.selector.locations(&mut function.block)?[0];
+        let mut start_selector = start_point.selector.clone();
+        start_selector.reject_conditions = true;
+        let mut end_selector = end_point.selector.clone();
+        end_selector.reject_conditions = true;
+        let a = start_selector.locations(&mut function.block)?[0];
+        let b = end_selector.locations(&mut function.block)?[0];
         if a.block != b.block || (a.statement, start_point.after) >= (b.statement, end_point.after)
         {
             return Err(syn::Error::new_spanned(
@@ -536,7 +707,9 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
     } else {
         for hook in &args.hooks {
             for location in hook.selector.locations(&mut function.block)? {
-                edits.add(location, true, &record(&hook.fields, &span))?;
+                let writes = (!hook.fields.is_empty()).then(|| record(&hook.fields, &span));
+                let event = hook.event.as_ref().map(|e| event(e, &level, &target));
+                edits.add(location, hook.after, &quote!(#writes #event))?;
             }
         }
     }
@@ -546,7 +719,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
     }
     if args.start.is_none() {
         let body = &function.block;
-        function.block = if let Some((binding, fields)) = &args.on_ok {
+        function.block = if args.on_ok.is_some() || args.err {
             let output = match &function.sig.output {
                 syn::ReturnType::Type(_, ty) if matches!(ty.as_ref(), syn::Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == "Result")) => {
                     ty
@@ -559,11 +732,22 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
                 }
             };
             let result = Ident::new("__gluesql_observe_result", Span::mixed_site());
-            let writes = record(fields, &span);
+            let success = args.on_ok.as_ref().map(|(binding, fields)| {
+                let writes = record(fields, &span);
+                quote!(if let ::std::result::Result::Ok(#binding) = &#result { #writes })
+            });
+            let error = args.err.then(|| {
+                quote! {
+                    if let ::std::result::Result::Err(error) = &#result {
+                        tracing::error!(target: #target, error = ?error);
+                    }
+                }
+            });
             Box::new(parse_quote!({
                 #start
                 let #result = (|| -> #output #body)();
-                if let ::std::result::Result::Ok(#binding) = &#result { #writes }
+                #success
+                #error
                 #result
             }))
         } else {
@@ -585,7 +769,7 @@ fn apply_counter(
         &format!("__gluesql_observe_count_{index}"),
         Span::mixed_site(),
     );
-    let field = counter.field.to_string();
+    let field = counter.field.unraw().to_string();
     let mut editor = CounterBody {
         location,
         block_id: 0,
@@ -695,16 +879,39 @@ mod tests {
                 "accepted {attr}"
             );
         }
-        for body in [
-            quote!(
-                async fn example() {}
-            ),
-            quote!(
-                const fn example() {}
-            ),
-        ] {
-            assert!(expand(quote!(name = "x"), body).is_err());
-        }
+        assert!(
+            expand(
+                quote!(name = "x"),
+                quote!(
+                    const fn example() {}
+                )
+            )
+            .is_err()
+        );
+        assert!(
+            expand(
+                quote!(name = "x", start = before_let(a), end = after_let(b)),
+                quote!(
+                    fn f() {
+                        #[cfg(any())]
+                        let a = 1;
+                        let b = 2;
+                    }
+                )
+            )
+            .is_err()
+        );
+        assert!(
+            expand(
+                quote!(name = "x", after_let(rows, record(n = rows.len()))),
+                quote!(
+                    async fn f() {
+                        let rows = [1];
+                    }
+                )
+            )
+            .is_err()
+        );
         assert!(
             expand(
                 quote!(name = "x", on_ok(v, record(n = v))),

--- a/macros/src/observe.rs
+++ b/macros/src/observe.rs
@@ -675,11 +675,11 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
         ));
     }
     if args.start.is_some()
-        && (!args.hooks.is_empty() || !args.counters.is_empty() || args.on_ok.is_some())
+        && (!args.hooks.is_empty() || !args.counters.is_empty() || args.on_ok.is_some() || args.err)
     {
         return Err(syn::Error::new_spanned(
             name,
-            "range observations support fields and record; use a separate observe attribute for other hooks",
+            "range observations do not support hooks, counters, on_ok, or err(Debug); use a separate function observation",
         ));
     }
     let mut edits = Edits::default();
@@ -720,18 +720,22 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
     if args.start.is_none() {
         let body = &function.block;
         function.block = if args.on_ok.is_some() || args.err {
-            let output = match &function.sig.output {
+            let mut output = match &function.sig.output {
                 syn::ReturnType::Type(_, ty) if matches!(ty.as_ref(), syn::Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == "Result")) => {
-                    ty
+                    ty.clone()
                 }
                 _ => {
                     return Err(syn::Error::new_spanned(
                         &function.sig.output,
-                        "on_ok requires a Result return type",
+                        "on_ok and err(Debug) require a Result return type",
                     ));
                 }
             };
+            InferOpaqueReturn.visit_type_mut(&mut output);
             let result = Ident::new("__gluesql_observe_result", Span::mixed_site());
+            // An explicit FnOnce bound permits mutable-reference returns without
+            // forcing unrelated arguments into a move closure.
+            let call = Ident::new("__gluesql_observe_call_once", Span::mixed_site());
             let success = args.on_ok.as_ref().map(|(binding, fields)| {
                 let writes = record(fields, &span);
                 quote!(if let ::std::result::Result::Ok(#binding) = &#result { #writes })
@@ -745,7 +749,10 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
             });
             Box::new(parse_quote!({
                 #start
-                let #result = (|| -> #output #body)();
+                let #result = {
+                    fn #call<R>(body: impl ::std::ops::FnOnce() -> R) -> R { body() }
+                    #call(|| -> #output #body)
+                };
                 #success
                 #error
                 #result
@@ -756,6 +763,18 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
         };
     }
     Ok(quote!(#function))
+}
+
+struct InferOpaqueReturn;
+
+impl VisitMut for InferOpaqueReturn {
+    fn visit_type_mut(&mut self, ty: &mut syn::Type) {
+        if matches!(ty, syn::Type::ImplTrait(_)) {
+            *ty = parse_quote!(_);
+        } else {
+            visit_mut::visit_type_mut(self, ty);
+        }
+    }
 }
 
 fn apply_counter(
@@ -873,6 +892,12 @@ mod tests {
             quote!(name = "x", level = "verbose"),
             quote!(name = "x", name = "y"),
             quote!(name = "x", unknown = true),
+            quote!(
+                name = "x",
+                start = before_let(rows, occurrence = 1),
+                end = after_let(rows, occurrence = 1),
+                err(Debug)
+            ),
         ] {
             assert!(
                 expand(attr.clone(), body.clone()).is_err(),

--- a/macros/src/observe.rs
+++ b/macros/src/observe.rs
@@ -1,0 +1,769 @@
+use {
+    proc_macro2::{Span, TokenStream},
+    quote::{format_ident, quote},
+    std::collections::{BTreeMap, BTreeSet},
+    syn::{
+        Block, Expr, Ident, ItemFn, LitInt, LitStr, Pat, Stmt, Token, parenthesized,
+        parse::{Parse, ParseStream},
+        parse_quote,
+        visit_mut::{self, VisitMut},
+    },
+};
+
+struct Field {
+    name: Ident,
+    value: Expr,
+    format: Option<char>,
+}
+
+impl Parse for Field {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let format = if input.peek(Token![?]) {
+            input.parse::<Token![?]>()?;
+            Some('?')
+        } else if input.peek(Token![%]) {
+            input.parse::<Token![%]>()?;
+            Some('%')
+        } else {
+            None
+        };
+        Ok(Self {
+            name,
+            value: input.parse()?,
+            format,
+        })
+    }
+}
+
+impl Field {
+    fn value(&self) -> TokenStream {
+        let value = &self.value;
+        match self.format {
+            Some('?') => quote!(tracing::field::debug(&(#value))),
+            Some('%') => quote!(tracing::field::display(&(#value))),
+            _ => quote!(&(#value)),
+        }
+    }
+}
+
+fn fields(input: ParseStream) -> syn::Result<Vec<Field>> {
+    let content;
+    parenthesized!(content in input);
+    Ok(content
+        .parse_terminated(Field::parse, Token![,])?
+        .into_iter()
+        .collect())
+}
+
+#[derive(Clone)]
+struct Selector {
+    binding: Ident,
+    occurrence: Option<usize>,
+    all: bool,
+    is_loop: bool,
+}
+
+impl Selector {
+    fn new(binding: Ident, is_loop: bool) -> Self {
+        Self {
+            binding,
+            occurrence: None,
+            all: false,
+            is_loop,
+        }
+    }
+
+    fn option(&mut self, key: &Ident, input: ParseStream) -> syn::Result<()> {
+        if key == "all" && !self.all && self.occurrence.is_none() {
+            self.all = true;
+        } else if key == "occurrence" && !self.all && self.occurrence.is_none() {
+            input.parse::<Token![=]>()?;
+            let n = input.parse::<LitInt>()?;
+            let value = n.base10_parse()?;
+            if value == 0 {
+                return Err(syn::Error::new_spanned(n, "occurrence starts at 1"));
+            }
+            self.occurrence = Some(value);
+        } else {
+            return Err(syn::Error::new_spanned(
+                key,
+                "expected one of `occurrence = N` or `all`",
+            ));
+        }
+        Ok(())
+    }
+
+    fn locations(&self, block: &mut Block) -> syn::Result<Vec<Location>> {
+        let mut search = Search {
+            selector: self,
+            block_id: 0,
+            found: Vec::new(),
+        };
+        search.visit_block_mut(block);
+        let found = search.found;
+        if let Some(n) = self.occurrence {
+            return found.get(n - 1).copied().map(|v| vec![v]).ok_or_else(|| {
+                syn::Error::new_spanned(&self.binding, "requested occurrence was not found")
+            });
+        }
+        if found.is_empty() || (found.len() > 1 && !self.all) {
+            return Err(syn::Error::new_spanned(
+                &self.binding,
+                if found.is_empty() {
+                    "observation target was not found"
+                } else {
+                    "ambiguous observation target; specify `occurrence = N` or `all`"
+                },
+            ));
+        }
+        Ok(found)
+    }
+}
+
+struct Hook {
+    selector: Selector,
+    fields: Vec<Field>,
+}
+struct Point {
+    selector: Selector,
+    after: bool,
+}
+struct Counter {
+    selector: Selector,
+    increment: Option<Selector>,
+    field: Ident,
+}
+
+fn point(input: ParseStream) -> syn::Result<Point> {
+    let kind: Ident = input.parse()?;
+    if kind != "before_let" && kind != "after_let" {
+        return Err(syn::Error::new_spanned(
+            kind,
+            "expected before_let(...) or after_let(...)",
+        ));
+    }
+    let content;
+    parenthesized!(content in input);
+    let mut selector = Selector::new(content.parse()?, false);
+    while !content.is_empty() {
+        content.parse::<Token![,]>()?;
+        if content.is_empty() {
+            break;
+        }
+        let key = content.parse()?;
+        selector.option(&key, &content)?;
+    }
+    if selector.all {
+        return Err(syn::Error::new_spanned(
+            kind,
+            "range endpoints must select exactly one statement",
+        ));
+    }
+    Ok(Point {
+        selector,
+        after: kind == "after_let",
+    })
+}
+
+#[derive(Default)]
+struct Args {
+    name: Option<LitStr>,
+    level: Option<LitStr>,
+    target: Option<LitStr>,
+    fields: Vec<Field>,
+    hooks: Vec<Hook>,
+    counters: Vec<Counter>,
+    start: Option<Point>,
+    end: Option<Point>,
+    record: Vec<Field>,
+    on_ok: Option<(Ident, Vec<Field>)>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut args = Self::default();
+        let mut seen = BTreeSet::new();
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            let name = key.to_string();
+            if !matches!(name.as_str(), "after_let" | "after_loop" | "count_loop")
+                && !seen.insert(name.clone())
+            {
+                return Err(syn::Error::new_spanned(key, "duplicate observation option"));
+            }
+            match name.as_str() {
+                "name" | "level" | "target" => {
+                    input.parse::<Token![=]>()?;
+                    let value = input.parse()?;
+                    match name.as_str() {
+                        "name" => args.name = Some(value),
+                        "level" => args.level = Some(value),
+                        _ => args.target = Some(value),
+                    }
+                }
+                "fields" => args.fields = fields(input)?,
+                "record" => args.record = fields(input)?,
+                "start" | "end" => {
+                    input.parse::<Token![=]>()?;
+                    let value = point(input)?;
+                    if name == "start" {
+                        args.start = Some(value);
+                    } else {
+                        args.end = Some(value);
+                    }
+                }
+                "after_let" | "after_loop" => {
+                    let content;
+                    parenthesized!(content in input);
+                    let mut selector = Selector::new(content.parse()?, name == "after_loop");
+                    let mut record = None;
+                    while !content.is_empty() {
+                        content.parse::<Token![,]>()?;
+                        if content.is_empty() {
+                            break;
+                        }
+                        let key: Ident = content.parse()?;
+                        if key == "record" && record.is_none() {
+                            record = Some(fields(&content)?);
+                        } else {
+                            selector.option(&key, &content)?;
+                        }
+                    }
+                    args.hooks.push(Hook {
+                        selector,
+                        fields: record
+                            .ok_or_else(|| syn::Error::new_spanned(key, "missing record(...)"))?,
+                    });
+                }
+                "on_ok" => {
+                    let content;
+                    parenthesized!(content in input);
+                    let binding = content.parse()?;
+                    content.parse::<Token![,]>()?;
+                    let key: Ident = content.parse()?;
+                    if key != "record" {
+                        return Err(syn::Error::new_spanned(key, "expected record(...)"));
+                    }
+                    let record = fields(&content)?;
+                    if content.peek(Token![,]) {
+                        content.parse::<Token![,]>()?;
+                    }
+                    if !content.is_empty() {
+                        return Err(content.error("unexpected on_ok option"));
+                    }
+                    args.on_ok = Some((binding, record));
+                }
+                "count_loop" => {
+                    let content;
+                    parenthesized!(content in input);
+                    let mut binding = None;
+                    let mut field = None;
+                    let mut increment = None;
+                    let mut occurrence = None;
+                    let mut options = BTreeSet::new();
+                    while !content.is_empty() {
+                        let key: Ident = content.parse()?;
+                        if !options.insert(key.to_string()) {
+                            return Err(syn::Error::new_spanned(key, "duplicate counter option"));
+                        }
+                        content.parse::<Token![=]>()?;
+                        match key.to_string().as_str() {
+                            "binding" => binding = Some(content.parse()?),
+                            "field" => field = Some(content.parse()?),
+                            "occurrence" => {
+                                let n: LitInt = content.parse()?;
+                                let value = n.base10_parse()?;
+                                if value == 0 {
+                                    return Err(syn::Error::new_spanned(
+                                        n,
+                                        "occurrence starts at 1",
+                                    ));
+                                }
+                                occurrence = Some(value);
+                            }
+                            "increment" => {
+                                let p = point(&content)?;
+                                if !p.after {
+                                    return Err(syn::Error::new_spanned(
+                                        key,
+                                        "increment requires after_let(...)",
+                                    ));
+                                }
+                                increment = Some(p.selector);
+                            }
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    key,
+                                    "unsupported counter option",
+                                ));
+                            }
+                        }
+                        if !content.is_empty() {
+                            content.parse::<Token![,]>()?;
+                        }
+                    }
+                    let mut selector = Selector::new(
+                        binding.ok_or_else(|| syn::Error::new_spanned(&key, "missing binding"))?,
+                        true,
+                    );
+                    selector.occurrence = occurrence;
+                    args.counters.push(Counter {
+                        selector,
+                        increment,
+                        field: field
+                            .ok_or_else(|| syn::Error::new_spanned(key, "missing field"))?,
+                    });
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        key,
+                        "unsupported observation option",
+                    ));
+                }
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(args)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Location {
+    block: usize,
+    statement: usize,
+}
+
+fn binds(pat: &Pat, name: &Ident) -> bool {
+    match pat {
+        Pat::Ident(p) => p.ident == *name || p.subpat.as_ref().is_some_and(|(_, p)| binds(p, name)),
+        Pat::Tuple(p) => p.elems.iter().any(|p| binds(p, name)),
+        Pat::TupleStruct(p) => p.elems.iter().any(|p| binds(p, name)),
+        Pat::Struct(p) => p.fields.iter().any(|p| binds(&p.pat, name)),
+        Pat::Slice(p) => p.elems.iter().any(|p| binds(p, name)),
+        Pat::Reference(p) => binds(&p.pat, name),
+        Pat::Type(p) => binds(&p.pat, name),
+        Pat::Paren(p) => binds(&p.pat, name),
+        _ => false,
+    }
+}
+
+struct Search<'a> {
+    selector: &'a Selector,
+    block_id: usize,
+    found: Vec<Location>,
+}
+
+impl VisitMut for Search<'_> {
+    fn visit_item_mut(&mut self, _: &mut syn::Item) {}
+    fn visit_expr_closure_mut(&mut self, _: &mut syn::ExprClosure) {}
+    fn visit_expr_async_mut(&mut self, _: &mut syn::ExprAsync) {}
+    fn visit_block_mut(&mut self, block: &mut Block) {
+        let id = self.block_id;
+        self.block_id += 1;
+        for (i, stmt) in block.stmts.iter_mut().enumerate() {
+            let matched = match stmt {
+                Stmt::Local(local) if !self.selector.is_loop => {
+                    local.init.is_some() && binds(&local.pat, &self.selector.binding)
+                }
+                Stmt::Expr(Expr::ForLoop(expr), _) if self.selector.is_loop => {
+                    binds(&expr.pat, &self.selector.binding)
+                }
+                _ => false,
+            };
+            if matched {
+                self.found.push(Location {
+                    block: id,
+                    statement: i,
+                });
+            }
+            visit_mut::visit_stmt_mut(self, stmt);
+        }
+    }
+}
+
+#[derive(Default)]
+struct Edits {
+    before: BTreeMap<Location, Vec<Stmt>>,
+    after: BTreeMap<Location, Vec<Stmt>>,
+    block_id: usize,
+}
+
+impl Edits {
+    fn add(&mut self, location: Location, after: bool, tokens: &TokenStream) -> syn::Result<()> {
+        let block: Block = syn::parse2(quote!({ #tokens }))?;
+        let map = if after {
+            &mut self.after
+        } else {
+            &mut self.before
+        };
+        map.entry(location).or_default().extend(block.stmts);
+        Ok(())
+    }
+}
+
+impl VisitMut for Edits {
+    fn visit_item_mut(&mut self, _: &mut syn::Item) {}
+    fn visit_expr_closure_mut(&mut self, _: &mut syn::ExprClosure) {}
+    fn visit_expr_async_mut(&mut self, _: &mut syn::ExprAsync) {}
+    fn visit_block_mut(&mut self, block: &mut Block) {
+        let id = self.block_id;
+        self.block_id += 1;
+        let mut stmts = Vec::new();
+        for (i, mut stmt) in std::mem::take(&mut block.stmts).into_iter().enumerate() {
+            self.visit_stmt_mut(&mut stmt);
+            let location = Location {
+                block: id,
+                statement: i,
+            };
+            stmts.extend(self.before.remove(&location).unwrap_or_default());
+            stmts.push(stmt);
+            stmts.extend(self.after.remove(&location).unwrap_or_default());
+        }
+        block.stmts = stmts;
+    }
+}
+
+fn record(fields: &[Field], span: &Ident) -> TokenStream {
+    let writes = fields.iter().map(|field| {
+        let name = field.name.to_string();
+        let value = field.value();
+        quote!(#span.record(#name, #value);)
+    });
+    quote!(if !#span.is_disabled() { #(#writes)* })
+}
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
+    let args: Args = syn::parse2(attr)?;
+    let mut function: ItemFn = syn::parse2(item)?;
+    if function.sig.asyncness.is_some() || function.sig.constness.is_some() {
+        return Err(syn::Error::new_spanned(
+            &function.sig,
+            "observe currently supports synchronous, non-const functions",
+        ));
+    }
+    let name = args
+        .name
+        .as_ref()
+        .ok_or_else(|| syn::Error::new(Span::call_site(), "missing name = \"...\""))?;
+    let level = args
+        .level
+        .as_ref()
+        .map_or_else(|| "debug".into(), LitStr::value);
+    if !matches!(
+        level.as_str(),
+        "trace" | "debug" | "info" | "warn" | "error"
+    ) {
+        return Err(syn::Error::new_spanned(
+            args.level,
+            "unsupported span level",
+        ));
+    }
+    let level = format_ident!("{}", level.to_uppercase());
+    let target = args
+        .target
+        .as_ref()
+        .map_or_else(|| quote!("gluesql"), |v| quote!(#v));
+    let span = Ident::new("__gluesql_observe_span", Span::mixed_site());
+    let entered = Ident::new("__gluesql_observe_entered", Span::mixed_site());
+    let mut names = BTreeSet::new();
+    for field in &args.fields {
+        if !names.insert(field.name.to_string()) {
+            return Err(syn::Error::new_spanned(
+                &field.name,
+                "duplicate initial field",
+            ));
+        }
+    }
+    for field in args
+        .hooks
+        .iter()
+        .flat_map(|h| &h.fields)
+        .chain(&args.record)
+        .chain(args.on_ok.iter().flat_map(|(_, f)| f))
+    {
+        names.insert(field.name.to_string());
+    }
+    for counter in &args.counters {
+        names.insert(counter.field.to_string());
+    }
+    let declarations = names.iter().map(|n| {
+        let ident = Ident::new(n, Span::call_site());
+        quote!(#ident = tracing::field::Empty)
+    });
+    let initial = record(&args.fields, &span);
+    let start = quote! {
+        let #span = tracing::span!(target: #target, tracing::Level::#level, #name, #(#declarations),*);
+        #initial
+        let #entered = #span.enter();
+    };
+    if args.start.is_some() != args.end.is_some() || (!args.record.is_empty() && args.end.is_none())
+    {
+        return Err(syn::Error::new_spanned(
+            name,
+            "start and end must be paired; record requires a range",
+        ));
+    }
+    if args.start.is_some()
+        && (!args.hooks.is_empty() || !args.counters.is_empty() || args.on_ok.is_some())
+    {
+        return Err(syn::Error::new_spanned(
+            name,
+            "range observations support fields and record; use a separate observe attribute for other hooks",
+        ));
+    }
+    let mut edits = Edits::default();
+    if let (Some(start_point), Some(end_point)) = (&args.start, &args.end) {
+        let a = start_point.selector.locations(&mut function.block)?[0];
+        let b = end_point.selector.locations(&mut function.block)?[0];
+        if a.block != b.block || (a.statement, start_point.after) >= (b.statement, end_point.after)
+        {
+            return Err(syn::Error::new_spanned(
+                name,
+                "range endpoints must be ordered within the same block",
+            ));
+        }
+        edits.add(a, start_point.after, &start)?;
+        let final_record = record(&args.record, &span);
+        edits.add(
+            b,
+            end_point.after,
+            &quote!(#final_record ::std::mem::drop(#entered); ::std::mem::drop(#span);),
+        )?;
+    } else {
+        for hook in &args.hooks {
+            for location in hook.selector.locations(&mut function.block)? {
+                edits.add(location, true, &record(&hook.fields, &span))?;
+            }
+        }
+    }
+    edits.visit_block_mut(&mut function.block);
+    for (i, counter) in args.counters.iter().enumerate() {
+        apply_counter(&mut function.block, counter, i, &span)?;
+    }
+    if args.start.is_none() {
+        let body = &function.block;
+        function.block = if let Some((binding, fields)) = &args.on_ok {
+            let output = match &function.sig.output {
+                syn::ReturnType::Type(_, ty) if matches!(ty.as_ref(), syn::Type::Path(p) if p.path.segments.last().is_some_and(|s| s.ident == "Result")) => {
+                    ty
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        &function.sig.output,
+                        "on_ok requires a Result return type",
+                    ));
+                }
+            };
+            let result = Ident::new("__gluesql_observe_result", Span::mixed_site());
+            let writes = record(fields, &span);
+            Box::new(parse_quote!({
+                #start
+                let #result = (|| -> #output #body)();
+                if let ::std::result::Result::Ok(#binding) = &#result { #writes }
+                #result
+            }))
+        } else {
+            let stmts = &body.stmts;
+            Box::new(parse_quote!({ #start #(#stmts)* }))
+        };
+    }
+    Ok(quote!(#function))
+}
+
+fn apply_counter(
+    block: &mut Block,
+    counter: &Counter,
+    index: usize,
+    span: &Ident,
+) -> syn::Result<()> {
+    let location = counter.selector.locations(block)?[0];
+    let guard = Ident::new(
+        &format!("__gluesql_observe_count_{index}"),
+        Span::mixed_site(),
+    );
+    let field = counter.field.to_string();
+    let mut editor = CounterBody {
+        location,
+        block_id: 0,
+        counter,
+        guard: &guard,
+        error: None,
+    };
+    editor.visit_block_mut(block);
+    if let Some(error) = editor.error {
+        return Err(error);
+    }
+    let mut edits = Edits::default();
+    edits.add(
+        location,
+        false,
+        &quote! {
+            let mut #guard = {
+                struct Count { span: tracing::Span, value: u64 }
+                impl ::std::ops::Drop for Count {
+                    fn drop(&mut self) { self.span.record(#field, self.value); }
+                }
+                Count { span: #span.clone(), value: 0 }
+            };
+        },
+    )?;
+    edits.add(location, true, &quote!(::std::mem::drop(#guard);))?;
+    edits.visit_block_mut(block);
+    Ok(())
+}
+
+struct CounterBody<'a> {
+    location: Location,
+    block_id: usize,
+    counter: &'a Counter,
+    guard: &'a Ident,
+    error: Option<syn::Error>,
+}
+
+impl VisitMut for CounterBody<'_> {
+    fn visit_item_mut(&mut self, _: &mut syn::Item) {}
+    fn visit_expr_closure_mut(&mut self, _: &mut syn::ExprClosure) {}
+    fn visit_expr_async_mut(&mut self, _: &mut syn::ExprAsync) {}
+    fn visit_block_mut(&mut self, block: &mut Block) {
+        let id = self.block_id;
+        self.block_id += 1;
+        for (i, stmt) in block.stmts.iter_mut().enumerate() {
+            if (Location {
+                block: id,
+                statement: i,
+            }) == self.location
+            {
+                let Stmt::Expr(Expr::ForLoop(expr), _) = stmt else {
+                    unreachable!()
+                };
+                let guard = self.guard;
+                let increment = quote!(if !#guard.span.is_disabled() { #guard.value += 1; });
+                if let Some(selector) = &self.counter.increment {
+                    let result = selector.locations(&mut expr.body).and_then(|locations| {
+                        let mut edits = Edits::default();
+                        for location in locations {
+                            edits.add(location, true, &increment)?;
+                        }
+                        edits.visit_block_mut(&mut expr.body);
+                        Ok(())
+                    });
+                    self.error = result.err();
+                } else {
+                    expr.body.stmts.insert(0, parse_quote!(#increment));
+                }
+                return;
+            }
+            self.visit_stmt_mut(stmt);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::expand, quote::quote};
+
+    #[test]
+    fn rejects_invalid_selectors_and_options() {
+        let body = quote!(
+            fn example() -> Result<(), ()> {
+                let rows = vec![1];
+                let rows = rows;
+                Ok(())
+            }
+        );
+        for attr in [
+            quote!(name = "x", after_let(missing, record(n = 1))),
+            quote!(name = "x", after_let(rows, record(n = 1))),
+            quote!(name = "x", after_let(rows, occurrence = 0, record(n = 1))),
+            quote!(name = "x", after_let(rows, occurrence = 3, record(n = 1))),
+            quote!(
+                name = "x",
+                start = before_let(rows, occurrence = 2),
+                end = after_let(rows, occurrence = 1)
+            ),
+            quote!(name = "x", start = before_let(rows, occurrence = 1)),
+            quote!(name = "x", level = "verbose"),
+            quote!(name = "x", name = "y"),
+            quote!(name = "x", unknown = true),
+        ] {
+            assert!(
+                expand(attr.clone(), body.clone()).is_err(),
+                "accepted {attr}"
+            );
+        }
+        for body in [
+            quote!(
+                async fn example() {}
+            ),
+            quote!(
+                const fn example() {}
+            ),
+        ] {
+            assert!(expand(quote!(name = "x"), body).is_err());
+        }
+        assert!(
+            expand(
+                quote!(name = "x", on_ok(v, record(n = v))),
+                quote!(
+                    fn f() -> usize {
+                        1
+                    }
+                )
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn does_not_search_separate_execution_scopes() {
+        for body in [
+            quote!(
+                fn f() {
+                    let closure = || {
+                        let rows = vec![1];
+                    };
+                }
+            ),
+            quote!(
+                fn f() {
+                    fn nested() {
+                        let rows = vec![1];
+                    }
+                }
+            ),
+            quote!(
+                fn f() {
+                    let future = async {
+                        let rows = vec![1];
+                    };
+                }
+            ),
+        ] {
+            assert!(
+                expand(
+                    quote!(name = "x", after_let(rows, record(n = rows.len()))),
+                    body
+                )
+                .is_err()
+            );
+        }
+        assert!(
+            expand(
+                quote!(name = "x", start = before_let(a), end = after_let(b)),
+                quote!(
+                    fn f() {
+                        let a = 1;
+                        if true {
+                            let b = 2;
+                        }
+                    }
+                )
+            )
+            .is_err()
+        );
+    }
+}

--- a/macros/tests/runtime_observe.rs
+++ b/macros/tests/runtime_observe.rs
@@ -323,6 +323,74 @@ impl ObservedStorage {
     async fn async_lookup(&self, key: u8) -> Result<u8> {
         self.lookup(key)
     }
+
+    fn opaque_rows(&self, fail: bool) -> Result<impl Iterator<Item = u8>> {
+        if fail {
+            return Err("opaque failure");
+        }
+        Ok([1, 2].into_iter())
+    }
+}
+
+struct MutableRows {
+    rows: Vec<u8>,
+}
+
+impl MutableRows {
+    #[observe(name = "mutable_rows", on_ok(rows, record(n = rows.len())))]
+    fn rows_mut(&mut self) -> Result<&mut Vec<u8>> {
+        Ok(&mut self.rows)
+    }
+}
+
+#[observe(name = "opaque_result", after_let(rows, record(n = rows.len())), on_ok(rows, record(returned = rows.len())))]
+fn opaque_result() -> Result<impl ExactSizeIterator<Item = u8>> {
+    let rows = [3, 4];
+    Ok(rows.into_iter())
+}
+
+#[observe(name = "borrow_input", on_ok(value, record(n = input.len(), result = *value)))]
+fn borrow_input(input: Vec<u8>) -> Result<usize> {
+    Ok(input.len())
+}
+
+#[test]
+fn preserves_mutable_and_opaque_return_values() {
+    let capture = Capture::default();
+    tracing::subscriber::with_default(Registry::default().with(capture.clone()), || {
+        let mut storage = MutableRows { rows: vec![1, 2] };
+        storage.rows_mut().unwrap().push(3);
+        assert_eq!(storage.rows, vec![1, 2, 3]);
+        assert_eq!(
+            ObservedStorage
+                .opaque_rows(false)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert!(matches!(
+            ObservedStorage.opaque_rows(true),
+            Err("opaque failure")
+        ));
+        assert_eq!(opaque_result().unwrap().collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(borrow_input(vec![1, 2, 3]), Ok(3));
+    });
+    let records = capture.0.lock().unwrap();
+    assert!(
+        records
+            .iter()
+            .any(|(name, fields)| name == "mutable_rows"
+                && fields.get("n").is_some_and(|n| n == "2"))
+    );
+    assert!(records.iter().any(|(name, fields)| name == "opaque_result"
+        && fields.get("returned").is_some_and(|n| n == "2")
+        && fields.get("n").is_some_and(|n| n == "2")));
+    assert!(records.iter().any(|(name, fields)| {
+        name == "event"
+            && fields
+                .get("error")
+                .is_some_and(|error| error == "\"opaque failure\"")
+    }));
 }
 
 #[test]

--- a/macros/tests/runtime_observe.rs
+++ b/macros/tests/runtime_observe.rs
@@ -1,0 +1,271 @@
+use {
+    gluesql_core::prelude::Glue,
+    gluesql_macros::observe,
+    gluesql_memory_storage::MemoryStorage,
+    std::{
+        collections::BTreeMap,
+        fmt,
+        sync::atomic::{AtomicUsize, Ordering},
+        sync::{Arc, Mutex},
+    },
+    tracing::{
+        Subscriber,
+        field::{Field, Visit},
+        span::{Attributes, Id, Record},
+    },
+    tracing_subscriber::{
+        Layer, Registry,
+        layer::{Context, SubscriberExt},
+        registry::LookupSpan,
+    },
+};
+
+type Result<T> = std::result::Result<T, &'static str>;
+type CapturedSpans = Vec<(String, BTreeMap<String, String>)>;
+
+#[derive(Clone, Default)]
+struct Capture(Arc<Mutex<CapturedSpans>>);
+
+#[derive(Default)]
+struct Values(BTreeMap<String, String>);
+
+impl Visit for Values {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Capture {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut values = Values::default();
+        attrs.record(&mut values);
+        ctx.span(id).unwrap().extensions_mut().insert(values);
+    }
+
+    fn on_record(&self, id: &Id, record: &Record<'_>, ctx: Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+        record.record(span.extensions_mut().get_mut::<Values>().unwrap());
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).unwrap();
+        let values = span.extensions().get::<Values>().unwrap().0.clone();
+        self.0
+            .lock()
+            .unwrap()
+            .push((span.name().to_owned(), values));
+    }
+}
+
+#[observe(name = "bindings", fields(kind = "test"), after_let(rows, occurrence = 2, record(buffered_rows = rows.len())))]
+fn bindings() -> Vec<usize> {
+    let rows = vec![1, 1, 2];
+    let rows = rows.into_iter().collect::<Vec<_>>();
+    rows.into_iter().filter(|n| *n == 2).collect()
+}
+
+#[observe(name = "branches", after_let(rows, all, record(n = rows.len())))]
+fn branches(left: bool) -> Vec<u8> {
+    if left {
+        let rows = vec![1];
+        rows
+    } else {
+        let rows = vec![2, 3];
+        rows
+    }
+}
+
+#[observe(name = "range", start = before_let(rows), end = after_let(n), record(n = n))]
+fn range(fail: bool) -> Result<usize> {
+    assert_eq!(
+        tracing::Span::current().metadata().unwrap().name(),
+        "parent"
+    );
+    let rows = [1, 2];
+    assert_eq!(tracing::Span::current().metadata().unwrap().name(), "range");
+    if fail {
+        return Err("failed");
+    }
+    let n = rows.len();
+    assert_eq!(
+        tracing::Span::current().metadata().unwrap().name(),
+        "parent"
+    );
+    Ok(n)
+}
+
+#[observe(name = "scan", count_loop(binding = row, increment = after_let(value), field = scanned_rows))]
+fn scan(rows: Vec<Result<u8>>, stop: bool) -> Result<()> {
+    for row in rows {
+        let value = row?;
+        if stop && value == 2 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[observe(name = "entries", count_loop(binding = row, field = entries), after_loop(row, record(done = true)))]
+fn entries() -> Result<()> {
+    for row in [Ok(1), Err("bad")] {
+        row?;
+    }
+    Ok(())
+}
+
+#[observe(name = "result", on_ok(value, record(n = value.len())))]
+fn result(early: bool, fail: bool) -> Result<Vec<usize>> {
+    if fail {
+        return Err("failed");
+    }
+    if early {
+        return Ok(vec![1]);
+    }
+    Ok(vec![1, 2])
+}
+
+struct Example;
+impl Example {
+    #[observe(name = "method", fields(key = ?key), on_ok(value, record(n = value.len())))]
+    fn method<'a>(&self, key: &'a str) -> Result<&'a str> {
+        Ok(key)
+    }
+}
+
+#[test]
+fn records_values_without_changing_control_flow() {
+    let capture = Capture::default();
+    let subscriber = Registry::default().with(capture.clone());
+    tracing::subscriber::with_default(subscriber, || {
+        let parent = tracing::info_span!("parent");
+        let _entered = parent.enter();
+        assert_eq!(bindings(), vec![2]);
+        assert_eq!(branches(true), vec![1]);
+        assert_eq!(branches(false), vec![2, 3]);
+        assert_eq!(range(false), Ok(2));
+        assert_eq!(range(true), Err("failed"));
+        assert_eq!(
+            tracing::Span::current().metadata().unwrap().name(),
+            "parent"
+        );
+        assert_eq!(scan(vec![Ok(1), Ok(2), Err("bad")], false), Err("bad"));
+        assert_eq!(scan(vec![Ok(1), Ok(2), Ok(3)], true), Ok(()));
+        assert_eq!(entries(), Err("bad"));
+        assert_eq!(result(false, false), Ok(vec![1, 2]));
+        assert_eq!(result(true, false), Ok(vec![1]));
+        assert_eq!(result(false, true), Err("failed"));
+        assert_eq!(Example.method("key"), Ok("key"));
+    });
+    let spans = capture.0.lock().unwrap();
+    let values = |name: &str, field: &str| -> Vec<Option<String>> {
+        spans
+            .iter()
+            .filter(|(n, _)| n == name)
+            .map(|(_, v)| v.get(field).cloned())
+            .collect()
+    };
+    assert_eq!(values("bindings", "buffered_rows"), vec![Some("3".into())]);
+    assert_eq!(
+        values("branches", "n"),
+        vec![Some("1".into()), Some("2".into())]
+    );
+    assert_eq!(values("range", "n"), vec![Some("2".into()), None]);
+    assert_eq!(
+        values("scan", "scanned_rows"),
+        vec![Some("2".into()), Some("2".into())]
+    );
+    assert_eq!(values("entries", "entries"), vec![Some("2".into())]);
+    assert_eq!(values("entries", "done"), vec![None]);
+    assert_eq!(
+        values("result", "n"),
+        vec![Some("2".into()), Some("1".into()), None]
+    );
+    assert_eq!(values("method", "n"), vec![Some("3".into())]);
+}
+
+static EVALUATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[observe(name = "disabled", fields(n = EVALUATIONS.fetch_add(1, Ordering::SeqCst)), after_let(rows, record(n = EVALUATIONS.fetch_add(rows.len(), Ordering::SeqCst))))]
+fn disabled() {
+    let rows = [1];
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn disabled_subscriber_does_not_evaluate_fields() {
+    tracing::subscriber::with_default(tracing::subscriber::NoSubscriber::default(), disabled);
+    assert_eq!(EVALUATIONS.load(Ordering::SeqCst), 0);
+}
+
+#[cfg_attr(any(), gluesql_macros::observe(name = "off", after_let(missing, record(n = nonexistent()))))]
+fn feature_off() -> u8 {
+    7
+}
+
+#[test]
+fn disabled_attribute_keeps_original_function() {
+    assert_eq!(feature_off(), 7);
+}
+
+#[test]
+fn query_pipeline_preserves_measurement_points() {
+    let capture = Capture::default();
+    tracing::subscriber::with_default(Registry::default().with(capture.clone()), || {
+        let mut glue = Glue::new(MemoryStorage::default());
+        glue.execute(
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, category INTEGER, code INTEGER UNIQUE)",
+        )
+        .unwrap();
+        glue.execute("INSERT INTO items VALUES (1, 10, 101), (2, 10, 102), (3, 20, 103)")
+            .unwrap();
+        glue.execute("SELECT DISTINCT category FROM items").unwrap();
+        glue.execute("SELECT category, COUNT(*) FROM items GROUP BY category")
+            .unwrap();
+        glue.execute("SELECT * FROM items ORDER BY id").unwrap();
+        glue.execute("SELECT a.id FROM items a JOIN items b ON a.id = b.id")
+            .unwrap();
+        glue.execute("INSERT INTO items VALUES (4, 20, 104)")
+            .unwrap();
+        glue.execute("UPDATE items SET category = 30 WHERE id = 1")
+            .unwrap();
+        glue.execute("DELETE FROM items WHERE id = 2").unwrap();
+        glue.execute("CREATE TABLE documents").unwrap();
+        glue.execute("INSERT INTO documents VALUES ('{\"name\":\"Tachibana Sherry\"}')")
+            .unwrap();
+        glue.execute("SELECT * FROM documents").unwrap();
+    });
+    let spans = capture.0.lock().unwrap();
+    let contains = |name: &str, field: &str, value: &str| {
+        spans
+            .iter()
+            .any(|(n, fields)| n == name && fields.get(field).is_some_and(|v| v == value))
+    };
+    assert!(contains("gluesql.query.distinct", "buffered_rows", "3"));
+    assert!(contains("gluesql.query.aggregate", "buffered_groups", "2"));
+    assert!(contains("gluesql.query.order_by", "buffered_rows", "3"));
+    assert!(contains(
+        "gluesql.query.hash_join.build",
+        "buffered_rows",
+        "3"
+    ));
+    assert!(contains("gluesql.insert.collect", "buffered_rows", "3"));
+    assert!(contains("gluesql.insert.collect", "buffered_rows", "1"));
+    assert!(contains("gluesql.result.materialize", "buffered_rows", "2"));
+    assert!(contains("gluesql.result.materialize", "buffered_rows", "1"));
+    assert!(contains("gluesql.validate.unique", "scanned_rows", "3"));
+    let mutations: Vec<_> = spans
+        .iter()
+        .filter(|(n, _)| n == "gluesql.mutation.collect")
+        .collect();
+    assert_eq!(mutations.len(), 2);
+    assert!(
+        mutations
+            .iter()
+            .all(|(_, fields)| fields.get("buffered_rows") == Some(&"1".to_owned()))
+    );
+    assert!(contains(
+        "gluesql.execute",
+        "sql",
+        "SELECT DISTINCT category FROM items"
+    ));
+}

--- a/macros/tests/runtime_observe.rs
+++ b/macros/tests/runtime_observe.rs
@@ -1,6 +1,6 @@
 use {
     gluesql_core::prelude::Glue,
-    gluesql_macros::observe,
+    gluesql_macros::{observe, trace_storage},
     gluesql_memory_storage::MemoryStorage,
     std::{
         collections::BTreeMap,
@@ -45,6 +45,12 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for Capture {
     fn on_record(&self, id: &Id, record: &Record<'_>, ctx: Context<'_, S>) {
         let span = ctx.span(id).unwrap();
         record.record(span.extensions_mut().get_mut::<Values>().unwrap());
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _: Context<'_, S>) {
+        let mut values = Values::default();
+        event.record(&mut values);
+        self.0.lock().unwrap().push(("event".into(), values.0));
     }
 
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
@@ -268,4 +274,108 @@ fn query_pipeline_preserves_measurement_points() {
         "sql",
         "SELECT DISTINCT category FROM items"
     ));
+}
+
+#[observe(name = "conditional", after_let(rows, all, record(n = rows.len())))]
+fn conditional_bindings() {
+    #[cfg(any())]
+    let rows = [1];
+    #[cfg_attr(all(), cfg(any()))]
+    let rows = [2];
+    #[cfg(test)]
+    let rows = [1, 2, 3];
+    #[cfg(test)]
+    assert_eq!(rows.len(), 3);
+}
+
+#[observe(name = "conditional_loop", count_loop(binding = row, increment = after_let(value), field = n))]
+fn conditional_loop() {
+    #[cfg(any())]
+    for row in [1] {
+        let value = row;
+    }
+}
+
+#[observe(name = "raw", fields(r#type = "initial"), after_let(value, record(r#type = value)))]
+fn raw_field() -> &'static str {
+    let value = "updated";
+    value
+}
+
+#[observe(
+    event("entry", access_path = "full_scan"),
+    after_let(key, event("lookup", access_path = "primary_key"))
+)]
+fn events(fail: bool) -> Result<()> {
+    let key = if fail { Err("bad key") } else { Ok(1) }?;
+    assert_eq!(key, 1);
+    Ok(())
+}
+
+struct ObservedStorage;
+
+#[trace_storage(name = "shared")]
+impl ObservedStorage {
+    fn lookup(&self, key: u8) -> Result<u8> {
+        if key == 0 { Err("missing") } else { Ok(key) }
+    }
+
+    async fn async_lookup(&self, key: u8) -> Result<u8> {
+        self.lookup(key)
+    }
+}
+
+#[test]
+fn conditional_raw_fields_events_and_storage_share_instrumentation() {
+    let capture = Capture::default();
+    tracing::subscriber::with_default(Registry::default().with(capture.clone()), || {
+        conditional_bindings();
+        conditional_loop();
+        assert_eq!(raw_field(), "updated");
+        assert_eq!(events(false), Ok(()));
+        assert_eq!(events(true), Err("bad key"));
+        assert_eq!(ObservedStorage.lookup(0), Err("missing"));
+        assert_eq!(ObservedStorage.lookup(1), Ok(1));
+        let mut future = Box::pin(ObservedStorage.async_lookup(2));
+        let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+        assert_eq!(
+            std::future::Future::poll(future.as_mut(), &mut context),
+            std::task::Poll::Ready(Ok(2))
+        );
+    });
+    let records = capture.0.lock().unwrap();
+    let field_values = |name: &str, field: &str| -> Vec<Option<String>> {
+        records
+            .iter()
+            .filter(|(n, _)| n == name)
+            .map(|(_, fields)| fields.get(field).cloned())
+            .collect()
+    };
+    assert_eq!(field_values("conditional", "n"), vec![Some("3".into())]);
+    assert_eq!(field_values("conditional_loop", "n"), vec![None]);
+    assert_eq!(
+        field_values("raw", "type"),
+        vec![Some("\"updated\"".into())]
+    );
+    assert_eq!(
+        field_values("gluesql.shared.lookup", "key"),
+        vec![Some("0".into()), Some("1".into()), Some("2".into())]
+    );
+    assert_eq!(
+        field_values("gluesql.shared.async_lookup", "key"),
+        vec![Some("2".into())]
+    );
+    let paths: Vec<_> = records
+        .iter()
+        .filter_map(|(_, fields)| fields.get("access_path"))
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["\"full_scan\"", "\"primary_key\"", "\"full_scan\""]
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(_, fields)| fields.get("error") == Some(&"\"missing\"".into()))
+    );
 }

--- a/macros/tests/runtime_ok_instrument_storage.rs
+++ b/macros/tests/runtime_ok_instrument_storage.rs
@@ -1,0 +1,34 @@
+use gluesql_macros::trace_storage;
+
+type Result<T> = std::result::Result<T, &'static str>;
+type Rows = Box<dyn Iterator<Item = Result<i32>>>;
+
+trait ExternalStore {
+    fn lookup(&self, key: i32, rows: Vec<i32>) -> Result<Vec<i32>>;
+    fn stream(&self) -> Result<Rows>;
+}
+
+struct Storage;
+
+#[trace_storage(name = "external")]
+impl ExternalStore for Storage {
+    fn lookup(&self, key: i32, rows: Vec<i32>) -> Result<Vec<i32>> {
+        Ok(rows.into_iter().filter(|value| *value == key).collect())
+    }
+
+    #[trace_iterator]
+    fn stream(&self) -> Result<Rows> {
+        Ok(Box::new([Ok(1), Err("broken row"), Ok(2)].into_iter()))
+    }
+}
+
+#[test]
+fn instruments_external_trait_without_changing_calls() {
+    let storage = Storage;
+
+    assert_eq!(storage.lookup(2, vec![1, 2, 3]), Ok(vec![2]));
+    assert_eq!(
+        storage.stream().unwrap().collect::<Vec<_>>(),
+        vec![Ok(1), Err("broken row"), Ok(2)]
+    );
+}

--- a/pkg/rust/Cargo.toml
+++ b/pkg/rust/Cargo.toml
@@ -32,6 +32,14 @@ gluesql-file-storage = { workspace = true, optional = true }
 gluesql-git-storage = { workspace = true, optional = true }
 
 [features]
+tracing = [
+  "gluesql-core/tracing",
+  "gluesql-redb-storage?/tracing",
+  "cli?/tracing",
+]
+tracing-flame = ["cli?/tracing-flame"]
+opentelemetry = ["cli?/opentelemetry"]
+
 # DB User
 default = [
   "cli",

--- a/pkg/rust/src/lib.rs
+++ b/pkg/rust/src/lib.rs
@@ -12,7 +12,7 @@ pub mod core {
 pub use gluesql_core::params;
 
 // Re-export the derive macros so users can `use gluesql::{FromGlueRow, ToGlueRow}`.
-pub use gluesql_macros::{FromGlueRow, ToGlueRow};
+pub use gluesql_macros::{FromGlueRow, ToGlueRow, trace_storage};
 
 #[cfg(feature = "gluesql_memory_storage")]
 pub use gluesql_memory_storage;

--- a/storages/redb-storage/Cargo.toml
+++ b/storages/redb-storage/Cargo.toml
@@ -7,16 +7,39 @@ license.workspace = true
 repository.workspace = true
 documentation.workspace = true
 
+[features]
+tracing = ["dep:gluesql-macros", "dep:tracing", "gluesql-core/tracing"]
+firefox-profile = [
+  "tracing",
+  "dep:fxprof-processed-profile",
+  "dep:serde_json",
+]
+
 [dependencies]
 gluesql-core.workspace = true
+gluesql-macros = { path = "../../macros", version = "0.20.0", optional = true }
 redb = "2.6"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2.0.3"
 bincode = "1.3.3"
 uuid = { version = "1.11.0", features = ["v7"] }
+tracing = { version = "0.1", optional = true, default-features = false, features = [
+  "attributes",
+  "std",
+] }
+fxprof-processed-profile = { version = "0.8.1", optional = true }
+serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 test-suite.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
+[[example]]
+name = "resource_benchmark"
+required-features = ["tracing"]
 
 [lints]
 workspace = true

--- a/storages/redb-storage/examples/resource_benchmark.rs
+++ b/storages/redb-storage/examples/resource_benchmark.rs
@@ -1,0 +1,258 @@
+use {
+    gluesql_core::prelude::Glue,
+    gluesql_redb_storage::RedbStorage,
+    std::{
+        env,
+        error::Error,
+        fs, io,
+        path::Path,
+        sync::mpsc::{self, RecvTimeoutError, Sender},
+        thread::{self, JoinHandle},
+        time::{Duration, Instant},
+    },
+    tracing::{Level, Span, field},
+    tracing_subscriber::fmt::format::FmtSpan,
+};
+
+const DEFAULT_MEMORY_SAMPLE_MS: u64 = 10;
+
+struct MemorySampler {
+    stop: Sender<()>,
+    handle: JoinHandle<io::Result<()>>,
+}
+
+impl MemorySampler {
+    fn start(parent: Span, interval: Duration) -> Self {
+        let (stop, receiver) = mpsc::channel();
+        let started_at = Instant::now();
+        let handle = thread::spawn(move || {
+            loop {
+                record_memory_sample(&parent, started_at)?;
+
+                match receiver.recv_timeout(interval) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => {
+                        record_memory_sample(&parent, started_at)?;
+                        return Ok(());
+                    }
+                    Err(RecvTimeoutError::Timeout) => {}
+                }
+            }
+        });
+
+        Self { stop, handle }
+    }
+
+    fn stop(self) -> io::Result<()> {
+        let _ = self.stop.send(());
+        self.handle
+            .join()
+            .map_err(|_| io::Error::other("memory sampler thread panicked"))?
+    }
+}
+
+#[cfg(feature = "firefox-profile")]
+#[path = "resource_benchmark/firefox_profile.rs"]
+mod firefox_profile;
+
+#[cfg(not(feature = "firefox-profile"))]
+fn init_tracing() -> Result<(), Box<dyn Error>> {
+    use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("gluesql=info")),
+        )
+        .with_span_events(FmtSpan::CLOSE)
+        .with_writer(io::stderr)
+        .finish()
+        .try_init()?;
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "firefox-profile")]
+    let firefox_profile = firefox_profile::init()?;
+    #[cfg(not(feature = "firefox-profile"))]
+    init_tracing()?;
+
+    let mut args = env::args_os().skip(1);
+    let database_path = args.next().ok_or("missing DATABASE_PATH")?;
+    let sql_path = args.next().ok_or("missing SQL_PATH")?;
+    if args.next().is_some() {
+        return Err("usage: resource_benchmark DATABASE_PATH SQL_PATH".into());
+    }
+
+    let benchmark_name = Path::new(&sql_path)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("redb");
+    let span = tracing::info_span!(
+        target: "gluesql",
+        "gluesql.benchmark.run",
+        benchmark.name = benchmark_name,
+        benchmark.storage = "redb",
+        process.memory.peak_bytes = field::Empty,
+        gluesql.database.size_bytes = field::Empty,
+        process.executable.size_bytes = field::Empty,
+    );
+    let entered = span.enter();
+
+    let memory_sampler = if tracing::enabled!(target: "gluesql", Level::DEBUG) {
+        let memory_sample_ms = env::var("GLUESQL_MEMORY_SAMPLE_MS")
+            .map_or(Ok(DEFAULT_MEMORY_SAMPLE_MS), |value| value.parse::<u64>())?;
+        if memory_sample_ms == 0 {
+            return Err("GLUESQL_MEMORY_SAMPLE_MS must be greater than zero".into());
+        }
+
+        Some(MemorySampler::start(
+            span.clone(),
+            Duration::from_millis(memory_sample_ms),
+        ))
+    } else {
+        None
+    };
+
+    let workload = (|| -> Result<(), Box<dyn Error>> {
+        let sql = fs::read_to_string(&sql_path)?;
+        let storage = RedbStorage::new(&database_path)?;
+        let mut glue = Glue::new(storage);
+
+        glue.execute(&sql)?;
+
+        Ok(())
+    })();
+    if let Some(memory_sampler) = memory_sampler {
+        memory_sampler.stop()?;
+    }
+    workload?;
+
+    span.record("process.memory.peak_bytes", peak_rss_bytes()?);
+    span.record(
+        "gluesql.database.size_bytes",
+        fs::metadata(database_path)?.len(),
+    );
+    span.record(
+        "process.executable.size_bytes",
+        fs::metadata(env::current_exe()?)?.len(),
+    );
+
+    drop(entered);
+    drop(span);
+    #[cfg(feature = "firefox-profile")]
+    firefox_profile.finish()?;
+    Ok(())
+}
+
+fn record_memory_sample(parent: &Span, started_at: Instant) -> io::Result<()> {
+    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+    let rss_bytes = current_rss_bytes()?;
+
+    tracing::debug!(
+        target: "gluesql",
+        parent: parent,
+        elapsed_ms,
+        rss_bytes,
+        "gluesql.benchmark.memory_sample"
+    );
+
+    Ok(())
+}
+
+#[cfg(target_vendor = "apple")]
+#[allow(deprecated)]
+fn current_rss_bytes() -> io::Result<u64> {
+    let mut info = std::mem::MaybeUninit::<libc::mach_task_basic_info>::uninit();
+    let mut count = libc::MACH_TASK_BASIC_INFO_COUNT;
+
+    // SAFETY: task_info writes at most `count` integers to the correctly sized output buffer.
+    let result = unsafe {
+        libc::task_info(
+            libc::mach_task_self(),
+            libc::MACH_TASK_BASIC_INFO,
+            info.as_mut_ptr().cast(),
+            &raw mut count,
+        )
+    };
+    if result != libc::KERN_SUCCESS {
+        return Err(io::Error::other(format!(
+            "failed to read current RSS: Mach error {result}"
+        )));
+    }
+
+    // SAFETY: the successful task_info call above initialized `info`.
+    Ok(unsafe { info.assume_init() }.resident_size)
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_bytes() -> io::Result<u64> {
+    let statm = fs::read_to_string("/proc/self/statm")?;
+    let resident_pages = statm
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing resident page count"))?
+        .parse::<u64>()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+
+    // SAFETY: sysconf reads the process configuration and does not dereference pointers.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    resident_pages
+        .checked_mul(page_size as u64)
+        .ok_or_else(|| io::Error::other("current RSS overflowed u64"))
+}
+
+#[cfg(not(any(target_vendor = "apple", target_os = "linux")))]
+fn current_rss_bytes() -> io::Result<u64> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "current RSS measurement is supported only on macOS and Linux",
+    ))
+}
+
+#[cfg(unix)]
+fn peak_rss_bytes() -> io::Result<u64> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+
+    // SAFETY: getrusage initializes `usage` when it returns zero.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: the successful getrusage call above initialized `usage`.
+    let peak_rss = unsafe { usage.assume_init() }.ru_maxrss as u64;
+
+    #[cfg(target_vendor = "apple")]
+    return Ok(peak_rss);
+
+    #[cfg(not(target_vendor = "apple"))]
+    Ok(peak_rss * 1024)
+}
+
+#[cfg(not(unix))]
+fn peak_rss_bytes() -> io::Result<u64> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "peak RSS measurement is supported only on Unix",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{current_rss_bytes, peak_rss_bytes};
+
+    #[cfg(any(target_vendor = "apple", target_os = "linux"))]
+    #[test]
+    fn current_rss_is_reported_in_bytes() {
+        assert!(current_rss_bytes().expect("current RSS should be available") > 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn peak_rss_is_reported_in_bytes() {
+        assert!(peak_rss_bytes().expect("peak RSS should be available") > 0);
+    }
+}

--- a/storages/redb-storage/examples/resource_benchmark.sql
+++ b/storages/redb-storage/examples/resource_benchmark.sql
@@ -1,0 +1,12 @@
+CREATE TABLE Items (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+
+INSERT INTO Items VALUES
+    (1, 'apple'),
+    (2, 'banana'),
+    (3, 'cherry');
+
+SELECT * FROM Items WHERE id = 1;
+SELECT * FROM Items;

--- a/storages/redb-storage/examples/resource_benchmark/firefox_profile.rs
+++ b/storages/redb-storage/examples/resource_benchmark/firefox_profile.rs
@@ -1,0 +1,307 @@
+use {
+    fxprof_processed_profile::{
+        CategoryHandle, CounterHandle, MarkerFieldFlags, MarkerFieldFormat, MarkerLocations,
+        MarkerTiming, ProcessHandle, Profile, SamplingInterval, StaticSchemaMarker,
+        StaticSchemaMarkerField, StringHandle, ThreadHandle, Timestamp,
+    },
+    std::{
+        env,
+        error::Error,
+        fs::File,
+        io::BufWriter,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::{Duration, Instant, SystemTime},
+    },
+    tracing::{Event, Subscriber, field::Visit, span},
+    tracing_subscriber::{
+        EnvFilter, Layer, fmt,
+        layer::{Context, SubscriberExt},
+        registry::LookupSpan,
+        util::SubscriberInitExt,
+    },
+};
+
+#[derive(Clone)]
+pub struct FirefoxProfileLayer {
+    state: Arc<Mutex<ProfileState>>,
+}
+
+struct ProfileState {
+    profile: Profile,
+    process: ProcessHandle,
+    thread: ThreadHandle,
+    rss_counter: CounterHandle,
+    started_at: Instant,
+    previous_rss: u64,
+    path: PathBuf,
+}
+
+struct SpanRecord {
+    name: &'static str,
+    started_at: Instant,
+    fields: FieldVisitor,
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    message: Option<String>,
+    rss_bytes: Option<u64>,
+    fields: Vec<String>,
+}
+
+struct TraceMarker {
+    name: StringHandle,
+    fields: StringHandle,
+}
+
+impl StaticSchemaMarker for TraceMarker {
+    const UNIQUE_MARKER_TYPE_NAME: &'static str = "GlueSQL tracing";
+    const LOCATIONS: MarkerLocations = MarkerLocations::MARKER_CHART
+        .union(MarkerLocations::MARKER_TABLE)
+        .union(MarkerLocations::TIMELINE_OVERVIEW);
+    const CHART_LABEL: Option<&'static str> = Some("{marker.name}");
+    const TABLE_LABEL: Option<&'static str> = Some("{marker.name}");
+    const FIELDS: &'static [StaticSchemaMarkerField] = &[StaticSchemaMarkerField {
+        key: "fields",
+        label: "Fields",
+        format: MarkerFieldFormat::String,
+        flags: MarkerFieldFlags::SEARCHABLE,
+    }];
+
+    fn name(&self, _profile: &mut Profile) -> StringHandle {
+        self.name
+    }
+
+    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+        CategoryHandle::OTHER
+    }
+
+    fn string_field_value(&self, _field_index: u32) -> StringHandle {
+        self.fields
+    }
+
+    fn number_field_value(&self, _field_index: u32) -> f64 {
+        unreachable!()
+    }
+}
+
+impl FirefoxProfileLayer {
+    fn new(path: PathBuf) -> Self {
+        let started_at = Instant::now();
+        let mut profile = Profile::new(
+            "GlueSQL resource benchmark",
+            SystemTime::now().into(),
+            SamplingInterval::from_millis(1),
+        );
+        let start = Timestamp::from_nanos_since_reference(0);
+        let pid = std::process::id();
+        let process = profile.add_process("resource_benchmark", pid, start);
+        let thread = profile.add_thread(process, pid, start, true);
+        profile.set_thread_name(thread, "GlueSQL");
+        profile.add_initial_visible_thread(thread);
+        profile.add_initial_selected_thread(thread);
+        profile.set_symbolicated(true);
+        let rss_counter = profile.add_counter(
+            process,
+            "process_rss",
+            "Memory",
+            "Resident set size in bytes",
+        );
+
+        Self {
+            state: Arc::new(Mutex::new(ProfileState {
+                profile,
+                process,
+                thread,
+                rss_counter,
+                started_at,
+                previous_rss: 0,
+                path,
+            })),
+        }
+    }
+
+    pub fn finish(&self) -> Result<(), Box<dyn Error>> {
+        let mut state = self.state.lock().expect("Firefox profile lock poisoned");
+        let end = timestamp(state.started_at.elapsed());
+        let process = state.process;
+        let thread = state.thread;
+        state.profile.set_process_end_time(process, end);
+        state.profile.set_thread_end_time(thread, end);
+        serde_json::to_writer(BufWriter::new(File::create(&state.path)?), &state.profile)?;
+        Ok(())
+    }
+
+    fn add_marker(&self, name: &str, fields: &str, timing: MarkerTiming) {
+        let mut state = self.state.lock().expect("Firefox profile lock poisoned");
+        let name = state.profile.intern_string(name);
+        let fields = state.profile.intern_string(fields);
+        let thread = state.thread;
+        state
+            .profile
+            .add_marker(thread, timing, TraceMarker { name, fields });
+    }
+
+    fn now(&self) -> Timestamp {
+        let state = self.state.lock().expect("Firefox profile lock poisoned");
+        timestamp(state.started_at.elapsed())
+    }
+}
+
+impl<S> Layer<S> for FirefoxProfileLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let mut fields = FieldVisitor::default();
+        attrs.record(&mut fields);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(SpanRecord {
+                name: attrs.metadata().name(),
+                started_at: Instant::now(),
+                fields,
+            });
+        }
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id)
+            && let Some(record) = span.extensions_mut().get_mut::<SpanRecord>()
+        {
+            values.record(&mut record.fields);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut fields = FieldVisitor::default();
+        event.record(&mut fields);
+        if let Some(rss_bytes) = fields.rss_bytes {
+            let mut state = self.state.lock().expect("Firefox profile lock poisoned");
+            let sample_time = timestamp(state.started_at.elapsed());
+            let delta = rss_bytes as f64 - state.previous_rss as f64;
+            state.previous_rss = rss_bytes;
+            let counter = state.rss_counter;
+            state
+                .profile
+                .add_counter_sample(counter, sample_time, delta, 0);
+            return;
+        }
+
+        let name = fields
+            .message
+            .as_deref()
+            .unwrap_or_else(|| event.metadata().name());
+        self.add_marker(
+            name,
+            &fields.fields.join(", "),
+            MarkerTiming::Instant(self.now()),
+        );
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id)
+            && let Some(record) = span.extensions_mut().remove::<SpanRecord>()
+        {
+            let state = self.state.lock().expect("Firefox profile lock poisoned");
+            let start = timestamp(record.started_at.duration_since(state.started_at));
+            let end = timestamp(state.started_at.elapsed());
+            drop(state);
+            self.add_marker(
+                record.name,
+                &record.fields.fields.join(", "),
+                MarkerTiming::Interval(start, end),
+            );
+        }
+    }
+}
+
+impl Visit for FieldVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "rss_bytes" {
+            self.rss_bytes = Some(value);
+        }
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        } else {
+            self.fields.push(format!("{}={value}", field.name()));
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        } else {
+            self.fields.push(format!("{}={value:?}", field.name()));
+        }
+    }
+}
+
+fn timestamp(elapsed: Duration) -> Timestamp {
+    Timestamp::from_nanos_since_reference(elapsed.as_nanos() as u64)
+}
+
+pub fn init() -> Result<FirefoxProfileLayer, Box<dyn Error>> {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("gluesql=info"));
+    let layer = FirefoxProfileLayer::new(
+        env::var_os("GLUESQL_FIREFOX_PROFILE_PATH")
+            .unwrap_or_else(|| "gluesql-benchmark-profile.json".into())
+            .into(),
+    );
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(
+            fmt::layer()
+                .with_span_events(super::FmtSpan::CLOSE)
+                .with_writer(super::io::stderr),
+        )
+        .with(layer.clone())
+        .try_init()?;
+
+    Ok(layer)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{FirefoxProfileLayer, MarkerTiming, Timestamp},
+        serde_json::Value,
+        std::path::PathBuf,
+    };
+
+    #[test]
+    fn profile_contains_tracing_markers_and_rss_counter() {
+        let layer = FirefoxProfileLayer::new(PathBuf::new());
+        layer.add_marker(
+            "gluesql.execute",
+            "rows=1",
+            MarkerTiming::Instant(Timestamp::from_nanos_since_reference(1)),
+        );
+
+        let state = layer.state.lock().expect("Firefox profile lock poisoned");
+        let profile = serde_json::to_value(&state.profile).expect("profile should serialize");
+
+        assert_eq!(profile["counters"][0]["name"], "process_rss");
+        assert_eq!(
+            profile["meta"]["markerSchema"][0]["name"],
+            "GlueSQL tracing"
+        );
+        assert_marker_exists(&profile);
+    }
+
+    fn assert_marker_exists(profile: &Value) {
+        assert_eq!(
+            profile["threads"][0]["markers"]["data"]
+                .as_array()
+                .expect("marker data should be an array")
+                .len(),
+            1
+        );
+    }
+}

--- a/storages/redb-storage/src/lib.rs
+++ b/storages/redb-storage/src/lib.rs
@@ -32,6 +32,7 @@ impl RedbStorage {
     }
 }
 
+#[cfg_attr(feature = "tracing", gluesql_macros::trace_storage(name = "redb"))]
 impl Store for RedbStorage {
     fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
         self.0.fetch_all_schemas().map_err(Into::into)
@@ -52,6 +53,7 @@ impl Store for RedbStorage {
     }
 }
 
+#[cfg_attr(feature = "tracing", gluesql_macros::trace_storage(name = "redb"))]
 impl StoreMut for RedbStorage {
     fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
         self.0.insert_schema(schema).map_err(Into::into)
@@ -74,6 +76,7 @@ impl StoreMut for RedbStorage {
     }
 }
 
+#[cfg_attr(feature = "tracing", gluesql_macros::trace_storage(name = "redb"))]
 impl Transaction for RedbStorage {
     fn begin(&mut self, autocommit: bool) -> Result<bool> {
         self.0.begin(autocommit).map_err(Into::into)


### PR DESCRIPTION
## Summary

This PR adds optional, tracing-based observability for diagnosing where time and resources are spent during GlueSQL query execution.

It includes:

- query pipeline spans for parsing, translation, planning, statement execution, and result materialization;
- opt-in storage method spans generated at implementation boundaries without changing Core call sites;
- structured access-path events for primary-key lookups, secondary-index scans, and full scans;
- a `trace_storage` attribute for adding storage-specific spans, argument and error capture, and lazy iterator instrumentation without changing call sites;
- RedbStorage as the reference integration for storage-specific instrumentation;
- a default formatted subscriber when `Glue::new` is called and no global subscriber is already configured;
- CLI exporters for formatted traces, folded Flamegraph data, and OpenTelemetry OTLP;
- a Redb resource benchmark that records RSS samples, peak RSS, database size, and executable size;
- optional Firefox Profiler JSON output for viewing spans and RSS on one timeline;
- documentation for applications, storage authors, exporters, profiling, and data handling.

All instrumentation and exporter dependencies remain disabled unless their Cargo features are enabled.

This implements the instrumentation and integration portions of #1958. Performance regression gating remains dependent on the representative benchmark suite proposed in #1957.

## Feature behavior

| Feature | Behavior |
| --- | --- |
| Disabled | Tracing and exporter dependencies are not compiled |
| `tracing` | Emits Core and enabled storage spans; installs a formatted fallback subscriber through `Glue::new` |
| `tracing-flame` | Enables tracing and writes folded stack data |
| `opentelemetry` | Enables tracing and exports OTLP traces over HTTP/Protobuf |
| `firefox-profile` on RedbStorage | Writes benchmark spans and RSS counters as Firefox Profiler JSON |

Applications may install their own subscriber before constructing `Glue`. GlueSQL detects an existing global dispatcher and does not replace it. The CLI installs its configured exporter layers before constructing `Glue`.

## Span hierarchy

The main SQL execution hierarchy is:

```text
gluesql.execute { sql, params }
├── gluesql.plan_sql { sql, params }
│   ├── gluesql.parse
│   ├── gluesql.translate
│   └── gluesql.plan
└── gluesql.execute_statement
    ├── gluesql.redb.begin
    ├── gluesql.redb.fetch_data
    ├── gluesql.redb.scan_data
    ├── gluesql.redb.scan_rows
    └── gluesql.redb.commit
```

The intended levels are:

| Level | Data |
| --- | --- |
| `INFO` | Total query execution, SQL source text, and bound parameters |
| `DEBUG` | Parse, translate, plan, execution, buffering, and selected access path |
| `TRACE` | Enabled storage method and lazy iterator boundaries |

Stable access-path values are:

```text
primary_key
secondary_index
full_scan
```

## Storage instrumentation

Core calls storage traits directly. Storage implementations opt in to method-level spans and lazy iterator instrumentation with one attribute:

```rust
#[cfg_attr(feature = "tracing", gluesql_macros::trace_storage(name = "my_storage"))]
impl Store for MyStorage {
    // Existing implementation
}
```

The macro works with GlueSQL storage traits, external traits, and inherent implementations.

- `capture = "full"` is the default and records simple named arguments, row counts for `rows` and `keys`, and `Result` errors.
- `capture = "off"` records timing without argument or error values.
- `scan_data` and `scan_indexed_data` are wrapped automatically; other boxed result iterators can use `#[trace_iterator]`.
- Iterator spans record `row_count`, `error_count`, and whether consumption completed, while yielded rows and errors are emitted as events.
- Existing storage method bodies and call sites remain unchanged.

RedbStorage uses this macro as the initial reference implementation. Its lazy scan path separates iterator creation from iterator consumption through `gluesql.redb.scan_data` and `gluesql.redb.scan_rows`.

## Resource profiling

The Redb resource benchmark records:

- periodic current RSS samples;
- peak process RSS;
- finalized database file size;
- executable size;
- GlueSQL spans and events for the same workload.

The optional `firefox-profile` feature writes a local JSON profile. It can be loaded directly into [Firefox Profiler](https://profiler.firefox.com/) to inspect GlueSQL intervals, instant events, and the `process_rss` counter on one timeline.

```bash
GLUESQL_FIREFOX_PROFILE_PATH=~/gluesql-benchmark-profile.json \
RUST_LOG=gluesql=debug \
cargo run --release \
  -p gluesql-redb-storage \
  --example resource_benchmark \
  --features firefox-profile \
  -- ~/gluesql-benchmark.redb \
  storages/redb-storage/examples/resource_benchmark.sql
```

The complete SQL document is passed to GlueSQL's parser, so statement separators inside valid SQL values are preserved.

## Exporters

The CLI can write formatted close events to stderr, folded stack data through `tracing-flame`, and OTLP traces through OpenTelemetry. Flamegraph and OpenTelemetry features may be enabled independently or together, and their buffered output is flushed when the CLI exits.

<details>
<summary>Example Flamegraph</summary>
<img width="2204" height="1254" alt="GlueSQL RedbStorage query Flamegraph" src="https://github.com/user-attachments/assets/d0ac1cb9-40fe-4749-8927-0554044d7630" />
</details>

## Data handling

Tracing can record values that contain secrets, personal data, or high-cardinality content:

- `gluesql.execute` and `gluesql.plan_sql` record SQL source text and bound parameters;
- `trace_storage(capture = "full")` records named arguments such as keys, schemas, and rows, together with errors;
- `trace_storage` emits an event for each yielded row or error from traced iterators.

Tracing should only be enabled where those values are acceptable. Storage authors can select `capture = "off"` for timing-only storage spans. Applications remain responsible for filtering, redaction, retention, and access control in their subscriber or exporter.

## Performance

The feature-disabled path does not initialize tracing or compile exporter dependencies. Parameter conversion remains single-pass in both tracing-enabled and tracing-disabled execution.

The representative suite proposed in #1957 is still required to compare:

```text
A. tracing feature disabled
B. tracing feature enabled with the fallback subscriber
C. tracing feature enabled with an application subscriber
```

OTLP transport and collector overhead should be measured separately from local instrumentation overhead.

## Validation

The implementation has been validated with:

```text
cargo test -p gluesql-core
cargo test -p gluesql-core --features tracing
cargo test -p gluesql-redb-storage --features tracing
cargo test -p gluesql-redb-storage --example resource_benchmark --features firefox-profile
cargo test -p gluesql-macros --test runtime_ok_instrument_storage
cargo check -p gluesql-cli --all-features
cargo clippy --all-targets -- -D warnings
cargo fmt --all
zensical build --clean --strict
```

Manual checks also confirmed formatted stderr output, access-path events, Redb iterator spans, Firefox Profiler output, Flamegraph generation, and OTLP export.


