### PR TITLE
Add tests for untested TranslateError paths

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -711,4 +711,71 @@ mod tests {
         let params = [1_i64.into_param_literal()];
         assert_invalid_placeholder(&params, "$foo");
     }
+
+    #[test]
+    fn reject_out_of_range_placeholder_index() {
+        let params = [1_i64.into_param_literal()];
+        let err = bind_placeholder(&params, "$2").unwrap_err();
+        assert_eq!(
+            err,
+            TranslateError::ParameterIndexOutOfRange { index: 2, len: 1 }.into()
+        );
+
+        let parsed = parse("SELECT $2").expect("parse");
+        let actual = translate_with_params(&parsed[0], &params);
+        let expected = Err(TranslateError::ParameterIndexOutOfRange { index: 2, len: 1 }.into());
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn multiple_alter_table_operations_not_supported() {
+        assert_translate_error(
+            "ALTER TABLE Foo DROP COLUMN a, DROP COLUMN b",
+            TranslateError::UnsupportedMultipleAlterTableOperations,
+        );
+    }
+
+    #[test]
+    fn parser_rejects_inputs_guarded_by_defensive_variants() {
+        // Each SQL below is the nearest miss for a defensive TranslateError
+        // branch; sqlparser (0.52, PostgreSqlDialect) rejects it at parse
+        // time, so the branch is unreachable through the public SQL API. If a
+        // sqlparser upgrade makes one of these parse, the guarded branch may
+        // have become reachable and deserves a real translate test instead.
+        let cases = [
+            // TranslateError::UnreachableEmptyAlterTableOperation
+            "ALTER TABLE Foo",
+            // TranslateError::UnreachableEmptyIdent
+            "UPDATE Foo SET = 1",
+            // TranslateError::UnreachableEmptyObject
+            "DROP TABLE",
+            // TranslateError::UnreachableEmptyTable
+            "DELETE FROM",
+            // TranslateError::UnreachableForeignKeyColumns (referencing side)
+            "CREATE TABLE T (a INT, FOREIGN KEY () REFERENCES B (id))",
+            // TranslateError::UnreachableForeignKeyColumns (referenced side)
+            "CREATE TABLE T (a INT, FOREIGN KEY (a) REFERENCES B ())",
+            "CREATE TABLE T (a INT, FOREIGN KEY (a) REFERENCES B)",
+            // TranslateError::UnreachableOmittingFromInDelete
+            "DELETE Foo WHERE id = 1",
+            // TranslateError::UnsupportedTrimChars
+            "SELECT TRIM('x', 'y')",
+        ];
+
+        for sql in cases {
+            assert!(parse(sql).is_err(), "expected parse error: {sql}");
+        }
+    }
+
+    #[test]
+    fn delete_always_carries_from_keyword() {
+        // Positive control for UnreachableOmittingFromInDelete: with
+        // PostgreSqlDialect the parser only emits FromTable::WithFromKeyword.
+        let parsed = parse("DELETE FROM Foo").expect("parse");
+        assert!(matches!(
+            &parsed[0],
+            SqlStatement::Delete(delete)
+                if matches!(delete.from, SqlFromTable::WithFromKeyword(_))
+        ));
+    }
 }

--- a/core/src/translate/function.rs
+++ b/core/src/translate/function.rs
@@ -783,4 +783,16 @@ mod tests {
         let expected = Err(TranslateError::SafeCastNotSupported.into());
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn subquery_function_arg_rejected() {
+        use crate::translate::NO_PARAMS;
+
+        // sqlparser parses `ARRAY(<query>)` into FunctionArguments::Subquery,
+        // so this branch is reachable through plain SQL despite its name.
+        let actual =
+            parse_expr("ARRAY(SELECT 1)").and_then(|parsed| translate_expr(&parsed, NO_PARAMS));
+        let expected = Err(TranslateError::UnreachableSubqueryFunctionArgNotSupported.into());
+        assert_eq!(actual, expected);
+    }
 }

--- a/core/src/translate/literal.rs
+++ b/core/src/translate/literal.rs
@@ -51,3 +51,20 @@ pub fn translate_trim_where_field(sql_trim_where_field: SqlTrimWhereField) -> Tr
         SqlTrimWhereField::Trailing => Trailing,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        parse_sql::parse_expr,
+        translate::{NO_PARAMS, TranslateError, translate_expr},
+    };
+
+    #[test]
+    fn dollar_quoted_string_literal_rejected() {
+        // PostgreSqlDialect tokenizes `$$..$$` into Value::DollarQuotedString,
+        // which translate_literal does not support.
+        let actual = parse_expr("$$abc$$").and_then(|parsed| translate_expr(&parsed, NO_PARAMS));
+        let expected = Err(TranslateError::UnsupportedLiteral("$$abc$$".to_owned()).into());
+        assert_eq!(actual, expected);
+    }
+}

--- a/core/src/translate/operator.rs
+++ b/core/src/translate/operator.rs
@@ -44,3 +44,29 @@ pub fn translate_binary_operator(
         _ => Err(TranslateError::UnsupportedBinaryOperator(sql_binary_operator.to_string()).into()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        parse_sql::parse_expr,
+        translate::{NO_PARAMS, TranslateError, translate_expr},
+    };
+
+    #[test]
+    fn pg_only_unary_operators_rejected() {
+        // PostgreSqlDialect parses these prefix operators, so the fallback
+        // branch is reachable through plain SQL despite the variant name.
+        let cases = [
+            ("|/ 25", "|/"),
+            ("||/ 27", "||/"),
+            ("!! 5", "!!"),
+            ("@ -5", "@"),
+        ];
+
+        for (sql, op) in cases {
+            let actual = parse_expr(sql).and_then(|parsed| translate_expr(&parsed, NO_PARAMS));
+            let expected = Err(TranslateError::UnreachableUnaryOperator(op.to_owned()).into());
+            assert_eq!(actual, expected, "unary operator `{op}`");
+        }
+    }
+}

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -446,6 +446,22 @@ mod tests {
     }
 
     #[test]
