### PR TITLE
perf(memory-storage): make Store::scan_data lazy to avoid full-table clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,7 @@ dependencies = [
 name = "gluesql_memory_storage"
 version = "0.19.0"
 dependencies = [
+ "criterion",
  "gluesql-core",
  "gluesql-test-suite",
  "serde",

--- a/storages/memory-storage/Cargo.toml
+++ b/storages/memory-storage/Cargo.toml
@@ -14,6 +14,11 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 test-suite.workspace = true
+criterion = "0.3"
+
+[[bench]]
+name = "memory_benchmark"
+harness = false
 
 [lints]
 workspace = true

--- a/storages/memory-storage/benches/memory_benchmark.rs
+++ b/storages/memory-storage/benches/memory_benchmark.rs
@@ -1,10 +1,13 @@
 use {
-    criterion::{Criterion, criterion_group, criterion_main},
+    criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     gluesql_core::prelude::Glue,
     gluesql_memory_storage::MemoryStorage,
 };
 
 const ITEM_SIZE: u32 = 5000;
+
+/// Width of the range selected by `select_many`.
+const RANGE: u32 = 50;
 
 fn seeded_glue() -> Glue<MemoryStorage> {
     let storage = MemoryStorage::default();
@@ -33,34 +36,33 @@ fn seeded_glue() -> Glue<MemoryStorage> {
 }
 
 pub fn bench_insert(c: &mut Criterion) {
-    let storage = MemoryStorage::default();
-    let mut glue = Glue::new(storage);
-
-    glue.execute(
-        "
-        CREATE TABLE Testing (
-            id INTEGER,
-            field_one TEXT,
-            field_two TEXT,
-            field_three TEXT
-        );
-    ",
-    )
-    .unwrap();
-
-    let mut id = 0;
-
+    // Insert into a fresh single-table database each iteration so the measured
+    // workload stays constant. Growing the table across iterations would make
+    // the timing depend on how many inserts ran before, not on the insert cost.
     c.bench_function("insert_one", |b| {
-        b.iter(|| {
-            let query_str = format!(
-                "INSERT INTO Testing
-                 VALUES ({:#}, 'Testing 1', 'Testing 2', 'Testing 3');",
-                &id
-            );
-            id += 1;
-
-            glue.execute(&query_str).unwrap();
-        });
+        b.iter_batched(
+            || {
+                let mut glue = Glue::new(MemoryStorage::default());
+                glue.execute(
+                    "CREATE TABLE Testing (
+                        id INTEGER,
+                        field_one TEXT,
+                        field_two TEXT,
+                        field_three TEXT
+                    );",
+                )
+                .unwrap();
+                glue
+            },
+            |mut glue| {
+                glue.execute(
+                    "INSERT INTO Testing
+                     VALUES (0, 'Testing 1', 'Testing 2', 'Testing 3');",
+                )
+                .unwrap();
+            },
+            BatchSize::SmallInput,
+        );
     });
 }
 
@@ -83,18 +85,22 @@ pub fn bench_select(c: &mut Criterion) {
         });
     });
 
-    // Range filter over a non-indexed column (full scan + filter).
+    // Range filter over a non-indexed column (full scan + filter). Use a
+    // dedicated counter that wraps before the range would run past the last
+    // row, so every iteration selects the same number of rows (a constant
+    // window of `RANGE`) instead of shrinking near the top of the table.
+    let mut range_start = 0;
     c.bench_function("select_many", |b| {
         b.iter(|| {
             let query_str = format!(
                 "SELECT * FROM Testing WHERE id > {} AND id < {}",
-                id,
-                id + 50
+                range_start,
+                range_start + RANGE
             );
 
-            id += 1;
-            if id >= ITEM_SIZE {
-                id = 1;
+            range_start += 1;
+            if range_start >= ITEM_SIZE - RANGE {
+                range_start = 0;
             }
 
             glue.execute(&query_str).unwrap();
@@ -112,9 +118,9 @@ pub fn bench_scan(c: &mut Criterion) {
         });
     });
 
-    // Early-termination case: only one row is needed, yet the current
-    // scan_data clones the entire table up front. This is the query where
-    // making scan_data lazy should show the largest win.
+    // Early-termination case: only one row is needed. With the lazy scan_data,
+    // only the single row consumed by `LIMIT 1` is cloned instead of the whole
+    // table, so this is the query where the optimization shows the largest win.
     c.bench_function("scan_limit_1", |b| {
         b.iter(|| {
             glue.execute("SELECT * FROM Testing LIMIT 1").unwrap();

--- a/storages/memory-storage/benches/memory_benchmark.rs
+++ b/storages/memory-storage/benches/memory_benchmark.rs
@@ -1,0 +1,133 @@
+use {
+    criterion::{Criterion, criterion_group, criterion_main},
+    gluesql_core::prelude::Glue,
+    gluesql_memory_storage::MemoryStorage,
+};
+
+const ITEM_SIZE: u32 = 5000;
+
+fn seeded_glue() -> Glue<MemoryStorage> {
+    let storage = MemoryStorage::default();
+    let mut glue = Glue::new(storage);
+
+    let mut sqls: String = "
+        CREATE TABLE Testing (
+            id INTEGER,
+            field_one TEXT,
+            field_two TEXT,
+            field_three TEXT
+        );"
+    .to_owned();
+
+    for i in 0..ITEM_SIZE {
+        sqls += &*format!(
+            "INSERT INTO Testing
+             VALUES ({:#}, 'Testing 1', 'Testing 2', 'Testing 3');",
+            &i
+        );
+    }
+
+    glue.execute(&sqls).unwrap();
+
+    glue
+}
+
+pub fn bench_insert(c: &mut Criterion) {
+    let storage = MemoryStorage::default();
+    let mut glue = Glue::new(storage);
+
+    glue.execute(
+        "
+        CREATE TABLE Testing (
+            id INTEGER,
+            field_one TEXT,
+            field_two TEXT,
+            field_three TEXT
+        );
+    ",
+    )
+    .unwrap();
+
+    let mut id = 0;
+
+    c.bench_function("insert_one", |b| {
+        b.iter(|| {
+            let query_str = format!(
+                "INSERT INTO Testing
+                 VALUES ({:#}, 'Testing 1', 'Testing 2', 'Testing 3');",
+                &id
+            );
+            id += 1;
+
+            glue.execute(&query_str).unwrap();
+        });
+    });
+}
+
+pub fn bench_select(c: &mut Criterion) {
+    let mut glue = seeded_glue();
+
+    let mut id = 0;
+
+    // Point-ish lookup via non-indexed equality (exercises full scan + filter).
+    c.bench_function("select_one", |b| {
+        b.iter(|| {
+            let query_str = format!("SELECT * FROM Testing WHERE id = {id}");
+
+            id += 1;
+            if id >= ITEM_SIZE {
+                id = 1;
+            }
+
+            glue.execute(&query_str).unwrap();
+        });
+    });
+
+    // Range filter over a non-indexed column (full scan + filter).
+    c.bench_function("select_many", |b| {
+        b.iter(|| {
+            let query_str = format!(
+                "SELECT * FROM Testing WHERE id > {} AND id < {}",
+                id,
+                id + 50
+            );
+
+            id += 1;
+            if id >= ITEM_SIZE {
+                id = 1;
+            }
+
+            glue.execute(&query_str).unwrap();
+        });
+    });
+}
+
+pub fn bench_scan(c: &mut Criterion) {
+    let mut glue = seeded_glue();
+
+    // Whole-table scan: pure scan_data cost.
+    c.bench_function("full_scan", |b| {
+        b.iter(|| {
+            glue.execute("SELECT * FROM Testing").unwrap();
+        });
+    });
+
+    // Early-termination case: only one row is needed, yet the current
+    // scan_data clones the entire table up front. This is the query where
+    // making scan_data lazy should show the largest win.
+    c.bench_function("scan_limit_1", |b| {
+        b.iter(|| {
+            glue.execute("SELECT * FROM Testing LIMIT 1").unwrap();
+        });
+    });
+
+    // Aggregate over the whole table (full scan, no materialized output rows).
+    c.bench_function("count_all", |b| {
+        b.iter(|| {
+            glue.execute("SELECT COUNT(*) FROM Testing").unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_insert, bench_select, bench_scan);
+criterion_main!(benches);

--- a/storages/memory-storage/src/lib.rs
+++ b/storages/memory-storage/src/lib.rs
@@ -88,9 +88,18 @@ impl Store for MemoryStorage {
     }
 
     fn scan_data<'a>(&'a self, table_name: &str) -> Result<RowIter<'a>> {
-        let rows = MemoryStorage::scan_data(self, table_name)
+        // Borrow the table's rows and clone each entry lazily, so callers that
+        // stop early (e.g. `LIMIT`) never pay to clone rows they don't consume.
+        // This deliberately avoids the eager full-table clone in the inherent
+        // `MemoryStorage::scan_data`, which is kept for `SharedMemoryStorage`
+        // where the rows must be materialized while the lock guard is held.
+        let rows = self
+            .items
+            .get(table_name)
+            .map(|item| item.rows.iter())
             .into_iter()
-            .map(Ok);
+            .flatten()
+            .map(|(key, row)| Ok((key.clone(), row.clone())));
 
         Ok(Box::new(rows))
     }


### PR DESCRIPTION
### What

Make MemoryStorage's Store::scan_data lazy so it no longer clones the entire table up front.

### Why

Store::scan_data called the inherent MemoryStorage::scan_data, which did item.rows.clone().into_iter().collect() — a deep clone of the whole BTreeMap followed by re-collecting into a Vec. Callers that stop early (e.g. LIMIT) still paid to clone every row, and full scans paid the redundant clone + intermediate allocation.

### Change

`Store::scan_data` now borrows `self.items` and clones each `(Key, Vec<Value>)` on demand while iterating `item.rows.iter()`:
- early-terminating callers (`LIMIT`) never clone rows they don't consume;
- the intermediate `Vec` and full-map clone are gone.

The inherent `MemoryStorage::scan_data(&self) -> Vec<...>` is intentionally kept, because `SharedMemoryStorage` (`Arc<RwLock<MemoryStorage>>`) must materialize rows into an owned `Vec` while the read-lock guard is held. A criterion benchmark for `memory-storage` is added (mirroring the existing `sled-storage` one).

### Benchmarks (memory_benchmark, 5000-row table)

Measured with the added `memory_benchmark` (criterion, 5000-row table), on
the same rebased commit. `before` = eager clone, `after` = lazy scan.

| query | before | after | change |
|-------|--------|-------|--------|
| `SELECT * ... LIMIT 1`        | 910.4 µs | 6.30 µs  | **−99.3%** |
| `WHERE id = X`                | 1.285 ms | 721.5 µs | −43.4% |
| `COUNT(*)`                    | 1.227 ms | 721.1 µs | −40.9% |
| `WHERE id > X AND id < X+50`  | 1.562 ms | 983.0 µs | −37.5% |
| `SELECT *` (full)             | 1.902 ms | 1.604 ms | −16.5% |
| `INSERT` (control, unchanged) | 7.12 µs  | 6.84 µs  | no change (p=0.56) |

### Verification

- No behavior change.
- cargo test -p gluesql_memory_storage → 196 passed
- cargo test -p gluesql-shared-memory-storage → 196 passed (depends on the kept inherent method)
- cargo test -p gluesql-core → 516 passed
- cargo clippy --all-targets -- -D warnings → clean
- cargo fmt --all -- --check → clean
- Branch rebased on latest upstream/main.

Closes #1984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved full-table scanning efficiency by avoiding unnecessary upfront data copying.
  * Data is now copied only as scan results are consumed, reducing memory overhead.

* **Tests**
  * Added benchmark coverage for inserts, point and range queries, full-table scans, limited scans, and count queries.
  * Benchmarks use a representative dataset to help track storage performance over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->