### PR TITLE
Skip NULL values in non-COUNT aggregates

### DIFF
--- a/core/src/executor/query/aggregation/state.rs
+++ b/core/src/executor/query/aggregation/state.rs
@@ -391,6 +391,13 @@ impl<'a, T: GStore> State<'a, T> {
             }
         };
 
+        // SQL eliminates NULL before applying a set function, so every aggregate but
+        // COUNT ignores NULL inputs entirely. Groups that see nothing but NULL keep an
+        // empty slot and fall back to `empty_value` on export.
+        if value.is_null() && !matches!(aggregate.func, AggregateFunctionPlan::Count(_)) {
+            return Ok(());
+        }
+
         let group = self
             .groups
             .get_mut(group_index)

--- a/test-suite/fixtures/aggregate/avg.sql
+++ b/test-suite/fixtures/aggregate/avg.sql
@@ -16,9 +16,9 @@ INSERT INTO Item (id, quantity, age, total) VALUES
 
 SELECT AVG(age) FROM Item
 -- @expect:
--- | AVG(age) |
--- | -------- |
--- | NULL     |
+-- | AVG(age): F64   |
+-- | --------------- |
+-- | 34.666666666667 |
 
 SELECT AVG(id), AVG(quantity) FROM Item
 -- @expect:
@@ -34,6 +34,6 @@ SELECT AVG(DISTINCT id) FROM Item
 
 SELECT AVG(DISTINCT age) FROM Item
 -- @expect:
--- | AVG(DISTINCT age) |
--- | ----------------- |
--- | NULL              |
+-- | AVG(DISTINCT age): F64 |
+-- | ---------------------- |
+-- | 34.666666666667        |

--- a/test-suite/fixtures/aggregate/expr.sql
+++ b/test-suite/fixtures/aggregate/expr.sql
@@ -47,4 +47,4 @@ SELECT SUM(age) IS NULL AS test FROM Item;
 -- @expect:
 -- | test: Bool |
 -- | ---------- |
--- | true       |
+-- | false      |

