### PR TITLE
Add EXPLAIN query support

### DIFF
--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -144,6 +144,20 @@ impl<'a, W: Write> Print<W> {
                 let table = Self::build_table(table);
                 self.writeln(table)?;
             }
+            Payload::Explain(lines) => {
+                if self.option.tabular {
+                    let mut table = Self::get_table(["QUERY PLAN"]);
+                    for line in lines {
+                        table.add_record([line]);
+                    }
+                    let table = Self::build_table(table);
+                    self.writeln(table)?;
+                } else {
+                    self.write_header(std::iter::once("QUERY PLAN"))?;
+                    let rows = lines.iter().map(|line| std::iter::once(line.to_owned()));
+                    self.write_rows(rows)?;
+                }
+            }
             Payload::Select { labels, rows } => match &self.option.tabular {
                 true => {
                     let labels = labels.iter().map(AsRef::as_ref);
@@ -399,6 +413,14 @@ mod tests {
         test!(Payload::Delete(300), "300 rows deleted");
         test!(Payload::Update(123), "123 rows updated");
         test!(
+            Payload::Explain(vec!["• project".to_owned(), "└─ • scan Player".to_owned(),]),
+            "
+| QUERY PLAN       |
+|------------------|
+| • project        |
+| └─ • scan Player |"
+        );
+        test!(
             Payload::ShowVariable(PayloadVariable::Version("11.6.1989".to_owned())),
             "v11.6.1989"
         );
@@ -583,6 +605,13 @@ mod tests {
 
         // ".set tabular OFF" should print SELECTED payload without tabular option
         print.set_option(SetOption::Tabular(false));
+        test!(
+            Payload::Explain(vec!["• project".to_owned(), "└─ • scan Player".to_owned(),]),
+            "
+QUERY PLAN
+• project
+└─ • scan Player"
+        );
         test!(
             Payload::Select {
                 labels: ["id", "title", "valid"]

--- a/cli/src/print.rs
+++ b/cli/src/print.rs
@@ -413,12 +413,12 @@ mod tests {
         test!(Payload::Delete(300), "300 rows deleted");
         test!(Payload::Update(123), "123 rows updated");
         test!(
-            Payload::Explain(vec!["• project".to_owned(), "└─ • scan Player".to_owned(),]),
+            Payload::Explain(vec!["• project".to_owned(), "└── • scan Player".to_owned(),]),
             "
-| QUERY PLAN       |
-|------------------|
-| • project        |
-| └─ • scan Player |"
+| QUERY PLAN        |
+|-------------------|
+| • project         |
+| └── • scan Player |"
         );
         test!(
             Payload::ShowVariable(PayloadVariable::Version("11.6.1989".to_owned())),
@@ -606,11 +606,11 @@ mod tests {
         // ".set tabular OFF" should print SELECTED payload without tabular option
         print.set_option(SetOption::Tabular(false));
         test!(
-            Payload::Explain(vec!["• project".to_owned(), "└─ • scan Player".to_owned(),]),
+            Payload::Explain(vec!["• project".to_owned(), "└── • scan Player".to_owned(),]),
             "
 QUERY PLAN
 • project
-└─ • scan Player"
+└── • scan Player"
         );
         test!(
             Payload::Select {

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -139,6 +139,8 @@ pub enum Statement {
     /// SHOW VARIABLE
     ShowVariable(Variable),
     ShowIndexes(String),
+    /// EXPLAIN
+    Explain(Query),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/core/src/executor/execute.rs
+++ b/core/src/executor/execute.rs
@@ -17,7 +17,7 @@ use {
         plan::{
             DictionarySourcePlan, ExprPlan, FilterInputPlan, FilterPlan, ProjectInputPlan,
             ProjectPlan, ProjectionPlan, QueryPlan, SelectItemPlan, SourcePlan, StatementPlan,
-            TableAliasPlan,
+            TableAliasPlan, explain,
         },
         result::{Error, Result},
         store::{GStore, GStoreMut},
@@ -51,6 +51,7 @@ pub enum Payload {
         rows: Vec<Vec<Value>>,
     },
     SelectMap(Vec<BTreeMap<String, Value>>),
+    Explain(Vec<String>),
     Delete(usize),
     Update(usize),
     DropTable(usize),
@@ -246,6 +247,7 @@ fn execute_inner<T: GStore + GStoreMut>(
         } => delete(storage, table_name, selection.as_ref()),
 
         //- Selection
+        StatementPlan::Explain(query) => Ok(Payload::Explain(explain(query))),
         StatementPlan::Query(query) => select::execute(storage, query),
         StatementPlan::ShowColumns { table_name } => {
             let Schema { column_defs, .. } = storage

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -1,3 +1,4 @@
+mod explain;
 mod statement;
 
-pub use statement::*;
+pub use {explain::explain, statement::*};

--- a/core/src/plan/explain.rs
+++ b/core/src/plan/explain.rs
@@ -4,23 +4,19 @@ pub fn explain(query: &QueryPlan) -> Vec<String> {
     explain_lines(query)
 }
 
+fn explain_lines(explainable: &impl Explain<Output = ExplainNode>) -> Vec<String> {
+    let mut context = ExplainContext::default();
+    let root = explainable.explain(&mut context);
+    let root = context.with_subqueries(root);
+    let mut lines = Vec::new();
+    render_root(&root, &mut lines);
+    lines
+}
+
 pub(crate) trait Explain {
     type Output;
 
     fn explain(&self, context: &mut ExplainContext) -> Self::Output;
-}
-
-#[derive(Default)]
-pub(crate) struct ExplainContext {
-    next_subquery_id: usize,
-    subqueries: Vec<ExplainNode>,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum ExplainSubqueryMode {
-    OneRow,
-    AllRows,
-    Exists,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -80,6 +76,36 @@ impl ExplainNode {
         self.children.extend(children);
         self
     }
+
+    fn title(&self) -> String {
+        match &self.annotation {
+            Some(annotation) => format!("{} ({annotation})", self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ExplainSubqueryMode {
+    OneRow,
+    AllRows,
+    Exists,
+}
+
+impl Display for ExplainSubqueryMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::OneRow => "one row",
+            Self::AllRows => "all rows",
+            Self::Exists => "exists",
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ExplainContext {
+    next_subquery_id: usize,
+    subqueries: Vec<ExplainNode>,
 }
 
 impl ExplainContext {
@@ -115,25 +141,6 @@ impl ExplainContext {
 
         ExplainNode::new("root").with_children(std::iter::once(main).chain(self.subqueries))
     }
-}
-
-impl Display for ExplainSubqueryMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::OneRow => "one row",
-            Self::AllRows => "all rows",
-            Self::Exists => "exists",
-        })
-    }
-}
-
-fn explain_lines(explainable: &impl Explain<Output = ExplainNode>) -> Vec<String> {
-    let mut context = ExplainContext::default();
-    let root = explainable.explain(&mut context);
-    let root = context.with_subqueries(root);
-    let mut lines = Vec::new();
-    render_root(&root, &mut lines);
-    lines
 }
 
 fn render_root(node: &ExplainNode, lines: &mut Vec<String>) {
@@ -198,15 +205,6 @@ fn render_child(node: &ExplainNode, prefix: &str, last: bool, lines: &mut Vec<St
         lines.push(format!("{child_prefix}│"));
     }
     render_children(node, &child_prefix, lines);
-}
-
-impl ExplainNode {
-    fn title(&self) -> String {
-        match &self.annotation {
-            Some(annotation) => format!("{} ({annotation})", self.name),
-            None => self.name.clone(),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -352,77 +350,6 @@ LIMIT 10 OFFSET 5
     }
 
     #[test]
-    fn explains_expression_subqueries_as_referenced_plans() {
-        assert_eq!(
-            explain_sql(
-                r"
-CREATE TABLE Player (id INT);
-CREATE TABLE Badge (player_id INT);
-",
-                r"
-EXPLAIN
-SELECT id, (SELECT COUNT(*) AS total FROM Badge) AS badge_count
-FROM Player
-WHERE id IN (SELECT player_id FROM Badge)
-AND EXISTS (
-    SELECT *
-    FROM Badge
-    WHERE Badge.player_id = Player.id
-)
-",
-            ),
-            r"
-• root
-├── • project
-│   │ columns: id, @S1 AS badge_count
-│   │
-│   └── • filter
-│       │ expression: id IN (@S2) AND EXISTS (@S3)
-│       │
-│       └── • scan Player
-│             access: full scan
-│
-├── • subquery
-│   │ id: @S1
-│   │ exec mode: one row
-│   │
-│   └── • project
-│       │ columns: COUNT(*) AS total
-│       │
-│       └── • aggregate
-│           │ aggregates: COUNT(*)
-│           │
-│           └── • scan Badge
-│                 access: full scan
-│
-├── • subquery
-│   │ id: @S2
-│   │ exec mode: all rows
-│   │
-│   └── • project
-│       │ columns: player_id
-│       │
-│       └── • scan Badge
-│             access: full scan
-│
-└── • subquery
-    │ id: @S3
-    │ exec mode: exists
-    │
-    └── • project
-        │ columns: *
-        │
-        └── • filter
-            │ expression: Badge.player_id = Player.id
-            │
-            └── • scan Badge
-                  access: full scan
-"
-            .trim()
-        );
-    }
-
-    #[test]
     fn explains_distinct_grouping_and_having() {
         assert_eq!(
             explain_sql(
@@ -517,36 +444,6 @@ LIMIT 1 OFFSET 1
     }
 
     #[test]
-    fn explains_subquery_in_values() {
-        assert_eq!(
-            explain_sql(
-                "CREATE TABLE Player (id INT);",
-                "EXPLAIN VALUES ((SELECT id FROM Player LIMIT 1))",
-            ),
-            r"
-• root
-├── • values
-│     size: 1 columns, 1 rows
-│     expressions: (@S1)
-│
-└── • subquery
-    │ id: @S1
-    │ exec mode: one row
-    │
-    └── • limit
-        │ count: 1
-        │
-        └── • project
-            │ columns: id
-            │
-            └── • scan Player
-                  access: full scan
-"
-            .trim()
-        );
-    }
-
-    #[test]
     fn explains_series_source() {
         assert_eq!(
             explain_sql("", "EXPLAIN SELECT * FROM SERIES(3) AS numbers"),
@@ -571,6 +468,107 @@ LIMIT 1 OFFSET 1
 │
 └── • dictionary GLUE_TABLES
       source: GLUE_TABLES
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_expression_subqueries_as_referenced_plans() {
+        assert_eq!(
+            explain_sql(
+                r"
+CREATE TABLE Player (id INT);
+CREATE TABLE Badge (player_id INT);
+",
+                r"
+EXPLAIN
+SELECT id, (SELECT COUNT(*) AS total FROM Badge) AS badge_count
+FROM Player
+WHERE id IN (SELECT player_id FROM Badge)
+AND EXISTS (
+    SELECT *
+    FROM Badge
+    WHERE Badge.player_id = Player.id
+)
+",
+            ),
+            r"
+• root
+├── • project
+│   │ columns: id, @S1 AS badge_count
+│   │
+│   └── • filter
+│       │ expression: id IN (@S2) AND EXISTS (@S3)
+│       │
+│       └── • scan Player
+│             access: full scan
+│
+├── • subquery
+│   │ id: @S1
+│   │ exec mode: one row
+│   │
+│   └── • project
+│       │ columns: COUNT(*) AS total
+│       │
+│       └── • aggregate
+│           │ aggregates: COUNT(*)
+│           │
+│           └── • scan Badge
+│                 access: full scan
+│
+├── • subquery
+│   │ id: @S2
+│   │ exec mode: all rows
+│   │
+│   └── • project
+│       │ columns: player_id
+│       │
+│       └── • scan Badge
+│             access: full scan
+│
+└── • subquery
+    │ id: @S3
+    │ exec mode: exists
+    │
+    └── • project
+        │ columns: *
+        │
+        └── • filter
+            │ expression: Badge.player_id = Player.id
+            │
+            └── • scan Badge
+                  access: full scan
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_subquery_in_values() {
+        assert_eq!(
+            explain_sql(
+                "CREATE TABLE Player (id INT);",
+                "EXPLAIN VALUES ((SELECT id FROM Player LIMIT 1))",
+            ),
+            r"
+• root
+├── • values
+│     size: 1 columns, 1 rows
+│     expressions: (@S1)
+│
+└── • subquery
+    │ id: @S1
+    │ exec mode: one row
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • project
+            │ columns: id
+            │
+            └── • scan Player
+                  access: full scan
 "
             .trim()
         );

--- a/core/src/plan/explain.rs
+++ b/core/src/plan/explain.rs
@@ -1,0 +1,569 @@
+use {super::QueryPlan, std::fmt::Display};
+
+pub fn explain(query: &QueryPlan) -> Vec<String> {
+    explain_lines(query)
+}
+
+pub(crate) trait Explain {
+    type Output;
+
+    fn explain(&self, context: &mut ExplainContext) -> Self::Output;
+}
+
+#[derive(Default)]
+pub(crate) struct ExplainContext {
+    next_subquery_id: usize,
+    subqueries: Vec<ExplainNode>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ExplainSubqueryMode {
+    OneRow,
+    AllRows,
+    Exists,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ExplainNode {
+    name: String,
+    annotation: Option<String>,
+    properties: Vec<ExplainProperty>,
+    children: Vec<ExplainNode>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExplainProperty {
+    key: &'static str,
+    value: String,
+}
+
+impl ExplainNode {
+    pub(crate) fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            annotation: None,
+            properties: Vec::new(),
+            children: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_annotation(mut self, annotation: impl Display) -> Self {
+        self.annotation = Some(annotation.to_string());
+        self
+    }
+
+    pub(crate) fn with_property(mut self, key: &'static str, value: impl Display) -> Self {
+        self.properties.push(ExplainProperty {
+            key,
+            value: value.to_string(),
+        });
+        self
+    }
+
+    pub(crate) fn with_optional_property<T: Display>(
+        self,
+        key: &'static str,
+        value: Option<T>,
+    ) -> Self {
+        match value {
+            Some(value) => self.with_property(key, value),
+            None => self,
+        }
+    }
+
+    pub(crate) fn with_child(mut self, child: ExplainNode) -> Self {
+        self.children.push(child);
+        self
+    }
+
+    pub(crate) fn with_children(mut self, children: impl IntoIterator<Item = ExplainNode>) -> Self {
+        self.children.extend(children);
+        self
+    }
+}
+
+impl ExplainContext {
+    pub(crate) fn subquery_count(&self) -> usize {
+        self.subqueries.len()
+    }
+
+    pub(crate) fn register_subquery(
+        &mut self,
+        query: &QueryPlan,
+        mode: ExplainSubqueryMode,
+    ) -> String {
+        self.next_subquery_id += 1;
+        let id = format!("@S{}", self.next_subquery_id);
+        let insertion_index = self.subqueries.len();
+
+        let plan = query.explain(self);
+        self.subqueries.insert(
+            insertion_index,
+            ExplainNode::new("subquery")
+                .with_property("id", &id)
+                .with_property("exec mode", mode)
+                .with_child(plan),
+        );
+
+        id
+    }
+
+    fn with_subqueries(self, main: ExplainNode) -> ExplainNode {
+        if self.subqueries.is_empty() {
+            return main;
+        }
+
+        ExplainNode::new("root").with_children(std::iter::once(main).chain(self.subqueries))
+    }
+}
+
+impl Display for ExplainSubqueryMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::OneRow => "one row",
+            Self::AllRows => "all rows",
+            Self::Exists => "exists",
+        })
+    }
+}
+
+fn explain_lines(explainable: &impl Explain<Output = ExplainNode>) -> Vec<String> {
+    let mut context = ExplainContext::default();
+    let root = explainable.explain(&mut context);
+    let root = context.with_subqueries(root);
+    let mut lines = Vec::new();
+    render_root(&root, &mut lines);
+    lines
+}
+
+fn render_root(node: &ExplainNode, lines: &mut Vec<String>) {
+    lines.push(format!("• {}", node.title()));
+
+    if node.children.is_empty() {
+        lines.extend(
+            node.properties
+                .iter()
+                .map(|property| format!("  {}: {}", property.key, property.value)),
+        );
+        return;
+    }
+
+    lines.extend(
+        node.properties
+            .iter()
+            .map(|property| format!("│ {}: {}", property.key, property.value)),
+    );
+    if !node.properties.is_empty() {
+        lines.push("│".to_owned());
+    }
+    render_children(node, "", lines);
+}
+
+fn render_children(node: &ExplainNode, prefix: &str, lines: &mut Vec<String>) {
+    for (index, child) in node.children.iter().enumerate() {
+        let last = index + 1 == node.children.len();
+        render_child(child, prefix, last, lines);
+        if !last {
+            lines.push(format!("{prefix}│"));
+        }
+    }
+}
+
+fn render_child(node: &ExplainNode, prefix: &str, last: bool, lines: &mut Vec<String>) {
+    let branch = if last { "└─ •" } else { "├─ •" };
+    let continuation = if last { "   " } else { "│  " };
+    let child_prefix = format!("{prefix}{continuation}");
+
+    lines.push(format!("{prefix}{branch} {}", node.title()));
+
+    if node.children.is_empty() {
+        lines.extend(
+            node.properties
+                .iter()
+                .map(|property| format!("{child_prefix}  {}: {}", property.key, property.value)),
+        );
+        return;
+    }
+
+    lines.extend(
+        node.properties
+            .iter()
+            .map(|property| format!("{child_prefix}│ {}: {}", property.key, property.value)),
+    );
+    if !node.properties.is_empty() {
+        lines.push(format!("{child_prefix}│"));
+    }
+    render_children(node, &child_prefix, lines);
+}
+
+impl ExplainNode {
+    fn title(&self) -> String {
+        match &self.annotation {
+            Some(annotation) => format!("{} ({annotation})", self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{Explain, ExplainContext, ExplainNode, explain_lines},
+        crate::{
+            executor::{Payload, execute},
+            mock::run,
+            parse_sql::parse,
+            plan::StatementPlan,
+            store::Planner,
+            translate::translate,
+        },
+    };
+
+    struct TestPlan;
+
+    impl Explain for TestPlan {
+        type Output = ExplainNode;
+
+        fn explain(&self, _context: &mut ExplainContext) -> ExplainNode {
+            ExplainNode::new("root")
+                .with_property("root property", 1)
+                .with_children([
+                    ExplainNode::new("first").with_property("leaf property", 2),
+                    ExplainNode::new("second").with_child(ExplainNode::new("nested leaf")),
+                ])
+        }
+    }
+
+    fn explain_sql(setup: &str, sql: &str) -> String {
+        let mut storage = run(setup);
+        let parsed = parse(sql).unwrap();
+        let statement = StatementPlan::from(translate(&parsed[0]).unwrap());
+        let planned = storage.plan(statement).unwrap();
+        let Payload::Explain(lines) = execute(&mut storage, &planned).unwrap() else {
+            panic!("expected explain payload");
+        };
+
+        lines.join("\n")
+    }
+
+    #[test]
+    fn renders_compact_cockroach_style_tree() {
+        assert_eq!(
+            explain_lines(&TestPlan).join("\n"),
+            r"
+• root
+│ root property: 1
+│
+├─ • first
+│    leaf property: 2
+│
+└─ • second
+   └─ • nested leaf
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_joined_aggregation_pipeline() {
+        let actual = explain_sql(
+            r"
+CREATE TABLE Player (id INT, team_id INT, active BOOLEAN);
+CREATE TABLE Badge (player_id INT);
+CREATE TABLE Team (id INT);
+",
+            r"
+EXPLAIN
+SELECT Player.team_id, COUNT(*) AS player_count
+FROM Player
+INNER JOIN Badge ON Player.id = Badge.player_id
+LEFT JOIN Team ON Player.team_id = Team.id
+WHERE Player.active = TRUE
+GROUP BY Player.team_id
+ORDER BY player_count DESC
+LIMIT 10 OFFSET 5
+",
+        );
+        let expected = r"
+• limit
+│ count: 10
+│
+└─ • offset
+   │ count: 5
+   │
+   └─ • sort
+      │ order: player_count DESC
+      │
+      └─ • project
+         │ columns: Player.team_id, COUNT(*) AS player_count
+         │
+         └─ • aggregate
+            │ group by: Player.team_id
+            │ aggregates: COUNT(*)
+            │
+            └─ • filter
+               │ expression: Player.active = TRUE
+               │
+               └─ • hash join (left outer)
+                  │ equality: Player.team_id = Team.id
+                  │
+                  ├─ • hash join (inner)
+                  │  │ equality: Player.id = Badge.player_id
+                  │  │
+                  │  ├─ • scan Player
+                  │  │    access: full scan
+                  │  │
+                  │  └─ • scan Badge
+                  │       access: full scan
+                  │
+                  └─ • scan Team
+                       access: full scan
+"
+        .trim();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn explains_primary_key_access_path() {
+        assert_eq!(
+            explain_sql(
+                "CREATE TABLE Player (id INT PRIMARY KEY, name TEXT);",
+                "EXPLAIN SELECT name FROM Player WHERE id = 1",
+            ),
+            r"
+• project
+│ columns: name
+│
+└─ • scan Player
+     access: primary key
+     key: 1
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_expression_subqueries_as_referenced_plans() {
+        assert_eq!(
+            explain_sql(
+                r"
+CREATE TABLE Player (id INT);
+CREATE TABLE Badge (player_id INT);
+",
+                r"
+EXPLAIN
+SELECT id, (SELECT COUNT(*) AS total FROM Badge) AS badge_count
+FROM Player
+WHERE id IN (SELECT player_id FROM Badge)
+AND EXISTS (
+    SELECT *
+    FROM Badge
+    WHERE Badge.player_id = Player.id
+)
+",
+            ),
+            r"
+• root
+├─ • project
+│  │ columns: id, @S1 AS badge_count
+│  │
+│  └─ • filter
+│     │ expression: id IN (@S2) AND EXISTS (@S3)
+│     │
+│     └─ • scan Player
+│          access: full scan
+│
+├─ • subquery
+│  │ id: @S1
+│  │ exec mode: one row
+│  │
+│  └─ • project
+│     │ columns: COUNT(*) AS total
+│     │
+│     └─ • aggregate
+│        │ aggregates: COUNT(*)
+│        │
+│        └─ • scan Badge
+│             access: full scan
+│
+├─ • subquery
+│  │ id: @S2
+│  │ exec mode: all rows
+│  │
+│  └─ • project
+│     │ columns: player_id
+│     │
+│     └─ • scan Badge
+│          access: full scan
+│
+└─ • subquery
+   │ id: @S3
+   │ exec mode: exists
+   │
+   └─ • project
+      │ columns: *
+      │
+      └─ • filter
+         │ expression: Badge.player_id = Player.id
+         │
+         └─ • scan Badge
+              access: full scan
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_distinct_grouping_and_having() {
+        assert_eq!(
+            explain_sql(
+                "CREATE TABLE Item (category TEXT);",
+                r"
+EXPLAIN
+SELECT DISTINCT category, COUNT(*) AS total
+FROM Item
+GROUP BY category
+HAVING COUNT(*) > 1
+ORDER BY total DESC
+",
+            ),
+            r"
+• distinct
+└─ • sort
+   │ order: total DESC
+   │
+   └─ • project
+      │ columns: category, COUNT(*) AS total
+      │
+      └─ • having
+         │ expression: COUNT(*) > 1
+         │
+         └─ • aggregate
+            │ group by: category
+            │ aggregates: COUNT(*)
+            │
+            └─ • scan Item
+                 access: full scan
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_derived_query() {
+        assert_eq!(
+            explain_sql(
+                "CREATE TABLE Player (id INT);",
+                r"
+EXPLAIN
+SELECT recent.id
+FROM (SELECT id FROM Player LIMIT 2) AS recent
+",
+            ),
+            r"
+• project
+│ columns: recent.id
+│
+└─ • derived recent
+   └─ • limit
+      │ count: 2
+      │
+      └─ • project
+         │ columns: id
+         │
+         └─ • scan Player
+              access: full scan
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_values_query() {
+        assert_eq!(
+            explain_sql(
+                "",
+                r"
+EXPLAIN
+VALUES (1, 'a'), (2, 'b')
+ORDER BY 1 DESC
+LIMIT 1 OFFSET 1
+",
+            ),
+            r"
+• limit
+│ count: 1
+│
+└─ • offset
+   │ count: 1
+   │
+   └─ • sort
+      │ order: 1 DESC
+      │
+      └─ • values
+           size: 2 columns, 2 rows
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_subquery_in_values() {
+        assert_eq!(
+            explain_sql(
+                "CREATE TABLE Player (id INT);",
+                "EXPLAIN VALUES ((SELECT id FROM Player LIMIT 1))",
+            ),
+            r"
+• root
+├─ • values
+│    size: 1 columns, 1 rows
+│    expressions: (@S1)
+│
+└─ • subquery
+   │ id: @S1
+   │ exec mode: one row
+   │
+   └─ • limit
+      │ count: 1
+      │
+      └─ • project
+         │ columns: id
+         │
+         └─ • scan Player
+              access: full scan
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_series_source() {
+        assert_eq!(
+            explain_sql("", "EXPLAIN SELECT * FROM SERIES(3) AS numbers"),
+            r"
+• project
+│ columns: *
+│
+└─ • series numbers
+     size: 3
+"
+            .trim()
+        );
+    }
+
+    #[test]
+    fn explains_dictionary_source() {
+        assert_eq!(
+            explain_sql("", "EXPLAIN SELECT * FROM GLUE_TABLES"),
+            r"
+• project
+│ columns: *
+│
+└─ • dictionary GLUE_TABLES
+     source: GLUE_TABLES
+"
+            .trim()
+        );
+    }
+}

--- a/core/src/plan/explain.rs
+++ b/core/src/plan/explain.rs
@@ -210,6 +210,11 @@ impl ExplainNode {
 }
 
 #[cfg(test)]
+pub(crate) fn test_explain(actual: &impl Explain<Output = ExplainNode>, expected: &str) {
+    pretty_assertions::assert_eq!(explain_lines(actual).join("\n"), expected.trim());
+}
+
+#[cfg(test)]
 mod tests {
     use {
         super::{Explain, ExplainContext, ExplainNode, explain_lines},

--- a/core/src/plan/explain.rs
+++ b/core/src/plan/explain.rs
@@ -170,8 +170,12 @@ fn render_children(node: &ExplainNode, prefix: &str, lines: &mut Vec<String>) {
 }
 
 fn render_child(node: &ExplainNode, prefix: &str, last: bool, lines: &mut Vec<String>) {
-    let branch = if last { "└─ •" } else { "├─ •" };
-    let continuation = if last { "   " } else { "│  " };
+    let branch = if last {
+        "└── •"
+    } else {
+        "├── •"
+    };
+    let continuation = if last { "    " } else { "│   " };
     let child_prefix = format!("{prefix}{continuation}");
 
     lines.push(format!("{prefix}{branch} {}", node.title()));
@@ -247,18 +251,18 @@ mod tests {
     }
 
     #[test]
-    fn renders_compact_cockroach_style_tree() {
+    fn renders_four_column_tree() {
         assert_eq!(
             explain_lines(&TestPlan).join("\n"),
             r"
 • root
 │ root property: 1
 │
-├─ • first
-│    leaf property: 2
+├── • first
+│     leaf property: 2
 │
-└─ • second
-   └─ • nested leaf
+└── • second
+    └── • nested leaf
 "
             .trim()
         );
@@ -288,36 +292,36 @@ LIMIT 10 OFFSET 5
 • limit
 │ count: 10
 │
-└─ • offset
-   │ count: 5
-   │
-   └─ • sort
-      │ order: player_count DESC
-      │
-      └─ • project
-         │ columns: Player.team_id, COUNT(*) AS player_count
-         │
-         └─ • aggregate
-            │ group by: Player.team_id
-            │ aggregates: COUNT(*)
+└── • offset
+    │ count: 5
+    │
+    └── • sort
+        │ order: player_count DESC
+        │
+        └── • project
+            │ columns: Player.team_id, COUNT(*) AS player_count
             │
-            └─ • filter
-               │ expression: Player.active = TRUE
-               │
-               └─ • hash join (left outer)
-                  │ equality: Player.team_id = Team.id
-                  │
-                  ├─ • hash join (inner)
-                  │  │ equality: Player.id = Badge.player_id
-                  │  │
-                  │  ├─ • scan Player
-                  │  │    access: full scan
-                  │  │
-                  │  └─ • scan Badge
-                  │       access: full scan
-                  │
-                  └─ • scan Team
-                       access: full scan
+            └── • aggregate
+                │ group by: Player.team_id
+                │ aggregates: COUNT(*)
+                │
+                └── • filter
+                    │ expression: Player.active = TRUE
+                    │
+                    └── • hash join (left outer)
+                        │ equality: Player.team_id = Team.id
+                        │
+                        ├── • hash join (inner)
+                        │   │ equality: Player.id = Badge.player_id
+                        │   │
+                        │   ├── • scan Player
+                        │   │     access: full scan
+                        │   │
+                        │   └── • scan Badge
+                        │         access: full scan
+                        │
+                        └── • scan Team
+                              access: full scan
 "
         .trim();
         assert_eq!(actual, expected);
@@ -334,9 +338,9 @@ LIMIT 10 OFFSET 5
 • project
 │ columns: name
 │
-└─ • scan Player
-     access: primary key
-     key: 1
+└── • scan Player
+      access: primary key
+      key: 1
 "
             .trim()
         );
@@ -364,50 +368,50 @@ AND EXISTS (
             ),
             r"
 • root
-├─ • project
-│  │ columns: id, @S1 AS badge_count
-│  │
-│  └─ • filter
-│     │ expression: id IN (@S2) AND EXISTS (@S3)
-│     │
-│     └─ • scan Player
-│          access: full scan
-│
-├─ • subquery
-│  │ id: @S1
-│  │ exec mode: one row
-│  │
-│  └─ • project
-│     │ columns: COUNT(*) AS total
-│     │
-│     └─ • aggregate
-│        │ aggregates: COUNT(*)
-│        │
-│        └─ • scan Badge
+├── • project
+│   │ columns: id, @S1 AS badge_count
+│   │
+│   └── • filter
+│       │ expression: id IN (@S2) AND EXISTS (@S3)
+│       │
+│       └── • scan Player
 │             access: full scan
 │
-├─ • subquery
-│  │ id: @S2
-│  │ exec mode: all rows
-│  │
-│  └─ • project
-│     │ columns: player_id
-│     │
-│     └─ • scan Badge
-│          access: full scan
+├── • subquery
+│   │ id: @S1
+│   │ exec mode: one row
+│   │
+│   └── • project
+│       │ columns: COUNT(*) AS total
+│       │
+│       └── • aggregate
+│           │ aggregates: COUNT(*)
+│           │
+│           └── • scan Badge
+│                 access: full scan
 │
-└─ • subquery
-   │ id: @S3
-   │ exec mode: exists
-   │
-   └─ • project
-      │ columns: *
-      │
-      └─ • filter
-         │ expression: Badge.player_id = Player.id
-         │
-         └─ • scan Badge
-              access: full scan
+├── • subquery
+│   │ id: @S2
+│   │ exec mode: all rows
+│   │
+│   └── • project
+│       │ columns: player_id
+│       │
+│       └── • scan Badge
+│             access: full scan
+│
+└── • subquery
+    │ id: @S3
+    │ exec mode: exists
+    │
+    └── • project
+        │ columns: *
+        │
+        └── • filter
+            │ expression: Badge.player_id = Player.id
+            │
+            └── • scan Badge
+                  access: full scan
 "
             .trim()
         );
@@ -429,21 +433,21 @@ ORDER BY total DESC
             ),
             r"
 • distinct
-└─ • sort
-   │ order: total DESC
-   │
-   └─ • project
-      │ columns: category, COUNT(*) AS total
-      │
-      └─ • having
-         │ expression: COUNT(*) > 1
-         │
-         └─ • aggregate
-            │ group by: category
-            │ aggregates: COUNT(*)
+└── • sort
+    │ order: total DESC
+    │
+    └── • project
+        │ columns: category, COUNT(*) AS total
+        │
+        └── • having
+            │ expression: COUNT(*) > 1
             │
-            └─ • scan Item
-                 access: full scan
+            └── • aggregate
+                │ group by: category
+                │ aggregates: COUNT(*)
+                │
+                └── • scan Item
+                      access: full scan
 "
             .trim()
         );
@@ -464,15 +468,15 @@ FROM (SELECT id FROM Player LIMIT 2) AS recent
 • project
 │ columns: recent.id
 │
-└─ • derived recent
-   └─ • limit
-      │ count: 2
-      │
-      └─ • project
-         │ columns: id
-         │
-         └─ • scan Player
-              access: full scan
+└── • derived recent
+    └── • limit
+        │ count: 2
+        │
+        └── • project
+            │ columns: id
+            │
+            └── • scan Player
+                  access: full scan
 "
             .trim()
         );
@@ -494,14 +498,14 @@ LIMIT 1 OFFSET 1
 • limit
 │ count: 1
 │
-└─ • offset
-   │ count: 1
-   │
-   └─ • sort
-      │ order: 1 DESC
-      │
-      └─ • values
-           size: 2 columns, 2 rows
+└── • offset
+    │ count: 1
+    │
+    └── • sort
+        │ order: 1 DESC
+        │
+        └── • values
+              size: 2 columns, 2 rows
 "
             .trim()
         );
@@ -516,22 +520,22 @@ LIMIT 1 OFFSET 1
             ),
             r"
 • root
-├─ • values
-│    size: 1 columns, 1 rows
-│    expressions: (@S1)
+├── • values
+│     size: 1 columns, 1 rows
+│     expressions: (@S1)
 │
-└─ • subquery
-   │ id: @S1
-   │ exec mode: one row
-   │
-   └─ • limit
-      │ count: 1
-      │
-      └─ • project
-         │ columns: id
-         │
-         └─ • scan Player
-              access: full scan
+└── • subquery
+    │ id: @S1
+    │ exec mode: one row
+    │
+    └── • limit
+        │ count: 1
+        │
+        └── • project
+            │ columns: id
+            │
+            └── • scan Player
+                  access: full scan
 "
             .trim()
         );
@@ -545,8 +549,8 @@ LIMIT 1 OFFSET 1
 • project
 │ columns: *
 │
-└─ • series numbers
-     size: 3
+└── • series numbers
+      size: 3
 "
             .trim()
         );
@@ -560,8 +564,8 @@ LIMIT 1 OFFSET 1
 • project
 │ columns: *
 │
-└─ • dictionary GLUE_TABLES
-     source: GLUE_TABLES
+└── • dictionary GLUE_TABLES
+      source: GLUE_TABLES
 "
             .trim()
         );

--- a/core/src/plan/statement.rs
+++ b/core/src/plan/statement.rs
@@ -3,6 +3,10 @@ mod expr;
 mod projection;
 mod query;
 
+use {
+    crate::ast::{self, ForeignKey, Variable},
+    serde::{Deserialize, Serialize},
+};
 pub use {
     ddl::AlterTableOperationPlan,
     expr::{
@@ -20,11 +24,6 @@ pub use {
         SeriesSourcePlan, SourcePlan, TableAccessPlan, TableAliasPlan, TableSourcePlan,
         ValuesOrderByPlan, ValuesPlan,
     },
-};
-
-use {
-    crate::ast::{self, ForeignKey, Variable},
-    serde::{Deserialize, Serialize},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -89,6 +88,7 @@ pub enum StatementPlan {
     Rollback,
     ShowVariable(Variable),
     ShowIndexes(String),
+    Explain(QueryPlan),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -100,6 +100,7 @@ pub struct AssignmentPlan {
 impl From<ast::Statement> for StatementPlan {
     fn from(statement: ast::Statement) -> Self {
         match statement {
+            ast::Statement::Explain(query) => Self::Explain(query.into()),
             ast::Statement::ShowColumns { table_name } => Self::ShowColumns { table_name },
             ast::Statement::Query(query) => Self::Query(query.into()),
             ast::Statement::Insert {

--- a/core/src/plan/statement/expr.rs
+++ b/core/src/plan/statement/expr.rs
@@ -410,16 +410,129 @@ fn fmt_expr_list(exprs: &[ExprPlan], context: &mut ExplainContext, output: &mut 
 #[cfg(test)]
 mod tests {
     use {
-        super::ExprPlan,
+        super::{
+            AggregateExprPlan, AggregateFunctionPlan, CountArgExprPlan, ExprPlan, FunctionExprPlan,
+        },
         crate::{
-            ast::{BinaryOperator, Literal, UnaryOperator},
-            plan::explain::{Explain, ExplainContext},
+            ast::{BinaryOperator, DataType, DateTimeField, Literal, UnaryOperator},
+            data::Value,
+            plan::{
+                QueryPlan, ValuesPlan,
+                explain::{Explain, ExplainContext},
+            },
         },
     };
 
     #[test]
-    fn displays_expression_for_explain() {
-        let expression = ExprPlan::BinaryOp {
+    fn explain() {
+        let actual = ExprPlan::Identifier("id".to_owned());
+        let expected = "id";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::CompoundIdentifier {
+            alias: "Player".to_owned(),
+            ident: "id".to_owned(),
+        };
+        let expected = "Player.id";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::IsNull(Box::new(ExprPlan::Identifier("team_id".to_owned())));
+        let expected = "team_id IS NULL";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::IsNotNull(Box::new(ExprPlan::Identifier("team_id".to_owned())));
+        let expected = "team_id IS NOT NULL";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::InList {
+            expr: Box::new(ExprPlan::Identifier("id".to_owned())),
+            list: vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+                ExprPlan::Literal(Literal::Number(2.into())),
+            ],
+            negated: false,
+        };
+        let expected = "id IN (1, 2)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::InList {
+            expr: Box::new(ExprPlan::Identifier("id".to_owned())),
+            list: vec![ExprPlan::Literal(Literal::Number(1.into()))],
+            negated: true,
+        };
+        let expected = "id NOT IN (1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let subquery = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Literal(
+            Literal::Number(1.into()),
+        )]]));
+        let actual = ExprPlan::InSubquery {
+            expr: Box::new(ExprPlan::Identifier("id".to_owned())),
+            subquery: Box::new(subquery.clone()),
+            negated: false,
+        };
+        let expected = "id IN (@S1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::InSubquery {
+            expr: Box::new(ExprPlan::Identifier("id".to_owned())),
+            subquery: Box::new(subquery.clone()),
+            negated: true,
+        };
+        let expected = "id NOT IN (@S1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Between {
+            expr: Box::new(ExprPlan::Identifier("score".to_owned())),
+            negated: false,
+            low: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
+            high: Box::new(ExprPlan::Literal(Literal::Number(10.into()))),
+        };
+        let expected = "score BETWEEN 1 AND 10";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Between {
+            expr: Box::new(ExprPlan::Identifier("score".to_owned())),
+            negated: true,
+            low: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
+            high: Box::new(ExprPlan::Literal(Literal::Number(10.into()))),
+        };
+        let expected = "score NOT BETWEEN 1 AND 10";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Like {
+            expr: Box::new(ExprPlan::Identifier("name".to_owned())),
+            negated: false,
+            pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("A%".to_owned()))),
+        };
+        let expected = "name LIKE 'A%'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Like {
+            expr: Box::new(ExprPlan::Identifier("name".to_owned())),
+            negated: true,
+            pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("A%".to_owned()))),
+        };
+        let expected = "name NOT LIKE 'A%'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::ILike {
+            expr: Box::new(ExprPlan::Identifier("name".to_owned())),
+            negated: false,
+            pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("a%".to_owned()))),
+        };
+        let expected = "name ILIKE 'a%'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::ILike {
+            expr: Box::new(ExprPlan::Identifier("name".to_owned())),
+            negated: true,
+            pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("a%".to_owned()))),
+        };
+        let expected = "name NOT ILIKE 'a%'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::BinaryOp {
             left: Box::new(ExprPlan::CompoundIdentifier {
                 alias: "Player".to_owned(),
                 ident: "id".to_owned(),
@@ -427,20 +540,143 @@ mod tests {
             op: BinaryOperator::Eq,
             right: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
         };
+        let expected = "Player.id = 1";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
 
-        assert_eq!(
-            expression.explain(&mut ExplainContext::default()),
-            "Player.id = 1"
-        );
-    }
+        let actual = ExprPlan::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
+        };
+        let expected = "-1";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
 
-    #[test]
-    fn displays_factorial_as_postfix_operator() {
-        let expression = ExprPlan::UnaryOp {
+        let actual = ExprPlan::UnaryOp {
             op: UnaryOperator::Factorial,
             expr: Box::new(ExprPlan::Literal(Literal::Number(5.into()))),
         };
+        let expected = "5!";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
 
-        assert_eq!(expression.explain(&mut ExplainContext::default()), "5!");
+        let actual = ExprPlan::Nested(Box::new(ExprPlan::BinaryOp {
+            left: Box::new(ExprPlan::Identifier("a".to_owned())),
+            op: BinaryOperator::Plus,
+            right: Box::new(ExprPlan::Identifier("b".to_owned())),
+        }));
+        let expected = "(a + b)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Literal(Literal::QuotedString("GlueSQL".to_owned()));
+        let expected = "'GlueSQL'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Value(Value::Bool(true));
+        let expected = "TRUE";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::TypedString {
+            data_type: DataType::Date,
+            value: "2026-08-17".to_owned(),
+        };
+        let expected = "DATE '2026-08-17'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Function(Box::new(FunctionExprPlan::Abs(ExprPlan::Identifier(
+            "score".to_owned(),
+        ))));
+        let expected = "ABS(score)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Aggregate(Box::new(AggregateExprPlan {
+            func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
+            distinct: false,
+            slot: Some(0),
+        }));
+        let expected = "COUNT(*)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Exists {
+            subquery: Box::new(subquery.clone()),
+            negated: false,
+        };
+        let expected = "EXISTS (@S1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Exists {
+            subquery: Box::new(subquery.clone()),
+            negated: true,
+        };
+        let expected = "NOT EXISTS (@S1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Subquery(Box::new(subquery));
+        let expected = "@S1";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Case {
+            operand: Some(Box::new(ExprPlan::Identifier("status".to_owned()))),
+            when_then: vec![(
+                ExprPlan::Literal(Literal::Number(1.into())),
+                ExprPlan::Literal(Literal::QuotedString("active".to_owned())),
+            )],
+            else_result: Some(Box::new(ExprPlan::Literal(Literal::QuotedString(
+                "inactive".to_owned(),
+            )))),
+        };
+        let expected = "CASE status WHEN 1 THEN 'active' ELSE 'inactive' END";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Case {
+            operand: None,
+            when_then: Vec::new(),
+            else_result: None,
+        };
+        let expected = "CASE END";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::ArrayIndex {
+            obj: Box::new(ExprPlan::Identifier("matrix".to_owned())),
+            indexes: vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+                ExprPlan::Literal(Literal::Number(2.into())),
+            ],
+        };
+        let expected = "matrix[1][2]";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Interval {
+            expr: Box::new(ExprPlan::Literal(Literal::QuotedString("1".to_owned()))),
+            leading_field: Some(DateTimeField::Day),
+            last_field: Some(DateTimeField::Hour),
+        };
+        let expected = "INTERVAL '1' DAY TO HOUR";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Interval {
+            expr: Box::new(ExprPlan::Literal(Literal::QuotedString("1 day".to_owned()))),
+            leading_field: None,
+            last_field: None,
+        };
+        let expected = "INTERVAL '1 day'";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ExprPlan::Array {
+            elem: vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+                ExprPlan::Literal(Literal::Number(2.into())),
+            ],
+        };
+        let expected = "[1, 2]";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = [
+            ExprPlan::Identifier("id".to_owned()),
+            ExprPlan::Identifier("name".to_owned()),
+        ];
+        let expected = "id, name";
+
+        assert_eq!(
+            actual.as_slice().explain(&mut ExplainContext::default()),
+            expected
+        );
     }
 }

--- a/core/src/plan/statement/expr.rs
+++ b/core/src/plan/statement/expr.rs
@@ -671,13 +671,15 @@ mod tests {
         };
         let expected = "[1, 2]";
         test(&actual, expected);
+    }
 
+    #[test]
+    fn explain_list() {
         let actual = [
             ExprPlan::Identifier("id".to_owned()),
             ExprPlan::Identifier("name".to_owned()),
         ];
         let expected = "id, name";
-
         assert_eq!(
             actual.as_slice().explain(&mut ExplainContext::default()),
             expected

--- a/core/src/plan/statement/expr.rs
+++ b/core/src/plan/statement/expr.rs
@@ -1,13 +1,19 @@
+mod aggregate;
+mod function;
+
+pub use {
+    aggregate::{AggregateExprPlan, AggregateFunctionPlan, CountArgExprPlan},
+    function::FunctionExprPlan,
+};
+
 use {
     super::QueryPlan,
     crate::{
-        ast::{
-            self, BinaryOperator, DataType, DateTimeField, Literal, TrimWhereField, UnaryOperator,
-        },
+        ast::{self, BinaryOperator, DataType, DateTimeField, Literal, ToSql, UnaryOperator},
         data::Value,
+        plan::explain::{Explain, ExplainContext, ExplainSubqueryMode},
     },
     serde::{Deserialize, Serialize},
-    strum_macros::Display,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -85,246 +91,6 @@ pub enum ExprPlan {
     Array {
         elem: Vec<ExprPlan>,
     },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
-#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
-pub enum FunctionExprPlan {
-    Abs(ExprPlan),
-    AddMonth {
-        expr: ExprPlan,
-        size: ExprPlan,
-    },
-    Lower(ExprPlan),
-    Initcap(ExprPlan),
-    Upper(ExprPlan),
-    Left {
-        expr: ExprPlan,
-        size: ExprPlan,
-    },
-    Right {
-        expr: ExprPlan,
-        size: ExprPlan,
-    },
-    Asin(ExprPlan),
-    Acos(ExprPlan),
-    Atan(ExprPlan),
-    Lpad {
-        expr: ExprPlan,
-        size: ExprPlan,
-        fill: Option<ExprPlan>,
-    },
-    Rpad {
-        expr: ExprPlan,
-        size: ExprPlan,
-        fill: Option<ExprPlan>,
-    },
-    Replace {
-        expr: ExprPlan,
-        old: ExprPlan,
-        new: ExprPlan,
-    },
-    Cast {
-        expr: ExprPlan,
-        data_type: DataType,
-    },
-    Ceil(ExprPlan),
-    Coalesce(Vec<ExprPlan>),
-    Concat(Vec<ExprPlan>),
-    ConcatWs {
-        separator: ExprPlan,
-        exprs: Vec<ExprPlan>,
-    },
-    Custom {
-        name: String,
-        exprs: Vec<ExprPlan>,
-    },
-    IfNull {
-        expr: ExprPlan,
-        then: ExprPlan,
-    },
-    NullIf {
-        expr1: ExprPlan,
-        expr2: ExprPlan,
-    },
-    Rand(Option<ExprPlan>),
-    Round(ExprPlan),
-    Trunc(ExprPlan),
-    Floor(ExprPlan),
-    Trim {
-        expr: ExprPlan,
-        filter_chars: Option<ExprPlan>,
-        trim_where_field: Option<TrimWhereField>,
-    },
-    Exp(ExprPlan),
-    Extract {
-        field: DateTimeField,
-        expr: ExprPlan,
-    },
-    Ln(ExprPlan),
-    Log {
-        antilog: ExprPlan,
-        base: ExprPlan,
-    },
-    Log2(ExprPlan),
-    Log10(ExprPlan),
-    Div {
-        dividend: ExprPlan,
-        divisor: ExprPlan,
-    },
-    Mod {
-        dividend: ExprPlan,
-        divisor: ExprPlan,
-    },
-    Gcd {
-        left: ExprPlan,
-        right: ExprPlan,
-    },
-    Lcm {
-        left: ExprPlan,
-        right: ExprPlan,
-    },
-    Sin(ExprPlan),
-    Cos(ExprPlan),
-    Tan(ExprPlan),
-    Sqrt(ExprPlan),
-    Power {
-        expr: ExprPlan,
-        power: ExprPlan,
-    },
-    Radians(ExprPlan),
-    Degrees(ExprPlan),
-    Now(),
-    CurrentDate(),
-    CurrentTime(),
-    CurrentTimestamp(),
-    Pi(),
-    LastDay(ExprPlan),
-    Ltrim {
-        expr: ExprPlan,
-        chars: Option<ExprPlan>,
-    },
-    Rtrim {
-        expr: ExprPlan,
-        chars: Option<ExprPlan>,
-    },
-    Reverse(ExprPlan),
-    Repeat {
-        expr: ExprPlan,
-        num: ExprPlan,
-    },
-    Sign(ExprPlan),
-    Substr {
-        expr: ExprPlan,
-        start: ExprPlan,
-        count: Option<ExprPlan>,
-    },
-    Unwrap {
-        expr: ExprPlan,
-        selector: ExprPlan,
-    },
-    GenerateUuid(),
-    Greatest(Vec<ExprPlan>),
-    Format {
-        expr: ExprPlan,
-        format: ExprPlan,
-    },
-    ToDate {
-        expr: ExprPlan,
-        format: ExprPlan,
-    },
-    ToTimestamp {
-        expr: ExprPlan,
-        format: ExprPlan,
-    },
-    ToTime {
-        expr: ExprPlan,
-        format: ExprPlan,
-    },
-    Position {
-        from_expr: ExprPlan,
-        sub_expr: ExprPlan,
-    },
-    FindIdx {
-        from_expr: ExprPlan,
-        sub_expr: ExprPlan,
-        start: Option<ExprPlan>,
-    },
-    Ascii(ExprPlan),
-    Chr(ExprPlan),
-    Md5(ExprPlan),
-    Hex(ExprPlan),
-    Append {
-        expr: ExprPlan,
-        value: ExprPlan,
-    },
-    Sort {
-        expr: ExprPlan,
-        order: Option<ExprPlan>,
-    },
-    Slice {
-        expr: ExprPlan,
-        start: ExprPlan,
-        length: ExprPlan,
-    },
-    Prepend {
-        expr: ExprPlan,
-        value: ExprPlan,
-    },
-    Skip {
-        expr: ExprPlan,
-        size: ExprPlan,
-    },
-    Take {
-        expr: ExprPlan,
-        size: ExprPlan,
-    },
-    GetX(ExprPlan),
-    GetY(ExprPlan),
-    Point {
-        x: ExprPlan,
-        y: ExprPlan,
-    },
-    CalcDistance {
-        geometry1: ExprPlan,
-        geometry2: ExprPlan,
-    },
-    IsEmpty(ExprPlan),
-    Length(ExprPlan),
-    Entries(ExprPlan),
-    Keys(ExprPlan),
-    Values(ExprPlan),
-    Splice {
-        list_data: ExprPlan,
-        begin_index: ExprPlan,
-        end_index: ExprPlan,
-        values: Option<ExprPlan>,
-    },
-    Dedup(ExprPlan),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct AggregateExprPlan {
-    pub func: AggregateFunctionPlan,
-    pub distinct: bool,
-    pub slot: Option<usize>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum AggregateFunctionPlan {
-    Count(CountArgExprPlan),
-    Sum(ExprPlan),
-    Max(ExprPlan),
-    Min(ExprPlan),
-    Avg(ExprPlan),
-    Variance(ExprPlan),
-    Stdev(ExprPlan),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum CountArgExprPlan {
-    Wildcard,
-    Expr(ExprPlan),
 }
 
 pub fn plan_scalar_expr(expr: ast::Expr) -> ExprPlan {
@@ -439,284 +205,242 @@ impl From<ast::Expr> for ExprPlan {
     }
 }
 
-impl From<ast::Function> for FunctionExprPlan {
-    fn from(function: ast::Function) -> Self {
-        match function {
-            ast::Function::Abs(expr) => Self::Abs(expr.into()),
-            ast::Function::AddMonth { expr, size } => Self::AddMonth {
-                expr: expr.into(),
-                size: size.into(),
-            },
-            ast::Function::Lower(expr) => Self::Lower(expr.into()),
-            ast::Function::Initcap(expr) => Self::Initcap(expr.into()),
-            ast::Function::Upper(expr) => Self::Upper(expr.into()),
-            ast::Function::Left { expr, size } => Self::Left {
-                expr: expr.into(),
-                size: size.into(),
-            },
-            ast::Function::Right { expr, size } => Self::Right {
-                expr: expr.into(),
-                size: size.into(),
-            },
-            ast::Function::Asin(expr) => Self::Asin(expr.into()),
-            ast::Function::Acos(expr) => Self::Acos(expr.into()),
-            ast::Function::Atan(expr) => Self::Atan(expr.into()),
-            ast::Function::Lpad { expr, size, fill } => Self::Lpad {
-                expr: expr.into(),
-                size: size.into(),
-                fill: fill.map(Into::into),
-            },
-            ast::Function::Rpad { expr, size, fill } => Self::Rpad {
-                expr: expr.into(),
-                size: size.into(),
-                fill: fill.map(Into::into),
-            },
-            ast::Function::Replace { expr, old, new } => Self::Replace {
-                expr: expr.into(),
-                old: old.into(),
-                new: new.into(),
-            },
-            ast::Function::Cast { expr, data_type } => Self::Cast {
-                expr: expr.into(),
-                data_type,
-            },
-            ast::Function::Ceil(expr) => Self::Ceil(expr.into()),
-            ast::Function::Coalesce(exprs) => {
-                Self::Coalesce(exprs.into_iter().map(Into::into).collect())
+impl Explain for ExprPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        fmt_expr(self, context, &mut output);
+        output
+    }
+}
+
+fn fmt_expr(expr: &ExprPlan, context: &mut ExplainContext, output: &mut String) {
+    match expr {
+        ExprPlan::Identifier(ident) => output.push_str(ident),
+        ExprPlan::CompoundIdentifier { alias, ident } => {
+            output.push_str(alias);
+            output.push('.');
+            output.push_str(ident);
+        }
+        ExprPlan::IsNull(expr) => {
+            fmt_expr(expr, context, output);
+            output.push_str(" IS NULL");
+        }
+        ExprPlan::IsNotNull(expr) => {
+            fmt_expr(expr, context, output);
+            output.push_str(" IS NOT NULL");
+        }
+        ExprPlan::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            fmt_expr(expr, context, output);
+            output.push_str(if *negated { " NOT IN (" } else { " IN (" });
+            fmt_expr_list(list, context, output);
+            output.push(')');
+        }
+        ExprPlan::InSubquery {
+            expr,
+            subquery,
+            negated,
+        } => {
+            fmt_expr(expr, context, output);
+            let id = context.register_subquery(subquery, ExplainSubqueryMode::AllRows);
+            output.push(' ');
+            if *negated {
+                output.push_str("NOT ");
             }
-            ast::Function::Concat(exprs) => {
-                Self::Concat(exprs.into_iter().map(Into::into).collect())
+            output.push_str("IN (");
+            output.push_str(&id);
+            output.push(')');
+        }
+        ExprPlan::Between {
+            expr,
+            negated,
+            low,
+            high,
+        } => {
+            fmt_expr(expr, context, output);
+            output.push_str(if *negated {
+                " NOT BETWEEN "
+            } else {
+                " BETWEEN "
+            });
+            fmt_expr(low, context, output);
+            output.push_str(" AND ");
+            fmt_expr(high, context, output);
+        }
+        ExprPlan::Like {
+            expr,
+            negated,
+            pattern,
+        } => {
+            fmt_expr(expr, context, output);
+            output.push_str(if *negated { " NOT LIKE " } else { " LIKE " });
+            fmt_expr(pattern, context, output);
+        }
+        ExprPlan::ILike {
+            expr,
+            negated,
+            pattern,
+        } => {
+            fmt_expr(expr, context, output);
+            output.push_str(if *negated { " NOT ILIKE " } else { " ILIKE " });
+            fmt_expr(pattern, context, output);
+        }
+        ExprPlan::BinaryOp { left, op, right } => {
+            fmt_expr(left, context, output);
+            output.push(' ');
+            output.push_str(&op.to_sql());
+            output.push(' ');
+            fmt_expr(right, context, output);
+        }
+        ExprPlan::UnaryOp { op, expr } => {
+            if op == &UnaryOperator::Factorial {
+                fmt_expr(expr, context, output);
+                output.push_str(&op.to_sql());
+            } else {
+                output.push_str(&op.to_sql());
+                fmt_expr(expr, context, output);
             }
-            ast::Function::ConcatWs { separator, exprs } => Self::ConcatWs {
-                separator: separator.into(),
-                exprs: exprs.into_iter().map(Into::into).collect(),
-            },
-            ast::Function::Custom { name, exprs } => Self::Custom {
-                name,
-                exprs: exprs.into_iter().map(Into::into).collect(),
-            },
-            ast::Function::IfNull { expr, then } => Self::IfNull {
-                expr: expr.into(),
-                then: then.into(),
-            },
-            ast::Function::NullIf { expr1, expr2 } => Self::NullIf {
-                expr1: expr1.into(),
-                expr2: expr2.into(),
-            },
-            ast::Function::Rand(expr) => Self::Rand(expr.map(Into::into)),
-            ast::Function::Round(expr) => Self::Round(expr.into()),
-            ast::Function::Trunc(expr) => Self::Trunc(expr.into()),
-            ast::Function::Floor(expr) => Self::Floor(expr.into()),
-            ast::Function::Trim {
-                expr,
-                filter_chars,
-                trim_where_field,
-            } => Self::Trim {
-                expr: expr.into(),
-                filter_chars: filter_chars.map(Into::into),
-                trim_where_field,
-            },
-            ast::Function::Exp(expr) => Self::Exp(expr.into()),
-            ast::Function::Extract { field, expr } => Self::Extract {
-                field,
-                expr: expr.into(),
-            },
-            ast::Function::Ln(expr) => Self::Ln(expr.into()),
-            ast::Function::Log { antilog, base } => Self::Log {
-                antilog: antilog.into(),
-                base: base.into(),
-            },
-            ast::Function::Log2(expr) => Self::Log2(expr.into()),
-            ast::Function::Log10(expr) => Self::Log10(expr.into()),
-            ast::Function::Div { dividend, divisor } => Self::Div {
-                dividend: dividend.into(),
-                divisor: divisor.into(),
-            },
-            ast::Function::Mod { dividend, divisor } => Self::Mod {
-                dividend: dividend.into(),
-                divisor: divisor.into(),
-            },
-            ast::Function::Gcd { left, right } => Self::Gcd {
-                left: left.into(),
-                right: right.into(),
-            },
-            ast::Function::Lcm { left, right } => Self::Lcm {
-                left: left.into(),
-                right: right.into(),
-            },
-            ast::Function::Sin(expr) => Self::Sin(expr.into()),
-            ast::Function::Cos(expr) => Self::Cos(expr.into()),
-            ast::Function::Tan(expr) => Self::Tan(expr.into()),
-            ast::Function::Sqrt(expr) => Self::Sqrt(expr.into()),
-            ast::Function::Power { expr, power } => Self::Power {
-                expr: expr.into(),
-                power: power.into(),
-            },
-            ast::Function::Radians(expr) => Self::Radians(expr.into()),
-            ast::Function::Degrees(expr) => Self::Degrees(expr.into()),
-            ast::Function::Now() => Self::Now(),
-            ast::Function::CurrentDate() => Self::CurrentDate(),
-            ast::Function::CurrentTime() => Self::CurrentTime(),
-            ast::Function::CurrentTimestamp() => Self::CurrentTimestamp(),
-            ast::Function::Pi() => Self::Pi(),
-            ast::Function::LastDay(expr) => Self::LastDay(expr.into()),
-            ast::Function::Ltrim { expr, chars } => Self::Ltrim {
-                expr: expr.into(),
-                chars: chars.map(Into::into),
-            },
-            ast::Function::Rtrim { expr, chars } => Self::Rtrim {
-                expr: expr.into(),
-                chars: chars.map(Into::into),
-            },
-            ast::Function::Reverse(expr) => Self::Reverse(expr.into()),
-            ast::Function::Repeat { expr, num } => Self::Repeat {
-                expr: expr.into(),
-                num: num.into(),
-            },
-            ast::Function::Sign(expr) => Self::Sign(expr.into()),
-            ast::Function::Substr { expr, start, count } => Self::Substr {
-                expr: expr.into(),
-                start: start.into(),
-                count: count.map(Into::into),
-            },
-            ast::Function::Unwrap { expr, selector } => Self::Unwrap {
-                expr: expr.into(),
-                selector: selector.into(),
-            },
-            ast::Function::GenerateUuid() => Self::GenerateUuid(),
-            ast::Function::Greatest(exprs) => {
-                Self::Greatest(exprs.into_iter().map(Into::into).collect())
+        }
+        ExprPlan::Nested(expr) => {
+            output.push('(');
+            fmt_expr(expr, context, output);
+            output.push(')');
+        }
+        ExprPlan::Literal(literal) => output.push_str(&literal.to_sql()),
+        ExprPlan::Value(value) => output.push_str(&value.to_sql()),
+        ExprPlan::TypedString { data_type, value } => {
+            output.push_str(&data_type.to_string());
+            output.push_str(" '");
+            output.push_str(value);
+            output.push('\'');
+        }
+        ExprPlan::Function(function) => output.push_str(&function.explain(context)),
+        ExprPlan::Aggregate(aggregate) => output.push_str(&aggregate.explain(context)),
+        ExprPlan::Exists { subquery, negated } => {
+            let id = context.register_subquery(subquery, ExplainSubqueryMode::Exists);
+            if *negated {
+                output.push_str("NOT ");
             }
-            ast::Function::Format { expr, format } => Self::Format {
-                expr: expr.into(),
-                format: format.into(),
-            },
-            ast::Function::ToDate { expr, format } => Self::ToDate {
-                expr: expr.into(),
-                format: format.into(),
-            },
-            ast::Function::ToTimestamp { expr, format } => Self::ToTimestamp {
-                expr: expr.into(),
-                format: format.into(),
-            },
-            ast::Function::ToTime { expr, format } => Self::ToTime {
-                expr: expr.into(),
-                format: format.into(),
-            },
-            ast::Function::Position {
-                from_expr,
-                sub_expr,
-            } => Self::Position {
-                from_expr: from_expr.into(),
-                sub_expr: sub_expr.into(),
-            },
-            ast::Function::FindIdx {
-                from_expr,
-                sub_expr,
-                start,
-            } => Self::FindIdx {
-                from_expr: from_expr.into(),
-                sub_expr: sub_expr.into(),
-                start: start.map(Into::into),
-            },
-            ast::Function::Ascii(expr) => Self::Ascii(expr.into()),
-            ast::Function::Chr(expr) => Self::Chr(expr.into()),
-            ast::Function::Md5(expr) => Self::Md5(expr.into()),
-            ast::Function::Hex(expr) => Self::Hex(expr.into()),
-            ast::Function::Append { expr, value } => Self::Append {
-                expr: expr.into(),
-                value: value.into(),
-            },
-            ast::Function::Sort { expr, order } => Self::Sort {
-                expr: expr.into(),
-                order: order.map(Into::into),
-            },
-            ast::Function::Slice {
-                expr,
-                start,
-                length,
-            } => Self::Slice {
-                expr: expr.into(),
-                start: start.into(),
-                length: length.into(),
-            },
-            ast::Function::Prepend { expr, value } => Self::Prepend {
-                expr: expr.into(),
-                value: value.into(),
-            },
-            ast::Function::Skip { expr, size } => Self::Skip {
-                expr: expr.into(),
-                size: size.into(),
-            },
-            ast::Function::Take { expr, size } => Self::Take {
-                expr: expr.into(),
-                size: size.into(),
-            },
-            ast::Function::GetX(expr) => Self::GetX(expr.into()),
-            ast::Function::GetY(expr) => Self::GetY(expr.into()),
-            ast::Function::Point { x, y } => Self::Point {
-                x: x.into(),
-                y: y.into(),
-            },
-            ast::Function::CalcDistance {
-                geometry1,
-                geometry2,
-            } => Self::CalcDistance {
-                geometry1: geometry1.into(),
-                geometry2: geometry2.into(),
-            },
-            ast::Function::IsEmpty(expr) => Self::IsEmpty(expr.into()),
-            ast::Function::Length(expr) => Self::Length(expr.into()),
-            ast::Function::Entries(expr) => Self::Entries(expr.into()),
-            ast::Function::Keys(expr) => Self::Keys(expr.into()),
-            ast::Function::Values(expr) => Self::Values(expr.into()),
-            ast::Function::Splice {
-                list_data,
-                begin_index,
-                end_index,
-                values,
-            } => Self::Splice {
-                list_data: list_data.into(),
-                begin_index: begin_index.into(),
-                end_index: end_index.into(),
-                values: values.map(Into::into),
-            },
-            ast::Function::Dedup(expr) => Self::Dedup(expr.into()),
+            output.push_str("EXISTS (");
+            output.push_str(&id);
+            output.push(')');
+        }
+        ExprPlan::Subquery(subquery) => {
+            let id = context.register_subquery(subquery, ExplainSubqueryMode::OneRow);
+            output.push_str(&id);
+        }
+        ExprPlan::Case {
+            operand,
+            when_then,
+            else_result,
+        } => {
+            output.push_str("CASE");
+            if let Some(operand) = operand {
+                output.push(' ');
+                fmt_expr(operand, context, output);
+            }
+            for (when, then) in when_then {
+                output.push_str(" WHEN ");
+                fmt_expr(when, context, output);
+                output.push_str(" THEN ");
+                fmt_expr(then, context, output);
+            }
+            if let Some(else_result) = else_result {
+                output.push_str(" ELSE ");
+                fmt_expr(else_result, context, output);
+            }
+            output.push_str(" END");
+        }
+        ExprPlan::ArrayIndex { obj, indexes } => {
+            fmt_expr(obj, context, output);
+            for index in indexes {
+                output.push('[');
+                fmt_expr(index, context, output);
+                output.push(']');
+            }
+        }
+        ExprPlan::Interval {
+            expr,
+            leading_field,
+            last_field,
+        } => {
+            output.push_str("INTERVAL ");
+            fmt_expr(expr, context, output);
+            if let Some(field) = leading_field {
+                output.push(' ');
+                output.push_str(&field.to_string());
+            }
+            if let Some(field) = last_field {
+                output.push_str(" TO ");
+                output.push_str(&field.to_string());
+            }
+        }
+        ExprPlan::Array { elem } => {
+            output.push('[');
+            fmt_expr_list(elem, context, output);
+            output.push(']');
         }
     }
 }
 
-impl From<ast::Aggregate> for AggregateExprPlan {
-    fn from(aggregate: ast::Aggregate) -> Self {
-        let ast::Aggregate { func, distinct } = aggregate;
+impl Explain for [ExprPlan] {
+    type Output = String;
 
-        Self {
-            func: func.into(),
-            distinct,
-            slot: None,
-        }
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        fmt_expr_list(self, context, &mut output);
+        output
     }
 }
 
-impl From<ast::AggregateFunction> for AggregateFunctionPlan {
-    fn from(func: ast::AggregateFunction) -> Self {
-        match func {
-            ast::AggregateFunction::Count(expr) => Self::Count(expr.into()),
-            ast::AggregateFunction::Sum(expr) => Self::Sum(expr.into()),
-            ast::AggregateFunction::Max(expr) => Self::Max(expr.into()),
-            ast::AggregateFunction::Min(expr) => Self::Min(expr.into()),
-            ast::AggregateFunction::Avg(expr) => Self::Avg(expr.into()),
-            ast::AggregateFunction::Variance(expr) => Self::Variance(expr.into()),
-            ast::AggregateFunction::Stdev(expr) => Self::Stdev(expr.into()),
+fn fmt_expr_list(exprs: &[ExprPlan], context: &mut ExplainContext, output: &mut String) {
+    for (index, expr) in exprs.iter().enumerate() {
+        if index > 0 {
+            output.push_str(", ");
         }
+        fmt_expr(expr, context, output);
     }
 }
 
-impl From<ast::CountArgExpr> for CountArgExprPlan {
-    fn from(expr: ast::CountArgExpr) -> Self {
-        match expr {
-            ast::CountArgExpr::Wildcard => Self::Wildcard,
-            ast::CountArgExpr::Expr(expr) => Self::Expr(expr.into()),
-        }
+#[cfg(test)]
+mod tests {
+    use {
+        super::ExprPlan,
+        crate::{
+            ast::{BinaryOperator, Literal, UnaryOperator},
+            plan::explain::{Explain, ExplainContext},
+        },
+    };
+
+    #[test]
+    fn displays_expression_for_explain() {
+        let expression = ExprPlan::BinaryOp {
+            left: Box::new(ExprPlan::CompoundIdentifier {
+                alias: "Player".to_owned(),
+                ident: "id".to_owned(),
+            }),
+            op: BinaryOperator::Eq,
+            right: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
+        };
+
+        assert_eq!(
+            expression.explain(&mut ExplainContext::default()),
+            "Player.id = 1"
+        );
+    }
+
+    #[test]
+    fn displays_factorial_as_postfix_operator() {
+        let expression = ExprPlan::UnaryOp {
+            op: UnaryOperator::Factorial,
+            expr: Box::new(ExprPlan::Literal(Literal::Number(5.into()))),
+        };
+
+        assert_eq!(expression.explain(&mut ExplainContext::default()), "5!");
     }
 }

--- a/core/src/plan/statement/expr.rs
+++ b/core/src/plan/statement/expr.rs
@@ -423,26 +423,30 @@ mod tests {
         },
     };
 
+    fn test(actual: &ExprPlan, expected: &str) {
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+    }
+
     #[test]
     fn explain() {
         let actual = ExprPlan::Identifier("id".to_owned());
         let expected = "id";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::CompoundIdentifier {
             alias: "Player".to_owned(),
             ident: "id".to_owned(),
         };
         let expected = "Player.id";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::IsNull(Box::new(ExprPlan::Identifier("team_id".to_owned())));
         let expected = "team_id IS NULL";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::IsNotNull(Box::new(ExprPlan::Identifier("team_id".to_owned())));
         let expected = "team_id IS NOT NULL";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::InList {
             expr: Box::new(ExprPlan::Identifier("id".to_owned())),
@@ -453,7 +457,7 @@ mod tests {
             negated: false,
         };
         let expected = "id IN (1, 2)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::InList {
             expr: Box::new(ExprPlan::Identifier("id".to_owned())),
@@ -461,7 +465,7 @@ mod tests {
             negated: true,
         };
         let expected = "id NOT IN (1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let subquery = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Literal(
             Literal::Number(1.into()),
@@ -472,7 +476,7 @@ mod tests {
             negated: false,
         };
         let expected = "id IN (@S1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::InSubquery {
             expr: Box::new(ExprPlan::Identifier("id".to_owned())),
@@ -480,7 +484,7 @@ mod tests {
             negated: true,
         };
         let expected = "id NOT IN (@S1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Between {
             expr: Box::new(ExprPlan::Identifier("score".to_owned())),
@@ -489,7 +493,7 @@ mod tests {
             high: Box::new(ExprPlan::Literal(Literal::Number(10.into()))),
         };
         let expected = "score BETWEEN 1 AND 10";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Between {
             expr: Box::new(ExprPlan::Identifier("score".to_owned())),
@@ -498,7 +502,7 @@ mod tests {
             high: Box::new(ExprPlan::Literal(Literal::Number(10.into()))),
         };
         let expected = "score NOT BETWEEN 1 AND 10";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Like {
             expr: Box::new(ExprPlan::Identifier("name".to_owned())),
@@ -506,7 +510,7 @@ mod tests {
             pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("A%".to_owned()))),
         };
         let expected = "name LIKE 'A%'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Like {
             expr: Box::new(ExprPlan::Identifier("name".to_owned())),
@@ -514,7 +518,7 @@ mod tests {
             pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("A%".to_owned()))),
         };
         let expected = "name NOT LIKE 'A%'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::ILike {
             expr: Box::new(ExprPlan::Identifier("name".to_owned())),
@@ -522,7 +526,7 @@ mod tests {
             pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("a%".to_owned()))),
         };
         let expected = "name ILIKE 'a%'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::ILike {
             expr: Box::new(ExprPlan::Identifier("name".to_owned())),
@@ -530,7 +534,7 @@ mod tests {
             pattern: Box::new(ExprPlan::Literal(Literal::QuotedString("a%".to_owned()))),
         };
         let expected = "name NOT ILIKE 'a%'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::BinaryOp {
             left: Box::new(ExprPlan::CompoundIdentifier {
@@ -541,21 +545,21 @@ mod tests {
             right: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
         };
         let expected = "Player.id = 1";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::UnaryOp {
             op: UnaryOperator::Minus,
             expr: Box::new(ExprPlan::Literal(Literal::Number(1.into()))),
         };
         let expected = "-1";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::UnaryOp {
             op: UnaryOperator::Factorial,
             expr: Box::new(ExprPlan::Literal(Literal::Number(5.into()))),
         };
         let expected = "5!";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Nested(Box::new(ExprPlan::BinaryOp {
             left: Box::new(ExprPlan::Identifier("a".to_owned())),
@@ -563,28 +567,28 @@ mod tests {
             right: Box::new(ExprPlan::Identifier("b".to_owned())),
         }));
         let expected = "(a + b)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Literal(Literal::QuotedString("GlueSQL".to_owned()));
         let expected = "'GlueSQL'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Value(Value::Bool(true));
         let expected = "TRUE";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::TypedString {
             data_type: DataType::Date,
             value: "2026-08-17".to_owned(),
         };
         let expected = "DATE '2026-08-17'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Function(Box::new(FunctionExprPlan::Abs(ExprPlan::Identifier(
             "score".to_owned(),
         ))));
         let expected = "ABS(score)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Aggregate(Box::new(AggregateExprPlan {
             func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
@@ -592,25 +596,25 @@ mod tests {
             slot: Some(0),
         }));
         let expected = "COUNT(*)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Exists {
             subquery: Box::new(subquery.clone()),
             negated: false,
         };
         let expected = "EXISTS (@S1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Exists {
             subquery: Box::new(subquery.clone()),
             negated: true,
         };
         let expected = "NOT EXISTS (@S1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Subquery(Box::new(subquery));
         let expected = "@S1";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Case {
             operand: Some(Box::new(ExprPlan::Identifier("status".to_owned()))),
@@ -623,7 +627,7 @@ mod tests {
             )))),
         };
         let expected = "CASE status WHEN 1 THEN 'active' ELSE 'inactive' END";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Case {
             operand: None,
@@ -631,7 +635,7 @@ mod tests {
             else_result: None,
         };
         let expected = "CASE END";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::ArrayIndex {
             obj: Box::new(ExprPlan::Identifier("matrix".to_owned())),
@@ -641,7 +645,7 @@ mod tests {
             ],
         };
         let expected = "matrix[1][2]";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Interval {
             expr: Box::new(ExprPlan::Literal(Literal::QuotedString("1".to_owned()))),
@@ -649,7 +653,7 @@ mod tests {
             last_field: Some(DateTimeField::Hour),
         };
         let expected = "INTERVAL '1' DAY TO HOUR";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Interval {
             expr: Box::new(ExprPlan::Literal(Literal::QuotedString("1 day".to_owned()))),
@@ -657,7 +661,7 @@ mod tests {
             last_field: None,
         };
         let expected = "INTERVAL '1 day'";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = ExprPlan::Array {
             elem: vec![
@@ -666,7 +670,7 @@ mod tests {
             ],
         };
         let expected = "[1, 2]";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
         let actual = [
             ExprPlan::Identifier("id".to_owned()),

--- a/core/src/plan/statement/expr/aggregate.rs
+++ b/core/src/plan/statement/expr/aggregate.rs
@@ -121,18 +121,56 @@ mod tests {
     };
 
     #[test]
-    fn displays_aggregate_for_explain() {
-        let aggregate = AggregateExprPlan {
-            func: AggregateFunctionPlan::Count(CountArgExprPlan::Expr(ExprPlan::Identifier(
-                "id".to_owned(),
-            ))),
-            distinct: true,
-            slot: Some(0),
-        };
+    fn explain() {
+        let actual = [
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
+                distinct: false,
+                slot: Some(0),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Count(CountArgExprPlan::Expr(ExprPlan::Identifier(
+                    "id".to_owned(),
+                ))),
+                distinct: true,
+                slot: Some(1),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Sum(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(2),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Max(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(3),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Min(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(4),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Avg(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(5),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Variance(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(6),
+            },
+            AggregateExprPlan {
+                func: AggregateFunctionPlan::Stdev(ExprPlan::Identifier("score".to_owned())),
+                distinct: false,
+                slot: Some(7),
+            },
+        ];
+        let expected = "COUNT(*), COUNT(DISTINCT id), SUM(score), MAX(score), MIN(score), AVG(score), VARIANCE(score), STDEV(score)";
 
         assert_eq!(
-            aggregate.explain(&mut ExplainContext::default()),
-            "COUNT(DISTINCT id)"
+            actual.as_slice().explain(&mut ExplainContext::default()),
+            expected
         );
     }
 }

--- a/core/src/plan/statement/expr/aggregate.rs
+++ b/core/src/plan/statement/expr/aggregate.rs
@@ -120,54 +120,94 @@ mod tests {
         },
     };
 
+    fn test(actual: &AggregateExprPlan, expected: &str) {
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+    }
+
     #[test]
     fn explain() {
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "COUNT(*)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Count(CountArgExprPlan::Expr(ExprPlan::Identifier(
+                "id".to_owned(),
+            ))),
+            distinct: true,
+            slot: None,
+        };
+        let expected = "COUNT(DISTINCT id)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Sum(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "SUM(score)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Max(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "MAX(score)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Min(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "MIN(score)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Avg(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "AVG(score)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Variance(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "VARIANCE(score)";
+        test(&actual, expected);
+
+        let actual = AggregateExprPlan {
+            func: AggregateFunctionPlan::Stdev(ExprPlan::Identifier("score".to_owned())),
+            distinct: false,
+            slot: None,
+        };
+        let expected = "STDEV(score)";
+        test(&actual, expected);
+    }
+
+    #[test]
+    fn explain_list() {
         let actual = [
             AggregateExprPlan {
                 func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
                 distinct: false,
-                slot: Some(0),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Count(CountArgExprPlan::Expr(ExprPlan::Identifier(
-                    "id".to_owned(),
-                ))),
-                distinct: true,
-                slot: Some(1),
+                slot: None,
             },
             AggregateExprPlan {
                 func: AggregateFunctionPlan::Sum(ExprPlan::Identifier("score".to_owned())),
                 distinct: false,
-                slot: Some(2),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Max(ExprPlan::Identifier("score".to_owned())),
-                distinct: false,
-                slot: Some(3),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Min(ExprPlan::Identifier("score".to_owned())),
-                distinct: false,
-                slot: Some(4),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Avg(ExprPlan::Identifier("score".to_owned())),
-                distinct: false,
-                slot: Some(5),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Variance(ExprPlan::Identifier("score".to_owned())),
-                distinct: false,
-                slot: Some(6),
-            },
-            AggregateExprPlan {
-                func: AggregateFunctionPlan::Stdev(ExprPlan::Identifier("score".to_owned())),
-                distinct: false,
-                slot: Some(7),
+                slot: None,
             },
         ];
-        let expected = "COUNT(*), COUNT(DISTINCT id), SUM(score), MAX(score), MIN(score), AVG(score), VARIANCE(score), STDEV(score)";
-
+        let expected = "COUNT(*), SUM(score)";
         assert_eq!(
             actual.as_slice().explain(&mut ExplainContext::default()),
             expected

--- a/core/src/plan/statement/expr/aggregate.rs
+++ b/core/src/plan/statement/expr/aggregate.rs
@@ -1,0 +1,138 @@
+use {
+    super::{ExprPlan, fmt_expr},
+    crate::{
+        ast,
+        plan::explain::{Explain, ExplainContext},
+    },
+    serde::{Deserialize, Serialize},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AggregateExprPlan {
+    pub func: AggregateFunctionPlan,
+    pub distinct: bool,
+    pub slot: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AggregateFunctionPlan {
+    Count(CountArgExprPlan),
+    Sum(ExprPlan),
+    Max(ExprPlan),
+    Min(ExprPlan),
+    Avg(ExprPlan),
+    Variance(ExprPlan),
+    Stdev(ExprPlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CountArgExprPlan {
+    Wildcard,
+    Expr(ExprPlan),
+}
+
+impl From<ast::Aggregate> for AggregateExprPlan {
+    fn from(aggregate: ast::Aggregate) -> Self {
+        let ast::Aggregate { func, distinct } = aggregate;
+
+        Self {
+            func: func.into(),
+            distinct,
+            slot: None,
+        }
+    }
+}
+
+impl From<ast::AggregateFunction> for AggregateFunctionPlan {
+    fn from(func: ast::AggregateFunction) -> Self {
+        match func {
+            ast::AggregateFunction::Count(expr) => Self::Count(expr.into()),
+            ast::AggregateFunction::Sum(expr) => Self::Sum(expr.into()),
+            ast::AggregateFunction::Max(expr) => Self::Max(expr.into()),
+            ast::AggregateFunction::Min(expr) => Self::Min(expr.into()),
+            ast::AggregateFunction::Avg(expr) => Self::Avg(expr.into()),
+            ast::AggregateFunction::Variance(expr) => Self::Variance(expr.into()),
+            ast::AggregateFunction::Stdev(expr) => Self::Stdev(expr.into()),
+        }
+    }
+}
+
+impl From<ast::CountArgExpr> for CountArgExprPlan {
+    fn from(expr: ast::CountArgExpr) -> Self {
+        match expr {
+            ast::CountArgExpr::Wildcard => Self::Wildcard,
+            ast::CountArgExpr::Expr(expr) => Self::Expr(expr.into()),
+        }
+    }
+}
+
+impl Explain for AggregateExprPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        let (name, expr) = match &self.func {
+            AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard) => ("COUNT", None),
+            AggregateFunctionPlan::Count(CountArgExprPlan::Expr(expr)) => ("COUNT", Some(expr)),
+            AggregateFunctionPlan::Sum(expr) => ("SUM", Some(expr)),
+            AggregateFunctionPlan::Max(expr) => ("MAX", Some(expr)),
+            AggregateFunctionPlan::Min(expr) => ("MIN", Some(expr)),
+            AggregateFunctionPlan::Avg(expr) => ("AVG", Some(expr)),
+            AggregateFunctionPlan::Variance(expr) => ("VARIANCE", Some(expr)),
+            AggregateFunctionPlan::Stdev(expr) => ("STDEV", Some(expr)),
+        };
+        output.push_str(name);
+        output.push('(');
+        if self.distinct {
+            output.push_str("DISTINCT ");
+        }
+        match expr {
+            Some(expr) => fmt_expr(expr, context, &mut output),
+            None => output.push('*'),
+        }
+        output.push(')');
+        output
+    }
+}
+
+impl Explain for [AggregateExprPlan] {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        for (index, aggregate) in self.iter().enumerate() {
+            if index > 0 {
+                output.push_str(", ");
+            }
+            output.push_str(&aggregate.explain(context));
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{AggregateExprPlan, AggregateFunctionPlan, CountArgExprPlan},
+        crate::plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext},
+        },
+    };
+
+    #[test]
+    fn displays_aggregate_for_explain() {
+        let aggregate = AggregateExprPlan {
+            func: AggregateFunctionPlan::Count(CountArgExprPlan::Expr(ExprPlan::Identifier(
+                "id".to_owned(),
+            ))),
+            distinct: true,
+            slot: Some(0),
+        };
+
+        assert_eq!(
+            aggregate.explain(&mut ExplainContext::default()),
+            "COUNT(DISTINCT id)"
+        );
+    }
+}

--- a/core/src/plan/statement/expr/function.rs
+++ b/core/src/plan/statement/expr/function.rs
@@ -1,0 +1,541 @@
+use {
+    super::{ExprPlan, fmt_expr, fmt_expr_list},
+    crate::{
+        ast::{self, DataType, DateTimeField, TrimWhereField},
+        plan::explain::{Explain, ExplainContext},
+    },
+    serde::{Deserialize, Serialize},
+    strum_macros::Display,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum FunctionExprPlan {
+    Abs(ExprPlan),
+    AddMonth {
+        expr: ExprPlan,
+        size: ExprPlan,
+    },
+    Lower(ExprPlan),
+    Initcap(ExprPlan),
+    Upper(ExprPlan),
+    Left {
+        expr: ExprPlan,
+        size: ExprPlan,
+    },
+    Right {
+        expr: ExprPlan,
+        size: ExprPlan,
+    },
+    Asin(ExprPlan),
+    Acos(ExprPlan),
+    Atan(ExprPlan),
+    Lpad {
+        expr: ExprPlan,
+        size: ExprPlan,
+        fill: Option<ExprPlan>,
+    },
+    Rpad {
+        expr: ExprPlan,
+        size: ExprPlan,
+        fill: Option<ExprPlan>,
+    },
+    Replace {
+        expr: ExprPlan,
+        old: ExprPlan,
+        new: ExprPlan,
+    },
+    Cast {
+        expr: ExprPlan,
+        data_type: DataType,
+    },
+    Ceil(ExprPlan),
+    Coalesce(Vec<ExprPlan>),
+    Concat(Vec<ExprPlan>),
+    ConcatWs {
+        separator: ExprPlan,
+        exprs: Vec<ExprPlan>,
+    },
+    Custom {
+        name: String,
+        exprs: Vec<ExprPlan>,
+    },
+    IfNull {
+        expr: ExprPlan,
+        then: ExprPlan,
+    },
+    NullIf {
+        expr1: ExprPlan,
+        expr2: ExprPlan,
+    },
+    Rand(Option<ExprPlan>),
+    Round(ExprPlan),
+    Trunc(ExprPlan),
+    Floor(ExprPlan),
+    Trim {
+        expr: ExprPlan,
+        filter_chars: Option<ExprPlan>,
+        trim_where_field: Option<TrimWhereField>,
+    },
+    Exp(ExprPlan),
+    Extract {
+        field: DateTimeField,
+        expr: ExprPlan,
+    },
+    Ln(ExprPlan),
+    Log {
+        antilog: ExprPlan,
+        base: ExprPlan,
+    },
+    Log2(ExprPlan),
+    Log10(ExprPlan),
+    Div {
+        dividend: ExprPlan,
+        divisor: ExprPlan,
+    },
+    Mod {
+        dividend: ExprPlan,
+        divisor: ExprPlan,
+    },
+    Gcd {
+        left: ExprPlan,
+        right: ExprPlan,
+    },
+    Lcm {
+        left: ExprPlan,
+        right: ExprPlan,
+    },
+    Sin(ExprPlan),
+    Cos(ExprPlan),
+    Tan(ExprPlan),
+    Sqrt(ExprPlan),
+    Power {
+        expr: ExprPlan,
+        power: ExprPlan,
+    },
+    Radians(ExprPlan),
+    Degrees(ExprPlan),
+    Now(),
+    CurrentDate(),
+    CurrentTime(),
+    CurrentTimestamp(),
+    Pi(),
+    LastDay(ExprPlan),
+    Ltrim {
+        expr: ExprPlan,
+        chars: Option<ExprPlan>,
+    },
+    Rtrim {
+        expr: ExprPlan,
+        chars: Option<ExprPlan>,
+    },
+    Reverse(ExprPlan),
+    Repeat {
+        expr: ExprPlan,
+        num: ExprPlan,
+    },
+    Sign(ExprPlan),
+    Substr {
+        expr: ExprPlan,
+        start: ExprPlan,
+        count: Option<ExprPlan>,
+    },
+    Unwrap {
+        expr: ExprPlan,
+        selector: ExprPlan,
+    },
+    GenerateUuid(),
+    Greatest(Vec<ExprPlan>),
+    Format {
+        expr: ExprPlan,
+        format: ExprPlan,
+    },
+    ToDate {
+        expr: ExprPlan,
+        format: ExprPlan,
+    },
+    ToTimestamp {
+        expr: ExprPlan,
+        format: ExprPlan,
+    },
+    ToTime {
+        expr: ExprPlan,
+        format: ExprPlan,
+    },
+    Position {
+        from_expr: ExprPlan,
+        sub_expr: ExprPlan,
+    },
+    FindIdx {
+        from_expr: ExprPlan,
+        sub_expr: ExprPlan,
+        start: Option<ExprPlan>,
+    },
+    Ascii(ExprPlan),
+    Chr(ExprPlan),
+    Md5(ExprPlan),
+    Hex(ExprPlan),
+    Append {
+        expr: ExprPlan,
+        value: ExprPlan,
+    },
+    Sort {
+        expr: ExprPlan,
+        order: Option<ExprPlan>,
+    },
+    Slice {
+        expr: ExprPlan,
+        start: ExprPlan,
+        length: ExprPlan,
+    },
+    Prepend {
+        expr: ExprPlan,
+        value: ExprPlan,
+    },
+    Skip {
+        expr: ExprPlan,
+        size: ExprPlan,
+    },
+    Take {
+        expr: ExprPlan,
+        size: ExprPlan,
+    },
+    GetX(ExprPlan),
+    GetY(ExprPlan),
+    Point {
+        x: ExprPlan,
+        y: ExprPlan,
+    },
+    CalcDistance {
+        geometry1: ExprPlan,
+        geometry2: ExprPlan,
+    },
+    IsEmpty(ExprPlan),
+    Length(ExprPlan),
+    Entries(ExprPlan),
+    Keys(ExprPlan),
+    Values(ExprPlan),
+    Splice {
+        list_data: ExprPlan,
+        begin_index: ExprPlan,
+        end_index: ExprPlan,
+        values: Option<ExprPlan>,
+    },
+    Dedup(ExprPlan),
+}
+
+impl From<ast::Function> for FunctionExprPlan {
+    fn from(function: ast::Function) -> Self {
+        match function {
+            ast::Function::Abs(expr) => Self::Abs(expr.into()),
+            ast::Function::AddMonth { expr, size } => Self::AddMonth {
+                expr: expr.into(),
+                size: size.into(),
+            },
+            ast::Function::Lower(expr) => Self::Lower(expr.into()),
+            ast::Function::Initcap(expr) => Self::Initcap(expr.into()),
+            ast::Function::Upper(expr) => Self::Upper(expr.into()),
+            ast::Function::Left { expr, size } => Self::Left {
+                expr: expr.into(),
+                size: size.into(),
+            },
+            ast::Function::Right { expr, size } => Self::Right {
+                expr: expr.into(),
+                size: size.into(),
+            },
+            ast::Function::Asin(expr) => Self::Asin(expr.into()),
+            ast::Function::Acos(expr) => Self::Acos(expr.into()),
+            ast::Function::Atan(expr) => Self::Atan(expr.into()),
+            ast::Function::Lpad { expr, size, fill } => Self::Lpad {
+                expr: expr.into(),
+                size: size.into(),
+                fill: fill.map(Into::into),
+            },
+            ast::Function::Rpad { expr, size, fill } => Self::Rpad {
+                expr: expr.into(),
+                size: size.into(),
+                fill: fill.map(Into::into),
+            },
+            ast::Function::Replace { expr, old, new } => Self::Replace {
+                expr: expr.into(),
+                old: old.into(),
+                new: new.into(),
+            },
+            ast::Function::Cast { expr, data_type } => Self::Cast {
+                expr: expr.into(),
+                data_type,
+            },
+            ast::Function::Ceil(expr) => Self::Ceil(expr.into()),
+            ast::Function::Coalesce(exprs) => {
+                Self::Coalesce(exprs.into_iter().map(Into::into).collect())
+            }
+            ast::Function::Concat(exprs) => {
+                Self::Concat(exprs.into_iter().map(Into::into).collect())
+            }
+            ast::Function::ConcatWs { separator, exprs } => Self::ConcatWs {
+                separator: separator.into(),
+                exprs: exprs.into_iter().map(Into::into).collect(),
+            },
+            ast::Function::Custom { name, exprs } => Self::Custom {
+                name,
+                exprs: exprs.into_iter().map(Into::into).collect(),
+            },
+            ast::Function::IfNull { expr, then } => Self::IfNull {
+                expr: expr.into(),
+                then: then.into(),
+            },
+            ast::Function::NullIf { expr1, expr2 } => Self::NullIf {
+                expr1: expr1.into(),
+                expr2: expr2.into(),
+            },
+            ast::Function::Rand(expr) => Self::Rand(expr.map(Into::into)),
+            ast::Function::Round(expr) => Self::Round(expr.into()),
+            ast::Function::Trunc(expr) => Self::Trunc(expr.into()),
+            ast::Function::Floor(expr) => Self::Floor(expr.into()),
+            ast::Function::Trim {
+                expr,
+                filter_chars,
+                trim_where_field,
+            } => Self::Trim {
+                expr: expr.into(),
+                filter_chars: filter_chars.map(Into::into),
+                trim_where_field,
+            },
+            ast::Function::Exp(expr) => Self::Exp(expr.into()),
+            ast::Function::Extract { field, expr } => Self::Extract {
+                field,
+                expr: expr.into(),
+            },
+            ast::Function::Ln(expr) => Self::Ln(expr.into()),
+            ast::Function::Log { antilog, base } => Self::Log {
+                antilog: antilog.into(),
+                base: base.into(),
+            },
+            ast::Function::Log2(expr) => Self::Log2(expr.into()),
+            ast::Function::Log10(expr) => Self::Log10(expr.into()),
+            ast::Function::Div { dividend, divisor } => Self::Div {
+                dividend: dividend.into(),
+                divisor: divisor.into(),
+            },
+            ast::Function::Mod { dividend, divisor } => Self::Mod {
+                dividend: dividend.into(),
+                divisor: divisor.into(),
+            },
+            ast::Function::Gcd { left, right } => Self::Gcd {
+                left: left.into(),
+                right: right.into(),
+            },
+            ast::Function::Lcm { left, right } => Self::Lcm {
+                left: left.into(),
+                right: right.into(),
+            },
+            ast::Function::Sin(expr) => Self::Sin(expr.into()),
+            ast::Function::Cos(expr) => Self::Cos(expr.into()),
+            ast::Function::Tan(expr) => Self::Tan(expr.into()),
+            ast::Function::Sqrt(expr) => Self::Sqrt(expr.into()),
+            ast::Function::Power { expr, power } => Self::Power {
+                expr: expr.into(),
+                power: power.into(),
+            },
+            ast::Function::Radians(expr) => Self::Radians(expr.into()),
+            ast::Function::Degrees(expr) => Self::Degrees(expr.into()),
+            ast::Function::Now() => Self::Now(),
+            ast::Function::CurrentDate() => Self::CurrentDate(),
+            ast::Function::CurrentTime() => Self::CurrentTime(),
+            ast::Function::CurrentTimestamp() => Self::CurrentTimestamp(),
+            ast::Function::Pi() => Self::Pi(),
+            ast::Function::LastDay(expr) => Self::LastDay(expr.into()),
+            ast::Function::Ltrim { expr, chars } => Self::Ltrim {
+                expr: expr.into(),
+                chars: chars.map(Into::into),
+            },
+            ast::Function::Rtrim { expr, chars } => Self::Rtrim {
+                expr: expr.into(),
+                chars: chars.map(Into::into),
+            },
+            ast::Function::Reverse(expr) => Self::Reverse(expr.into()),
+            ast::Function::Repeat { expr, num } => Self::Repeat {
+                expr: expr.into(),
+                num: num.into(),
+            },
+            ast::Function::Sign(expr) => Self::Sign(expr.into()),
+            ast::Function::Substr { expr, start, count } => Self::Substr {
+                expr: expr.into(),
+                start: start.into(),
+                count: count.map(Into::into),
+            },
+            ast::Function::Unwrap { expr, selector } => Self::Unwrap {
+                expr: expr.into(),
+                selector: selector.into(),
+            },
+            ast::Function::GenerateUuid() => Self::GenerateUuid(),
+            ast::Function::Greatest(exprs) => {
+                Self::Greatest(exprs.into_iter().map(Into::into).collect())
+            }
+            ast::Function::Format { expr, format } => Self::Format {
+                expr: expr.into(),
+                format: format.into(),
+            },
+            ast::Function::ToDate { expr, format } => Self::ToDate {
+                expr: expr.into(),
+                format: format.into(),
+            },
+            ast::Function::ToTimestamp { expr, format } => Self::ToTimestamp {
+                expr: expr.into(),
+                format: format.into(),
+            },
+            ast::Function::ToTime { expr, format } => Self::ToTime {
+                expr: expr.into(),
+                format: format.into(),
+            },
+            ast::Function::Position {
+                from_expr,
+                sub_expr,
+            } => Self::Position {
+                from_expr: from_expr.into(),
+                sub_expr: sub_expr.into(),
+            },
+            ast::Function::FindIdx {
+                from_expr,
+                sub_expr,
+                start,
+            } => Self::FindIdx {
+                from_expr: from_expr.into(),
+                sub_expr: sub_expr.into(),
+                start: start.map(Into::into),
+            },
+            ast::Function::Ascii(expr) => Self::Ascii(expr.into()),
+            ast::Function::Chr(expr) => Self::Chr(expr.into()),
+            ast::Function::Md5(expr) => Self::Md5(expr.into()),
+            ast::Function::Hex(expr) => Self::Hex(expr.into()),
+            ast::Function::Append { expr, value } => Self::Append {
+                expr: expr.into(),
+                value: value.into(),
+            },
+            ast::Function::Sort { expr, order } => Self::Sort {
+                expr: expr.into(),
+                order: order.map(Into::into),
+            },
+            ast::Function::Slice {
+                expr,
+                start,
+                length,
+            } => Self::Slice {
+                expr: expr.into(),
+                start: start.into(),
+                length: length.into(),
+            },
+            ast::Function::Prepend { expr, value } => Self::Prepend {
+                expr: expr.into(),
+                value: value.into(),
+            },
+            ast::Function::Skip { expr, size } => Self::Skip {
+                expr: expr.into(),
+                size: size.into(),
+            },
+            ast::Function::Take { expr, size } => Self::Take {
+                expr: expr.into(),
+                size: size.into(),
+            },
+            ast::Function::GetX(expr) => Self::GetX(expr.into()),
+            ast::Function::GetY(expr) => Self::GetY(expr.into()),
+            ast::Function::Point { x, y } => Self::Point {
+                x: x.into(),
+                y: y.into(),
+            },
+            ast::Function::CalcDistance {
+                geometry1,
+                geometry2,
+            } => Self::CalcDistance {
+                geometry1: geometry1.into(),
+                geometry2: geometry2.into(),
+            },
+            ast::Function::IsEmpty(expr) => Self::IsEmpty(expr.into()),
+            ast::Function::Length(expr) => Self::Length(expr.into()),
+            ast::Function::Entries(expr) => Self::Entries(expr.into()),
+            ast::Function::Keys(expr) => Self::Keys(expr.into()),
+            ast::Function::Values(expr) => Self::Values(expr.into()),
+            ast::Function::Splice {
+                list_data,
+                begin_index,
+                end_index,
+                values,
+            } => Self::Splice {
+                list_data: list_data.into(),
+                begin_index: begin_index.into(),
+                end_index: end_index.into(),
+                values: values.map(Into::into),
+            },
+            ast::Function::Dedup(expr) => Self::Dedup(expr.into()),
+        }
+    }
+}
+
+impl Explain for FunctionExprPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        match self {
+            Self::Cast { expr, data_type } => {
+                output.push_str("CAST(");
+                fmt_expr(expr, context, &mut output);
+                output.push_str(" AS ");
+                output.push_str(&data_type.to_string());
+                output.push(')');
+            }
+            Self::Extract { field, expr } => {
+                output.push_str("EXTRACT(");
+                output.push_str(&field.to_string());
+                output.push_str(" FROM ");
+                fmt_expr(expr, context, &mut output);
+                output.push(')');
+            }
+            Self::Custom { name, exprs } => {
+                output.push_str(name);
+                output.push('(');
+                fmt_expr_list(exprs, context, &mut output);
+                output.push(')');
+            }
+            _ => {
+                output.push_str(&self.to_string());
+                output.push('(');
+                for (index, expr) in self.as_exprs().enumerate() {
+                    if index > 0 {
+                        output.push_str(", ");
+                    }
+                    fmt_expr(expr, context, &mut output);
+                }
+                output.push(')');
+            }
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::FunctionExprPlan,
+        crate::{
+            ast::DataType,
+            plan::{
+                ExprPlan,
+                explain::{Explain, ExplainContext},
+            },
+        },
+    };
+
+    #[test]
+    fn displays_function_for_explain() {
+        let function = FunctionExprPlan::Cast {
+            expr: ExprPlan::Identifier("id".to_owned()),
+            data_type: DataType::Text,
+        };
+
+        assert_eq!(
+            function.explain(&mut ExplainContext::default()),
+            "CAST(id AS TEXT)"
+        );
+    }
+}

--- a/core/src/plan/statement/expr/function.rs
+++ b/core/src/plan/statement/expr/function.rs
@@ -518,7 +518,7 @@ mod tests {
     use {
         super::FunctionExprPlan,
         crate::{
-            ast::DataType,
+            ast::{DataType, DateTimeField, Literal},
             plan::{
                 ExprPlan,
                 explain::{Explain, ExplainContext},
@@ -527,15 +527,44 @@ mod tests {
     };
 
     #[test]
-    fn displays_function_for_explain() {
-        let function = FunctionExprPlan::Cast {
+    fn explain() {
+        let actual = FunctionExprPlan::Cast {
             expr: ExprPlan::Identifier("id".to_owned()),
             data_type: DataType::Text,
         };
+        let expected = "CAST(id AS TEXT)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
 
-        assert_eq!(
-            function.explain(&mut ExplainContext::default()),
-            "CAST(id AS TEXT)"
-        );
+        let actual = FunctionExprPlan::Extract {
+            field: DateTimeField::Year,
+            expr: ExprPlan::Identifier("created_at".to_owned()),
+        };
+        let expected = "EXTRACT(YEAR FROM created_at)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = FunctionExprPlan::Custom {
+            name: "score".to_owned(),
+            exprs: vec![
+                ExprPlan::Identifier("id".to_owned()),
+                ExprPlan::Literal(Literal::Number(1.into())),
+            ],
+        };
+        let expected = "score(id, 1)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = FunctionExprPlan::Abs(ExprPlan::Identifier("score".to_owned()));
+        let expected = "ABS(score)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = FunctionExprPlan::Now();
+        let expected = "NOW()";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = FunctionExprPlan::Concat(vec![
+            ExprPlan::Identifier("first_name".to_owned()),
+            ExprPlan::Identifier("last_name".to_owned()),
+        ]);
+        let expected = "CONCAT(first_name, last_name)";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
     }
 }

--- a/core/src/plan/statement/expr/function.rs
+++ b/core/src/plan/statement/expr/function.rs
@@ -518,7 +518,7 @@ mod tests {
     use {
         super::FunctionExprPlan,
         crate::{
-            ast::{DataType, DateTimeField, Literal},
+            ast::{DataType, DateTimeField, TrimWhereField},
             plan::{
                 ExprPlan,
                 explain::{Explain, ExplainContext},
@@ -526,45 +526,565 @@ mod tests {
         },
     };
 
+    fn test(actual: &FunctionExprPlan, expected: &str) {
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+    }
+
     #[test]
     fn explain() {
+        let actual = FunctionExprPlan::Abs(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ABS(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::AddMonth {
+            expr: ExprPlan::Identifier("date".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+        };
+        let expected = "ADD_MONTH(date, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Lower(ExprPlan::Identifier("value".to_owned()));
+        let expected = "LOWER(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Initcap(ExprPlan::Identifier("value".to_owned()));
+        let expected = "INITCAP(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Upper(ExprPlan::Identifier("value".to_owned()));
+        let expected = "UPPER(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Left {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+        };
+        let expected = "LEFT(value, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Right {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+        };
+        let expected = "RIGHT(value, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Asin(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ASIN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Acos(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ACOS(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Atan(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ATAN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Lpad {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+            fill: None,
+        };
+        let expected = "LPAD(value, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Lpad {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+            fill: Some(ExprPlan::Identifier("fill".to_owned())),
+        };
+        let expected = "LPAD(value, size, fill)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rpad {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+            fill: None,
+        };
+        let expected = "RPAD(value, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rpad {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+            fill: Some(ExprPlan::Identifier("fill".to_owned())),
+        };
+        let expected = "RPAD(value, size, fill)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Replace {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            old: ExprPlan::Identifier("old".to_owned()),
+            new: ExprPlan::Identifier("new".to_owned()),
+        };
+        let expected = "REPLACE(value, old, new)";
+        test(&actual, expected);
+
         let actual = FunctionExprPlan::Cast {
-            expr: ExprPlan::Identifier("id".to_owned()),
+            expr: ExprPlan::Identifier("value".to_owned()),
             data_type: DataType::Text,
         };
-        let expected = "CAST(id AS TEXT)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        let expected = "CAST(value AS TEXT)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Ceil(ExprPlan::Identifier("value".to_owned()));
+        let expected = "CEIL(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Coalesce(vec![
+            ExprPlan::Identifier("left".to_owned()),
+            ExprPlan::Identifier("right".to_owned()),
+        ]);
+        let expected = "COALESCE(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Concat(vec![
+            ExprPlan::Identifier("left".to_owned()),
+            ExprPlan::Identifier("right".to_owned()),
+        ]);
+        let expected = "CONCAT(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::ConcatWs {
+            separator: ExprPlan::Identifier("separator".to_owned()),
+            exprs: vec![
+                ExprPlan::Identifier("left".to_owned()),
+                ExprPlan::Identifier("right".to_owned()),
+            ],
+        };
+        let expected = "CONCAT_WS(separator, left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Custom {
+            name: "custom_function".to_owned(),
+            exprs: vec![
+                ExprPlan::Identifier("left".to_owned()),
+                ExprPlan::Identifier("right".to_owned()),
+            ],
+        };
+        let expected = "custom_function(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::IfNull {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            then: ExprPlan::Identifier("fallback".to_owned()),
+        };
+        let expected = "IF_NULL(value, fallback)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::NullIf {
+            expr1: ExprPlan::Identifier("left".to_owned()),
+            expr2: ExprPlan::Identifier("right".to_owned()),
+        };
+        let expected = "NULL_IF(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rand(None);
+        let expected = "RAND()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rand(Some(ExprPlan::Identifier("seed".to_owned())));
+        let expected = "RAND(seed)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Round(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ROUND(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trunc(ExprPlan::Identifier("value".to_owned()));
+        let expected = "TRUNC(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Floor(ExprPlan::Identifier("value".to_owned()));
+        let expected = "FLOOR(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: None,
+            trim_where_field: None,
+        };
+        let expected = "TRIM(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: Some(ExprPlan::Identifier("chars".to_owned())),
+            trim_where_field: Some(TrimWhereField::Leading),
+        };
+        let expected = "TRIM(value, chars)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Exp(ExprPlan::Identifier("value".to_owned()));
+        let expected = "EXP(value)";
+        test(&actual, expected);
 
         let actual = FunctionExprPlan::Extract {
             field: DateTimeField::Year,
             expr: ExprPlan::Identifier("created_at".to_owned()),
         };
         let expected = "EXTRACT(YEAR FROM created_at)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
-        let actual = FunctionExprPlan::Custom {
-            name: "score".to_owned(),
-            exprs: vec![
-                ExprPlan::Identifier("id".to_owned()),
-                ExprPlan::Literal(Literal::Number(1.into())),
-            ],
+        let actual = FunctionExprPlan::Ln(ExprPlan::Identifier("value".to_owned()));
+        let expected = "LN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Log {
+            antilog: ExprPlan::Identifier("antilog".to_owned()),
+            base: ExprPlan::Identifier("base".to_owned()),
         };
-        let expected = "score(id, 1)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        let expected = "LOG(antilog, base)";
+        test(&actual, expected);
 
-        let actual = FunctionExprPlan::Abs(ExprPlan::Identifier("score".to_owned()));
-        let expected = "ABS(score)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        let actual = FunctionExprPlan::Log2(ExprPlan::Identifier("value".to_owned()));
+        let expected = "LOG2(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Log10(ExprPlan::Identifier("value".to_owned()));
+        let expected = "LOG10(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Div {
+            dividend: ExprPlan::Identifier("dividend".to_owned()),
+            divisor: ExprPlan::Identifier("divisor".to_owned()),
+        };
+        let expected = "DIV(dividend, divisor)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Mod {
+            dividend: ExprPlan::Identifier("dividend".to_owned()),
+            divisor: ExprPlan::Identifier("divisor".to_owned()),
+        };
+        let expected = "MOD(dividend, divisor)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Gcd {
+            left: ExprPlan::Identifier("left".to_owned()),
+            right: ExprPlan::Identifier("right".to_owned()),
+        };
+        let expected = "GCD(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Lcm {
+            left: ExprPlan::Identifier("left".to_owned()),
+            right: ExprPlan::Identifier("right".to_owned()),
+        };
+        let expected = "LCM(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Sin(ExprPlan::Identifier("value".to_owned()));
+        let expected = "SIN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Cos(ExprPlan::Identifier("value".to_owned()));
+        let expected = "COS(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Tan(ExprPlan::Identifier("value".to_owned()));
+        let expected = "TAN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Sqrt(ExprPlan::Identifier("value".to_owned()));
+        let expected = "SQRT(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Power {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            power: ExprPlan::Identifier("power".to_owned()),
+        };
+        let expected = "POWER(value, power)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Radians(ExprPlan::Identifier("value".to_owned()));
+        let expected = "RADIANS(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Degrees(ExprPlan::Identifier("value".to_owned()));
+        let expected = "DEGREES(value)";
+        test(&actual, expected);
 
         let actual = FunctionExprPlan::Now();
         let expected = "NOW()";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        test(&actual, expected);
 
-        let actual = FunctionExprPlan::Concat(vec![
-            ExprPlan::Identifier("first_name".to_owned()),
-            ExprPlan::Identifier("last_name".to_owned()),
+        let actual = FunctionExprPlan::CurrentDate();
+        let expected = "CURRENT_DATE()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::CurrentTime();
+        let expected = "CURRENT_TIME()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::CurrentTimestamp();
+        let expected = "CURRENT_TIMESTAMP()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Pi();
+        let expected = "PI()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::LastDay(ExprPlan::Identifier("date".to_owned()));
+        let expected = "LAST_DAY(date)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Ltrim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            chars: None,
+        };
+        let expected = "LTRIM(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Ltrim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            chars: Some(ExprPlan::Identifier("chars".to_owned())),
+        };
+        let expected = "LTRIM(value, chars)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rtrim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            chars: None,
+        };
+        let expected = "RTRIM(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Rtrim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            chars: Some(ExprPlan::Identifier("chars".to_owned())),
+        };
+        let expected = "RTRIM(value, chars)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Reverse(ExprPlan::Identifier("value".to_owned()));
+        let expected = "REVERSE(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Repeat {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            num: ExprPlan::Identifier("count".to_owned()),
+        };
+        let expected = "REPEAT(value, count)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Sign(ExprPlan::Identifier("value".to_owned()));
+        let expected = "SIGN(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Substr {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            start: ExprPlan::Identifier("start".to_owned()),
+            count: None,
+        };
+        let expected = "SUBSTR(value, start)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Substr {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            start: ExprPlan::Identifier("start".to_owned()),
+            count: Some(ExprPlan::Identifier("count".to_owned())),
+        };
+        let expected = "SUBSTR(value, start, count)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Unwrap {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            selector: ExprPlan::Identifier("selector".to_owned()),
+        };
+        let expected = "UNWRAP(value, selector)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::GenerateUuid();
+        let expected = "GENERATE_UUID()";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Greatest(vec![
+            ExprPlan::Identifier("left".to_owned()),
+            ExprPlan::Identifier("right".to_owned()),
         ]);
-        let expected = "CONCAT(first_name, last_name)";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        let expected = "GREATEST(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Format {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            format: ExprPlan::Identifier("format".to_owned()),
+        };
+        let expected = "FORMAT(value, format)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::ToDate {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            format: ExprPlan::Identifier("format".to_owned()),
+        };
+        let expected = "TO_DATE(value, format)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::ToTimestamp {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            format: ExprPlan::Identifier("format".to_owned()),
+        };
+        let expected = "TO_TIMESTAMP(value, format)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::ToTime {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            format: ExprPlan::Identifier("format".to_owned()),
+        };
+        let expected = "TO_TIME(value, format)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Position {
+            from_expr: ExprPlan::Identifier("value".to_owned()),
+            sub_expr: ExprPlan::Identifier("substring".to_owned()),
+        };
+        let expected = "POSITION(substring, value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::FindIdx {
+            from_expr: ExprPlan::Identifier("value".to_owned()),
+            sub_expr: ExprPlan::Identifier("substring".to_owned()),
+            start: None,
+        };
+        let expected = "FIND_IDX(value, substring)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::FindIdx {
+            from_expr: ExprPlan::Identifier("value".to_owned()),
+            sub_expr: ExprPlan::Identifier("substring".to_owned()),
+            start: Some(ExprPlan::Identifier("start".to_owned())),
+        };
+        let expected = "FIND_IDX(value, substring, start)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Ascii(ExprPlan::Identifier("value".to_owned()));
+        let expected = "ASCII(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Chr(ExprPlan::Identifier("value".to_owned()));
+        let expected = "CHR(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Md5(ExprPlan::Identifier("value".to_owned()));
+        let expected = "MD5(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Hex(ExprPlan::Identifier("value".to_owned()));
+        let expected = "HEX(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Append {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            value: ExprPlan::Identifier("value".to_owned()),
+        };
+        let expected = "APPEND(list, value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Sort {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            order: None,
+        };
+        let expected = "SORT(list)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Sort {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            order: Some(ExprPlan::Identifier("order".to_owned())),
+        };
+        let expected = "SORT(list, order)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Slice {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            start: ExprPlan::Identifier("start".to_owned()),
+            length: ExprPlan::Identifier("length".to_owned()),
+        };
+        let expected = "SLICE(list, start, length)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Prepend {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            value: ExprPlan::Identifier("value".to_owned()),
+        };
+        let expected = "PREPEND(list, value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Skip {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+        };
+        let expected = "SKIP(list, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Take {
+            expr: ExprPlan::Identifier("list".to_owned()),
+            size: ExprPlan::Identifier("size".to_owned()),
+        };
+        let expected = "TAKE(list, size)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::GetX(ExprPlan::Identifier("point".to_owned()));
+        let expected = "GET_X(point)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::GetY(ExprPlan::Identifier("point".to_owned()));
+        let expected = "GET_Y(point)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Point {
+            x: ExprPlan::Identifier("x".to_owned()),
+            y: ExprPlan::Identifier("y".to_owned()),
+        };
+        let expected = "POINT(x, y)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::CalcDistance {
+            geometry1: ExprPlan::Identifier("left".to_owned()),
+            geometry2: ExprPlan::Identifier("right".to_owned()),
+        };
+        let expected = "CALC_DISTANCE(left, right)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::IsEmpty(ExprPlan::Identifier("value".to_owned()));
+        let expected = "IS_EMPTY(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Length(ExprPlan::Identifier("value".to_owned()));
+        let expected = "LENGTH(value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Entries(ExprPlan::Identifier("map".to_owned()));
+        let expected = "ENTRIES(map)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Keys(ExprPlan::Identifier("map".to_owned()));
+        let expected = "KEYS(map)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Values(ExprPlan::Identifier("map".to_owned()));
+        let expected = "VALUES(map)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Splice {
+            list_data: ExprPlan::Identifier("list".to_owned()),
+            begin_index: ExprPlan::Identifier("begin".to_owned()),
+            end_index: ExprPlan::Identifier("end".to_owned()),
+            values: None,
+        };
+        let expected = "SPLICE(list, begin, end)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Splice {
+            list_data: ExprPlan::Identifier("list".to_owned()),
+            begin_index: ExprPlan::Identifier("begin".to_owned()),
+            end_index: ExprPlan::Identifier("end".to_owned()),
+            values: Some(ExprPlan::Identifier("values".to_owned())),
+        };
+        let expected = "SPLICE(list, begin, end, values)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Dedup(ExprPlan::Identifier("list".to_owned()));
+        let expected = "DEDUP(list)";
+        test(&actual, expected);
     }
 }

