### PR TITLE
Reject unsupported table function arguments

### DIFF
--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -261,10 +261,18 @@ fn translate_table_factor(
             let alias = translate_table_alias(alias.as_ref());
 
             match (object_name.as_str(), args) {
-                ("SERIES", Some(SqlTableFunctionArgs { args, .. })) => Ok(TableFactor::Series {
-                    alias: alias_or_name(alias, object_name),
-                    size: translate_table_args(args)?,
-                }),
+                ("SERIES", Some(SqlTableFunctionArgs { args, .. })) => {
+                    if args.len() > 1 {
+                        return Err(TranslateError::UnsupportedQueryTableFactor(
+                            sql_table_factor.to_string(),
+                        )
+                        .into());
+                    }
+                    Ok(TableFactor::Series {
+                        alias: alias_or_name(alias, object_name),
+                        size: translate_table_args(args)?,
+                    })
+                }
                 ("GLUE_OBJECTS", None) => Ok(TableFactor::Dictionary {
                     dict: Dictionary::GlueObjects,
                     alias: alias_or_name(alias, object_name),
@@ -390,6 +398,10 @@ mod tests {
         assert_query_error(
             "SELECT * FROM Foo(1)",
             TranslateError::UnsupportedQueryTableFactor("Foo(1)".into()),
+        );
+        assert_query_error(
+            "SELECT * FROM SERIES(1, 2)",
+            TranslateError::UnsupportedQueryTableFactor("SERIES(1, 2)".into()),
         );
     }
 

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -265,22 +265,26 @@ fn translate_table_factor(
                     alias: alias_or_name(alias, object_name),
                     size: translate_table_args(args)?,
                 }),
-                ("GLUE_OBJECTS", _) => Ok(TableFactor::Dictionary {
+                ("GLUE_OBJECTS", None) => Ok(TableFactor::Dictionary {
                     dict: Dictionary::GlueObjects,
                     alias: alias_or_name(alias, object_name),
                 }),
-                ("GLUE_TABLES", _) => Ok(TableFactor::Dictionary {
+                ("GLUE_TABLES", None) => Ok(TableFactor::Dictionary {
                     dict: Dictionary::GlueTables,
                     alias: alias_or_name(alias, object_name),
                 }),
-                ("GLUE_INDEXES", _) => Ok(TableFactor::Dictionary {
+                ("GLUE_INDEXES", None) => Ok(TableFactor::Dictionary {
                     dict: Dictionary::GlueIndexes,
                     alias: alias_or_name(alias, object_name),
                 }),
-                ("GLUE_TABLE_COLUMNS", _) => Ok(TableFactor::Dictionary {
+                ("GLUE_TABLE_COLUMNS", None) => Ok(TableFactor::Dictionary {
                     dict: Dictionary::GlueTableColumns,
                     alias: alias_or_name(alias, object_name),
                 }),
+                (_, Some(_)) => Err(TranslateError::UnsupportedQueryTableFactor(
+                    sql_table_factor.to_string(),
+                )
+                .into()),
                 _ => Ok(TableFactor::Table {
                     name: translate_object_name(name)?,
                     alias,
@@ -371,6 +375,22 @@ mod tests {
         let actual = translate_query(&query, NO_PARAMS);
         let expected = Err::<Query, Error>(Error::Translate(expected));
         assert_eq!(actual, expected, "translate_query mismatch for `{sql}`");
+    }
+
+    #[test]
+    fn unsupported_table_function_args_rejected() {
+        assert_query_error(
+            "SELECT * FROM GLUE_TABLES(1)",
+            TranslateError::UnsupportedQueryTableFactor("GLUE_TABLES(1)".into()),
+        );
+        assert_query_error(
+            "SELECT * FROM GLUE_INDEXES(1)",
+            TranslateError::UnsupportedQueryTableFactor("GLUE_INDEXES(1)".into()),
+        );
+        assert_query_error(
+            "SELECT * FROM Foo(1)",
+            TranslateError::UnsupportedQueryTableFactor("Foo(1)".into()),
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Summary**

- Reject table factors with unsupported function arguments during translation.
- Allow dictionary tables only when no arguments are supplied.
- Add regression tests for dictionary and unknown table factors.

**Test plan**

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-features`
- [x] `cargo test -p gluesql-core`

Closes #1904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported arguments from being accepted for non-series table sources.
  * Preserved dictionary table support when used without arguments.
  * Enforced the requirement that `SERIES` receive exactly one argument.
  * Added clearer errors for invalid table-factor arguments, including dictionary tables, ordinary tables, and `SERIES`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->