### PR TITLE
Use typed enums for unsupported SQL options in translate errors

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -209,7 +209,7 @@ pub fn translate_with_params(
             } else if like.is_some() {
                 Some(CreateTableOption::Like)
             } else if clone.is_some() {
-                Some(CreateTableOption::Clone)
+                Some(CreateTableOption::CloneTable)
             } else {
                 None
             };
@@ -686,7 +686,7 @@ mod tests {
             ),
             (
                 "CREATE TABLE Foo CLONE Bar",
-                TranslateError::UnsupportedCreateTableOption(CreateTableOption::Clone),
+                TranslateError::UnsupportedCreateTableOption(CreateTableOption::CloneTable),
             ),
         ];
 

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -12,8 +12,8 @@ pub use self::{
     data_type::translate_data_type,
     ddl::translate_column_def,
     error::{
-        CreateTableOption, DeleteOption, InsertOption, QueryOption, SelectOption, TranslateError,
-        UpdateOption,
+        CreateTableOption, DeleteOption, InsertOption, JoinConstraintReason, QueryOption,
+        SelectOption, TranslateError, UpdateOption,
     },
     expr::{translate_expr, translate_order_by_expr},
     param::{IntoParamLiteral, ParamLiteral},

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -11,7 +11,10 @@ mod query;
 pub use self::{
     data_type::translate_data_type,
     ddl::translate_column_def,
-    error::TranslateError,
+    error::{
+        CreateTableOption, DeleteOption, InsertOption, QueryOption, SelectOption, TranslateError,
+        UpdateOption,
+    },
     expr::{translate_expr, translate_order_by_expr},
     param::{IntoParamLiteral, ParamLiteral},
     query::{alias_or_name, translate_query, translate_select_item},
@@ -74,17 +77,17 @@ pub fn translate_with_params(
             ..
         }) => {
             let violation = if returning.is_some() {
-                Some("RETURNING clause")
+                Some(InsertOption::Returning)
             } else if on.is_some() {
-                Some("ON CONFLICT clause")
+                Some(InsertOption::OnConflict)
             } else if table_alias.is_some() {
-                Some("table alias")
+                Some(InsertOption::TableAlias)
             } else if partitioned.is_some() {
-                Some("PARTITION clause")
+                Some(InsertOption::Partition)
             } else if *overwrite {
-                Some("OVERWRITE clause")
+                Some(InsertOption::Overwrite)
             } else if *table {
-                Some("TABLE keyword")
+                Some(InsertOption::TableKeyword)
             } else {
                 None
             };
@@ -120,9 +123,9 @@ pub fn translate_with_params(
             ..
         } => {
             let violation = if from.is_some() {
-                Some("FROM clause")
+                Some(UpdateOption::From)
             } else if returning.is_some() {
-                Some("RETURNING clause")
+                Some(UpdateOption::Returning)
             } else {
                 None
             };
@@ -153,13 +156,13 @@ pub fn translate_with_params(
             ..
         }) => {
             let violation = if using.is_some() {
-                Some("USING clause")
+                Some(DeleteOption::Using)
             } else if returning.is_some() {
-                Some("RETURNING clause")
+                Some(DeleteOption::Returning)
             } else if !order_by.is_empty() {
-                Some("ORDER BY clause")
+                Some(DeleteOption::OrderBy)
             } else if limit.is_some() {
-                Some("LIMIT clause")
+                Some(DeleteOption::Limit)
             } else {
                 None
             };
@@ -202,11 +205,11 @@ pub fn translate_with_params(
             ..
         }) => {
             let violation = if *temporary {
-                Some("TEMPORARY clause")
+                Some(CreateTableOption::Temporary)
             } else if like.is_some() {
-                Some("LIKE clause")
+                Some(CreateTableOption::Like)
             } else if clone.is_some() {
-                Some("CLONE clause")
+                Some(CreateTableOption::Clone)
             } else {
                 None
             };
@@ -597,27 +600,27 @@ mod tests {
         let cases = [
             (
                 "INSERT INTO Foo VALUES (1) RETURNING *",
-                TranslateError::UnsupportedInsertOption("RETURNING clause"),
+                TranslateError::UnsupportedInsertOption(InsertOption::Returning),
             ),
             (
                 "INSERT INTO Foo VALUES (1) ON CONFLICT DO NOTHING",
-                TranslateError::UnsupportedInsertOption("ON CONFLICT clause"),
+                TranslateError::UnsupportedInsertOption(InsertOption::OnConflict),
             ),
             (
                 "INSERT INTO Foo AS f VALUES (1)",
-                TranslateError::UnsupportedInsertOption("table alias"),
+                TranslateError::UnsupportedInsertOption(InsertOption::TableAlias),
             ),
             (
                 "INSERT INTO Foo PARTITION (bar = 1) VALUES (1)",
-                TranslateError::UnsupportedInsertOption("PARTITION clause"),
+                TranslateError::UnsupportedInsertOption(InsertOption::Partition),
             ),
             (
                 "INSERT OVERWRITE TABLE Foo VALUES (1)",
-                TranslateError::UnsupportedInsertOption("OVERWRITE clause"),
+                TranslateError::UnsupportedInsertOption(InsertOption::Overwrite),
             ),
             (
                 "INSERT TABLE Foo VALUES (1)",
-                TranslateError::UnsupportedInsertOption("TABLE keyword"),
+                TranslateError::UnsupportedInsertOption(InsertOption::TableKeyword),
             ),
         ];
 
@@ -631,11 +634,11 @@ mod tests {
         let cases = [
             (
                 "UPDATE Foo SET id = 1 FROM Bar",
-                TranslateError::UnsupportedUpdateOption("FROM clause"),
+                TranslateError::UnsupportedUpdateOption(UpdateOption::From),
             ),
             (
                 "UPDATE Foo SET id = 1 WHERE id = 1 RETURNING *",
-                TranslateError::UnsupportedUpdateOption("RETURNING clause"),
+                TranslateError::UnsupportedUpdateOption(UpdateOption::Returning),
             ),
         ];
 
@@ -649,19 +652,19 @@ mod tests {
         let cases = [
             (
                 "DELETE FROM Foo USING Bar",
-                TranslateError::UnsupportedDeleteOption("USING clause"),
+                TranslateError::UnsupportedDeleteOption(DeleteOption::Using),
             ),
             (
                 "DELETE FROM Foo WHERE id = 1 RETURNING *",
-                TranslateError::UnsupportedDeleteOption("RETURNING clause"),
+                TranslateError::UnsupportedDeleteOption(DeleteOption::Returning),
             ),
             (
                 "DELETE FROM Foo WHERE id = 1 ORDER BY id",
-                TranslateError::UnsupportedDeleteOption("ORDER BY clause"),
+                TranslateError::UnsupportedDeleteOption(DeleteOption::OrderBy),
             ),
             (
                 "DELETE FROM Foo WHERE id = 1 LIMIT 1",
-                TranslateError::UnsupportedDeleteOption("LIMIT clause"),
+                TranslateError::UnsupportedDeleteOption(DeleteOption::Limit),
             ),
         ];
 
@@ -675,15 +678,15 @@ mod tests {
         let cases = [
             (
                 "CREATE TEMPORARY TABLE Foo (id INTEGER)",
-                TranslateError::UnsupportedCreateTableOption("TEMPORARY clause"),
+                TranslateError::UnsupportedCreateTableOption(CreateTableOption::Temporary),
             ),
             (
                 "CREATE TABLE Foo LIKE Bar",
-                TranslateError::UnsupportedCreateTableOption("LIKE clause"),
+                TranslateError::UnsupportedCreateTableOption(CreateTableOption::Like),
             ),
             (
                 "CREATE TABLE Foo CLONE Bar",
-                TranslateError::UnsupportedCreateTableOption("CLONE clause"),
+                TranslateError::UnsupportedCreateTableOption(CreateTableOption::Clone),
             ),
         ];
 

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -1,113 +1,116 @@
 use {serde::Serialize, std::fmt::Debug, strum_macros::Display, thiserror::Error};
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreateTableOption {
     #[strum(to_string = "TEMPORARY clause")]
-    #[serde(rename = "TEMPORARY clause")]
     Temporary,
 
     #[strum(to_string = "LIKE clause")]
-    #[serde(rename = "LIKE clause")]
     Like,
 
     #[strum(to_string = "CLONE clause")]
-    #[serde(rename = "CLONE clause")]
     Clone,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertOption {
     #[strum(to_string = "RETURNING clause")]
-    #[serde(rename = "RETURNING clause")]
     Returning,
 
     #[strum(to_string = "ON CONFLICT clause")]
-    #[serde(rename = "ON CONFLICT clause")]
     OnConflict,
 
     #[strum(to_string = "table alias")]
-    #[serde(rename = "table alias")]
     TableAlias,
 
     #[strum(to_string = "PARTITION clause")]
-    #[serde(rename = "PARTITION clause")]
     Partition,
 
     #[strum(to_string = "OVERWRITE clause")]
-    #[serde(rename = "OVERWRITE clause")]
     Overwrite,
 
     #[strum(to_string = "TABLE keyword")]
-    #[serde(rename = "TABLE keyword")]
     TableKeyword,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateOption {
     #[strum(to_string = "FROM clause")]
-    #[serde(rename = "FROM clause")]
     From,
 
     #[strum(to_string = "RETURNING clause")]
-    #[serde(rename = "RETURNING clause")]
     Returning,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeleteOption {
     #[strum(to_string = "USING clause")]
-    #[serde(rename = "USING clause")]
     Using,
 
     #[strum(to_string = "RETURNING clause")]
-    #[serde(rename = "RETURNING clause")]
     Returning,
 
     #[strum(to_string = "ORDER BY clause")]
-    #[serde(rename = "ORDER BY clause")]
     OrderBy,
 
     #[strum(to_string = "LIMIT clause")]
-    #[serde(rename = "LIMIT clause")]
     Limit,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueryOption {
     #[strum(to_string = "WITH clause")]
-    #[serde(rename = "WITH clause")]
     With,
 
     #[strum(to_string = "FETCH clause")]
-    #[serde(rename = "FETCH clause")]
     Fetch,
 
     #[strum(to_string = "LOCK clause")]
-    #[serde(rename = "LOCK clause")]
     Lock,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectOption {
     #[strum(to_string = "INTO clause")]
-    #[serde(rename = "INTO clause")]
     Into,
 
     #[strum(to_string = "WINDOW clause")]
-    #[serde(rename = "WINDOW clause")]
     Window,
 }
 
-#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JoinConstraintReason {
     #[strum(to_string = "USING")]
-    #[serde(rename = "USING")]
     Using,
 
     #[strum(to_string = "NATURAL")]
-    #[serde(rename = "NATURAL")]
     Natural,
 }
+
+/// Serializes a `strum::Display`-backed enum as its display string, keeping
+/// JSON output identical to the pre-refactor `&'static str`/`String` fields
+/// without duplicating each variant's text in a second `#[serde(rename)]`.
+macro_rules! serialize_via_display {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl Serialize for $ty {
+                fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                    serializer.collect_str(self)
+                }
+            }
+        )+
+    };
+}
+
+serialize_via_display!(
+    CreateTableOption,
+    InsertOption,
+    UpdateOption,
+    DeleteOption,
+    QueryOption,
+    SelectOption,
+    JoinConstraintReason,
+);
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
 pub enum TranslateError {

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -3,79 +3,110 @@ use {serde::Serialize, std::fmt::Debug, strum_macros::Display, thiserror::Error}
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum CreateTableOption {
     #[strum(to_string = "TEMPORARY clause")]
+    #[serde(rename = "TEMPORARY clause")]
     Temporary,
 
     #[strum(to_string = "LIKE clause")]
+    #[serde(rename = "LIKE clause")]
     Like,
 
     #[strum(to_string = "CLONE clause")]
+    #[serde(rename = "CLONE clause")]
     Clone,
 }
 
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum InsertOption {
     #[strum(to_string = "RETURNING clause")]
+    #[serde(rename = "RETURNING clause")]
     Returning,
 
     #[strum(to_string = "ON CONFLICT clause")]
+    #[serde(rename = "ON CONFLICT clause")]
     OnConflict,
 
     #[strum(to_string = "table alias")]
+    #[serde(rename = "table alias")]
     TableAlias,
 
     #[strum(to_string = "PARTITION clause")]
+    #[serde(rename = "PARTITION clause")]
     Partition,
 
     #[strum(to_string = "OVERWRITE clause")]
+    #[serde(rename = "OVERWRITE clause")]
     Overwrite,
 
     #[strum(to_string = "TABLE keyword")]
+    #[serde(rename = "TABLE keyword")]
     TableKeyword,
 }
 
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum UpdateOption {
     #[strum(to_string = "FROM clause")]
+    #[serde(rename = "FROM clause")]
     From,
 
     #[strum(to_string = "RETURNING clause")]
+    #[serde(rename = "RETURNING clause")]
     Returning,
 }
 
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum DeleteOption {
     #[strum(to_string = "USING clause")]
+    #[serde(rename = "USING clause")]
     Using,
 
     #[strum(to_string = "RETURNING clause")]
+    #[serde(rename = "RETURNING clause")]
     Returning,
 
     #[strum(to_string = "ORDER BY clause")]
+    #[serde(rename = "ORDER BY clause")]
     OrderBy,
 
     #[strum(to_string = "LIMIT clause")]
+    #[serde(rename = "LIMIT clause")]
     Limit,
 }
 
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum QueryOption {
     #[strum(to_string = "WITH clause")]
+    #[serde(rename = "WITH clause")]
     With,
 
     #[strum(to_string = "FETCH clause")]
+    #[serde(rename = "FETCH clause")]
     Fetch,
 
     #[strum(to_string = "LOCK clause")]
+    #[serde(rename = "LOCK clause")]
     Lock,
 }
 
 #[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum SelectOption {
     #[strum(to_string = "INTO clause")]
+    #[serde(rename = "INTO clause")]
     Into,
 
     #[strum(to_string = "WINDOW clause")]
+    #[serde(rename = "WINDOW clause")]
     Window,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum JoinConstraintReason {
+    #[strum(to_string = "USING")]
+    #[serde(rename = "USING")]
+    Using,
+
+    #[strum(to_string = "NATURAL")]
+    #[serde(rename = "NATURAL")]
+    Natural,
 }
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
@@ -238,7 +269,7 @@ pub enum TranslateError {
     UnsupportedQueryTableFactor(String),
 
     #[error("unsupported join constraint: {0}")]
-    UnsupportedJoinConstraint(String),
+    UnsupportedJoinConstraint(JoinConstraintReason),
 
     #[error("unsupported join operator: {0}")]
     UnsupportedJoinOperator(String),

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -17,7 +17,7 @@ pub enum CreateTableOption {
 
     /// `CREATE TABLE ... CLONE <table>`
     #[strum(to_string = "CLONE clause")]
-    Clone,
+    CloneTable,
 }
 
 /// `INSERT` clauses that `GlueSQL` does not support yet.

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -1,88 +1,146 @@
 use {serde::Serialize, std::fmt::Debug, strum_macros::Display, thiserror::Error};
 
+/// `CREATE TABLE` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedCreateTableOption`] so callers
+/// can match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreateTableOption {
+    /// `CREATE TEMPORARY TABLE ...`
     #[strum(to_string = "TEMPORARY clause")]
     Temporary,
 
+    /// `CREATE TABLE ... LIKE <table>`
     #[strum(to_string = "LIKE clause")]
     Like,
 
+    /// `CREATE TABLE ... CLONE <table>`
     #[strum(to_string = "CLONE clause")]
     Clone,
 }
 
+/// `INSERT` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedInsertOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertOption {
+    /// `INSERT ... RETURNING ...`
     #[strum(to_string = "RETURNING clause")]
     Returning,
 
+    /// `INSERT ... ON CONFLICT ...`
     #[strum(to_string = "ON CONFLICT clause")]
     OnConflict,
 
+    /// `INSERT INTO <table> AS <alias> ...`
     #[strum(to_string = "table alias")]
     TableAlias,
 
+    /// `INSERT INTO <table> PARTITION (...) ...`
     #[strum(to_string = "PARTITION clause")]
     Partition,
 
+    /// `INSERT OVERWRITE TABLE <table> ...`
     #[strum(to_string = "OVERWRITE clause")]
     Overwrite,
 
+    /// `INSERT TABLE <table> ...` (the `TABLE` keyword form)
     #[strum(to_string = "TABLE keyword")]
     TableKeyword,
 }
 
+/// `UPDATE` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedUpdateOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateOption {
+    /// `UPDATE ... FROM ...`
     #[strum(to_string = "FROM clause")]
     From,
 
+    /// `UPDATE ... RETURNING ...`
     #[strum(to_string = "RETURNING clause")]
     Returning,
 }
 
+/// `DELETE` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedDeleteOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeleteOption {
+    /// `DELETE ... USING ...`
     #[strum(to_string = "USING clause")]
     Using,
 
+    /// `DELETE ... RETURNING ...`
     #[strum(to_string = "RETURNING clause")]
     Returning,
 
+    /// `DELETE ... ORDER BY ...`
     #[strum(to_string = "ORDER BY clause")]
     OrderBy,
 
+    /// `DELETE ... LIMIT ...`
     #[strum(to_string = "LIMIT clause")]
     Limit,
 }
 
+/// Query-level (`WITH`/`FETCH`/locking) clauses that `GlueSQL` does not
+/// support yet.
+///
+/// Carried by [`TranslateError::UnsupportedQueryOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueryOption {
+    /// `WITH <cte> ... SELECT ...`
     #[strum(to_string = "WITH clause")]
     With,
 
+    /// `SELECT ... FETCH FIRST ...`
     #[strum(to_string = "FETCH clause")]
     Fetch,
 
+    /// `SELECT ... FOR UPDATE` / other row-locking clauses
     #[strum(to_string = "LOCK clause")]
     Lock,
 }
 
+/// `SELECT` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedSelectOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectOption {
+    /// `SELECT ... INTO <table> ...`
     #[strum(to_string = "INTO clause")]
     Into,
 
+    /// `SELECT ... WINDOW <name> AS (...)`
     #[strum(to_string = "WINDOW clause")]
     Window,
 }
 
+/// `JOIN` constraint forms that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedJoinConstraint`] so callers can
+/// match exhaustively on every currently-rejected form instead of
+/// inspecting a free-form string.
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JoinConstraintReason {
+    /// `... JOIN ... USING (...)`
     #[strum(to_string = "USING")]
     Using,
 
+    /// `... NATURAL JOIN ...`
     #[strum(to_string = "NATURAL")]
     Natural,
 }

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -1,4 +1,82 @@
-use {serde::Serialize, std::fmt::Debug, thiserror::Error};
+use {serde::Serialize, std::fmt::Debug, strum_macros::Display, thiserror::Error};
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum CreateTableOption {
+    #[strum(to_string = "TEMPORARY clause")]
+    Temporary,
+
+    #[strum(to_string = "LIKE clause")]
+    Like,
+
+    #[strum(to_string = "CLONE clause")]
+    Clone,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum InsertOption {
+    #[strum(to_string = "RETURNING clause")]
+    Returning,
+
+    #[strum(to_string = "ON CONFLICT clause")]
+    OnConflict,
+
+    #[strum(to_string = "table alias")]
+    TableAlias,
+
+    #[strum(to_string = "PARTITION clause")]
+    Partition,
+
+    #[strum(to_string = "OVERWRITE clause")]
+    Overwrite,
+
+    #[strum(to_string = "TABLE keyword")]
+    TableKeyword,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum UpdateOption {
+    #[strum(to_string = "FROM clause")]
+    From,
+
+    #[strum(to_string = "RETURNING clause")]
+    Returning,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum DeleteOption {
+    #[strum(to_string = "USING clause")]
+    Using,
+
+    #[strum(to_string = "RETURNING clause")]
+    Returning,
+
+    #[strum(to_string = "ORDER BY clause")]
+    OrderBy,
+
+    #[strum(to_string = "LIMIT clause")]
+    Limit,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum QueryOption {
+    #[strum(to_string = "WITH clause")]
+    With,
+
+    #[strum(to_string = "FETCH clause")]
+    Fetch,
+
+    #[strum(to_string = "LOCK clause")]
+    Lock,
+}
+
+#[derive(Display, Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum SelectOption {
+    #[strum(to_string = "INTO clause")]
+    Into,
+
+    #[strum(to_string = "WINDOW clause")]
+    Window,
+}
 
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
 pub enum TranslateError {
@@ -69,22 +147,22 @@ pub enum TranslateError {
     UnsupportedUnnamedIndex,
 
     #[error("unsupported INSERT option: {0}")]
-    UnsupportedInsertOption(&'static str),
+    UnsupportedInsertOption(InsertOption),
 
     #[error("unsupported CREATE TABLE option: {0}")]
-    UnsupportedCreateTableOption(&'static str),
+    UnsupportedCreateTableOption(CreateTableOption),
 
     #[error("unsupported UPDATE option: {0}")]
-    UnsupportedUpdateOption(&'static str),
+    UnsupportedUpdateOption(UpdateOption),
 
     #[error("unsupported DELETE option: {0}")]
-    UnsupportedDeleteOption(&'static str),
+    UnsupportedDeleteOption(DeleteOption),
 
     #[error("unsupported query option: {0}")]
-    UnsupportedQueryOption(&'static str),
+    UnsupportedQueryOption(QueryOption),
 
     #[error("unsupported SELECT option: {0}")]
-    UnsupportedSelectOption(&'static str),
+    UnsupportedSelectOption(SelectOption),
 
     #[error(
         "unsupported trim chars: expected: `TRIM((BOTH | LEADING | TRAILING) <text> FROM <expr>)`, got: `TRIM(<expr> [<chars>, ..])` syntax"

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        ParamLiteral, QueryOption, SelectOption, TranslateError,
+        JoinConstraintReason, ParamLiteral, QueryOption, SelectOption, TranslateError,
         function::translate_function_arg_exprs, translate_expr, translate_idents,
         translate_object_name, translate_order_by_expr,
     },
@@ -324,10 +324,10 @@ fn translate_join(params: &[ParamLiteral], sql_join: &SqlJoin) -> Result<Join> {
         SqlJoinConstraint::On(expr) => translate_expr(expr, params).map(JoinConstraint::On),
         SqlJoinConstraint::None => Ok(JoinConstraint::None),
         SqlJoinConstraint::Using(_) => {
-            Err(TranslateError::UnsupportedJoinConstraint("USING".to_owned()).into())
+            Err(TranslateError::UnsupportedJoinConstraint(JoinConstraintReason::Using).into())
         }
         SqlJoinConstraint::Natural => {
-            Err(TranslateError::UnsupportedJoinConstraint("NATURAL".to_owned()).into())
+            Err(TranslateError::UnsupportedJoinConstraint(JoinConstraintReason::Natural).into())
         }
     };
 
@@ -398,6 +398,18 @@ mod tests {
         assert_query_error(
             "SELECT * FROM Foo WINDOW w AS (PARTITION BY id)",
             TranslateError::UnsupportedSelectOption(SelectOption::Window),
+        );
+    }
+
+    #[test]
+    fn join_constraint_not_supported() {
+        assert_query_error(
+            "SELECT * FROM TableA JOIN TableB USING (id)",
+            TranslateError::UnsupportedJoinConstraint(JoinConstraintReason::Using),
+        );
+        assert_query_error(
+            "SELECT * FROM TableA NATURAL JOIN TableB",
+            TranslateError::UnsupportedJoinConstraint(JoinConstraintReason::Natural),
         );
     }
 

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -1,7 +1,8 @@
 use {
     super::{
-        ParamLiteral, TranslateError, function::translate_function_arg_exprs, translate_expr,
-        translate_idents, translate_object_name, translate_order_by_expr,
+        ParamLiteral, QueryOption, SelectOption, TranslateError,
+        function::translate_function_arg_exprs, translate_expr, translate_idents,
+        translate_object_name, translate_order_by_expr,
     },
     crate::{
         ast::{
@@ -39,11 +40,11 @@ pub fn translate_query(sql_query: &SqlQuery, params: &[ParamLiteral]) -> Result<
     } = sql_query;
 
     let violation = if with.is_some() {
-        Some("WITH clause")
+        Some(QueryOption::With)
     } else if fetch.is_some() {
-        Some("FETCH clause")
+        Some(QueryOption::Fetch)
     } else if !locks.is_empty() {
-        Some("LOCK clause")
+        Some(QueryOption::Lock)
     } else {
         None
     };
@@ -110,9 +111,9 @@ fn translate_select(sql_select: &SqlSelect, params: &[ParamLiteral]) -> Result<S
     } = sql_select;
 
     if into.is_some() {
-        return Err(TranslateError::UnsupportedSelectOption("INTO clause").into());
+        return Err(TranslateError::UnsupportedSelectOption(SelectOption::Into).into());
     } else if !named_window.is_empty() {
-        return Err(TranslateError::UnsupportedSelectOption("WINDOW clause").into());
+        return Err(TranslateError::UnsupportedSelectOption(SelectOption::Window).into());
     }
 
     if from.len() > 1 {
@@ -376,15 +377,15 @@ mod tests {
     fn query_options_rejected() {
         assert_query_error(
             "WITH t AS (SELECT 1) SELECT * FROM t",
-            TranslateError::UnsupportedQueryOption("WITH clause"),
+            TranslateError::UnsupportedQueryOption(QueryOption::With),
         );
         assert_query_error(
             "SELECT * FROM Foo FETCH FIRST 1 ROW ONLY",
-            TranslateError::UnsupportedQueryOption("FETCH clause"),
+            TranslateError::UnsupportedQueryOption(QueryOption::Fetch),
         );
         assert_query_error(
             "SELECT * FROM Foo FOR UPDATE",
-            TranslateError::UnsupportedQueryOption("LOCK clause"),
+            TranslateError::UnsupportedQueryOption(QueryOption::Lock),
         );
     }
 
@@ -392,11 +393,11 @@ mod tests {
     fn select_options_rejected() {
         assert_query_error(
             "SELECT * INTO Foo FROM Bar",
-            TranslateError::UnsupportedSelectOption("INTO clause"),
+            TranslateError::UnsupportedSelectOption(SelectOption::Into),
         );
         assert_query_error(
             "SELECT * FROM Foo WINDOW w AS (PARTITION BY id)",
-            TranslateError::UnsupportedSelectOption("WINDOW clause"),
+            TranslateError::UnsupportedSelectOption(SelectOption::Window),
         );
     }
 
@@ -405,7 +406,7 @@ mod tests {
     fn query_option_helper_panics_on_non_query() {
         assert_query_error(
             "INSERT INTO Foo VALUES (1)",
-            TranslateError::UnsupportedQueryOption("unused"),
+            TranslateError::UnsupportedQueryOption(QueryOption::With),
         );
     }
 


### PR DESCRIPTION
**Summary**

`TranslateError`'s "unsupported option" variants used `&'static str`/
`String` to describe the rejected clause, which meant typos in the
reason weren't caught by the compiler and there was no single place
listing every valid value. This replaces those fields with dedicated
enums deriving `strum::Display`, so the compiler now checks the option
names and error messages stay auto-derived instead of hand-typed at
every call site.

Converted 7 variants total:

- `UnsupportedInsertOption` → `InsertOption`
- `UnsupportedUpdateOption` → `UpdateOption`
- `UnsupportedDeleteOption` → `DeleteOption`
- `UnsupportedQueryOption` → `QueryOption`
- `UnsupportedSelectOption` → `SelectOption`
- `UnsupportedCreateTableOption` → `CreateTableOption`
- `UnsupportedJoinConstraint` → `JoinConstraintReason`

The issue only listed the first 5 as examples. `UnsupportedCreateTableOption`
(added in #1972) and `UnsupportedJoinConstraint` have the exact same
closed-set-of-strings pattern, so I included them too rather than
leaving inconsistent holdouts.

`strum_macros` was already a dependency, so no new crates were added.
`Display` output is byte-for-byte unchanged.

`Serialize` is implemented by delegating to `Display` via
`serializer.collect_str(self)` (through a small module-private
`macro_rules!` in `error.rs`), instead of deriving `Serialize` and
repeating each variant's string a second time in `#[serde(rename)]`.
This keeps JSON output identical while avoiding the exact kind of
duplication that caused a regression during development (see test
plan below) — one string per variant instead of two that can drift
out of sync.

**Test plan**

- [x] `cargo test -p gluesql-core --lib` — all 515 tests pass
- [x] `cargo test -p gluesql_memory_storage --test memory_storage` — all
      196 fixture-based integration tests pass. All 13 storage crates
      run the exact same fixtures via `generate_store_tests!`, and
      `translate()` runs before any storage is touched, so this one
      backend's pass is representative of all of them.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all`
- [x] `cargo build --all-features` — clean
- [x] Manually verified via `gluesql-cli` and `serde_json::to_string`
      that each of the 7 option categories produces the same Display
      message and JSON output as before the refactor (e.g.
      `unsupported INSERT option: RETURNING clause`,
      `{"UnsupportedCreateTableOption":"TEMPORARY clause"}`)

Closes #1975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SQL translation errors now provide structured, consistently categorized reasons for unsupported options.
  * Enhanced diagnostics cover unsupported INSERT, UPDATE, DELETE, SELECT, query, CREATE TABLE, and join options.
  * Error messages remain clear and readable while offering more reliable values for integrations.
* **Bug Fixes**
  * Improved reporting for unsupported `USING` and `NATURAL` join constraints.
* **Tests**
  * Expanded coverage for structured error details across SQL translation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->