### PR TITLE
Remove Clone requirement from ToGlueRow derive

### DIFF
--- a/core/src/query_builder/insert.rs
+++ b/core/src/query_builder/insert.rs
@@ -103,7 +103,7 @@ mod tests {
         query_builder::{Build, QueryBuilderError, num, table, test, value},
         result::Error,
         row_conversion::ToGlueRow,
-        translate::{IntoParamLiteral, ParamLiteral},
+        translate::{IntoParamLiteral, ParamLiteral, ToParamLiteral},
     };
 
     #[test]
@@ -150,9 +150,9 @@ mod tests {
 
         fn to_glue_row(&self) -> Vec<ParamLiteral> {
             vec![
-                self.id.into_param_literal(),
-                self.name.clone().into_param_literal(),
-                self.in_stock.into_param_literal(),
+                self.id.to_param_literal(),
+                self.name.to_param_literal(),
+                self.in_stock.to_param_literal(),
             ]
         }
     }

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -13,7 +13,7 @@ pub use self::{
     ddl::translate_column_def,
     error::TranslateError,
     expr::{translate_expr, translate_order_by_expr},
-    param::{IntoParamLiteral, ParamLiteral},
+    param::{IntoParamLiteral, ParamLiteral, ToParamLiteral},
     query::{alias_or_name, translate_query, translate_select_item},
 };
 

--- a/core/src/translate/param.rs
+++ b/core/src/translate/param.rs
@@ -315,6 +315,30 @@ mod tests {
     }
 
     #[test]
+    fn converts_borrowed_literals() {
+        let bytes = vec![0x12_u8, 0xAB];
+        let expr = bytes.to_param_literal().into_expr();
+        assert_eq!(expr, Expr::Value(Value::Bytea(bytes)));
+
+        let bytes = [0xCD_u8, 0xEF];
+        let slice = bytes.as_slice();
+        let expr = slice.to_param_literal().into_expr();
+        assert_eq!(expr, Expr::Value(Value::Bytea(bytes.to_vec())));
+
+        let signed = 42_isize;
+        let expr = signed.to_param_literal().into_expr();
+        assert_eq!(expr, Expr::Value(Value::I64(42)));
+
+        let unsigned = 42_usize;
+        let expr = unsigned.to_param_literal().into_expr();
+        assert_eq!(expr, Expr::Value(Value::U64(42)));
+
+        let uuid = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let expr = uuid.to_param_literal().into_expr();
+        assert_eq!(expr, Expr::Value(Value::Uuid(uuid.as_u128())));
+    }
+
+    #[test]
     fn converts_scalars_and_structs() {
         let expr = 1.25_f64.into_param_literal().into_expr();
         assert_eq!(expr, Expr::Value(Value::F64(1.25)));

--- a/core/src/translate/param.rs
+++ b/core/src/translate/param.rs
@@ -29,13 +29,24 @@ pub trait IntoParamLiteral {
     fn into_param_literal(self) -> ParamLiteral;
 }
 
+pub trait ToParamLiteral {
+    /// Converts a borrowed value into an owned [`ParamLiteral`].
+    fn to_param_literal(&self) -> ParamLiteral;
+}
+
 impl IntoParamLiteral for ParamLiteral {
     fn into_param_literal(self) -> ParamLiteral {
         self
     }
 }
 
-macro_rules! impl_into_param_literal {
+impl ToParamLiteral for ParamLiteral {
+    fn to_param_literal(&self) -> ParamLiteral {
+        self.clone()
+    }
+}
+
+macro_rules! impl_param_literal_copy {
     ($($rust_ty:ty => $value_variant:ident),+ $(,)?) => {
         $(
             impl IntoParamLiteral for $rust_ty {
@@ -43,11 +54,17 @@ macro_rules! impl_into_param_literal {
                     ParamLiteral(Value::$value_variant(self))
                 }
             }
+
+            impl ToParamLiteral for $rust_ty {
+                fn to_param_literal(&self) -> ParamLiteral {
+                    ParamLiteral(Value::$value_variant(*self))
+                }
+            }
         )+
     };
 }
 
-impl_into_param_literal!(
+impl_param_literal_copy!(
     bool => Bool,
     i8 => I8,
     i16 => I16,
@@ -62,8 +79,6 @@ impl_into_param_literal!(
     f32 => F32,
     f64 => F64,
     Decimal => Decimal,
-    String => Str,
-    Vec<u8> => Bytea,
     IpAddr => Inet,
     NaiveDate => Date,
     NaiveTime => Time,
@@ -72,10 +87,40 @@ impl_into_param_literal!(
     Interval => Interval,
 );
 
+impl IntoParamLiteral for String {
+    fn into_param_literal(self) -> ParamLiteral {
+        ParamLiteral(Value::Str(self))
+    }
+}
+
+impl ToParamLiteral for String {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::Str(self.clone()))
+    }
+}
+
+impl IntoParamLiteral for Vec<u8> {
+    fn into_param_literal(self) -> ParamLiteral {
+        ParamLiteral(Value::Bytea(self))
+    }
+}
+
+impl ToParamLiteral for Vec<u8> {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::Bytea(self.clone()))
+    }
+}
+
 // Types that need conversion
 impl IntoParamLiteral for isize {
     fn into_param_literal(self) -> ParamLiteral {
         ParamLiteral(Value::I64(self as i64))
+    }
+}
+
+impl ToParamLiteral for isize {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::I64(*self as i64))
     }
 }
 
