### PR TITLE
Reject unsupported transaction statement clauses

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -345,6 +345,7 @@ pub fn translate_with_params(
         SqlStatement::StartTransaction {
             modes,
             modifier,
+            // `begin` only records the `BEGIN` vs `START TRANSACTION` spelling.
             begin: _,
         } => {
             let violation = if !modes.is_empty() {
@@ -793,7 +794,9 @@ mod tests {
             ("BEGIN", Statement::StartTransaction),
             ("START TRANSACTION", Statement::StartTransaction),
             ("COMMIT", Statement::Commit),
+            ("COMMIT AND NO CHAIN", Statement::Commit),
             ("ROLLBACK", Statement::Rollback),
+            ("ROLLBACK AND NO CHAIN", Statement::Rollback),
         ];
 
         for (sql, expected) in cases {

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -13,7 +13,7 @@ pub use self::{
     ddl::translate_column_def,
     error::{
         CreateTableOption, DeleteOption, InsertOption, JoinConstraintReason, QueryOption,
-        SelectOption, TranslateError, UpdateOption,
+        SelectOption, TransactionOption, TranslateError, UpdateOption,
     },
     expr::{translate_expr, translate_order_by_expr},
     param::{IntoParamLiteral, ParamLiteral},
@@ -342,9 +342,49 @@ pub fn translate_with_params(
 
             Ok(Statement::DropIndex { name, table_name })
         }
-        SqlStatement::StartTransaction { .. } => Ok(Statement::StartTransaction),
-        SqlStatement::Commit { .. } => Ok(Statement::Commit),
-        SqlStatement::Rollback { .. } => Ok(Statement::Rollback),
+        SqlStatement::StartTransaction {
+            modes,
+            modifier,
+            begin: _,
+        } => {
+            let violation = if !modes.is_empty() {
+                Some(TransactionOption::Mode)
+            } else if modifier.is_some() {
+                Some(TransactionOption::Modifier)
+            } else {
+                None
+            };
+
+            if let Some(reason) = violation {
+                return Err(TranslateError::UnsupportedTransactionOption(reason).into());
+            }
+
+            Ok(Statement::StartTransaction)
+        }
+        SqlStatement::Commit { chain } => {
+            if *chain {
+                return Err(
+                    TranslateError::UnsupportedTransactionOption(TransactionOption::Chain).into(),
+                );
+            }
+
+            Ok(Statement::Commit)
+        }
+        SqlStatement::Rollback { chain, savepoint } => {
+            let violation = if *chain {
+                Some(TransactionOption::Chain)
+            } else if savepoint.is_some() {
+                Some(TransactionOption::Savepoint)
+            } else {
+                None
+            };
+
+            if let Some(reason) = violation {
+                return Err(TranslateError::UnsupportedTransactionOption(reason).into());
+            }
+
+            Ok(Statement::Rollback)
+        }
         SqlStatement::ShowTables {
             filter: None,
             db_name: None,
@@ -560,7 +600,10 @@ pub fn translate_foreign_key(table_constraint: &SqlTableConstraint) -> Result<Fo
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::parse_sql::parse};
+    use {
+        super::*, crate::parse_sql::parse,
+        sqlparser::ast::TransactionModifier as SqlTransactionModifier,
+    };
 
     fn assert_translate_error(sql: &str, error: TranslateError) {
         let actual = parse(sql).and_then(|parsed| translate(&parsed[0]));
@@ -692,6 +735,70 @@ mod tests {
 
         for (sql, err) in cases {
             assert_translate_error(sql, err);
+        }
+    }
+
+    #[test]
+    fn transaction_options_not_supported() {
+        let cases = [
+            (
+                "START TRANSACTION ISOLATION LEVEL SERIALIZABLE",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Mode),
+            ),
+            (
+                "START TRANSACTION READ ONLY",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Mode),
+            ),
+            (
+                "COMMIT AND CHAIN",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Chain),
+            ),
+            (
+                "ROLLBACK AND CHAIN",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Chain),
+            ),
+            (
+                "ROLLBACK TO SAVEPOINT sp1",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Savepoint),
+            ),
+            (
+                "ROLLBACK TO sp1",
+                TranslateError::UnsupportedTransactionOption(TransactionOption::Savepoint),
+            ),
+        ];
+
+        for (sql, err) in cases {
+            assert_translate_error(sql, err);
+        }
+    }
+
+    #[test]
+    fn transaction_modifier_not_supported() {
+        // PostgreSqlDialect never parses `BEGIN DEFERRED`, but translate()
+        // accepts any sqlparser AST, so guard direct AST input too.
+        let statement = SqlStatement::StartTransaction {
+            modes: Vec::new(),
+            begin: true,
+            modifier: Some(SqlTransactionModifier::Deferred),
+        };
+        assert_eq!(
+            translate(&statement),
+            Err(TranslateError::UnsupportedTransactionOption(TransactionOption::Modifier).into())
+        );
+    }
+
+    #[test]
+    fn plain_transaction_statements() {
+        let cases = [
+            ("BEGIN", Statement::StartTransaction),
+            ("START TRANSACTION", Statement::StartTransaction),
+            ("COMMIT", Statement::Commit),
+            ("ROLLBACK", Statement::Rollback),
+        ];
+
+        for (sql, expected) in cases {
+            let parsed = parse(sql).expect("parse");
+            assert_eq!(translate(&parsed[0]), Ok(expected));
         }
     }
 

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -92,6 +92,31 @@ pub enum DeleteOption {
     Limit,
 }
 
+/// Transaction statement (`START TRANSACTION`/`COMMIT`/`ROLLBACK`) clauses
+/// that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedTransactionOption`] so callers can
+/// match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionOption {
+    /// `START TRANSACTION READ ONLY | READ WRITE | ISOLATION LEVEL ...`
+    #[strum(to_string = "transaction mode")]
+    Mode,
+
+    /// `BEGIN DEFERRED | IMMEDIATE | EXCLUSIVE` (`SQLite`)
+    #[strum(to_string = "transaction modifier")]
+    Modifier,
+
+    /// `COMMIT AND CHAIN` / `ROLLBACK AND CHAIN`
+    #[strum(to_string = "AND CHAIN clause")]
+    Chain,
+
+    /// `ROLLBACK TO [SAVEPOINT] <name>`
+    #[strum(to_string = "TO SAVEPOINT clause")]
+    Savepoint,
+}
+
 /// Query-level (`WITH`/`FETCH`/locking) clauses that `GlueSQL` does not
 /// support yet.
 ///
