### PR TITLE
json-storage: error on an invalid schemaless row shape instead of storing {} (#1878)

### DIFF
--- a/storages/json-storage/src/store_mut.rs
+++ b/storages/json-storage/src/store_mut.rs
@@ -195,7 +195,7 @@ impl JsonStorage {
                             Value::Map(map) => Some(map),
                             _ => None,
                         })
-                        .unwrap_or_default();
+                        .map_storage_err(JsonStorageError::JsonObjectTypeRequired)?;
 
                     map.into_iter()
                         .map(|(key, value)| Ok((key, value.try_into()?)))

--- a/storages/json-storage/tests/schemaless_invalid_shape.rs
+++ b/storages/json-storage/tests/schemaless_invalid_shape.rs
@@ -1,0 +1,40 @@
+use {
+    gluesql_core::{
+        data::{Schema, Value},
+        prelude::Error,
+        store::StoreMut,
+    },
+    gluesql_json_storage::{JsonStorage, error::JsonStorageError},
+    std::fs::{create_dir_all, remove_dir_all},
+};
+
+// #1878: a schemaless row must be a single `Value::Map`. A non-Map row is an
+// invalid shape and must return an error rather than silently persisting `{}`.
+#[test]
+fn schemaless_write_rejects_non_map_row() {
+    let path = "./tests/schemaless_invalid_shape/";
+    let _ = remove_dir_all(path);
+    create_dir_all(path).unwrap();
+
+    let mut storage = JsonStorage::new(path).unwrap();
+
+    let schema = Schema {
+        table_name: "Schemaless".to_owned(),
+        column_defs: None,
+        indexes: Vec::new(),
+        engine: None,
+        foreign_keys: Vec::new(),
+        comment: None,
+    };
+    storage.insert_schema(&schema).unwrap();
+
+    let result = storage.append_data("Schemaless", vec![vec![Value::I64(1)]]);
+    assert_eq!(
+        result,
+        Err(Error::StorageMsg(
+            JsonStorageError::JsonObjectTypeRequired.to_string()
+        ))
+    );
+
+    remove_dir_all(path).unwrap();
+}


### PR DESCRIPTION
Fixes #1878.

### Problem

`JsonStorage::write`, on the schemaless branch (`storages/json-storage/src/store_mut.rs`), extracted a `Value::Map` from the first column of each row and fell back to `.unwrap_or_default()` when the value was not a map:

```rust
.and_then(|v| match v {
    Value::Map(map) => Some(map),
    _ => None,
})
.unwrap_or_default();
```

A schemaless row whose shape is not a single map was therefore silently persisted as an empty `{}`, and the write returned `Ok(())` -- a silent data loss reachable via the `StoreMut` API (custom-storage / embedder use).

### Fix

Return `JsonStorageError::JsonObjectTypeRequired` for that case (the existing "json object type is required" error) instead of coercing to an empty object, matching the behavior the issue asks for. Only the invalid-shape branch changes; valid maps are unaffected.

### Test

Added `storages/json-storage/tests/schemaless_invalid_shape.rs`, which inserts a schemaless schema and calls `append_data` with a non-map row directly through `StoreMut`. Red-green verified with `cargo test -p gluesql-json-storage`: before the change the append returns `Ok(())` (storing `{}`); after, it returns `Err(StorageMsg("json object type is required"))`. The full `gluesql-json-storage` suite passes; `cargo fmt --check` and `clippy` are clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I reproduced the silent coercion, ran the tests (red-green) and the suite, and take responsibility for the contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Schemaless JSON storage now correctly rejects missing or non-object values instead of treating them as empty objects.
  - Clearer validation errors are returned when JSON data is not a single object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->