@@ -85,9 +130,21 @@ impl IntoParamLiteral for usize {
     }
 }
 
+impl ToParamLiteral for usize {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::U64(*self as u64))
+    }
+}
+
 impl IntoParamLiteral for &str {
     fn into_param_literal(self) -> ParamLiteral {
         ParamLiteral(Value::Str(self.to_owned()))
+    }
+}
+
+impl ToParamLiteral for &str {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::Str((*self).to_owned()))
     }
 }
 
@@ -97,8 +154,20 @@ impl IntoParamLiteral for &[u8] {
     }
 }
 
+impl ToParamLiteral for &[u8] {
+    fn to_param_literal(&self) -> ParamLiteral {
+        ParamLiteral(Value::Bytea(self.to_vec()))
+    }
+}
+
 impl IntoParamLiteral for Uuid {
     fn into_param_literal(self) -> ParamLiteral {
+        ParamLiteral(Value::Uuid(self.as_u128()))
+    }
+}
+
+impl ToParamLiteral for Uuid {
+    fn to_param_literal(&self) -> ParamLiteral {
         ParamLiteral(Value::Uuid(self.as_u128()))
     }
 }
@@ -110,6 +179,18 @@ where
     fn into_param_literal(self) -> ParamLiteral {
         match self {
             Some(value) => value.into_param_literal(),
+            None => ParamLiteral::null(),
+        }
+    }
+}
+
+impl<T> ToParamLiteral for Option<T>
+where
+    T: ToParamLiteral,
+{
+    fn to_param_literal(&self) -> ParamLiteral {
+        match self {
+            Some(value) => value.to_param_literal(),
             None => ParamLiteral::null(),
         }
     }
@@ -141,8 +222,10 @@ mod tests {
     fn accepts_param_literal() {
         let literal = ParamLiteral::null();
         let converted = literal.clone().into_param_literal();
+        let borrowed = literal.to_param_literal();
         assert!(matches!(literal.into_expr(), Expr::Value(Value::Null)));
         assert!(matches!(converted.into_expr(), Expr::Value(Value::Null)));
+        assert!(matches!(borrowed.into_expr(), Expr::Value(Value::Null)));
     }
 
     #[test]
@@ -212,6 +295,23 @@ mod tests {
 
         let expr = (None::<i32>).into_param_literal().into_expr();
         assert_eq!(expr, Expr::Value(Value::Null));
+    }
+
+    #[test]
+    fn converts_borrowed_non_clone_option() {
+        struct NonClone(i64);
+
+        impl ToParamLiteral for NonClone {
+            fn to_param_literal(&self) -> ParamLiteral {
+                self.0.to_param_literal()
+            }
+        }
+
+        let value = Some(NonClone(7));
+        let expr = value.to_param_literal().into_expr();
+
+        assert_eq!(expr, Expr::Value(Value::I64(7)));
+        assert!(value.is_some());
     }
 
     #[test]

--- a/macros/src/to_glue_row.rs
+++ b/macros/src/to_glue_row.rs
@@ -1,7 +1,7 @@
 use {
     crate::{parse_glue_rename, resolve_gluesql_crate},
     quote::quote,
-    syn::{Data, DeriveInput, Fields, spanned::Spanned},
+    syn::{Data, DeriveInput, Fields, parse_quote, spanned::Spanned},
 };
 
 pub(crate) fn expand_to_glue_row(
@@ -32,11 +32,13 @@ pub(crate) fn expand_to_glue_row(
 
     let mut seen_columns: Vec<String> = Vec::new();
     let mut column_names = Vec::new();
+    let mut field_types = Vec::new();
     let mut field_literals = Vec::new();
 
     for field in &fields {
         let field_ident = field.ident.clone().expect("named field");
         let field_name_literal = field_ident.to_string();
+        field_types.push(field.ty.clone());
 
         let mut rename: Option<String> = None;
         for attr in &field.attrs {
@@ -59,14 +61,23 @@ pub(crate) fn expand_to_glue_row(
         column_names.push(quote! { #column_name });
 
         field_literals.push(quote! {
-            #gluesql_crate::translate::IntoParamLiteral::into_param_literal(
-                ::core::clone::Clone::clone(&self.#field_ident)
+            #gluesql_crate::translate::ToParamLiteral::to_param_literal(
+                &self.#field_ident
             )
         });
     }
 
     let columns_len = column_names.len();
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let mut generics = input.generics;
+    if !field_types.is_empty() {
+        let where_clause = generics.make_where_clause();
+        for field_type in field_types {
+            where_clause.predicates.push(parse_quote! {
+                #field_type: #gluesql_crate::translate::ToParamLiteral
+            });
+        }
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let expanded = quote! {
         impl #impl_generics #gluesql_crate::row_conversion::ToGlueRow for #ident #ty_generics #where_clause {
@@ -154,7 +165,7 @@ mod tests {
         let di: syn::DeriveInput = parse_quote! {
             struct Record<'a, T>
             where
-                T: Clone + crate::translate::IntoParamLiteral,
+                T: 'a,
             {
                 name: &'a str,
                 value: T,
@@ -163,6 +174,14 @@ mod tests {
         let ts = expand_to_glue_row(di).expect("expand ok").to_string();
         assert!(ts.contains("impl < 'a , T >"));
         assert!(ts.contains("ToGlueRow for Record < 'a , T >"));
-        assert!(ts.contains("where T : Clone + crate :: translate :: IntoParamLiteral"));
+        assert!(ts.contains("where T : 'a"));
+        assert!(
+            ts.contains("& 'a str : :: gluesql_core :: translate :: ToParamLiteral"),
+            "{ts}"
+        );
+        assert!(
+            ts.contains("T : :: gluesql_core :: translate :: ToParamLiteral"),
+            "{ts}"
+        );
     }
 }

--- a/macros/tests/compile-fail/to_glue_row_missing_bounds.stderr
+++ b/macros/tests/compile-fail/to_glue_row_missing_bounds.stderr
@@ -1,23 +1,21 @@
-error[E0277]: the trait bound `T: Clone` is not satisfied
- --> tests/compile-fail/to_glue_row_missing_bounds.rs:8:10
-  |
-8 | #[derive(ToGlueRow)]
-  |          ^^^^^^^^^ the trait `Clone` is not implemented for `T`
-  |
-  = note: this error originates in the derive macro `ToGlueRow` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `Clone`
-  |
-9 | struct Record<T: std::clone::Clone> {
-  |                +++++++++++++++++++
-
-error[E0277]: the trait bound `T: IntoParamLiteral` is not satisfied
- --> tests/compile-fail/to_glue_row_missing_bounds.rs:8:10
-  |
-8 | #[derive(ToGlueRow)]
-  |          ^^^^^^^^^ the trait `IntoParamLiteral` is not implemented for `T`
-  |
-  = note: this error originates in the derive macro `ToGlueRow` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `IntoParamLiteral`
-  |
-9 | struct Record<T: gluesql_core::translate::IntoParamLiteral> {
-  |                +++++++++++++++++++++++++++++++++++++++++++
+error[E0599]: the method `to_glue_row` exists for struct `Record<NotConvertible>`, but its trait bounds were not satisfied
+  --> tests/compile-fail/to_glue_row_missing_bounds.rs:17:17
+   |
+ 6 | struct NotConvertible;
+   | --------------------- doesn't satisfy `NotConvertible: ToParamLiteral`
+...
+ 9 | struct Record<T> {
+   | ---------------- method `to_glue_row` not found for this struct because it doesn't satisfy `Record<NotConvertible>: ToGlueRow`
+...
+17 |     let _ = rec.to_glue_row();
+   |                 ^^^^^^^^^^^ method cannot be called on `Record<NotConvertible>` due to unsatisfied trait bounds
+   |
+   = note: trait bound `NotConvertible: ToParamLiteral` was not satisfied
+note: the trait `ToParamLiteral` must be implemented
+  --> $WORKSPACE/core/src/translate/param.rs
+   |
+   | pub trait ToParamLiteral {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `to_glue_row`, perhaps you need to implement it:
+           candidate #1: `ToGlueRow`

--- a/macros/tests/runtime_ok_to_glue_row.rs
+++ b/macros/tests/runtime_ok_to_glue_row.rs
@@ -1,5 +1,10 @@
 use {
-    gluesql_core::{ast::Expr, data::Value, row_conversion::ToGlueRow, translate::ParamLiteral},
+    gluesql_core::{
+        ast::Expr,
+        data::Value,
+        row_conversion::ToGlueRow,
+        translate::{ParamLiteral, ToParamLiteral},
+    },
     gluesql_macros::{FromGlueRow, ToGlueRow},
 };
 
@@ -118,21 +123,29 @@ fn values_from_round_trip_with_memory_storage() {
 }
 
 #[derive(ToGlueRow)]
-struct GenericRecord<'a, T>
-where
-    T: Clone + gluesql_core::translate::IntoParamLiteral,
-{
+struct GenericRecord<'a, T> {
     name: &'a str,
-    value: T,
+    value: Option<T>,
+}
+
+struct NonCloneParam(i64);
+
+impl ToParamLiteral for NonCloneParam {
+    fn to_param_literal(&self) -> ParamLiteral {
+        self.0.to_param_literal()
+    }
 }
 
 #[test]
 fn to_glue_row_supports_generics_and_lifetimes() {
     let rec = GenericRecord {
         name: "test",
-        value: 42_i64,
+        value: Some(NonCloneParam(42)),
     };
-    assert_eq!(GenericRecord::<i64>::glue_columns(), &["name", "value"]);
+    assert_eq!(
+        GenericRecord::<NonCloneParam>::glue_columns(),
+        &["name", "value"]
+    );
     let exprs = rec
         .to_glue_row()
         .into_iter()
@@ -148,10 +161,7 @@ fn to_glue_row_supports_generics_and_lifetimes() {
 }
 
 #[derive(ToGlueRow)]
-struct ConstGenericRecord<T, const N: usize>
-where
-    T: Clone + gluesql_core::translate::IntoParamLiteral,
-{
+struct ConstGenericRecord<T, const N: usize> {
     tag: String,
     payload: T,
 }

--- a/macros/tests/runtime_ok_to_glue_row.rs
+++ b/macros/tests/runtime_ok_to_glue_row.rs
@@ -17,6 +17,15 @@ struct Item {
     in_stock: Option<bool>,
 }
 
+#[derive(ToGlueRow)]
+struct Empty {}
+
+#[test]
+fn to_glue_row_supports_empty_structs() {
+    assert!(Empty::glue_columns().is_empty());
+    assert!(Empty {}.to_glue_row().is_empty());
+}
+
 #[test]
 fn glue_columns_honors_rename() {
     assert_eq!(


### PR DESCRIPTION
## Summary

- add `ToParamLiteral` for converting borrowed values into query parameters
- generate `ToParamLiteral` bounds for fields in the `ToGlueRow` derive
- support non-`Clone` field types, including recursive `Option<T>` conversion

## Motivation

`ToGlueRow` previously cloned every field before converting it through
`IntoParamLiteral`. This made `Clone` an implementation-detail requirement and
made the compile-fail snapshot sensitive to unrelated changes involving the
`Clone` name.

The derive now converts fields by reference and expresses only the actual
conversion requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added borrowed parameter conversion support for strings, byte data, optional values, UUIDs, and other supported types.
  * Expanded row generation to work with non-`Clone` parameter values.
  * Re-exported the new parameter conversion capability for easier access.

* **Bug Fixes**
  * Reduced unnecessary cloning and ownership requirements when building database rows.
  * Improved support for generic and lifetime-based record types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->