--- a/core/src/plan/statement/expr/function.rs
+++ b/core/src/plan/statement/expr/function.rs
@@ -1,5 +1,5 @@
 use {
-    super::{ExprPlan, fmt_expr, fmt_expr_list},
+    super::{ExprPlan, fmt_expr},
     crate::{
         ast::{self, DataType, DateTimeField, TrimWhereField},
         plan::explain::{Explain, ExplainContext},
@@ -477,6 +477,29 @@ impl Explain for FunctionExprPlan {
     fn explain(&self, context: &mut ExplainContext) -> String {
         let mut output = String::new();
         match self {
+            Self::Abs(expr) => fmt_call("ABS", [expr], context, &mut output),
+            Self::AddMonth { expr, size } => {
+                fmt_call("ADD_MONTH", [expr, size], context, &mut output);
+            }
+            Self::Lower(expr) => fmt_call("LOWER", [expr], context, &mut output),
+            Self::Initcap(expr) => fmt_call("INITCAP", [expr], context, &mut output),
+            Self::Upper(expr) => fmt_call("UPPER", [expr], context, &mut output),
+            Self::Left { expr, size } => fmt_call("LEFT", [expr, size], context, &mut output),
+            Self::Right { expr, size } => fmt_call("RIGHT", [expr, size], context, &mut output),
+            Self::Asin(expr) => fmt_call("ASIN", [expr], context, &mut output),
+            Self::Acos(expr) => fmt_call("ACOS", [expr], context, &mut output),
+            Self::Atan(expr) => fmt_call("ATAN", [expr], context, &mut output),
+            Self::Lpad { expr, size, fill } => match fill {
+                Some(fill) => fmt_call("LPAD", [expr, size, fill], context, &mut output),
+                None => fmt_call("LPAD", [expr, size], context, &mut output),
+            },
+            Self::Rpad { expr, size, fill } => match fill {
+                Some(fill) => fmt_call("RPAD", [expr, size, fill], context, &mut output),
+                None => fmt_call("RPAD", [expr, size], context, &mut output),
+            },
+            Self::Replace { expr, old, new } => {
+                fmt_call("REPLACE", [expr, old, new], context, &mut output);
+            }
             Self::Cast { expr, data_type } => {
                 output.push_str("CAST(");
                 fmt_expr(expr, context, &mut output);
@@ -484,6 +507,43 @@ impl Explain for FunctionExprPlan {
                 output.push_str(&data_type.to_string());
                 output.push(')');
             }
+            Self::Ceil(expr) => fmt_call("CEIL", [expr], context, &mut output),
+            Self::Coalesce(exprs) => fmt_call("COALESCE", exprs, context, &mut output),
+            Self::Concat(exprs) => fmt_call("CONCAT", exprs, context, &mut output),
+            Self::ConcatWs { separator, exprs } => fmt_call(
+                "CONCAT_WS",
+                std::iter::once(separator).chain(exprs.iter()),
+                context,
+                &mut output,
+            ),
+            Self::Custom { name, exprs } => {
+                fmt_call(name, exprs, context, &mut output);
+            }
+            Self::IfNull { expr, then } => {
+                fmt_call("IF_NULL", [expr, then], context, &mut output);
+            }
+            Self::NullIf { expr1, expr2 } => {
+                fmt_call("NULL_IF", [expr1, expr2], context, &mut output);
+            }
+            Self::Rand(expr) => match expr {
+                Some(expr) => fmt_call("RAND", [expr], context, &mut output),
+                None => fmt_call("RAND", std::iter::empty(), context, &mut output),
+            },
+            Self::Round(expr) => fmt_call("ROUND", [expr], context, &mut output),
+            Self::Trunc(expr) => fmt_call("TRUNC", [expr], context, &mut output),
+            Self::Floor(expr) => fmt_call("FLOOR", [expr], context, &mut output),
+            Self::Trim {
+                expr,
+                filter_chars,
+                trim_where_field,
+            } => fmt_trim(
+                expr,
+                filter_chars.as_ref(),
+                trim_where_field.as_ref(),
+                context,
+                &mut output,
+            ),
+            Self::Exp(expr) => fmt_call("EXP", [expr], context, &mut output),
             Self::Extract { field, expr } => {
                 output.push_str("EXTRACT(");
                 output.push_str(&field.to_string());
@@ -491,26 +551,199 @@ impl Explain for FunctionExprPlan {
                 fmt_expr(expr, context, &mut output);
                 output.push(')');
             }
-            Self::Custom { name, exprs } => {
-                output.push_str(name);
-                output.push('(');
-                fmt_expr_list(exprs, context, &mut output);
-                output.push(')');
+            Self::Ln(expr) => fmt_call("LN", [expr], context, &mut output),
+            Self::Log { antilog, base } => {
+                fmt_call("LOG", [antilog, base], context, &mut output);
             }
-            _ => {
-                output.push_str(&self.to_string());
-                output.push('(');
-                for (index, expr) in self.as_exprs().enumerate() {
-                    if index > 0 {
-                        output.push_str(", ");
-                    }
-                    fmt_expr(expr, context, &mut output);
-                }
-                output.push(')');
+            Self::Log2(expr) => fmt_call("LOG2", [expr], context, &mut output),
+            Self::Log10(expr) => fmt_call("LOG10", [expr], context, &mut output),
+            Self::Div { dividend, divisor } => {
+                fmt_call("DIV", [dividend, divisor], context, &mut output);
             }
+            Self::Mod { dividend, divisor } => {
+                fmt_call("MOD", [dividend, divisor], context, &mut output);
+            }
+            Self::Gcd { left, right } => fmt_call("GCD", [left, right], context, &mut output),
+            Self::Lcm { left, right } => fmt_call("LCM", [left, right], context, &mut output),
+            Self::Sin(expr) => fmt_call("SIN", [expr], context, &mut output),
+            Self::Cos(expr) => fmt_call("COS", [expr], context, &mut output),
+            Self::Tan(expr) => fmt_call("TAN", [expr], context, &mut output),
+            Self::Sqrt(expr) => fmt_call("SQRT", [expr], context, &mut output),
+            Self::Power { expr, power } => {
+                fmt_call("POWER", [expr, power], context, &mut output);
+            }
+            Self::Radians(expr) => fmt_call("RADIANS", [expr], context, &mut output),
+            Self::Degrees(expr) => fmt_call("DEGREES", [expr], context, &mut output),
+            Self::Now() => fmt_call("NOW", std::iter::empty(), context, &mut output),
+            Self::CurrentDate() => {
+                fmt_call("CURRENT_DATE", std::iter::empty(), context, &mut output);
+            }
+            Self::CurrentTime() => {
+                fmt_call("CURRENT_TIME", std::iter::empty(), context, &mut output);
+            }
+            Self::CurrentTimestamp() => fmt_call(
+                "CURRENT_TIMESTAMP",
+                std::iter::empty(),
+                context,
+                &mut output,
+            ),
+            Self::Pi() => fmt_call("PI", std::iter::empty(), context, &mut output),
+            Self::LastDay(expr) => fmt_call("LAST_DAY", [expr], context, &mut output),
+            Self::Ltrim { expr, chars } => match chars {
+                Some(chars) => fmt_call("LTRIM", [expr, chars], context, &mut output),
+                None => fmt_call("LTRIM", [expr], context, &mut output),
+            },
+            Self::Rtrim { expr, chars } => match chars {
+                Some(chars) => fmt_call("RTRIM", [expr, chars], context, &mut output),
+                None => fmt_call("RTRIM", [expr], context, &mut output),
+            },
+            Self::Reverse(expr) => fmt_call("REVERSE", [expr], context, &mut output),
+            Self::Repeat { expr, num } => {
+                fmt_call("REPEAT", [expr, num], context, &mut output);
+            }
+            Self::Sign(expr) => fmt_call("SIGN", [expr], context, &mut output),
+            Self::Substr { expr, start, count } => match count {
+                Some(count) => fmt_call("SUBSTR", [expr, start, count], context, &mut output),
+                None => fmt_call("SUBSTR", [expr, start], context, &mut output),
+            },
+            Self::Unwrap { expr, selector } => {
+                fmt_call("UNWRAP", [expr, selector], context, &mut output);
+            }
+            Self::GenerateUuid() => {
+                fmt_call("GENERATE_UUID", std::iter::empty(), context, &mut output);
+            }
+            Self::Greatest(exprs) => fmt_call("GREATEST", exprs, context, &mut output),
+            Self::Format { expr, format } => {
+                fmt_call("FORMAT", [expr, format], context, &mut output);
+            }
+            Self::ToDate { expr, format } => {
+                fmt_call("TO_DATE", [expr, format], context, &mut output);
+            }
+            Self::ToTimestamp { expr, format } => {
+                fmt_call("TO_TIMESTAMP", [expr, format], context, &mut output);
+            }
+            Self::ToTime { expr, format } => {
+                fmt_call("TO_TIME", [expr, format], context, &mut output);
+            }
+            Self::Position {
+                from_expr,
+                sub_expr,
+            } => fmt_call("POSITION", [sub_expr, from_expr], context, &mut output),
+            Self::FindIdx {
+                from_expr,
+                sub_expr,
+                start,
+            } => match start {
+                Some(start) => fmt_call(
+                    "FIND_IDX",
+                    [from_expr, sub_expr, start],
+                    context,
+                    &mut output,
+                ),
+                None => fmt_call("FIND_IDX", [from_expr, sub_expr], context, &mut output),
+            },
+            Self::Ascii(expr) => fmt_call("ASCII", [expr], context, &mut output),
+            Self::Chr(expr) => fmt_call("CHR", [expr], context, &mut output),
+            Self::Md5(expr) => fmt_call("MD5", [expr], context, &mut output),
+            Self::Hex(expr) => fmt_call("HEX", [expr], context, &mut output),
+            Self::Append { expr, value } => {
+                fmt_call("APPEND", [expr, value], context, &mut output);
+            }
+            Self::Sort { expr, order } => match order {
+                Some(order) => fmt_call("SORT", [expr, order], context, &mut output),
+                None => fmt_call("SORT", [expr], context, &mut output),
+            },
+            Self::Slice {
+                expr,
+                start,
+                length,
+            } => fmt_call("SLICE", [expr, start, length], context, &mut output),
+            Self::Prepend { expr, value } => {
+                fmt_call("PREPEND", [expr, value], context, &mut output);
+            }
+            Self::Skip { expr, size } => {
+                fmt_call("SKIP", [expr, size], context, &mut output);
+            }
+            Self::Take { expr, size } => {
+                fmt_call("TAKE", [expr, size], context, &mut output);
+            }
+            Self::GetX(expr) => fmt_call("GET_X", [expr], context, &mut output),
+            Self::GetY(expr) => fmt_call("GET_Y", [expr], context, &mut output),
+            Self::Point { x, y } => fmt_call("POINT", [x, y], context, &mut output),
+            Self::CalcDistance {
+                geometry1,
+                geometry2,
+            } => fmt_call(
+                "CALC_DISTANCE",
+                [geometry1, geometry2],
+                context,
+                &mut output,
+            ),
+            Self::IsEmpty(expr) => fmt_call("IS_EMPTY", [expr], context, &mut output),
+            Self::Length(expr) => fmt_call("LENGTH", [expr], context, &mut output),
+            Self::Entries(expr) => fmt_call("ENTRIES", [expr], context, &mut output),
+            Self::Keys(expr) => fmt_call("KEYS", [expr], context, &mut output),
+            Self::Values(expr) => fmt_call("VALUES", [expr], context, &mut output),
+            Self::Splice {
+                list_data,
+                begin_index,
+                end_index,
+                values,
+            } => match values {
+                Some(values) => fmt_call(
+                    "SPLICE",
+                    [list_data, begin_index, end_index, values],
+                    context,
+                    &mut output,
+                ),
+                None => fmt_call(
+                    "SPLICE",
+                    [list_data, begin_index, end_index],
+                    context,
+                    &mut output,
+                ),
+            },
+            Self::Dedup(expr) => fmt_call("DEDUP", [expr], context, &mut output),
         }
         output
     }
+}
+
+fn fmt_call<'a>(
+    name: &str,
+    exprs: impl IntoIterator<Item = &'a ExprPlan>,
+    context: &mut ExplainContext,
+    output: &mut String,
+) {
+    output.push_str(name);
+    output.push('(');
+    for (index, expr) in exprs.into_iter().enumerate() {
+        if index > 0 {
+            output.push_str(", ");
+        }
+        fmt_expr(expr, context, output);
+    }
+    output.push(')');
+}
+
+fn fmt_trim(
+    expr: &ExprPlan,
+    filter_chars: Option<&ExprPlan>,
+    trim_where_field: Option<&TrimWhereField>,
+    context: &mut ExplainContext,
+    output: &mut String,
+) {
+    output.push_str("TRIM(");
+    if let Some(trim_where_field) = trim_where_field {
+        output.push_str(&trim_where_field.to_string());
+        output.push(' ');
+    }
+    if let Some(filter_chars) = filter_chars {
+        fmt_expr(filter_chars, context, output);
+        output.push_str(" FROM ");
+    }
+    fmt_expr(expr, context, output);
+    output.push(')');
 }
 
 #[cfg(test)]
@@ -711,9 +944,41 @@ mod tests {
         let actual = FunctionExprPlan::Trim {
             expr: ExprPlan::Identifier("value".to_owned()),
             filter_chars: Some(ExprPlan::Identifier("chars".to_owned())),
+            trim_where_field: None,
+        };
+        let expected = "TRIM(chars FROM value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: Some(ExprPlan::Identifier("chars".to_owned())),
+            trim_where_field: Some(TrimWhereField::Both),
+        };
+        let expected = "TRIM(BOTH chars FROM value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: Some(ExprPlan::Identifier("chars".to_owned())),
             trim_where_field: Some(TrimWhereField::Leading),
         };
-        let expected = "TRIM(value, chars)";
+        let expected = "TRIM(LEADING chars FROM value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: Some(ExprPlan::Identifier("chars".to_owned())),
+            trim_where_field: Some(TrimWhereField::Trailing),
+        };
+        let expected = "TRIM(TRAILING chars FROM value)";
+        test(&actual, expected);
+
+        let actual = FunctionExprPlan::Trim {
+            expr: ExprPlan::Identifier("value".to_owned()),
+            filter_chars: None,
+            trim_where_field: Some(TrimWhereField::Leading),
+        };
+        let expected = "TRIM(LEADING value)";
         test(&actual, expected);
 
         let actual = FunctionExprPlan::Exp(ExprPlan::Identifier("value".to_owned()));

--- a/core/src/plan/statement/projection.rs
+++ b/core/src/plan/statement/projection.rs
@@ -92,15 +92,23 @@ impl From<ast::SelectItem> for SelectItemPlan {
 mod tests {
     use {
         super::{ProjectionPlan, SelectItemPlan},
-        crate::plan::{
-            ExprPlan,
-            explain::{Explain, ExplainContext},
+        crate::{
+            ast::Literal,
+            plan::{
+                ExprPlan,
+                explain::{Explain, ExplainContext},
+            },
         },
     };
 
     #[test]
-    fn displays_projection_for_explain() {
-        let projection = ProjectionPlan::SelectItems(vec![
+    fn explain() {
+        let actual = ProjectionPlan::SchemalessMap;
+        let expected = "map";
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+
+        let actual = ProjectionPlan::SelectItems(vec![
+            SelectItemPlan::Wildcard,
             SelectItemPlan::QualifiedWildcard("Player".to_owned()),
             SelectItemPlan::Expr {
                 expr: ExprPlan::Identifier("team_id".to_owned()),
@@ -110,11 +118,20 @@ mod tests {
                 expr: ExprPlan::Identifier("name".to_owned()),
                 label: "player_name".to_owned(),
             },
+            SelectItemPlan::Expr {
+                expr: ExprPlan::CompoundIdentifier {
+                    alias: "Player".to_owned(),
+                    ident: "id".to_owned(),
+                },
+                label: "id".to_owned(),
+            },
+            SelectItemPlan::Expr {
+                expr: ExprPlan::Literal(Literal::Number(1.into())),
+                label: String::new(),
+            },
         ]);
+        let expected = "*, Player.*, team_id, name AS player_name, Player.id, 1";
 
-        assert_eq!(
-            projection.explain(&mut ExplainContext::default()),
-            "Player.*, team_id, name AS player_name"
-        );
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
     }
 }

--- a/core/src/plan/statement/projection.rs
+++ b/core/src/plan/statement/projection.rs
@@ -1,6 +1,9 @@
 use {
     super::ExprPlan,
-    crate::ast,
+    crate::{
+        ast,
+        plan::explain::{Explain, ExplainContext},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -15,6 +18,51 @@ pub enum SelectItemPlan {
     Expr { expr: ExprPlan, label: String },
     QualifiedWildcard(String),
     Wildcard,
+}
+
+impl Explain for ProjectionPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        match self {
+            ProjectionPlan::SchemalessMap => output.push_str("map"),
+            ProjectionPlan::SelectItems(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    if index > 0 {
+                        output.push_str(", ");
+                    }
+                    output.push_str(&item.explain(context));
+                }
+            }
+        }
+        output
+    }
+}
+
+impl Explain for SelectItemPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        match self {
+            Self::Wildcard => "*".to_owned(),
+            Self::QualifiedWildcard(alias) => format!("{alias}.*"),
+            Self::Expr { expr, label } => {
+                let mut output = expr.explain(context);
+                let natural_label = match expr {
+                    ExprPlan::Identifier(ident) | ExprPlan::CompoundIdentifier { ident, .. } => {
+                        Some(ident.as_str())
+                    }
+                    _ => None,
+                };
+                if !label.is_empty() && natural_label != Some(label.as_str()) {
+                    output.push_str(" AS ");
+                    output.push_str(label);
+                }
+                output
+            }
+        }
+    }
 }
 
 impl From<ast::Projection> for ProjectionPlan {
@@ -37,5 +85,36 @@ impl From<ast::SelectItem> for SelectItemPlan {
             ast::SelectItem::QualifiedWildcard(table_alias) => Self::QualifiedWildcard(table_alias),
             ast::SelectItem::Wildcard => Self::Wildcard,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{ProjectionPlan, SelectItemPlan},
+        crate::plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext},
+        },
+    };
+
+    #[test]
+    fn displays_projection_for_explain() {
+        let projection = ProjectionPlan::SelectItems(vec![
+            SelectItemPlan::QualifiedWildcard("Player".to_owned()),
+            SelectItemPlan::Expr {
+                expr: ExprPlan::Identifier("team_id".to_owned()),
+                label: "team_id".to_owned(),
+            },
+            SelectItemPlan::Expr {
+                expr: ExprPlan::Identifier("name".to_owned()),
+                label: "player_name".to_owned(),
+            },
+        ]);
+
+        assert_eq!(
+            projection.explain(&mut ExplainContext::default()),
+            "Player.*, team_id, name AS player_name"
+        );
     }
 }

--- a/core/src/plan/statement/projection.rs
+++ b/core/src/plan/statement/projection.rs
@@ -101,37 +101,60 @@ mod tests {
         },
     };
 
+    fn test(actual: &impl Explain<Output = String>, expected: &str) {
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+    }
+
     #[test]
     fn explain() {
-        let actual = ProjectionPlan::SchemalessMap;
-        let expected = "map";
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
-
         let actual = ProjectionPlan::SelectItems(vec![
             SelectItemPlan::Wildcard,
             SelectItemPlan::QualifiedWildcard("Player".to_owned()),
-            SelectItemPlan::Expr {
-                expr: ExprPlan::Identifier("team_id".to_owned()),
-                label: "team_id".to_owned(),
-            },
-            SelectItemPlan::Expr {
-                expr: ExprPlan::Identifier("name".to_owned()),
-                label: "player_name".to_owned(),
-            },
-            SelectItemPlan::Expr {
-                expr: ExprPlan::CompoundIdentifier {
-                    alias: "Player".to_owned(),
-                    ident: "id".to_owned(),
-                },
-                label: "id".to_owned(),
-            },
-            SelectItemPlan::Expr {
-                expr: ExprPlan::Literal(Literal::Number(1.into())),
-                label: String::new(),
-            },
         ]);
-        let expected = "*, Player.*, team_id, name AS player_name, Player.id, 1";
+        let expected = "*, Player.*";
+        test(&actual, expected);
 
-        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+        let actual = ProjectionPlan::SchemalessMap;
+        let expected = "map";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::Expr {
+            expr: ExprPlan::Identifier("team_id".to_owned()),
+            label: "team_id".to_owned(),
+        };
+        let expected = "team_id";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::Expr {
+            expr: ExprPlan::Identifier("name".to_owned()),
+            label: "player_name".to_owned(),
+        };
+        let expected = "name AS player_name";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::Expr {
+            expr: ExprPlan::CompoundIdentifier {
+                alias: "Player".to_owned(),
+                ident: "id".to_owned(),
+            },
+            label: "id".to_owned(),
+        };
+        let expected = "Player.id";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::Expr {
+            expr: ExprPlan::Literal(Literal::Number(1.into())),
+            label: String::new(),
+        };
+        let expected = "1";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::QualifiedWildcard("Player".to_owned());
+        let expected = "Player.*";
+        test(&actual, expected);
+
+        let actual = SelectItemPlan::Wildcard;
+        let expected = "*";
+        test(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query.rs
+++ b/core/src/plan/statement/query.rs
@@ -34,7 +34,10 @@ pub use {
 };
 
 use {
-    crate::ast,
+    crate::{
+        ast,
+        plan::explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -259,6 +262,22 @@ fn limit(input: LimitInputPlan, expr: Option<ast::Expr>) -> QueryPlan {
             LimitInputPlan::Distinct(distinct) => QueryPlan::Distinct(distinct),
             LimitInputPlan::Offset(offset) => QueryPlan::Offset(offset),
         },
+    }
+}
+
+impl Explain for QueryPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Project(project) => project.explain(context),
+            Self::Values(values) => values.explain(context),
+            Self::SelectOrderBy(order_by) => order_by.explain(context),
+            Self::ValuesOrderBy(order_by) => order_by.explain(context),
+            Self::Distinct(distinct) => distinct.explain(context),
+            Self::Offset(offset) => offset.explain(context),
+            Self::Limit(limit) => limit.explain(context),
+        }
     }
 }
 

--- a/core/src/plan/statement/query.rs
+++ b/core/src/plan/statement/query.rs
@@ -298,7 +298,7 @@ mod tests {
                 JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan,
                 LeftOuterJoinPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, ProjectionPlan,
                 SelectItemPlan, SelectOrderByPlan, SourcePlan, StatementPlan, TableAccessPlan,
-                TableSourcePlan, ValuesOrderByPlan,
+                TableSourcePlan, ValuesOrderByPlan, ValuesPlan, explain::test_explain,
             },
             translate::translate,
         },
@@ -726,5 +726,114 @@ mod tests {
                 ..
             }))
         ));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = QueryPlan::Project(ProjectPlan {
+            input: ProjectInputPlan::Source(relation_plan()),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        });
+        let expected = r"
+• project
+│ columns: *
+│
+└── • scan Item
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Literal(Literal::Number(
+            1.into(),
+        ))]]));
+        let expected = r"
+• values
+  size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::SelectOrderBy(SelectOrderByPlan {
+            input: ProjectPlan {
+                input: ProjectInputPlan::Source(relation_plan()),
+                projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+            },
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Identifier("id".to_owned()),
+                asc: Some(false),
+            }],
+        });
+        let expected = r"
+• sort
+│ order: id DESC
+│
+└── • project
+    │ columns: *
+    │
+    └── • scan Item
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::ValuesOrderBy(ValuesOrderByPlan {
+            input: ValuesPlan(vec![vec![ExprPlan::Literal(Literal::Number(1.into()))]]),
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Literal(Literal::Number(1.into())),
+                asc: Some(false),
+            }],
+        });
+        let expected = r"
+• sort
+│ order: 1 DESC
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::Distinct(DistinctPlan {
+            input: DistinctInputPlan::Project(ProjectPlan {
+                input: ProjectInputPlan::Source(relation_plan()),
+                projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+            }),
+        });
+        let expected = r"
+• distinct
+└── • project
+    │ columns: *
+    │
+    └── • scan Item
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::Offset(OffsetPlan {
+            input: OffsetInputPlan::Values(ValuesPlan(vec![vec![ExprPlan::Literal(
+                Literal::Number(1.into()),
+            )]])),
+            count: ExprPlan::Literal(Literal::Number(2.into())),
+        });
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = QueryPlan::Limit(LimitPlan {
+            input: LimitInputPlan::Values(ValuesPlan(vec![vec![ExprPlan::Literal(
+                Literal::Number(1.into()),
+            )]])),
+            count: ExprPlan::Literal(Literal::Number(3.into())),
+        });
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/aggregation.rs
+++ b/core/src/plan/statement/query/aggregation.rs
@@ -1,6 +1,9 @@
 use {
     super::FilterPlan,
-    crate::plan::{AggregateExprPlan, ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan},
+    crate::plan::{
+        AggregateExprPlan, ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -37,6 +40,37 @@ pub struct AggregationPlan {
     pub input: AggregationInputPlan,
     pub group_by: Vec<ExprPlan>,
     pub aggregate_slots: Vec<AggregateExprPlan>,
+}
+
+impl Explain for AggregationPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("aggregate")
+            .with_optional_property(
+                "group by",
+                (!self.group_by.is_empty()).then(|| self.group_by.as_slice().explain(context)),
+            )
+            .with_optional_property(
+                "aggregates",
+                (!self.aggregate_slots.is_empty())
+                    .then(|| self.aggregate_slots.as_slice().explain(context)),
+            )
+            .with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for AggregationInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Source(source) => source.explain(context),
+            Self::InnerJoin(join) => join.explain(context),
+            Self::LeftOuterJoin(join) => join.explain(context),
+            Self::Filter(filter) => filter.explain(context),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/aggregation.rs
+++ b/core/src/plan/statement/query/aggregation.rs
@@ -80,9 +80,11 @@ mod tests {
         crate::{
             data::Value,
             plan::{
-                ExprPlan, FilterInputPlan, FilterPlan, InnerJoinInputPlan, InnerJoinPlan,
+                AggregateExprPlan, AggregateFunctionPlan, CountArgExprPlan, ExprPlan,
+                FilterInputPlan, FilterPlan, InnerJoinInputPlan, InnerJoinPlan,
                 LeftOuterJoinInputPlan, LeftOuterJoinPlan, NestedLoopJoinInputPlan,
                 NestedLoopJoinPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+                explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -166,5 +168,87 @@ mod tests {
             filtered.input.joined_sources(),
             expected.iter().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn explain() {
+        let actual = AggregationPlan {
+            input: AggregationInputPlan::Source(table("Player")),
+            group_by: vec![ExprPlan::Identifier("team_id".to_owned())],
+            aggregate_slots: vec![AggregateExprPlan {
+                func: AggregateFunctionPlan::Count(CountArgExprPlan::Wildcard),
+                distinct: false,
+                slot: Some(0),
+            }],
+        };
+        let expected = r"
+• aggregate
+│ group by: team_id
+│ aggregates: COUNT(*)
+│
+└── • scan Player
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = AggregationPlan {
+            input: AggregationInputPlan::InnerJoin(Box::new(InnerJoinPlan {
+                input: InnerJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            group_by: Vec::new(),
+            aggregate_slots: Vec::new(),
+        };
+        let expected = r"
+• aggregate
+└── • nested-loop join (inner)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = AggregationPlan {
+            input: AggregationInputPlan::LeftOuterJoin(Box::new(LeftOuterJoinPlan {
+                input: LeftOuterJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            group_by: Vec::new(),
+            aggregate_slots: Vec::new(),
+        };
+        let expected = r"
+• aggregate
+└── • nested-loop join (left outer)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = AggregationPlan {
+            input: AggregationInputPlan::Filter(FilterPlan {
+                input: FilterInputPlan::Source(table("Player")),
+                expr: ExprPlan::Identifier("active".to_owned()),
+            }),
+            group_by: Vec::new(),
+            aggregate_slots: Vec::new(),
+        };
+        let expected = r"
+• aggregate
+└── • filter
+    │ expression: active
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/distinct.rs
+++ b/core/src/plan/statement/query/distinct.rs
@@ -1,5 +1,6 @@
 use {
     super::{ProjectPlan, SelectOrderByPlan},
+    crate::plan::explain::{Explain, ExplainContext, ExplainNode},
     serde::{Deserialize, Serialize},
 };
 
@@ -23,13 +24,32 @@ pub enum DistinctInputPlan {
     SelectOrderBy(SelectOrderByPlan),
 }
 
+impl Explain for DistinctPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("distinct").with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for DistinctInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Project(project) => project.explain(context),
+            Self::SelectOrderBy(order_by) => order_by.explain(context),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::{DistinctInputPlan, DistinctPlan},
         crate::plan::{
-            ProjectInputPlan, ProjectPlan, ProjectionPlan, SelectOrderByPlan, SourcePlan,
-            TableAccessPlan, TableSourcePlan,
+            ProjectInputPlan, ProjectPlan, ProjectionPlan, SelectItemPlan, SelectOrderByPlan,
+            SourcePlan, TableAccessPlan, TableSourcePlan,
         },
     };
 
@@ -40,7 +60,7 @@ mod tests {
                 alias: None,
                 access: TableAccessPlan::FullScan,
             })),
-            projection: ProjectionPlan::SelectItems(Vec::new()),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
         }
     }
 

--- a/core/src/plan/statement/query/distinct.rs
+++ b/core/src/plan/statement/query/distinct.rs
@@ -48,8 +48,9 @@ mod tests {
     use {
         super::{DistinctInputPlan, DistinctPlan},
         crate::plan::{
-            ProjectInputPlan, ProjectPlan, ProjectionPlan, SelectItemPlan, SelectOrderByPlan,
-            SourcePlan, TableAccessPlan, TableSourcePlan,
+            ExprPlan, OrderByExprPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan,
+            SelectItemPlan, SelectOrderByPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+            explain::test_explain,
         },
     };
 
@@ -81,5 +82,43 @@ mod tests {
             order_by.input,
             DistinctInputPlan::SelectOrderBy(_)
         ));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = DistinctPlan {
+            input: DistinctInputPlan::Project(project_plan()),
+        };
+        let expected = r"
+• distinct
+└── • project
+    │ columns: *
+    │
+    └── • scan Item
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = DistinctPlan {
+            input: DistinctInputPlan::SelectOrderBy(SelectOrderByPlan {
+                input: project_plan(),
+                exprs: vec![OrderByExprPlan {
+                    expr: ExprPlan::Identifier("id".to_owned()),
+                    asc: Some(false),
+                }],
+            }),
+        };
+        let expected = r"
+• distinct
+└── • sort
+    │ order: id DESC
+    │
+    └── • project
+        │ columns: *
+        │
+        └── • scan Item
+              access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/filter.rs
+++ b/core/src/plan/statement/query/filter.rs
@@ -1,5 +1,8 @@
 use {
-    crate::plan::{ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan},
+    crate::plan::{
+        ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -40,6 +43,28 @@ impl FilterInputPlan {
 pub struct FilterPlan {
     pub input: FilterInputPlan,
     pub expr: ExprPlan,
+}
+
+impl Explain for FilterPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("filter")
+            .with_property("expression", self.expr.explain(context))
+            .with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for FilterInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Source(source) => source.explain(context),
+            Self::InnerJoin(join) => join.explain(context),
+            Self::LeftOuterJoin(join) => join.explain(context),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/filter.rs
+++ b/core/src/plan/statement/query/filter.rs
@@ -76,7 +76,7 @@ mod tests {
             plan::{
                 ExprPlan, InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan,
                 LeftOuterJoinPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan,
-                TableAccessPlan, TableSourcePlan,
+                TableAccessPlan, TableSourcePlan, explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -150,5 +150,65 @@ mod tests {
         );
         *left_outer.input.base_source_mut() = table("left-outer");
         assert_eq!(left_outer.input.base_source(), &table("left-outer"));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = FilterPlan {
+            input: FilterInputPlan::Source(table("Player")),
+            expr: ExprPlan::Identifier("active".to_owned()),
+        };
+        let expected = r"
+• filter
+│ expression: active
+│
+└── • scan Player
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = FilterPlan {
+            input: FilterInputPlan::InnerJoin(Box::new(InnerJoinPlan {
+                input: InnerJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            expr: ExprPlan::Identifier("active".to_owned()),
+        };
+        let expected = r"
+• filter
+│ expression: active
+│
+└── • nested-loop join (inner)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = FilterPlan {
+            input: FilterInputPlan::LeftOuterJoin(Box::new(LeftOuterJoinPlan {
+                input: LeftOuterJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            expr: ExprPlan::Identifier("active".to_owned()),
+        };
+        let expected = r"
+• filter
+│ expression: active
+│
+└── • nested-loop join (left outer)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/having.rs
+++ b/core/src/plan/statement/query/having.rs
@@ -31,7 +31,7 @@ mod tests {
             data::Value,
             plan::{
                 AggregationInputPlan, AggregationPlan, ExprPlan, SourcePlan, TableAccessPlan,
-                TableSourcePlan,
+                TableSourcePlan, explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -56,5 +56,32 @@ mod tests {
 
         assert_eq!(having.input, input);
         assert_eq!(having.expr, expr);
+    }
+
+    #[test]
+    fn explain() {
+        let actual = HavingPlan {
+            input: AggregationPlan {
+                input: AggregationInputPlan::Source(SourcePlan::Table(TableSourcePlan {
+                    name: "Item".to_owned(),
+                    alias: None,
+                    access: TableAccessPlan::FullScan,
+                })),
+                group_by: vec![ExprPlan::Identifier("category".to_owned())],
+                aggregate_slots: Vec::new(),
+            },
+            expr: ExprPlan::Identifier("total".to_owned()),
+        };
+        let expected = r"
+• having
+│ expression: total
+│
+└── • aggregate
+    │ group by: category
+    │
+    └── • scan Item
+          access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/having.rs
+++ b/core/src/plan/statement/query/having.rs
@@ -1,6 +1,9 @@
 use {
     super::AggregationPlan,
-    crate::plan::ExprPlan,
+    crate::plan::{
+        ExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,6 +11,16 @@ use {
 pub struct HavingPlan {
     pub input: AggregationPlan,
     pub expr: ExprPlan,
+}
+
+impl Explain for HavingPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("having")
+            .with_property("expression", self.expr.explain(context))
+            .with_child(self.input.explain(context))
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/join/condition.rs
+++ b/core/src/plan/statement/query/join/condition.rs
@@ -61,10 +61,9 @@ mod tests {
         crate::{
             data::Value,
             plan::{
-                ExprPlan, HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan,
-                NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan, TableAccessPlan,
-                TableSourcePlan,
-                explain::{Explain, ExplainContext, ExplainNode},
+                ExprPlan, HashJoinInputPlan, HashJoinPlan, NestedLoopJoinInputPlan,
+                NestedLoopJoinPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+                explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -127,23 +126,38 @@ mod tests {
     }
 
     #[test]
-    fn explains_join_condition_on_its_algorithm_node() {
-        let plan = InnerJoinPlan {
-            input: InnerJoinInputPlan::Condition(JoinConditionPlan {
-                input: JoinConditionInputPlan::NestedLoop(nested_loop()),
-                expr: ExprPlan::Value(Value::Bool(true)),
-            }),
+    fn explain() {
+        let actual = JoinConditionPlan {
+            input: JoinConditionInputPlan::NestedLoop(nested_loop()),
+            expr: ExprPlan::Value(Value::Bool(true)),
         };
+        let expected = r"
+• nested-loop join
+│ condition: TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
 
-        assert_eq!(
-            plan.explain(&mut ExplainContext::default()),
-            ExplainNode::new("nested-loop join")
-                .with_annotation("inner")
-                .with_property("condition", "TRUE")
-                .with_children([
-                    ExplainNode::new("scan A").with_property("access", "full scan"),
-                    ExplainNode::new("scan B").with_property("access", "full scan"),
-                ])
-        );
+        let actual = JoinConditionPlan {
+            input: JoinConditionInputPlan::Hash(hash()),
+            expr: ExprPlan::Value(Value::Bool(true)),
+        };
+        let expected = r"
+• hash join
+│ equality: TRUE = TRUE
+│ condition: TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/join/condition.rs
+++ b/core/src/plan/statement/query/join/condition.rs
@@ -1,6 +1,9 @@
 use {
     super::{HashJoinPlan, NestedLoopJoinPlan},
-    crate::plan::{ExprPlan, SourcePlan},
+    crate::plan::{
+        ExprPlan, SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -39,6 +42,18 @@ impl JoinConditionPlan {
     }
 }
 
+impl Explain for JoinConditionPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        let node = match &self.input {
+            JoinConditionInputPlan::NestedLoop(join) => join.explain(context),
+            JoinConditionInputPlan::Hash(join) => join.explain(context),
+        };
+        node.with_property("condition", self.expr.explain(context))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -46,8 +61,10 @@ mod tests {
         crate::{
             data::Value,
             plan::{
-                ExprPlan, HashJoinInputPlan, HashJoinPlan, NestedLoopJoinInputPlan,
-                NestedLoopJoinPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+                ExprPlan, HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan,
+                NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan, TableAccessPlan,
+                TableSourcePlan,
+                explain::{Explain, ExplainContext, ExplainNode},
             },
         },
         pretty_assertions::assert_eq,
@@ -107,5 +124,26 @@ mod tests {
         assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
         *actual.base_source_mut() = table("hash");
         assert_eq!(actual.base_source(), &table("hash"));
+    }
+
+    #[test]
+    fn explains_join_condition_on_its_algorithm_node() {
+        let plan = InnerJoinPlan {
+            input: InnerJoinInputPlan::Condition(JoinConditionPlan {
+                input: JoinConditionInputPlan::NestedLoop(nested_loop()),
+                expr: ExprPlan::Value(Value::Bool(true)),
+            }),
+        };
+
+        assert_eq!(
+            plan.explain(&mut ExplainContext::default()),
+            ExplainNode::new("nested-loop join")
+                .with_annotation("inner")
+                .with_property("condition", "TRUE")
+                .with_children([
+                    ExplainNode::new("scan A").with_property("access", "full scan"),
+                    ExplainNode::new("scan B").with_property("access", "full scan"),
+                ])
+        );
     }
 }

--- a/core/src/plan/statement/query/join/hash.rs
+++ b/core/src/plan/statement/query/join/hash.rs
@@ -1,6 +1,9 @@
 use {
     super::{InnerJoinPlan, LeftOuterJoinPlan},
-    crate::plan::{ExprPlan, SourcePlan},
+    crate::plan::{
+        ExprPlan, SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -49,6 +52,36 @@ impl HashJoinPlan {
     }
 }
 
+impl Explain for HashJoinPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        let equality = format!(
+            "{} = {}",
+            self.input_key.explain(context),
+            self.right_key.explain(context)
+        );
+        let right_filter = self.right_filter.as_ref().map(|expr| expr.explain(context));
+
+        ExplainNode::new("hash join")
+            .with_property("equality", equality)
+            .with_optional_property("right filter", right_filter)
+            .with_children([self.input.explain(context), self.right.explain(context)])
+    }
+}
+
+impl Explain for HashJoinInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Source(source) => source.explain(context),
+            Self::InnerJoin(join) => join.explain(context),
+            Self::LeftOuterJoin(join) => join.explain(context),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -59,6 +92,7 @@ mod tests {
                 ExprPlan, InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan,
                 LeftOuterJoinPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan,
                 TableAccessPlan, TableSourcePlan,
+                explain::{Explain, ExplainContext, ExplainNode},
             },
         },
         pretty_assertions::assert_eq,
@@ -140,5 +174,36 @@ mod tests {
         assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
         *actual.base_source_mut() = table("left-outer");
         assert_eq!(actual.base_source(), &table("left-outer"));
+    }
+
+    #[test]
+    fn explains_hash_join_node() {
+        let plan = InnerJoinPlan {
+            input: InnerJoinInputPlan::Hash(HashJoinPlan {
+                input: HashJoinInputPlan::Source(table("A")),
+                right: table("B"),
+                input_key: ExprPlan::CompoundIdentifier {
+                    alias: "A".to_owned(),
+                    ident: "id".to_owned(),
+                },
+                right_key: ExprPlan::CompoundIdentifier {
+                    alias: "B".to_owned(),
+                    ident: "id".to_owned(),
+                },
+                right_filter: Some(ExprPlan::Value(Value::Bool(true))),
+            }),
+        };
+
+        assert_eq!(
+            plan.explain(&mut ExplainContext::default()),
+            ExplainNode::new("hash join")
+                .with_annotation("inner")
+                .with_property("equality", "A.id = B.id")
+                .with_property("right filter", "TRUE")
+                .with_children([
+                    ExplainNode::new("scan A").with_property("access", "full scan"),
+                    ExplainNode::new("scan B").with_property("access", "full scan"),
+                ])
+        );
     }
 }

--- a/core/src/plan/statement/query/join/hash.rs
+++ b/core/src/plan/statement/query/join/hash.rs
@@ -91,8 +91,7 @@ mod tests {
             plan::{
                 ExprPlan, InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan,
                 LeftOuterJoinPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan,
-                TableAccessPlan, TableSourcePlan,
-                explain::{Explain, ExplainContext, ExplainNode},
+                TableAccessPlan, TableSourcePlan, explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -177,33 +176,77 @@ mod tests {
     }
 
     #[test]
-    fn explains_hash_join_node() {
-        let plan = InnerJoinPlan {
-            input: InnerJoinInputPlan::Hash(HashJoinPlan {
-                input: HashJoinInputPlan::Source(table("A")),
-                right: table("B"),
-                input_key: ExprPlan::CompoundIdentifier {
-                    alias: "A".to_owned(),
-                    ident: "id".to_owned(),
-                },
-                right_key: ExprPlan::CompoundIdentifier {
-                    alias: "B".to_owned(),
-                    ident: "id".to_owned(),
-                },
-                right_filter: Some(ExprPlan::Value(Value::Bool(true))),
-            }),
+    fn explain() {
+        let actual = HashJoinPlan {
+            input: HashJoinInputPlan::Source(table("A")),
+            right: table("B"),
+            input_key: ExprPlan::CompoundIdentifier {
+                alias: "A".to_owned(),
+                ident: "id".to_owned(),
+            },
+            right_key: ExprPlan::CompoundIdentifier {
+                alias: "B".to_owned(),
+                ident: "id".to_owned(),
+            },
+            right_filter: Some(ExprPlan::Value(Value::Bool(true))),
         };
+        let expected = r"
+• hash join
+│ equality: A.id = B.id
+│ right filter: TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
 
-        assert_eq!(
-            plan.explain(&mut ExplainContext::default()),
-            ExplainNode::new("hash join")
-                .with_annotation("inner")
-                .with_property("equality", "A.id = B.id")
-                .with_property("right filter", "TRUE")
-                .with_children([
-                    ExplainNode::new("scan A").with_property("access", "full scan"),
-                    ExplainNode::new("scan B").with_property("access", "full scan"),
-                ])
-        );
+        let actual = HashJoinPlan {
+            input: HashJoinInputPlan::InnerJoin(Box::new(inner_join())),
+            right: table("C"),
+            input_key: expr(),
+            right_key: expr(),
+            right_filter: None,
+        };
+        let expected = r"
+• hash join
+│ equality: TRUE = TRUE
+│
+├── • nested-loop join (inner)
+│   ├── • scan A
+│   │     access: full scan
+│   │
+│   └── • scan B
+│         access: full scan
+│
+└── • scan C
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = HashJoinPlan {
+            input: HashJoinInputPlan::LeftOuterJoin(Box::new(left_outer_join())),
+            right: table("C"),
+            input_key: expr(),
+            right_key: expr(),
+            right_filter: None,
+        };
+        let expected = r"
+• hash join
+│ equality: TRUE = TRUE
+│
+├── • nested-loop join (left outer)
+│   ├── • scan A
+│   │     access: full scan
+│   │
+│   └── • scan B
+│         access: full scan
+│
+└── • scan C
+      access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/join/inner.rs
+++ b/core/src/plan/statement/query/join/inner.rs
@@ -74,7 +74,7 @@ mod tests {
             plan::{
                 ExprPlan, HashJoinInputPlan, HashJoinPlan, JoinConditionInputPlan,
                 JoinConditionPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan,
-                TableAccessPlan, TableSourcePlan,
+                TableAccessPlan, TableSourcePlan, explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -150,5 +150,51 @@ mod tests {
         assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
         *actual.base_source_mut() = table("condition");
         assert_eq!(actual.base_source(), &table("condition"));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = InnerJoinPlan {
+            input: InnerJoinInputPlan::NestedLoop(nested_loop()),
+        };
+        let expected = r"
+• nested-loop join (inner)
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = InnerJoinPlan {
+            input: InnerJoinInputPlan::Hash(hash()),
+        };
+        let expected = r"
+• hash join (inner)
+│ equality: TRUE = TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = InnerJoinPlan {
+            input: InnerJoinInputPlan::Condition(condition()),
+        };
+        let expected = r"
+• nested-loop join (inner)
+│ condition: TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/join/inner.rs
+++ b/core/src/plan/statement/query/join/inner.rs
@@ -1,6 +1,9 @@
 use {
     super::{HashJoinPlan, JoinConditionPlan, NestedLoopJoinPlan},
-    crate::plan::SourcePlan,
+    crate::plan::{
+        SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -38,6 +41,26 @@ impl InnerJoinPlan {
             InnerJoinInputPlan::NestedLoop(join) => join.joined_sources(),
             InnerJoinInputPlan::Hash(join) => join.joined_sources(),
             InnerJoinInputPlan::Condition(condition) => condition.joined_sources(),
+        }
+    }
+}
+
+impl Explain for InnerJoinPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        self.input.explain(context).with_annotation("inner")
+    }
+}
+
+impl Explain for InnerJoinInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::NestedLoop(join) => join.explain(context),
+            Self::Hash(join) => join.explain(context),
+            Self::Condition(condition) => condition.explain(context),
         }
     }
 }

--- a/core/src/plan/statement/query/join/left_outer.rs
+++ b/core/src/plan/statement/query/join/left_outer.rs
@@ -1,6 +1,9 @@
 use {
     super::{HashJoinPlan, JoinConditionPlan, NestedLoopJoinPlan},
-    crate::plan::SourcePlan,
+    crate::plan::{
+        SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -38,6 +41,26 @@ impl LeftOuterJoinPlan {
             LeftOuterJoinInputPlan::NestedLoop(join) => join.joined_sources(),
             LeftOuterJoinInputPlan::Hash(join) => join.joined_sources(),
             LeftOuterJoinInputPlan::Condition(condition) => condition.joined_sources(),
+        }
+    }
+}
+
+impl Explain for LeftOuterJoinPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        self.input.explain(context).with_annotation("left outer")
+    }
+}
+
+impl Explain for LeftOuterJoinInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::NestedLoop(join) => join.explain(context),
+            Self::Hash(join) => join.explain(context),
+            Self::Condition(condition) => condition.explain(context),
         }
     }
 }

--- a/core/src/plan/statement/query/join/left_outer.rs
+++ b/core/src/plan/statement/query/join/left_outer.rs
@@ -74,7 +74,7 @@ mod tests {
             plan::{
                 ExprPlan, HashJoinInputPlan, HashJoinPlan, JoinConditionInputPlan,
                 JoinConditionPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, SourcePlan,
-                TableAccessPlan, TableSourcePlan,
+                TableAccessPlan, TableSourcePlan, explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -150,5 +150,51 @@ mod tests {
         assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
         *actual.base_source_mut() = table("condition");
         assert_eq!(actual.base_source(), &table("condition"));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = LeftOuterJoinPlan {
+            input: LeftOuterJoinInputPlan::NestedLoop(nested_loop()),
+        };
+        let expected = r"
+• nested-loop join (left outer)
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = LeftOuterJoinPlan {
+            input: LeftOuterJoinInputPlan::Hash(hash()),
+        };
+        let expected = r"
+• hash join (left outer)
+│ equality: TRUE = TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = LeftOuterJoinPlan {
+            input: LeftOuterJoinInputPlan::Condition(condition()),
+        };
+        let expected = r"
+• nested-loop join (left outer)
+│ condition: TRUE
+│
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/join/nested_loop.rs
+++ b/core/src/plan/statement/query/join/nested_loop.rs
@@ -1,6 +1,9 @@
 use {
     super::{InnerJoinPlan, LeftOuterJoinPlan},
-    crate::plan::SourcePlan,
+    crate::plan::{
+        SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -46,6 +49,27 @@ impl NestedLoopJoinPlan {
     }
 }
 
+impl Explain for NestedLoopJoinPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("nested-loop join")
+            .with_children([self.input.explain(context), self.right.explain(context)])
+    }
+}
+
+impl Explain for NestedLoopJoinInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Source(source) => source.explain(context),
+            Self::InnerJoin(join) => join.explain(context),
+            Self::LeftOuterJoin(join) => join.explain(context),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -53,6 +77,7 @@ mod tests {
         crate::plan::{
             InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             SourcePlan, TableAccessPlan, TableSourcePlan,
+            explain::{Explain, ExplainContext, ExplainNode},
         },
         pretty_assertions::assert_eq,
     };
@@ -120,5 +145,25 @@ mod tests {
         assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
         *actual.base_source_mut() = table("left-outer");
         assert_eq!(actual.base_source(), &table("left-outer"));
+    }
+
+    #[test]
+    fn explains_nested_loop_join_node() {
+        let plan = InnerJoinPlan {
+            input: InnerJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                input: NestedLoopJoinInputPlan::Source(table("A")),
+                right: table("B"),
+            }),
+        };
+
+        assert_eq!(
+            plan.explain(&mut ExplainContext::default()),
+            ExplainNode::new("nested-loop join")
+                .with_annotation("inner")
+                .with_children([
+                    ExplainNode::new("scan A").with_property("access", "full scan"),
+                    ExplainNode::new("scan B").with_property("access", "full scan"),
+                ])
+        );
     }
 }

--- a/core/src/plan/statement/query/join/nested_loop.rs
+++ b/core/src/plan/statement/query/join/nested_loop.rs
@@ -76,8 +76,7 @@ mod tests {
         super::{NestedLoopJoinInputPlan, NestedLoopJoinPlan},
         crate::plan::{
             InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
-            SourcePlan, TableAccessPlan, TableSourcePlan,
-            explain::{Explain, ExplainContext, ExplainNode},
+            SourcePlan, TableAccessPlan, TableSourcePlan, explain::test_explain,
         },
         pretty_assertions::assert_eq,
     };
@@ -148,22 +147,55 @@ mod tests {
     }
 
     #[test]
-    fn explains_nested_loop_join_node() {
-        let plan = InnerJoinPlan {
-            input: InnerJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
-                input: NestedLoopJoinInputPlan::Source(table("A")),
-                right: table("B"),
-            }),
+    fn explain() {
+        let actual = NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::Source(table("A")),
+            right: table("B"),
         };
+        let expected = r"
+• nested-loop join
+├── • scan A
+│     access: full scan
+│
+└── • scan B
+      access: full scan
+";
+        test_explain(&actual, expected);
 
-        assert_eq!(
-            plan.explain(&mut ExplainContext::default()),
-            ExplainNode::new("nested-loop join")
-                .with_annotation("inner")
-                .with_children([
-                    ExplainNode::new("scan A").with_property("access", "full scan"),
-                    ExplainNode::new("scan B").with_property("access", "full scan"),
-                ])
-        );
+        let actual = NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::InnerJoin(Box::new(inner_join())),
+            right: table("C"),
+        };
+        let expected = r"
+• nested-loop join
+├── • nested-loop join (inner)
+│   ├── • scan A
+│   │     access: full scan
+│   │
+│   └── • scan B
+│         access: full scan
+│
+└── • scan C
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::LeftOuterJoin(Box::new(left_outer_join())),
+            right: table("C"),
+        };
+        let expected = r"
+• nested-loop join
+├── • nested-loop join (left outer)
+│   ├── • scan A
+│   │     access: full scan
+│   │
+│   └── • scan B
+│         access: full scan
+│
+└── • scan C
+      access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/limit.rs
+++ b/core/src/plan/statement/query/limit.rs
@@ -2,7 +2,10 @@ use {
     super::{
         DistinctPlan, OffsetPlan, ProjectPlan, SelectOrderByPlan, ValuesOrderByPlan, ValuesPlan,
     },
-    crate::plan::ExprPlan,
+    crate::plan::{
+        ExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -32,6 +35,31 @@ pub enum LimitInputPlan {
     ValuesOrderBy(ValuesOrderByPlan),
     Distinct(DistinctPlan),
     Offset(OffsetPlan),
+}
+
+impl Explain for LimitPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("limit")
+            .with_property("count", self.count.explain(context))
+            .with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for LimitInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Project(project) => project.explain(context),
+            Self::Values(values) => values.explain(context),
+            Self::SelectOrderBy(order_by) => order_by.explain(context),
+            Self::ValuesOrderBy(order_by) => order_by.explain(context),
+            Self::Distinct(distinct) => distinct.explain(context),
+            Self::Offset(offset) => offset.explain(context),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/limit.rs
+++ b/core/src/plan/statement/query/limit.rs
@@ -68,7 +68,12 @@ mod tests {
         super::{LimitInputPlan, LimitPlan},
         crate::{
             ast::Literal,
-            plan::{ExprPlan, OffsetInputPlan, OffsetPlan, ValuesPlan},
+            plan::{
+                DistinctInputPlan, DistinctPlan, ExprPlan, OffsetInputPlan, OffsetPlan,
+                OrderByExprPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan, SelectItemPlan,
+                SelectOrderByPlan, SourcePlan, TableAccessPlan, TableSourcePlan, ValuesOrderByPlan,
+                ValuesPlan, explain::test_explain,
+            },
         },
     };
 
@@ -84,6 +89,41 @@ mod tests {
 
     fn count(value: i64) -> ExprPlan {
         ExprPlan::Literal(Literal::Number(value.into()))
+    }
+
+    fn project() -> ProjectPlan {
+        ProjectPlan {
+            input: ProjectInputPlan::Source(SourcePlan::Table(TableSourcePlan {
+                name: "Player".to_owned(),
+                alias: None,
+                access: TableAccessPlan::FullScan,
+            })),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        }
+    }
+
+    fn values() -> ValuesPlan {
+        ValuesPlan(vec![vec![count(1)]])
+    }
+
+    fn select_order_by() -> SelectOrderByPlan {
+        SelectOrderByPlan {
+            input: project(),
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Identifier("id".to_owned()),
+                asc: Some(false),
+            }],
+        }
+    }
+
+    fn values_order_by() -> ValuesOrderByPlan {
+        ValuesOrderByPlan {
+            input: values(),
+            exprs: vec![OrderByExprPlan {
+                expr: count(1),
+                asc: Some(false),
+            }],
+        }
     }
 
     #[test]
@@ -103,5 +143,110 @@ mod tests {
                 count: actual,
             } if actual == count(3)
         ));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = LimitPlan {
+            input: LimitInputPlan::Project(project()),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • project
+    │ columns: *
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = LimitPlan {
+            input: LimitInputPlan::Values(values()),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = LimitPlan {
+            input: LimitInputPlan::SelectOrderBy(select_order_by()),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • sort
+    │ order: id DESC
+    │
+    └── • project
+        │ columns: *
+        │
+        └── • scan Player
+              access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = LimitPlan {
+            input: LimitInputPlan::ValuesOrderBy(values_order_by()),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • sort
+    │ order: 1 DESC
+    │
+    └── • values
+          size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = LimitPlan {
+            input: LimitInputPlan::Distinct(DistinctPlan {
+                input: DistinctInputPlan::Project(project()),
+            }),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • distinct
+    └── • project
+        │ columns: *
+        │
+        └── • scan Player
+              access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = LimitPlan {
+            input: LimitInputPlan::Offset(OffsetPlan {
+                input: OffsetInputPlan::Values(values()),
+                count: count(2),
+            }),
+            count: count(3),
+        };
+        let expected = r"
+• limit
+│ count: 3
+│
+└── • offset
+    │ count: 2
+    │
+    └── • values
+          size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/offset.rs
+++ b/core/src/plan/statement/query/offset.rs
@@ -63,12 +63,52 @@ mod tests {
         super::{OffsetInputPlan, OffsetPlan},
         crate::{
             ast::Literal,
-            plan::{ExprPlan, ValuesPlan},
+            plan::{
+                DistinctInputPlan, DistinctPlan, ExprPlan, OrderByExprPlan, ProjectInputPlan,
+                ProjectPlan, ProjectionPlan, SelectItemPlan, SelectOrderByPlan, SourcePlan,
+                TableAccessPlan, TableSourcePlan, ValuesOrderByPlan, ValuesPlan,
+                explain::test_explain,
+            },
         },
     };
 
     fn count(value: i64) -> ExprPlan {
         ExprPlan::Literal(Literal::Number(value.into()))
+    }
+
+    fn project() -> ProjectPlan {
+        ProjectPlan {
+            input: ProjectInputPlan::Source(SourcePlan::Table(TableSourcePlan {
+                name: "Player".to_owned(),
+                alias: None,
+                access: TableAccessPlan::FullScan,
+            })),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        }
+    }
+
+    fn values() -> ValuesPlan {
+        ValuesPlan(vec![vec![count(1)]])
+    }
+
+    fn select_order_by() -> SelectOrderByPlan {
+        SelectOrderByPlan {
+            input: project(),
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Identifier("id".to_owned()),
+                asc: Some(false),
+            }],
+        }
+    }
+
+    fn values_order_by() -> ValuesOrderByPlan {
+        ValuesOrderByPlan {
+            input: values(),
+            exprs: vec![OrderByExprPlan {
+                expr: count(1),
+                asc: Some(false),
+            }],
+        }
     }
 
     #[test]
@@ -85,5 +125,91 @@ mod tests {
                 count: actual,
             } if actual == count(2)
         ));
+    }
+
+    #[test]
+    fn explain() {
+        let actual = OffsetPlan {
+            input: OffsetInputPlan::Project(project()),
+            count: count(2),
+        };
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • project
+    │ columns: *
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = OffsetPlan {
+            input: OffsetInputPlan::Values(values()),
+            count: count(2),
+        };
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = OffsetPlan {
+            input: OffsetInputPlan::SelectOrderBy(select_order_by()),
+            count: count(2),
+        };
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • sort
+    │ order: id DESC
+    │
+    └── • project
+        │ columns: *
+        │
+        └── • scan Player
+              access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = OffsetPlan {
+            input: OffsetInputPlan::ValuesOrderBy(values_order_by()),
+            count: count(2),
+        };
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • sort
+    │ order: 1 DESC
+    │
+    └── • values
+          size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = OffsetPlan {
+            input: OffsetInputPlan::Distinct(DistinctPlan {
+                input: DistinctInputPlan::Project(project()),
+            }),
+            count: count(2),
+        };
+        let expected = r"
+• offset
+│ count: 2
+│
+└── • distinct
+    └── • project
+        │ columns: *
+        │
+        └── • scan Player
+              access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/offset.rs
+++ b/core/src/plan/statement/query/offset.rs
@@ -1,6 +1,9 @@
 use {
     super::{DistinctPlan, ProjectPlan, SelectOrderByPlan, ValuesOrderByPlan, ValuesPlan},
-    crate::plan::ExprPlan,
+    crate::plan::{
+        ExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -28,6 +31,30 @@ pub enum OffsetInputPlan {
     SelectOrderBy(SelectOrderByPlan),
     ValuesOrderBy(ValuesOrderByPlan),
     Distinct(DistinctPlan),
+}
+
+impl Explain for OffsetPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("offset")
+            .with_property("count", self.count.explain(context))
+            .with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for OffsetInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Project(project) => project.explain(context),
+            Self::Values(values) => values.explain(context),
+            Self::SelectOrderBy(order_by) => order_by.explain(context),
+            Self::ValuesOrderBy(order_by) => order_by.explain(context),
+            Self::Distinct(distinct) => distinct.explain(context),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/order_by_expr.rs
+++ b/core/src/plan/statement/query/order_by_expr.rs
@@ -64,8 +64,12 @@ mod tests {
     };
 
     #[test]
-    fn displays_order_by_for_explain() {
-        let order_by = [
+    fn explain() {
+        let actual = [
+            OrderByExprPlan {
+                expr: ExprPlan::Identifier("name".to_owned()),
+                asc: Some(true),
+            },
             OrderByExprPlan {
                 expr: ExprPlan::Identifier("created_at".to_owned()),
                 asc: Some(false),
@@ -75,10 +79,11 @@ mod tests {
                 asc: None,
             },
         ];
+        let expected = "name ASC, created_at DESC, id";
 
         assert_eq!(
-            order_by.as_slice().explain(&mut ExplainContext::default()),
-            "created_at DESC, id"
+            actual.as_slice().explain(&mut ExplainContext::default()),
+            expected
         );
     }
 }

--- a/core/src/plan/statement/query/order_by_expr.rs
+++ b/core/src/plan/statement/query/order_by_expr.rs
@@ -63,8 +63,36 @@ mod tests {
         },
     };
 
+    fn test(actual: &OrderByExprPlan, expected: &str) {
+        assert_eq!(actual.explain(&mut ExplainContext::default()), expected);
+    }
+
     #[test]
     fn explain() {
+        let actual = OrderByExprPlan {
+            expr: ExprPlan::Identifier("name".to_owned()),
+            asc: Some(true),
+        };
+        let expected = "name ASC";
+        test(&actual, expected);
+
+        let actual = OrderByExprPlan {
+            expr: ExprPlan::Identifier("created_at".to_owned()),
+            asc: Some(false),
+        };
+        let expected = "created_at DESC";
+        test(&actual, expected);
+
+        let actual = OrderByExprPlan {
+            expr: ExprPlan::Identifier("id".to_owned()),
+            asc: None,
+        };
+        let expected = "id";
+        test(&actual, expected);
+    }
+
+    #[test]
+    fn explain_list() {
         let actual = [
             OrderByExprPlan {
                 expr: ExprPlan::Identifier("name".to_owned()),
@@ -74,13 +102,8 @@ mod tests {
                 expr: ExprPlan::Identifier("created_at".to_owned()),
                 asc: Some(false),
             },
-            OrderByExprPlan {
-                expr: ExprPlan::Identifier("id".to_owned()),
-                asc: None,
-            },
         ];
-        let expected = "name ASC, created_at DESC, id";
-
+        let expected = "name ASC, created_at DESC";
         assert_eq!(
             actual.as_slice().explain(&mut ExplainContext::default()),
             expected

--- a/core/src/plan/statement/query/order_by_expr.rs
+++ b/core/src/plan/statement/query/order_by_expr.rs
@@ -1,5 +1,11 @@
 use {
-    crate::{ast, plan::ExprPlan},
+    crate::{
+        ast,
+        plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext},
+        },
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -7,6 +13,33 @@ use {
 pub struct OrderByExprPlan {
     pub expr: ExprPlan,
     pub asc: Option<bool>,
+}
+
+impl Explain for OrderByExprPlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = self.expr.explain(context);
+        if let Some(asc) = self.asc {
+            output.push_str(if asc { " ASC" } else { " DESC" });
+        }
+        output
+    }
+}
+
+impl Explain for [OrderByExprPlan] {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let mut output = String::new();
+        for (index, order_by) in self.iter().enumerate() {
+            if index > 0 {
+                output.push_str(", ");
+            }
+            output.push_str(&order_by.explain(context));
+        }
+        output
+    }
 }
 
 impl From<ast::OrderByExpr> for OrderByExprPlan {
@@ -17,5 +50,35 @@ impl From<ast::OrderByExpr> for OrderByExprPlan {
             expr: expr.into(),
             asc,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::OrderByExprPlan,
+        crate::plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext},
+        },
+    };
+
+    #[test]
+    fn displays_order_by_for_explain() {
+        let order_by = [
+            OrderByExprPlan {
+                expr: ExprPlan::Identifier("created_at".to_owned()),
+                asc: Some(false),
+            },
+            OrderByExprPlan {
+                expr: ExprPlan::Identifier("id".to_owned()),
+                asc: None,
+            },
+        ];
+
+        assert_eq!(
+            order_by.as_slice().explain(&mut ExplainContext::default()),
+            "created_at DESC, id"
+        );
     }
 }

--- a/core/src/plan/statement/query/project.rs
+++ b/core/src/plan/statement/query/project.rs
@@ -1,6 +1,9 @@
 use {
     super::{AggregationPlan, FilterPlan, HavingPlan},
-    crate::plan::{InnerJoinPlan, LeftOuterJoinPlan, ProjectionPlan, SourcePlan},
+    crate::plan::{
+        InnerJoinPlan, LeftOuterJoinPlan, ProjectionPlan, SourcePlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -42,6 +45,31 @@ impl ProjectInputPlan {
 pub struct ProjectPlan {
     pub input: ProjectInputPlan,
     pub projection: ProjectionPlan,
+}
+
+impl Explain for ProjectPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("project")
+            .with_property("columns", self.projection.explain(context))
+            .with_child(self.input.explain(context))
+    }
+}
+
+impl Explain for ProjectInputPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Source(source) => source.explain(context),
+            Self::InnerJoin(join) => join.explain(context),
+            Self::LeftOuterJoin(join) => join.explain(context),
+            Self::Filter(filter) => filter.explain(context),
+            Self::Aggregation(aggregation) => aggregation.explain(context),
+            Self::Having(having) => having.explain(context),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/plan/statement/query/project.rs
+++ b/core/src/plan/statement/query/project.rs
@@ -82,7 +82,8 @@ mod tests {
                 AggregationInputPlan, AggregationPlan, ExprPlan, FilterInputPlan, FilterPlan,
                 HavingPlan, InnerJoinInputPlan, InnerJoinPlan, LeftOuterJoinInputPlan,
                 LeftOuterJoinPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, ProjectionPlan,
-                SourcePlan, TableAccessPlan, TableSourcePlan,
+                SelectItemPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+                explain::test_explain,
             },
         },
         pretty_assertions::assert_eq,
@@ -195,5 +196,128 @@ mod tests {
             having.input.joined_sources(),
             expected.iter().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn explain() {
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::Source(table("Player")),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • scan Player
+      access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::InnerJoin(Box::new(InnerJoinPlan {
+                input: InnerJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • nested-loop join (inner)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::LeftOuterJoin(Box::new(LeftOuterJoinPlan {
+                input: LeftOuterJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+                    input: NestedLoopJoinInputPlan::Source(table("A")),
+                    right: table("B"),
+                }),
+            })),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • nested-loop join (left outer)
+    ├── • scan A
+    │     access: full scan
+    │
+    └── • scan B
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::Filter(FilterPlan {
+                input: FilterInputPlan::Source(table("Player")),
+                expr: ExprPlan::Identifier("active".to_owned()),
+            }),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • filter
+    │ expression: active
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::Aggregation(AggregationPlan {
+                input: AggregationInputPlan::Source(table("Player")),
+                group_by: vec![ExprPlan::Identifier("team_id".to_owned())],
+                aggregate_slots: Vec::new(),
+            }),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • aggregate
+    │ group by: team_id
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = ProjectPlan {
+            input: ProjectInputPlan::Having(HavingPlan {
+                input: AggregationPlan {
+                    input: AggregationInputPlan::Source(table("Player")),
+                    group_by: Vec::new(),
+                    aggregate_slots: Vec::new(),
+                },
+                expr: ExprPlan::Value(Value::Bool(true)),
+            }),
+            projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+        };
+        let expected = r"
+• project
+│ columns: *
+│
+└── • having
+    │ expression: TRUE
+    │
+    └── • aggregate
+        └── • scan Player
+              access: full scan
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/select_order_by.rs
+++ b/core/src/plan/statement/query/select_order_by.rs
@@ -22,3 +22,43 @@ impl Explain for SelectOrderByPlan {
             .with_child(self.input.explain(context))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::SelectOrderByPlan,
+        crate::plan::{
+            ExprPlan, OrderByExprPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan,
+            SelectItemPlan, SourcePlan, TableAccessPlan, TableSourcePlan, explain::test_explain,
+        },
+    };
+
+    #[test]
+    fn explain() {
+        let actual = SelectOrderByPlan {
+            input: ProjectPlan {
+                input: ProjectInputPlan::Source(SourcePlan::Table(TableSourcePlan {
+                    name: "Player".to_owned(),
+                    alias: None,
+                    access: TableAccessPlan::FullScan,
+                })),
+                projection: ProjectionPlan::SelectItems(vec![SelectItemPlan::Wildcard]),
+            },
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Identifier("id".to_owned()),
+                asc: Some(false),
+            }],
+        };
+        let expected = r"
+• sort
+│ order: id DESC
+│
+└── • project
+    │ columns: *
+    │
+    └── • scan Player
+          access: full scan
+";
+        test_explain(&actual, expected);
+    }
+}

--- a/core/src/plan/statement/query/select_order_by.rs
+++ b/core/src/plan/statement/query/select_order_by.rs
@@ -1,6 +1,9 @@
 use {
     super::ProjectPlan,
-    crate::plan::OrderByExprPlan,
+    crate::plan::{
+        OrderByExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,4 +11,14 @@ use {
 pub struct SelectOrderByPlan {
     pub input: ProjectPlan,
     pub exprs: Vec<OrderByExprPlan>,
+}
+
+impl Explain for SelectOrderByPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("sort")
+            .with_property("order", self.exprs.as_slice().explain(context))
+            .with_child(self.input.explain(context))
+    }
 }

--- a/core/src/plan/statement/query/source.rs
+++ b/core/src/plan/statement/query/source.rs
@@ -13,7 +13,10 @@ pub use {
 };
 
 use {
-    crate::ast,
+    crate::{
+        ast,
+        plan::explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -84,6 +87,19 @@ impl From<ast::TableAlias> for TableAliasPlan {
         let ast::TableAlias { name, columns } = alias;
 
         Self { name, columns }
+    }
+}
+
+impl Explain for SourcePlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::Table(table) => table.explain(context),
+            Self::Derived(derived) => derived.explain(context),
+            Self::Series(series) => series.explain(context),
+            Self::Dictionary(dictionary) => dictionary.explain(context),
+        }
     }
 }
 

--- a/core/src/plan/statement/query/source.rs
+++ b/core/src/plan/statement/query/source.rs
@@ -112,7 +112,7 @@ mod tests {
         },
         crate::{
             ast::{self, Dictionary, Expr, Literal, Query, SetExpr, Values},
-            plan::{ExprPlan, QueryPlan},
+            plan::{ExprPlan, QueryPlan, ValuesPlan, explain::test_explain},
         },
         pretty_assertions::assert_eq,
     };
@@ -184,5 +184,66 @@ mod tests {
             },
         });
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn explain() {
+        let actual = SourcePlan::Table(TableSourcePlan {
+            name: "Item".to_owned(),
+            alias: Some(TableAliasPlan {
+                name: "i".to_owned(),
+                columns: Vec::new(),
+            }),
+            access: TableAccessPlan::FullScan,
+        });
+        let expected = r"
+• scan Item as i
+  access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = SourcePlan::Derived(DerivedSourcePlan {
+            query: Box::new(QueryPlan::Values(ValuesPlan(vec![vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+            ]]))),
+            alias: TableAliasPlan {
+                name: "derived".to_owned(),
+                columns: vec!["value".to_owned()],
+            },
+        });
+        let expected = r"
+• derived derived
+│ columns: value
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = SourcePlan::Series(SeriesSourcePlan {
+            alias: TableAliasPlan {
+                name: "numbers".to_owned(),
+                columns: vec!["number".to_owned()],
+            },
+            size: ExprPlan::Literal(Literal::Number(3.into())),
+        });
+        let expected = r"
+• series numbers
+  size: 3
+";
+        test_explain(&actual, expected);
+
+        let actual = SourcePlan::Dictionary(DictionarySourcePlan {
+            dictionary: Dictionary::GlueTables,
+            alias: TableAliasPlan {
+                name: "tables".to_owned(),
+                columns: Vec::new(),
+            },
+        });
+        let expected = r"
+• dictionary tables
+  source: GLUE_TABLES
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/source/derived.rs
+++ b/core/src/plan/statement/query/source/derived.rs
@@ -1,6 +1,9 @@
 use {
     super::TableAliasPlan,
-    crate::plan::QueryPlan,
+    crate::plan::{
+        QueryPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,4 +11,17 @@ use {
 pub struct DerivedSourcePlan {
     pub query: Box<QueryPlan>,
     pub alias: TableAliasPlan,
+}
+
+impl Explain for DerivedSourcePlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new(format!("derived {}", self.alias.name))
+            .with_optional_property(
+                "columns",
+                (!self.alias.columns.is_empty()).then(|| self.alias.columns.join(", ")),
+            )
+            .with_child(self.query.explain(context))
+    }
 }

--- a/core/src/plan/statement/query/source/derived.rs
+++ b/core/src/plan/statement/query/source/derived.rs
@@ -25,3 +25,35 @@ impl Explain for DerivedSourcePlan {
             .with_child(self.query.explain(context))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{DerivedSourcePlan, TableAliasPlan},
+        crate::{
+            ast::Literal,
+            plan::{ExprPlan, QueryPlan, ValuesPlan, explain::test_explain},
+        },
+    };
+
+    #[test]
+    fn explain() {
+        let actual = DerivedSourcePlan {
+            query: Box::new(QueryPlan::Values(ValuesPlan(vec![vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+            ]]))),
+            alias: TableAliasPlan {
+                name: "derived".to_owned(),
+                columns: vec!["value".to_owned()],
+            },
+        };
+        let expected = r"
+• derived derived
+│ columns: value
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+    }
+}

--- a/core/src/plan/statement/query/source/dictionary.rs
+++ b/core/src/plan/statement/query/source/dictionary.rs
@@ -1,6 +1,9 @@
 use {
     super::TableAliasPlan,
-    crate::ast,
+    crate::{
+        ast,
+        plan::explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,4 +11,13 @@ use {
 pub struct DictionarySourcePlan {
     pub dictionary: ast::Dictionary,
     pub alias: TableAliasPlan,
+}
+
+impl Explain for DictionarySourcePlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, _context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new(format!("dictionary {}", self.alias.name))
+            .with_property("source", &self.dictionary)
+    }
 }

--- a/core/src/plan/statement/query/source/dictionary.rs
+++ b/core/src/plan/statement/query/source/dictionary.rs
@@ -21,3 +21,27 @@ impl Explain for DictionarySourcePlan {
             .with_property("source", &self.dictionary)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{DictionarySourcePlan, TableAliasPlan},
+        crate::{ast::Dictionary, plan::explain::test_explain},
+    };
+
+    #[test]
+    fn explain() {
+        let actual = DictionarySourcePlan {
+            dictionary: Dictionary::GlueTables,
+            alias: TableAliasPlan {
+                name: "tables".to_owned(),
+                columns: Vec::new(),
+            },
+        };
+        let expected = r"
+• dictionary tables
+  source: GLUE_TABLES
+";
+        test_explain(&actual, expected);
+    }
+}

--- a/core/src/plan/statement/query/source/series.rs
+++ b/core/src/plan/statement/query/source/series.rs
@@ -21,3 +21,30 @@ impl Explain for SeriesSourcePlan {
             .with_property("size", self.size.explain(context))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{SeriesSourcePlan, TableAliasPlan},
+        crate::{
+            ast::Literal,
+            plan::{ExprPlan, explain::test_explain},
+        },
+    };
+
+    #[test]
+    fn explain() {
+        let actual = SeriesSourcePlan {
+            alias: TableAliasPlan {
+                name: "numbers".to_owned(),
+                columns: vec!["number".to_owned()],
+            },
+            size: ExprPlan::Literal(Literal::Number(3.into())),
+        };
+        let expected = r"
+• series numbers
+  size: 3
+";
+        test_explain(&actual, expected);
+    }
+}

--- a/core/src/plan/statement/query/source/series.rs
+++ b/core/src/plan/statement/query/source/series.rs
@@ -1,6 +1,9 @@
 use {
     super::TableAliasPlan,
-    crate::plan::ExprPlan,
+    crate::plan::{
+        ExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,4 +11,13 @@ use {
 pub struct SeriesSourcePlan {
     pub alias: TableAliasPlan,
     pub size: ExprPlan,
+}
+
+impl Explain for SeriesSourcePlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new(format!("series {}", self.alias.name))
+            .with_property("size", self.size.explain(context))
+    }
 }

--- a/core/src/plan/statement/query/source/table.rs
+++ b/core/src/plan/statement/query/source/table.rs
@@ -1,5 +1,6 @@
 use {
     super::{TableAccessPlan, TableAliasPlan},
+    crate::plan::explain::{Explain, ExplainContext, ExplainNode},
     serde::{Deserialize, Serialize},
 };
 
@@ -8,4 +9,58 @@ pub struct TableSourcePlan {
     pub name: String,
     pub alias: Option<TableAliasPlan>,
     pub access: TableAccessPlan,
+}
+
+impl Explain for TableSourcePlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        let name = self.alias.as_ref().map_or_else(
+            || self.name.clone(),
+            |alias| format!("{} as {}", self.name, alias.name),
+        );
+        self.access
+            .explain(ExplainNode::new(format!("scan {name}")), context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::TableSourcePlan,
+        crate::{
+            ast::{IndexOperator, Literal},
+            plan::{
+                ExprPlan, IndexPredicatePlan, TableAccessPlan, TableAliasPlan,
+                explain::{Explain, ExplainContext, ExplainNode},
+            },
+        },
+    };
+
+    #[test]
+    fn explains_index_access() {
+        let table = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: Some(TableAliasPlan {
+                name: "p".to_owned(),
+                columns: Vec::new(),
+            }),
+            access: TableAccessPlan::Index {
+                name: "idx_created_at".to_owned(),
+                asc: Some(false),
+                predicate: Some(IndexPredicatePlan {
+                    operator: IndexOperator::Gt,
+                    expr: ExprPlan::Literal(Literal::Number(10.into())),
+                }),
+            },
+        };
+
+        assert_eq!(
+            table.explain(&mut ExplainContext::default()),
+            ExplainNode::new("scan Player as p")
+                .with_property("access", "index idx_created_at")
+                .with_property("order", "descending")
+                .with_property("predicate", "> 10")
+        );
+    }
 }

--- a/core/src/plan/statement/query/source/table.rs
+++ b/core/src/plan/statement/query/source/table.rs
@@ -19,8 +19,15 @@ impl Explain for TableSourcePlan {
             || self.name.clone(),
             |alias| format!("{} as {}", self.name, alias.name),
         );
-        self.access
-            .explain(ExplainNode::new(format!("scan {name}")), context)
+        let columns = self
+            .alias
+            .as_ref()
+            .filter(|alias| !alias.columns.is_empty())
+            .map(|alias| alias.columns.join(", "));
+        let node =
+            ExplainNode::new(format!("scan {name}")).with_optional_property("columns", columns);
+
+        self.access.explain(node, context)
     }
 }
 
@@ -49,6 +56,21 @@ mod tests {
         };
         let expected = r"
 • scan Player as p
+  access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: Some(TableAliasPlan {
+                name: "p".to_owned(),
+                columns: vec!["id".to_owned(), "name".to_owned()],
+            }),
+            access: TableAccessPlan::FullScan,
+        };
+        let expected = r"
+• scan Player as p
+  columns: id, name
   access: full scan
 ";
         test_explain(&actual, expected);

--- a/core/src/plan/statement/query/source/table.rs
+++ b/core/src/plan/statement/query/source/table.rs
@@ -32,35 +32,151 @@ mod tests {
             ast::{IndexOperator, Literal},
             plan::{
                 ExprPlan, IndexPredicatePlan, TableAccessPlan, TableAliasPlan,
-                explain::{Explain, ExplainContext, ExplainNode},
+                explain::test_explain,
             },
         },
     };
 
     #[test]
-    fn explains_index_access() {
-        let table = TableSourcePlan {
+    fn explain() {
+        let actual = TableSourcePlan {
             name: "Player".to_owned(),
             alias: Some(TableAliasPlan {
                 name: "p".to_owned(),
                 columns: Vec::new(),
             }),
+            access: TableAccessPlan::FullScan,
+        };
+        let expected = r"
+• scan Player as p
+  access: full scan
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::PrimaryKey {
+                expr: ExprPlan::Literal(Literal::Number(1.into())),
+            },
+        };
+        let expected = r"
+• scan Player
+  access: primary key
+  key: 1
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
             access: TableAccessPlan::Index {
-                name: "idx_created_at".to_owned(),
-                asc: Some(false),
+                name: "idx_name".to_owned(),
+                asc: None,
+                predicate: None,
+            },
+        };
+        let expected = r"
+• scan Player
+  access: index idx_name
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::Index {
+                name: "idx_score".to_owned(),
+                asc: Some(true),
                 predicate: Some(IndexPredicatePlan {
                     operator: IndexOperator::Gt,
                     expr: ExprPlan::Literal(Literal::Number(10.into())),
                 }),
             },
         };
+        let expected = r"
+• scan Player
+  access: index idx_score
+  order: ascending
+  predicate: > 10
+";
+        test_explain(&actual, expected);
 
-        assert_eq!(
-            table.explain(&mut ExplainContext::default()),
-            ExplainNode::new("scan Player as p")
-                .with_property("access", "index idx_created_at")
-                .with_property("order", "descending")
-                .with_property("predicate", "> 10")
-        );
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::Index {
+                name: "idx_score".to_owned(),
+                asc: Some(false),
+                predicate: Some(IndexPredicatePlan {
+                    operator: IndexOperator::Lt,
+                    expr: ExprPlan::Literal(Literal::Number(10.into())),
+                }),
+            },
+        };
+        let expected = r"
+• scan Player
+  access: index idx_score
+  order: descending
+  predicate: < 10
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::Index {
+                name: "idx_score".to_owned(),
+                asc: None,
+                predicate: Some(IndexPredicatePlan {
+                    operator: IndexOperator::GtEq,
+                    expr: ExprPlan::Literal(Literal::Number(10.into())),
+                }),
+            },
+        };
+        let expected = r"
+• scan Player
+  access: index idx_score
+  predicate: >= 10
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::Index {
+                name: "idx_score".to_owned(),
+                asc: None,
+                predicate: Some(IndexPredicatePlan {
+                    operator: IndexOperator::LtEq,
+                    expr: ExprPlan::Literal(Literal::Number(10.into())),
+                }),
+            },
+        };
+        let expected = r"
+• scan Player
+  access: index idx_score
+  predicate: <= 10
+";
+        test_explain(&actual, expected);
+
+        let actual = TableSourcePlan {
+            name: "Player".to_owned(),
+            alias: None,
+            access: TableAccessPlan::Index {
+                name: "idx_score".to_owned(),
+                asc: None,
+                predicate: Some(IndexPredicatePlan {
+                    operator: IndexOperator::Eq,
+                    expr: ExprPlan::Literal(Literal::Number(10.into())),
+                }),
+            },
+        };
+        let expected = r"
+• scan Player
+  access: index idx_score
+  predicate: = 10
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/source/table_access.rs
+++ b/core/src/plan/statement/query/source/table_access.rs
@@ -3,7 +3,13 @@ mod index_predicate;
 pub use index_predicate::IndexPredicatePlan;
 
 use {
-    crate::plan::ExprPlan,
+    crate::{
+        ast::IndexOperator,
+        plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext, ExplainNode},
+        },
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -18,4 +24,45 @@ pub enum TableAccessPlan {
         asc: Option<bool>,
         predicate: Option<IndexPredicatePlan>,
     },
+}
+
+impl TableAccessPlan {
+    pub(super) fn explain(&self, node: ExplainNode, context: &mut ExplainContext) -> ExplainNode {
+        match self {
+            Self::FullScan => node.with_property("access", "full scan"),
+            Self::PrimaryKey { expr } => node
+                .with_property("access", "primary key")
+                .with_property("key", expr.explain(context)),
+            Self::Index {
+                name,
+                asc,
+                predicate,
+            } => node
+                .with_property("access", format!("index {name}"))
+                .with_optional_property(
+                    "order",
+                    asc.map(|asc| if asc { "ascending" } else { "descending" }),
+                )
+                .with_optional_property(
+                    "predicate",
+                    predicate.as_ref().map(|predicate| {
+                        format!(
+                            "{} {}",
+                            explain_index_operator(&predicate.operator),
+                            predicate.expr.explain(context)
+                        )
+                    }),
+                ),
+        }
+    }
+}
+
+fn explain_index_operator(operator: &IndexOperator) -> &'static str {
+    match operator {
+        IndexOperator::Gt => ">",
+        IndexOperator::Lt => "<",
+        IndexOperator::GtEq => ">=",
+        IndexOperator::LtEq => "<=",
+        IndexOperator::Eq => "=",
+    }
 }

--- a/core/src/plan/statement/query/source/table_access.rs
+++ b/core/src/plan/statement/query/source/table_access.rs
@@ -3,12 +3,9 @@ mod index_predicate;
 pub use index_predicate::IndexPredicatePlan;
 
 use {
-    crate::{
-        ast::IndexOperator,
-        plan::{
-            ExprPlan,
-            explain::{Explain, ExplainContext, ExplainNode},
-        },
+    crate::plan::{
+        ExprPlan,
+        explain::{Explain, ExplainContext, ExplainNode},
     },
     serde::{Deserialize, Serialize},
 };
@@ -45,24 +42,10 @@ impl TableAccessPlan {
                 )
                 .with_optional_property(
                     "predicate",
-                    predicate.as_ref().map(|predicate| {
-                        format!(
-                            "{} {}",
-                            explain_index_operator(&predicate.operator),
-                            predicate.expr.explain(context)
-                        )
-                    }),
+                    predicate
+                        .as_ref()
+                        .map(|predicate| predicate.explain(context)),
                 ),
         }
-    }
-}
-
-fn explain_index_operator(operator: &IndexOperator) -> &'static str {
-    match operator {
-        IndexOperator::Gt => ">",
-        IndexOperator::Lt => "<",
-        IndexOperator::GtEq => ">=",
-        IndexOperator::LtEq => "<=",
-        IndexOperator::Eq => "=",
     }
 }

--- a/core/src/plan/statement/query/source/table_access/index_predicate.rs
+++ b/core/src/plan/statement/query/source/table_access/index_predicate.rs
@@ -1,10 +1,32 @@
 use {
-    crate::{ast, plan::ExprPlan},
+    crate::{
+        ast::IndexOperator,
+        plan::{
+            ExprPlan,
+            explain::{Explain, ExplainContext},
+        },
+    },
     serde::{Deserialize, Serialize},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IndexPredicatePlan {
-    pub operator: ast::IndexOperator,
+    pub operator: IndexOperator,
     pub expr: ExprPlan,
+}
+
+impl Explain for IndexPredicatePlan {
+    type Output = String;
+
+    fn explain(&self, context: &mut ExplainContext) -> String {
+        let operator = match &self.operator {
+            IndexOperator::Gt => ">",
+            IndexOperator::Lt => "<",
+            IndexOperator::GtEq => ">=",
+            IndexOperator::LtEq => "<=",
+            IndexOperator::Eq => "=",
+        };
+
+        format!("{operator} {}", self.expr.explain(context))
+    }
 }

--- a/core/src/plan/statement/query/values.rs
+++ b/core/src/plan/statement/query/values.rs
@@ -66,7 +66,7 @@ mod tests {
         super::{ValuesOrderByPlan, ValuesPlan},
         crate::{
             ast::Literal,
-            plan::{ExprPlan, OrderByExprPlan},
+            plan::{ExprPlan, OrderByExprPlan, QueryPlan, explain::test_explain},
         },
     };
 
@@ -85,5 +85,58 @@ mod tests {
                 && plan.exprs.len() == 1
                 && plan.exprs[0].asc == Some(false)
         );
+    }
+
+    #[test]
+    fn explain() {
+        let actual = ValuesPlan(vec![
+            vec![
+                ExprPlan::Literal(Literal::Number(1.into())),
+                ExprPlan::Literal(Literal::QuotedString("a".to_owned())),
+            ],
+            vec![
+                ExprPlan::Literal(Literal::Number(2.into())),
+                ExprPlan::Literal(Literal::QuotedString("b".to_owned())),
+            ],
+        ]);
+        let expected = r"
+• values
+  size: 2 columns, 2 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = ValuesPlan(vec![vec![ExprPlan::Subquery(Box::new(QueryPlan::Values(
+            ValuesPlan(vec![vec![ExprPlan::Literal(Literal::Number(1.into()))]]),
+        )))]]);
+        let expected = r"
+• root
+├── • values
+│     size: 1 columns, 1 rows
+│     expressions: (@S1)
+│
+└── • subquery
+    │ id: @S1
+    │ exec mode: one row
+    │
+    └── • values
+          size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
+
+        let actual = ValuesOrderByPlan {
+            input: ValuesPlan(vec![vec![ExprPlan::Literal(Literal::Number(1.into()))]]),
+            exprs: vec![OrderByExprPlan {
+                expr: ExprPlan::Literal(Literal::Number(1.into())),
+                asc: Some(false),
+            }],
+        };
+        let expected = r"
+• sort
+│ order: 1 DESC
+│
+└── • values
+      size: 1 columns, 1 rows
+";
+        test_explain(&actual, expected);
     }
 }

--- a/core/src/plan/statement/query/values.rs
+++ b/core/src/plan/statement/query/values.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         ast,
-        plan::{ExprPlan, OrderByExprPlan},
+        plan::{
+            ExprPlan, OrderByExprPlan,
+            explain::{Explain, ExplainContext, ExplainNode},
+        },
     },
     serde::{Deserialize, Serialize},
 };
@@ -24,6 +27,36 @@ impl From<ast::Values> for ValuesPlan {
                 .map(|exprs| exprs.into_iter().map(Into::into).collect())
                 .collect(),
         )
+    }
+}
+
+impl Explain for ValuesPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        let columns = self.0.first().map_or(0, Vec::len);
+        let subquery_count = context.subquery_count();
+        let expressions = self
+            .0
+            .iter()
+            .map(|row| format!("({})", row.as_slice().explain(context)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let has_subqueries = context.subquery_count() > subquery_count;
+
+        ExplainNode::new("values")
+            .with_property("size", format!("{columns} columns, {} rows", self.0.len()))
+            .with_optional_property("expressions", has_subqueries.then_some(expressions))
+    }
+}
+
+impl Explain for ValuesOrderByPlan {
+    type Output = ExplainNode;
+
+    fn explain(&self, context: &mut ExplainContext) -> ExplainNode {
+        ExplainNode::new("sort")
+            .with_property("order", self.exprs.as_slice().explain(context))
+            .with_child(self.input.explain(context))
     }
 }
 

--- a/core/src/planner/aggregate.rs
+++ b/core/src/planner/aggregate.rs
@@ -14,6 +14,10 @@ use {
 
 pub fn plan(statement: StatementPlan) -> StatementPlan {
     match statement {
+        StatementPlan::Explain(mut query) => {
+            plan_query(&mut query);
+            StatementPlan::Explain(query)
+        }
         StatementPlan::Query(mut query) => {
             plan_query(&mut query);
             StatementPlan::Query(query)

--- a/core/src/planner/hash_join.rs
+++ b/core/src/planner/hash_join.rs
@@ -21,6 +21,11 @@ pub fn plan<S: BuildHasher>(
     let planner = HashJoinPlanner { schema_map };
 
     match statement {
+        StatementPlan::Explain(query) => {
+            let query = planner.query(None, query);
+
+            StatementPlan::Explain(query)
+        }
         StatementPlan::Query(query) => {
             let query = planner.query(None, query);
 

--- a/core/src/planner/index.rs
+++ b/core/src/planner/index.rs
@@ -24,6 +24,11 @@ pub fn plan<S: BuildHasher>(
     let planner = IndexPlanner { schema_map };
 
     match statement {
+        StatementPlan::Explain(query) => {
+            let query = planner.query(None, query);
+
+            StatementPlan::Explain(query)
+        }
         StatementPlan::Query(query) => {
             let query = planner.query(None, query);
 

--- a/core/src/planner/primary_key.rs
+++ b/core/src/planner/primary_key.rs
@@ -25,6 +25,11 @@ pub fn plan<S: BuildHasher>(
     let planner = PrimaryKeyPlanner { schema_map };
 
     match statement {
+        StatementPlan::Explain(query) => {
+            let query = planner.query(None, query);
+
+            StatementPlan::Explain(query)
+        }
         StatementPlan::Query(query) => {
             let query = planner.query(None, query);
 

--- a/core/src/planner/schema.rs
+++ b/core/src/planner/schema.rs
@@ -22,7 +22,7 @@ pub fn fetch_schema_map<T: Store + ?Sized>(
     statement: &StatementPlan,
 ) -> Result<HashMap<String, Schema>> {
     match statement {
-        StatementPlan::Query(query) => scan_query(storage, query),
+        StatementPlan::Explain(query) | StatementPlan::Query(query) => scan_query(storage, query),
         StatementPlan::Insert {
             table_name, source, ..
         } => {

--- a/core/src/planner/schemaless.rs
+++ b/core/src/planner/schemaless.rs
@@ -33,6 +33,10 @@ fn transform_statement<S: BuildHasher>(
     statement: StatementPlan,
 ) -> StatementPlan {
     match statement {
+        StatementPlan::Explain(mut query) => {
+            transform_query(schema_map, &mut query);
+            StatementPlan::Explain(query)
+        }
         StatementPlan::Query(mut query) => {
             transform_query(schema_map, &mut query);
             StatementPlan::Query(query)

--- a/core/src/planner/schemaless/validate.rs
+++ b/core/src/planner/schemaless/validate.rs
@@ -31,7 +31,9 @@ fn validate_statement_inner(
     statement: &StatementPlan,
 ) -> ValidateResult {
     match statement {
-        StatementPlan::Query(query) => validate_query(schema_map, query),
+        StatementPlan::Explain(query) | StatementPlan::Query(query) => {
+            validate_query(schema_map, query)
+        }
         StatementPlan::Insert {
             table_name,
             columns,

--- a/core/src/planner/validate.rs
+++ b/core/src/planner/validate.rs
@@ -15,7 +15,7 @@ type SchemaMap = HashMap<String, Schema>;
 /// Validate user select column should not be ambiguous
 pub fn validate(schema_map: &SchemaMap, statement: &StatementPlan) -> Result<()> {
     let query = match statement {
-        StatementPlan::Query(query) => Some(query),
+        StatementPlan::Explain(query) | StatementPlan::Query(query) => Some(query),
         StatementPlan::Insert { source, .. } => Some(source),
         StatementPlan::CreateTable { source, .. } => source.as_deref(),
         _ => None,

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -67,10 +67,10 @@ pub fn translate_with_params(
             describe_alias: SqlDescribeAlias::Explain,
             analyze: false,
             verbose: false,
+            query_plan: false,
             statement,
             format: None,
             options: None,
-            ..
         } => match statement.as_ref() {
             SqlStatement::Query(query) => translate_query(query, params).map(Statement::Explain),
             _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
@@ -683,6 +683,7 @@ mod tests {
         for sql in [
             "EXPLAIN ANALYZE SELECT * FROM Foo",
             "EXPLAIN VERBOSE SELECT * FROM Foo",
+            "EXPLAIN QUERY PLAN SELECT * FROM Foo",
             "EXPLAIN DELETE FROM Foo",
         ] {
             assert!(matches!(

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -30,8 +30,8 @@ use {
         Assignment as SqlAssignment, AssignmentTarget as SqlAssignmentTarget,
         CommentDef as SqlCommentDef, CreateFunctionBody as SqlCreateFunctionBody,
         CreateIndex as SqlCreateIndex, CreateTable as SqlCreateTable, Delete as SqlDelete,
-        FromTable as SqlFromTable, Ident as SqlIdent, Insert as SqlInsert,
-        ObjectName as SqlObjectName, ObjectType as SqlObjectType,
+        DescribeAlias as SqlDescribeAlias, FromTable as SqlFromTable, Ident as SqlIdent,
+        Insert as SqlInsert, ObjectName as SqlObjectName, ObjectType as SqlObjectType,
         ReferentialAction as SqlReferentialAction, Statement as SqlStatement,
         TableConstraint as SqlTableConstraint, TableFactor, TableWithJoins,
     },
@@ -63,6 +63,18 @@ pub fn translate_with_params(
     params: &[ParamLiteral],
 ) -> Result<Statement> {
     match sql_statement {
+        SqlStatement::Explain {
+            describe_alias: SqlDescribeAlias::Explain,
+            analyze: false,
+            verbose: false,
+            statement,
+            format: None,
+            options: None,
+            ..
+        } => match statement.as_ref() {
+            SqlStatement::Query(query) => translate_query(query, params).map(Statement::Explain),
+            _ => Err(TranslateError::UnsupportedStatement(sql_statement.to_string()).into()),
+        },
         SqlStatement::Query(query) => translate_query(query, params).map(Statement::Query),
         SqlStatement::Insert(SqlInsert {
             table_name,
@@ -585,6 +597,26 @@ mod tests {
             "INSERT INTO Foo DEFAULT VALUES",
             TranslateError::DefaultValuesOnInsertNotSupported("Foo".to_owned()),
         );
+    }
+
+    #[test]
+    fn explain_query() {
+        let parsed = parse("EXPLAIN SELECT * FROM Foo").unwrap();
+        let actual = translate(&parsed[0]).unwrap();
+        assert!(matches!(actual, Statement::Explain(_)));
+
+        for sql in [
+            "EXPLAIN ANALYZE SELECT * FROM Foo",
+            "EXPLAIN VERBOSE SELECT * FROM Foo",
+            "EXPLAIN DELETE FROM Foo",
+        ] {
+            assert!(matches!(
+                parse(sql).and_then(|parsed| translate(&parsed[0])),
+                Err(crate::result::Error::Translate(
+                    TranslateError::UnsupportedStatement(_)
+                ))
+            ));
+        }
     }
 
     #[test]

--- a/test-suite/fixtures/explain.sql
+++ b/test-suite/fixtures/explain.sql
@@ -1,0 +1,133 @@
+CREATE TABLE Player (
+    id INTEGER PRIMARY KEY,
+    team_id INTEGER,
+    active BOOLEAN
+);
+-- @expect: ok
+
+CREATE TABLE Badge (
+    player_id INTEGER
+);
+-- @expect: ok
+
+CREATE TABLE Team (
+    id INTEGER
+);
+-- @expect: ok
+
+-- @name: primary key predicate becomes a direct lookup
+EXPLAIN
+SELECT team_id
+FROM Player
+WHERE id = 1;
+-- @expect: explain
+-- • project
+-- │ columns: team_id
+-- │
+-- └─ • scan Player
+--      access: primary key
+--      key: 1
+
+-- @name: query clauses form the planned execution pipeline
+EXPLAIN
+SELECT Player.team_id, COUNT(*) AS player_count
+FROM Player
+INNER JOIN Badge ON Player.id = Badge.player_id
+LEFT JOIN Team ON Player.team_id = Team.id
+WHERE Player.active = TRUE
+GROUP BY Player.team_id
+ORDER BY player_count DESC
+LIMIT 10 OFFSET 5;
+-- @expect: explain
+-- • limit
+-- │ count: 10
+-- │
+-- └─ • offset
+--    │ count: 5
+--    │
+--    └─ • sort
+--       │ order: player_count DESC
+--       │
+--       └─ • project
+--          │ columns: Player.team_id, COUNT(*) AS player_count
+--          │
+--          └─ • aggregate
+--             │ group by: Player.team_id
+--             │ aggregates: COUNT(*)
+--             │
+--             └─ • filter
+--                │ expression: Player.active = TRUE
+--                │
+--                └─ • hash join (left outer)
+--                   │ equality: Player.team_id = Team.id
+--                   │
+--                   ├─ • hash join (inner)
+--                   │  │ equality: Player.id = Badge.player_id
+--                   │  │
+--                   │  ├─ • scan Player
+--                   │  │    access: full scan
+--                   │  │
+--                   │  └─ • scan Badge
+--                   │       access: full scan
+--                   │
+--                   └─ • scan Team
+--                        access: full scan
+
+-- @name: expression subqueries are referenced from the main plan
+EXPLAIN
+SELECT
+    id,
+    (SELECT COUNT(*) AS total FROM Badge) AS badge_count
+FROM Player
+WHERE id IN (SELECT player_id FROM Badge)
+AND EXISTS (
+    SELECT *
+    FROM Badge
+    WHERE Badge.player_id = Player.id
+);
+-- @expect: explain
+-- • root
+-- ├─ • project
+-- │  │ columns: id, @S1 AS badge_count
+-- │  │
+-- │  └─ • filter
+-- │     │ expression: id IN (@S2) AND EXISTS (@S3)
+-- │     │
+-- │     └─ • scan Player
+-- │          access: full scan
+-- │
+-- ├─ • subquery
+-- │  │ id: @S1
+-- │  │ exec mode: one row
+-- │  │
+-- │  └─ • project
+-- │     │ columns: COUNT(*) AS total
+-- │     │
+-- │     └─ • aggregate
+-- │        │ aggregates: COUNT(*)
+-- │        │
+-- │        └─ • scan Badge
+-- │             access: full scan
+-- │
+-- ├─ • subquery
+-- │  │ id: @S2
+-- │  │ exec mode: all rows
+-- │  │
+-- │  └─ • project
+-- │     │ columns: player_id
+-- │     │
+-- │     └─ • scan Badge
+-- │          access: full scan
+-- │
+-- └─ • subquery
+--    │ id: @S3
+--    │ exec mode: exists
+--    │
+--    └─ • project
+--       │ columns: *
+--       │
+--       └─ • filter
+--          │ expression: Badge.player_id = Player.id
+--          │
+--          └─ • scan Badge
+--               access: full scan

--- a/test-suite/fixtures/explain.sql
+++ b/test-suite/fixtures/explain.sql
@@ -24,9 +24,9 @@ WHERE id = 1;
 -- • project
 -- │ columns: team_id
 -- │
--- └─ • scan Player
---      access: primary key
---      key: 1
+-- └── • scan Player
+--       access: primary key
+--       key: 1
 
 -- @name: query clauses form the planned execution pipeline
 EXPLAIN
@@ -42,36 +42,36 @@ LIMIT 10 OFFSET 5;
 -- • limit
 -- │ count: 10
 -- │
--- └─ • offset
---    │ count: 5
---    │
---    └─ • sort
---       │ order: player_count DESC
---       │
---       └─ • project
---          │ columns: Player.team_id, COUNT(*) AS player_count
---          │
---          └─ • aggregate
---             │ group by: Player.team_id
---             │ aggregates: COUNT(*)
+-- └── • offset
+--     │ count: 5
+--     │
+--     └── • sort
+--         │ order: player_count DESC
+--         │
+--         └── • project
+--             │ columns: Player.team_id, COUNT(*) AS player_count
 --             │
---             └─ • filter
---                │ expression: Player.active = TRUE
---                │
---                └─ • hash join (left outer)
---                   │ equality: Player.team_id = Team.id
---                   │
---                   ├─ • hash join (inner)
---                   │  │ equality: Player.id = Badge.player_id
---                   │  │
---                   │  ├─ • scan Player
---                   │  │    access: full scan
---                   │  │
---                   │  └─ • scan Badge
---                   │       access: full scan
---                   │
---                   └─ • scan Team
---                        access: full scan
+--             └── • aggregate
+--                 │ group by: Player.team_id
+--                 │ aggregates: COUNT(*)
+--                 │
+--                 └── • filter
+--                     │ expression: Player.active = TRUE
+--                     │
+--                     └── • hash join (left outer)
+--                         │ equality: Player.team_id = Team.id
+--                         │
+--                         ├── • hash join (inner)
+--                         │   │ equality: Player.id = Badge.player_id
+--                         │   │
+--                         │   ├── • scan Player
+--                         │   │     access: full scan
+--                         │   │
+--                         │   └── • scan Badge
+--                         │         access: full scan
+--                         │
+--                         └── • scan Team
+--                               access: full scan
 
 -- @name: expression subqueries are referenced from the main plan
 EXPLAIN
@@ -87,47 +87,47 @@ AND EXISTS (
 );
 -- @expect: explain
 -- • root
--- ├─ • project
--- │  │ columns: id, @S1 AS badge_count
--- │  │
--- │  └─ • filter
--- │     │ expression: id IN (@S2) AND EXISTS (@S3)
--- │     │
--- │     └─ • scan Player
--- │          access: full scan
--- │
--- ├─ • subquery
--- │  │ id: @S1
--- │  │ exec mode: one row
--- │  │
--- │  └─ • project
--- │     │ columns: COUNT(*) AS total
--- │     │
--- │     └─ • aggregate
--- │        │ aggregates: COUNT(*)
--- │        │
--- │        └─ • scan Badge
+-- ├── • project
+-- │   │ columns: id, @S1 AS badge_count
+-- │   │
+-- │   └── • filter
+-- │       │ expression: id IN (@S2) AND EXISTS (@S3)
+-- │       │
+-- │       └── • scan Player
 -- │             access: full scan
 -- │
--- ├─ • subquery
--- │  │ id: @S2
--- │  │ exec mode: all rows
--- │  │
--- │  └─ • project
--- │     │ columns: player_id
--- │     │
--- │     └─ • scan Badge
--- │          access: full scan
+-- ├── • subquery
+-- │   │ id: @S1
+-- │   │ exec mode: one row
+-- │   │
+-- │   └── • project
+-- │       │ columns: COUNT(*) AS total
+-- │       │
+-- │       └── • aggregate
+-- │           │ aggregates: COUNT(*)
+-- │           │
+-- │           └── • scan Badge
+-- │                 access: full scan
 -- │
--- └─ • subquery
---    │ id: @S3
---    │ exec mode: exists
---    │
---    └─ • project
---       │ columns: *
---       │
---       └─ • filter
---          │ expression: Badge.player_id = Player.id
---          │
---          └─ • scan Badge
---               access: full scan
+-- ├── • subquery
+-- │   │ id: @S2
+-- │   │ exec mode: all rows
+-- │   │
+-- │   └── • project
+-- │       │ columns: player_id
+-- │       │
+-- │       └── • scan Badge
+-- │             access: full scan
+-- │
+-- └── • subquery
+--     │ id: @S3
+--     │ exec mode: exists
+--     │
+--     └── • project
+--         │ columns: *
+--         │
+--         └── • filter
+--             │ expression: Badge.player_id = Player.id
+--             │
+--             └── • scan Badge
+--                   access: full scan

--- a/test-suite/src/fixture.rs
+++ b/test-suite/src/fixture.rs
@@ -105,14 +105,8 @@ where
                 assert_payload(actual, &expected, &context);
             }
             Expectation::Explain(expected) => {
-                let payloads = actual.unwrap_or_else(|error| {
-                    panic!("{context}\nexpected EXPLAIN payload but execution failed: {error:#?}")
-                });
-                let [payload] = payloads.as_slice() else {
-                    panic!("{context}\nexpected one payload, found {}", payloads.len());
-                };
-                let Payload::Explain(actual) = payload else {
-                    panic!("{context}\nexpected EXPLAIN payload, found {payload:?}")
+                let [Payload::Explain(actual)] = actual.as_deref().expect(&context) else {
+                    panic!("{context}\nexpected one EXPLAIN payload");
                 };
                 pretty_assert_eq!(actual, &expected, "{context}\nquery plan mismatch");
             }

--- a/test-suite/src/fixture.rs
+++ b/test-suite/src/fixture.rs
@@ -993,7 +993,7 @@ SELECT 1;
 EXPLAIN SELECT 1;
 -- @expect: explain
 -- • project
--- └─ • values
+-- └── • values
 
 UPDATE Example SET id = 1;
 -- @expect: payload Update
@@ -1027,7 +1027,7 @@ SELECT ADD_MONTH('invalid', 1);
         assert!(matches!(steps[1].expectation, Expectation::Select(_)));
         assert_eq!(
             steps[2].expectation,
-            Expectation::Explain(vec!["• project".to_owned(), "└─ • values".to_owned()])
+            Expectation::Explain(vec!["• project".to_owned(), "└── • values".to_owned()])
         );
         assert!(matches!(steps[3].expectation, Expectation::Payload(_)));
         assert!(matches!(steps[4].expectation, Expectation::Count(0)));

--- a/test-suite/src/fixture.rs
+++ b/test-suite/src/fixture.rs
@@ -37,6 +37,7 @@ enum Expectation {
     Ok,
     Select(Payload),
     Maps(Payload),
+    Explain(Vec<String>),
     Payload(SerdeExpectation),
     Error(SerdeExpectation),
     Count(usize),
@@ -102,6 +103,18 @@ where
                     panic!("{context}\nexpected one payload, found {}", payloads.len());
                 };
                 assert_payload(actual, &expected, &context);
+            }
+            Expectation::Explain(expected) => {
+                let payloads = actual.unwrap_or_else(|error| {
+                    panic!("{context}\nexpected EXPLAIN payload but execution failed: {error:#?}")
+                });
+                let [payload] = payloads.as_slice() else {
+                    panic!("{context}\nexpected one payload, found {}", payloads.len());
+                };
+                let Payload::Explain(actual) = payload else {
+                    panic!("{context}\nexpected EXPLAIN payload, found {payload:?}")
+                };
+                pretty_assert_eq!(actual, &expected, "{context}\nquery plan mismatch");
             }
             Expectation::Payload(expected) => {
                 let payloads = actual.unwrap_or_else(|error| {
@@ -554,6 +567,10 @@ fn parse_expectation(lines: &[&str], index: usize, directive: &str) -> (Expectat
             assert_table_format(&rows, None);
             (Expectation::Maps(parse_maps(&rows)), index)
         }
+        "explain" => {
+            let (plan, index) = take_explain_lines(lines, index);
+            (Expectation::Explain(plan), index)
+        }
         "types" => {
             let (rows, index) = take_table_rows(lines, index);
             assert_table_format(&rows, None);
@@ -591,6 +608,28 @@ fn take_table_rows<'a>(lines: &[&'a str], mut index: usize) -> (Vec<&'a str>, us
         index += 1;
     }
     (rows, index)
+}
+
+fn take_explain_lines(lines: &[&str], mut index: usize) -> (Vec<String>, usize) {
+    let mut plan = Vec::new();
+
+    while let Some(line) = lines.get(index) {
+        let line = if *line == "--" {
+            ""
+        } else if let Some(line) = line.strip_prefix("-- ") {
+            line
+        } else {
+            break;
+        };
+        if line.starts_with('@') {
+            break;
+        }
+        plan.push(line.to_owned());
+        index += 1;
+    }
+
+    assert!(!plan.is_empty(), "explain expectation requires plan lines");
+    (plan, index)
 }
 
 fn assert_table_format(lines: &[&str], separator: Option<usize>) {
@@ -951,6 +990,11 @@ SELECT 1;
 -- | 1          | Str("a") |
 -- | NULL       | I64(2)   |
 
+EXPLAIN SELECT 1;
+-- @expect: explain
+-- • project
+-- └─ • values
+
 UPDATE Example SET id = 1;
 -- @expect: payload Update
 -- @json: 0
@@ -976,16 +1020,20 @@ SELECT ADD_MONTH('invalid', 1);
 "#;
 
         let steps = parse_fixture(source);
-        assert_eq!(steps.len(), 7);
+        assert_eq!(steps.len(), 8);
         assert_eq!(steps[1].name.as_deref(), Some("mixed result"));
         assert_eq!(steps[2].name, None);
         assert!(matches!(steps[0].expectation, Expectation::Ok));
         assert!(matches!(steps[1].expectation, Expectation::Select(_)));
-        assert!(matches!(steps[2].expectation, Expectation::Payload(_)));
-        assert!(matches!(steps[3].expectation, Expectation::Count(0)));
-        assert!(matches!(steps[4].expectation, Expectation::Types(_)));
-        assert!(matches!(steps[5].expectation, Expectation::Error(_)));
+        assert_eq!(
+            steps[2].expectation,
+            Expectation::Explain(vec!["• project".to_owned(), "└─ • values".to_owned()])
+        );
+        assert!(matches!(steps[3].expectation, Expectation::Payload(_)));
+        assert!(matches!(steps[4].expectation, Expectation::Count(0)));
+        assert!(matches!(steps[5].expectation, Expectation::Types(_)));
         assert!(matches!(steps[6].expectation, Expectation::Error(_)));
+        assert!(matches!(steps[7].expectation, Expectation::Error(_)));
     }
 
     #[test]

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -158,6 +158,7 @@ macro_rules! generate_store_tests {
         sql_case!(insert);
         sql_case!(delete);
         sql_case!(basic);
+        sql_case!(explain);
         sql_case!(array);
         sql_case!(aggregate::avg);
         sql_case!(aggregate::count);


### PR DESCRIPTION
## Summary

Add `EXPLAIN` support for query statements so users can inspect GlueSQL's planned typed execution pipeline without executing the query.

## Changes

- Translate `EXPLAIN <query>` into dedicated AST and statement-plan variants.
- Render query plans through a semantic tree that describes scans, joins, filters, aggregation, projection, ordering, pagination, expressions, and subqueries.
- Report selected table access paths, including primary-key lookups, secondary indexes, and full scans.
- Return a dedicated explain payload and display it in both tabular and plain CLI output.
- Add readable SQL fixtures covering primary-key access, join and aggregation pipelines, and expression subqueries.

## Impact

Users can see how `SELECT` and `VALUES` queries will be executed, including planner-selected access paths, execution stages, and subquery modes. This also gives contributors a stable representation for understanding planner transformations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SQL `EXPLAIN` queries.
  * View detailed plans for scans, joins, filters, aggregations, sorting, pagination, and subqueries.
  * Query plans are available in tabular and plain-text CLI formats.
* **Bug Fixes**
  * `EXPLAIN` queries now pass through validation and planning consistently.
* **Tests**
  * Added coverage for query-plan output across common query patterns and CLI formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->