@@ -165,6 +190,7 @@ serialize_via_display!(
     InsertOption,
     UpdateOption,
     DeleteOption,
+    TransactionOption,
     QueryOption,
     SelectOption,
     JoinConstraintReason,
@@ -249,6 +275,9 @@ pub enum TranslateError {
 
     #[error("unsupported DELETE option: {0}")]
     UnsupportedDeleteOption(DeleteOption),
+
+    #[error("unsupported transaction option: {0}")]
+    UnsupportedTransactionOption(TransactionOption),
 
     #[error("unsupported query option: {0}")]
     UnsupportedQueryOption(QueryOption),


### PR DESCRIPTION
**Summary**

- `START TRANSACTION`, `COMMIT`, and `ROLLBACK` were translated with `..` patterns that silently discarded every clause GlueSQL does not support. The worst case was `ROLLBACK TO SAVEPOINT sp1`: the whole transaction was rolled back while the response claimed success.
- Destructure the three statements explicitly and reject transaction modes (`READ ONLY`, `ISOLATION LEVEL ...`), the SQLite `BEGIN` modifier, `AND CHAIN`, and `TO SAVEPOINT` with a new `TranslateError::UnsupportedTransactionOption(TransactionOption)`, following the existing `InsertOption`-style option enums.
- Add regression tests for each rejected clause (including the `SAVEPOINT`-keyword-omitted `ROLLBACK TO sp1` form and a direct-AST test for the parser-unreachable SQLite modifier) plus positive controls for the plain statement forms.

**Test plan**

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo check --workspace`
- [x] `cargo test -p gluesql-core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction statements now reject unsupported modes, modifiers, chaining options, and savepoint clauses.
  * Standard `BEGIN`, `START TRANSACTION`, `COMMIT`, and `ROLLBACK` statements remain supported.
  * Error messages now identify the unsupported transaction option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->