### PR TITLE
Apply schemaless rewrites to CREATE TABLE AS SELECT sources

### DIFF
--- a/core/src/planner/schemaless.rs
+++ b/core/src/planner/schemaless.rs
@@ -109,6 +109,28 @@ fn transform_statement<S: BuildHasher>(
                 selection,
             }
         }
+        StatementPlan::CreateTable {
+            if_not_exists,
+            name,
+            columns,
+            mut source,
+            engine,
+            foreign_keys,
+            comment,
+        } => {
+            if let Some(source) = source.as_mut() {
+                transform_query(schema_map, source);
+            }
+            StatementPlan::CreateTable {
+                if_not_exists,
+                name,
+                columns,
+                source,
+                engine,
+                foreign_keys,
+                comment,
+            }
+        }
         _ => statement,
     }
 }
@@ -493,6 +515,19 @@ mod tests {
         let actual = "DELETE FROM Item WHERE Item.id = 1";
         let expected = "DELETE FROM Item WHERE Item.id = 1";
         test(actual, expected, "delete schemaful compound no-op");
+
+        let actual = "CREATE TABLE ItemName AS SELECT name FROM Player";
+        let expected = "CREATE TABLE ItemName AS SELECT _doc['name'] as name FROM Player";
+        test(actual, expected, "create table as select");
+
+        let actual = "CREATE TABLE ItemName AS SELECT id FROM Player WHERE id = 1";
+        let expected =
+            "CREATE TABLE ItemName AS SELECT _doc['id'] as id FROM Player WHERE _doc['id'] = 1";
+        test(actual, expected, "create table as select with filter");
+
+        let actual = "CREATE TABLE ItemId AS SELECT id FROM Item";
+        let expected = "CREATE TABLE ItemId AS SELECT id FROM Item";
+        test(actual, expected, "create table as select schemaful no-op");
     }
 
     #[test]
@@ -503,9 +538,16 @@ mod tests {
             let statement = StatementPlan::from(translate(&parsed).unwrap());
             let schema_map = fetch_schema_map(&storage, &statement).unwrap();
             let planned = plan_schemaless(&schema_map, statement).unwrap();
-
-            let StatementPlan::Query(QueryPlan::Project(project)) = planned else {
-                panic!("expected query statement");
+            let query = match planned {
+                StatementPlan::Query(query) => query,
+                StatementPlan::CreateTable {
+                    source: Some(source),
+                    ..
+                } => *source,
+                _ => panic!("expected query or create table as select"),
+            };
+            let QueryPlan::Project(project) = query else {
+                panic!("expected project query");
             };
             assert_eq!(
                 matches!(project.projection, ProjectionPlan::SchemalessMap),
@@ -531,6 +573,10 @@ mod tests {
             "SELECT P.*, T.* FROM Player AS P JOIN Team AS T WHERE P.id = T.id",
             false,
         );
+
+        test("CREATE TABLE T AS SELECT * FROM Player", true);
+        test("CREATE TABLE T AS SELECT id FROM Player", false);
+        test("CREATE TABLE T AS SELECT * FROM Item", false);
     }
 
     #[test]

--- a/test-suite/fixtures/schemaless/basic.sql
+++ b/test-suite/fixtures/schemaless/basic.sql
@@ -100,3 +100,20 @@ WHERE flag IS NOT NULL;
 -- | player_id: I64 | player_name: Str | item_cost: I64 |
 -- | -------------- | ---------------- | -------------- |
 -- | 1001           | "Beam"           | 3000           |
+
+CREATE TABLE ItemName AS SELECT name, dex FROM Item
+-- @expect: ok
+
+SELECT name, dex FROM ItemName
+-- @expect:
+-- | name: Str  | dex: I64 |
+-- | ---------- | -------- |
+-- | "Test 001" | 324      |
+
+CREATE TABLE ItemCopy AS SELECT * FROM Item
+-- @expect: ok
+
+SELECT * FROM ItemCopy
+-- @expect: maps
+-- | {"dex":324,"id":101,"name":"Test 001","new_field":"Hello","obj":{"cost":3000},"rare":true} |
+


### PR DESCRIPTION
## Summary

- apply the schemaless transform to `CREATE TABLE ... AS SELECT` source queries
- add plan-level tests for CTAS rewrite, wildcard projection mode, and schemaful no-op
- add an end-to-end fixture covering both CTAS paths from a schemaless table

## Why

`plan::schemaless` validates CTAS source queries in `validate_statement`, but
`transform_statement` handled only `Query`, `Insert`, `Update`, and `Delete` 
`CreateTable` fell through to `_ => statement`.

As a result, a CTAS reading from a schemaless table passed validation and then
reached the executor with unrewritten identifiers, failing with
`EvaluateError::IdentifierNotFound`.

`CREATE TABLE ItemName AS SELECT name FROM Player`, before:

```
SelectItems([Expr { expr: Identifier("name"), label: "name" }])
```

after:

```
SelectItems([Expr { expr: ArrayIndex {
    obj: Identifier("_doc"),
    indexes: [Literal(QuotedString("name"))],
}, label: "name" }])
```

This also makes the `ProjectionPlan::SchemalessMap` arm of
`can_copy_source_schema` reachable from SQL for the first time, so
`CREATE TABLE X AS SELECT * FROM <schemaless>` now copies the source's
`column_defs: None` and produces a schemaless target table.

The new branch follows the same shape `plan::aggregate` already uses for
CTAS sources.

## Tests

- `cargo test -p gluesql-core`: 515 passed
- `cargo test -p gluesql_memory_storage`: 196 passed
- `cargo test -p gluesql-json-storage`: 191 passed
- `cargo test -p gluesql-test-suite`: 16 passed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all`

Closes #1905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for creating tables from query results when using schemaless data.
  - Queries selecting specific columns or all available columns now produce correctly structured tables.
  - Ensured created tables contain the latest source data after updates.
  - Added coverage for schema-aware and schemaless table creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->