--- a/test-suite/fixtures/aggregate/null.sql
+++ b/test-suite/fixtures/aggregate/null.sql
@@ -1,0 +1,107 @@
+CREATE TABLE Item (
+    id INTEGER,
+    val INTEGER NULL
+);
+-- @expect: ok
+
+INSERT INTO Item (id, val) VALUES
+    (1, NULL),
+    (2,    5),
+    (3, NULL),
+    (4,    3);
+-- @expect: ok
+
+-- @name: SUM skips NULL in the first row
+SELECT SUM(val) FROM Item
+-- @expect:
+-- | SUM(val): I64 |
+-- | ------------- |
+-- | 8             |
+
+-- @name: AVG divides by the number of non-NULL rows
+SELECT AVG(val) FROM Item
+-- @expect:
+-- | AVG(val): F64 |
+-- | ------------- |
+-- | 4.0           |
+
+-- @name: MIN skips a leading NULL instead of keeping it
+SELECT MIN(val) FROM Item
+-- @expect:
+-- | MIN(val): I64 |
+-- | ------------- |
+-- | 3             |
+
+-- @name: MAX skips a leading NULL instead of keeping it
+SELECT MAX(val) FROM Item
+-- @expect:
+-- | MAX(val): I64 |
+-- | ------------- |
+-- | 5             |
+
+-- @name: VARIANCE skips NULL
+SELECT VARIANCE(val) FROM Item
+-- @expect:
+-- | VARIANCE(val): F64 |
+-- | ------------------ |
+-- | 1.0                |
+
+-- @name: STDEV skips NULL
+SELECT STDEV(val) FROM Item
+-- @expect:
+-- | STDEV(val): F64 |
+-- | --------------- |
+-- | 1.0             |
+
+-- @name: COUNT keeps counting NULL rows only for the wildcard form
+SELECT COUNT(val), COUNT(*) FROM Item
+-- @expect:
+-- | COUNT(val): I64 | COUNT(*): I64 |
+-- | --------------- | ------------- |
+-- | 2               | 4             |
+
+-- @name: DISTINCT aggregates skip NULL as well
+SELECT SUM(DISTINCT val), MIN(DISTINCT val), MAX(DISTINCT val) FROM Item
+-- @expect:
+-- | SUM(DISTINCT val): I64 | MIN(DISTINCT val): I64 | MAX(DISTINCT val): I64 |
+-- | ---------------------- | ---------------------- | ---------------------- |
+-- | 8                      | 3                      | 5                      |
+
+CREATE TABLE AllNull (val INTEGER NULL);
+-- @expect: ok
+
+INSERT INTO AllNull VALUES (NULL), (NULL);
+-- @expect: ok
+
+-- @name: an all-NULL column aggregates to NULL
+SELECT SUM(val), MIN(val), MAX(val), AVG(val), VARIANCE(val), STDEV(val) FROM AllNull
+-- @expect:
+-- | SUM(val) | MIN(val) | MAX(val) | AVG(val) | VARIANCE(val) | STDEV(val) |
+-- | -------- | -------- | -------- | -------- | ------------- | ---------- |
+-- | NULL     | NULL     | NULL     | NULL     | NULL          | NULL       |
+
+-- @name: an all-NULL column still counts rows
+SELECT COUNT(val), COUNT(*) FROM AllNull
+-- @expect:
+-- | COUNT(val): I64 | COUNT(*): I64 |
+-- | --------------- | ------------- |
+-- | 0               | 2             |
+
+CREATE TABLE Grouped (city TEXT, val INTEGER NULL);
+-- @expect: ok
+
+INSERT INTO Grouped VALUES
+    ('Seoul', NULL),
+    ('Seoul',   10),
+    ('Busan', NULL),
+    ('Seoul',    2),
+    ('Busan', NULL);
+-- @expect: ok
+
+-- @name: NULL elimination applies per group
+SELECT city, SUM(val), MIN(val), COUNT(val) FROM Grouped GROUP BY city
+-- @expect:
+-- | city: Str | SUM(val) | MIN(val) | COUNT(val): I64 |
+-- | --------- | -------- | -------- | --------------- |
+-- | "Seoul"   | I64(12)  | I64(2)   | 2               |
+-- | "Busan"   | NULL     | NULL     | 0               |

--- a/test-suite/fixtures/aggregate/stdev.sql
+++ b/test-suite/fixtures/aggregate/stdev.sql
@@ -16,9 +16,9 @@ INSERT INTO Item (id, quantity, age, total) VALUES
 
 SELECT STDEV(age) FROM Item
 -- @expect:
--- | STDEV(age) |
--- | ---------- |
--- | NULL       |
+-- | STDEV(age): F64 |
+-- | --------------- |
+-- | 39.262648351271 |
 
 SELECT STDEV(total) FROM Item
 -- @expect:
@@ -34,6 +34,6 @@ SELECT STDEV(DISTINCT id) FROM Item
 
 SELECT STDEV(DISTINCT age) FROM Item
 -- @expect:
--- | STDEV(DISTINCT age) |
--- | ------------------- |
--- | NULL                |
+-- | STDEV(DISTINCT age): F64 |
+-- | ------------------------ |
+-- | 39.262648351271          |

--- a/test-suite/fixtures/aggregate/sum.sql
+++ b/test-suite/fixtures/aggregate/sum.sql
@@ -16,9 +16,9 @@ INSERT INTO Item (id, quantity, age, total) VALUES
 
 SELECT SUM(age) FROM Item
 -- @expect:
--- | SUM(age) |
--- | -------- |
--- | NULL     |
+-- | SUM(age): I64 |
+-- | ------------- |
+-- | 104           |
 
 SELECT SUM(id), SUM(quantity) FROM Item
 -- @expect:
@@ -64,9 +64,9 @@ SELECT SUM(DISTINCT id) FROM Item
 
 SELECT SUM(DISTINCT age) FROM Item
 -- @expect:
--- | SUM(DISTINCT age) |
--- | ----------------- |
--- | NULL              |
+-- | SUM(DISTINCT age): I64 |
+-- | ---------------------- |
+-- | 104                    |
 
 CREATE TABLE EmptyItem (id INTEGER NULL);
 -- @expect: ok

--- a/test-suite/fixtures/aggregate/variance.sql
+++ b/test-suite/fixtures/aggregate/variance.sql
@@ -18,9 +18,9 @@ INSERT INTO Item (id, quantity, age, total) VALUES
 
 SELECT VARIANCE(age) FROM Item
 -- @expect:
--- | VARIANCE(age) |
--- | ------------- |
--- | NULL          |
+-- | VARIANCE(age): F64 |
+-- | ------------------ |
+-- | 1609.2             |
 
 SELECT VARIANCE(id), VARIANCE(quantity) FROM Item
 -- @expect:
@@ -36,9 +36,9 @@ SELECT VARIANCE(DISTINCT id) FROM Item
 
 SELECT VARIANCE(DISTINCT age) FROM Item
 -- @expect:
--- | VARIANCE(DISTINCT age) |
--- | ---------------------- |
--- | NULL                   |
+-- | VARIANCE(DISTINCT age): F64 |
+-- | --------------------------- |
+-- | 1541.555555555556           |
 
 SELECT VARIANCE(quantity), VARIANCE(DISTINCT quantity) FROM Item
 -- @expect:

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -165,6 +165,7 @@ macro_rules! generate_store_tests {
         sql_case!(aggregate::having);
         sql_case!(aggregate::max);
         sql_case!(aggregate::min);
+        sql_case!(aggregate::null);
         sql_case!(aggregate::stdev);
         sql_case!(aggregate::sum);
         sql_case!(aggregate::variance);


### PR DESCRIPTION
Fixes #1897.

## The clearest evidence is the test suite itself

`test-suite/fixtures/aggregate/sum.sql` currently asserts, on `age` values `11, 90, NULL, 3, NULL`:

```diff
 SELECT SUM(age) FROM Item
 -- @expect:
--- | SUM(age) |
--- | -------- |
--- | NULL     |
+-- | SUM(age): I64 |
+-- | ------------- |
+-- | 104           |
```

The suite encodes the bug as expected behavior, so a fix necessarily rewrites these fixtures. The same applies to `avg.sql`, `variance.sql`, `stdev.sql`, and one case in `expr.sql`.

## The bug

`SUM`, `MIN`, `MAX`, `AVG`, `VARIANCE`, and `STDEV` feed every evaluated value straight into the accumulator. `COUNT` is unaffected because it already checks `is_null()`.

```sql
CREATE TABLE T (val INTEGER NULL);
INSERT INTO T VALUES (NULL), (5), (3);

SELECT SUM(val) FROM T;  -- expected 8, actual NULL
SELECT AVG(val) FROM T;  -- expected 4, actual NULL
SELECT MIN(val) FROM T;  -- expected 3, actual NULL
SELECT MAX(val) FROM T;  -- expected 5, actual NULL
```

Two distinct mechanisms:

- `SUM`/`AVG`/`VARIANCE`/`STDEV`: `Value::add` and `Value::multiply` implement *expression* semantics, where `NULL + 5 = NULL`. One NULL anywhere in the column poisons the accumulator. `AVG`/`VARIANCE`/`STDEV` additionally inflate their divisor, since NULL rows still bump `count`.
- `MIN`/`MAX`: `Value::Null.evaluate_cmp(other)` hits the `_ => None` catch-all, so the comparison never yields `Ordering`, and a NULL that arrives first is never replaced. This is why it only misbehaves when the first row of a group is NULL — which is exactly why `min.sql` and `max.sql` pass today and needed no edits here.

SQL:2016 §10.9 (`<aggregate function>`), General Rule 4: the null value is effectively eliminated before the set function is applied. `COUNT(*)` is the stated exception.

## The fix

One guard in `State::accumulate`, before the aggregate slot is touched:

```rust
if value.is_null() && !matches!(aggregate.func, AggregateFunctionPlan::Count(_)) {
    return Ok(());
}
```

This is the single-layer placement @panarch asked for on #1912 rather than a per-arm guard inside each `AggrValue::accumulate` variant. It keeps the invariant in one place: `AggrValue` never receives NULL for a non-COUNT aggregate, so neither `new` nor `accumulate` needs its own check. All-NULL input still works without a special case — the slot stays `None` and `export` already falls back to `empty_value`, which is `Null` for these six and `I64(0)` for `COUNT`.

Placing it before the slot branch also fixes the `DISTINCT` variants for free: NULL never reaches `track_distinct`, so it cannot occupy a slot in the distinct set.

## Credit

@kimjune01 diagnosed this and posted the same fix in #1912, which @ever0de approved. It was self-closed as stale after the async-to-sync conversion (#1928), the fixture migration (#1941), and the typed execution pipeline (#1937) moved `core/src/executor/aggregate/state.rs` to `core/src/executor/query/aggregation/state.rs` and replaced the Rust test modules. This is that work redone against the current layout, with @panarch's review comment folded in.

## Tests

New fixture `test-suite/fixtures/aggregate/null.sql` (registered in `test-suite/src/lib.rs`), using `-- @name:` so each case names itself in the failure message — the fixture-era equivalent of the `named_test` @panarch asked for on #1912. It covers what the updated fixtures do not:

- leading NULL for all six aggregates, including the `MIN`/`MAX` first-row case that `min.sql`/`max.sql` cannot reach
- an all-NULL column returning NULL for the six, while `COUNT(val)` returns `0` and `COUNT(*)` returns the row count
- `SUM`/`MIN`/`MAX` with `DISTINCT`
- `GROUP BY` where one group is all-NULL and another mixes NULL with values, confirming elimination is per group

Verification, in the order that matters given the fixtures encoded the old behavior — fixtures updated first, source untouched:

```
test sql_aggregate_sum ... FAILED
  [FIXTURE] aggregate/sum.sql:17
  SELECT SUM(age) FROM Item
  Diff < left / right > :
  <Null
  >I64(
  >    104,
  >)

test result: FAILED. 6 passed; 6 failed
```

Then with the guard applied:

```
test result: ok. 12 passed; 0 failed
```

Full `gluesql_memory_storage` suite: 198 passed, 0 failed. Also green across `gluesql-core`, `test-suite`, shared-memory, json, csv, redb, file, parquet, and composite storages. `cargo clippy --all-targets -- -D warnings` is clean and `cargo fmt --all` is a no-op.

I mutation-tested the new fixture three ways: guarding only the first value (later NULLs still poison) fails 6 cases; dropping the `COUNT` exclusion fails 5, including `count.sql` and `group_by.sql`; and guarding everything except `MIN`/`MAX` fails only `null.sql`, confirming the new first-row coverage is what catches that half of the bug.

One pre-existing unrelated failure, `sled_storage::timeout_tests::sled_transaction_timeout_store`, reproduces on a clean checkout of the base commit and is untouched here.

## Not changed

- `Value::add`, `Value::multiply`, and `evaluate_cmp` keep their current NULL propagation. That is correct for scalar expression evaluation; only aggregate accumulation needed different semantics, so the fix belongs at the accumulation boundary rather than in the value layer.
- `min.sql` and `max.sql` are untouched — their data happens to start with a non-NULL `age`, so they were already asserting the correct results.
- `COUNT` behavior is unchanged in every form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Aggregate functions now ignore `NULL` values, matching standard behavior for `SUM`, `AVG`, `MIN`, `MAX`, variance, and standard deviation.
  - `COUNT` continues counting rows correctly, including wildcard counts.
  - Groups containing only `NULL` values return appropriate empty results.
  - Aggregate predicates and distinct aggregates now produce correct numeric results.

- **Tests**
  - Added comprehensive coverage for `NULL` handling across aggregate functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->