+    fn group_by_all_rejected() {
+        assert_query_error(
+            "SELECT a FROM Foo GROUP BY ALL",
+            TranslateError::UnsupportedGroupByAll,
+        );
+    }
+
+    #[test]
+    fn nested_join_table_factor_rejected() {
+        assert_query_error(
+            "SELECT * FROM (Foo JOIN Bar ON 1 = 1)",
+            TranslateError::UnsupportedQueryTableFactor("(Foo JOIN Bar ON 1 = 1)".to_owned()),
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "expected query statement")]
     fn query_option_helper_panics_on_non_query() {
         assert_query_error(


### PR DESCRIPTION
## What this PR does

Of the 62 `TranslateError` variants, **14 variants (15 construction sites)** were not exercised by any test — neither by the SQL fixtures in `test-suite/fixtures/` nor by the inline test modules in `core/src/translate*`. Any refactoring (e.g. the upcoming StatementPlan redesign, #1910) could silently drop or change one of these error paths without a single test failing.

This PR is **tests only** — no variant is renamed or removed, and no parsing behavior changes.

Each untested path was classified by reading the sqlparser 0.52 sources directly (GlueSQL pins `PostgreSqlDialect`, `core/src/parse_sql.rs`):

### Reachable through plain SQL — pinned with unit tests (7 variants)

| Variant | Reproduction |
|---|---|
| `UnreachableSubqueryFunctionArgNotSupported` | `SELECT ARRAY(SELECT 1)` — sqlparser turns `ARRAY(<query>)` into `FunctionArguments::Subquery`, so this is reachable despite the name |
| `UnreachableUnaryOperator` | `SELECT \|/ 25` — PG-only prefix operators (`\|/`, `\|\|/`, `!!`, `@`) parse but are not handled; also reachable despite the name |
| `UnsupportedGroupByAll` | `SELECT a FROM Foo GROUP BY ALL` |
| `UnsupportedLiteral` | `SELECT $$abc$$` (dollar-quoted string) |
| `UnsupportedMultipleAlterTableOperations` | `ALTER TABLE Foo DROP COLUMN a, DROP COLUMN b` |
| `UnsupportedQueryTableFactor` | `SELECT * FROM (Foo JOIN Bar ON 1 = 1)` (nested join) |
| `ParameterIndexOutOfRange` | `SELECT $2` with one bound parameter (`bind_placeholder` unit test + `translate_with_params` end-to-end) |

Tests live in the module that owns each construction site, reusing the existing helpers (`assert_translate_error`, `assert_query_error`, `parse_expr` + `translate_expr`). New `#[cfg(test)]` modules were added to `operator.rs` and `literal.rs`.

### Unreachable by parser contract — recorded as contract tests (7 variants / 8 sites)

For each defensive branch, `parser_rejects_inputs_guarded_by_defensive_variants` asserts that the nearest-miss SQL fails to **parse** with sqlparser 0.52 + `PostgreSqlDialect`, with a comment naming the guarded variant:

| Variant | Contract evidence |
|---|---|
| `UnreachableEmptyAlterTableOperation` | operations list is `parse_comma_separated` (≥ 1) — `ALTER TABLE Foo` is a parse error |
| `UnreachableEmptyIdent` | assignment target needs ≥ 1 identifier — `UPDATE Foo SET = 1` |
| `UnreachableEmptyObject` | `parse_object_name` needs ≥ 1 identifier — `DROP TABLE` |
| `UnreachableEmptyTable` | DELETE's FROM list is ≥ 1 — `DELETE FROM` |
| `UnreachableForeignKeyColumns` (2 sites) | both column lists are `parse_parenthesized_column_list(Mandatory, allow_empty = false)` — `FOREIGN KEY ()`, `REFERENCES B ()`, and `REFERENCES B` all fail to parse |
| `UnreachableOmittingFromInDelete` | `FromTable::WithoutKeyword` is only produced for BigQuery/Generic dialects; a positive-control test pins that `DELETE FROM Foo` parses as `WithFromKeyword` |
| `UnsupportedTrimChars` | `trim_characters` comes only from the comma syntax, which is Snowflake/BigQuery/Generic-only — `SELECT TRIM('x', 'y')` fails to parse |

If a future sqlparser upgrade changes any of these contracts, the tests break — turning a silent "unreachable became reachable" into a visible failure.

## Follow-up candidates (out of scope here)

- `UnreachableSubqueryFunctionArgNotSupported` and `UnreachableUnaryOperator` are misnamed — they are reachable through plain SQL. Renaming is left for a separate PR.
- Found while auditing: `DELETE Foo FROM Bar` (MySQL multi-table syntax) parses under `PostgreSqlDialect` and translate silently ignores the leading `tables` list. Possibly worth its own issue.

## Verification

- `cargo test -p gluesql-core` — 522 passed
- `cargo clippy -p gluesql-core --all-targets` — clean
- `cargo fmt -p gluesql-core -- --check` — clean
- Coverage re-audit: every one of the 62 variant names now appears in fixture or inline test code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for unsupported SQL syntax and translation scenarios, including:
    - Out-of-range parameter placeholders
    - Multiple `ALTER TABLE` operations
    - Subqueries in function arguments
    - Dollar-quoted string literals
    - PostgreSQL-only unary operators
    - `GROUP BY ALL`
    - Parenthesized nested joins
  - Added parser validation ensuring `DELETE` statements include `FROM`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->