### PR TITLE
Reject unsupported CREATE INDEX options during translation

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -12,8 +12,8 @@ pub use self::{
     data_type::translate_data_type,
     ddl::translate_column_def,
     error::{
-        CreateTableOption, DeleteOption, InsertOption, JoinConstraintReason, QueryOption,
-        SelectOption, TransactionOption, TranslateError, UpdateOption,
+        CreateIndexOption, CreateTableOption, DeleteOption, InsertOption, JoinConstraintReason,
+        QueryOption, SelectOption, TransactionOption, TranslateError, UpdateOption,
     },
     expr::{translate_expr, translate_order_by_expr},
     param::{IntoParamLiteral, ParamLiteral},
@@ -297,8 +297,39 @@ pub fn translate_with_params(
             name,
             table_name,
             columns,
-            ..
+            using,
+            unique,
+            concurrently,
+            if_not_exists,
+            include,
+            nulls_distinct,
+            with,
+            predicate,
         }) => {
+            let violation = if *unique {
+                Some(CreateIndexOption::Unique)
+            } else if *concurrently {
+                Some(CreateIndexOption::Concurrently)
+            } else if *if_not_exists {
+                Some(CreateIndexOption::IfNotExists)
+            } else if using.is_some() {
+                Some(CreateIndexOption::Using)
+            } else if !include.is_empty() {
+                Some(CreateIndexOption::Include)
+            } else if nulls_distinct.is_some() {
+                Some(CreateIndexOption::NullsDistinct)
+            } else if !with.is_empty() {
+                Some(CreateIndexOption::With)
+            } else if predicate.is_some() {
+                Some(CreateIndexOption::Where)
+            } else {
+                None
+            };
+
+            if let Some(reason) = violation {
+                return Err(TranslateError::UnsupportedCreateIndexOption(reason).into());
+            }
+
             if columns.len() > 1 {
                 return Err(TranslateError::CompositeIndexNotSupported.into());
             }
@@ -736,6 +767,48 @@ mod tests {
 
         for (sql, err) in cases {
             assert_translate_error(sql, err);
+        }
+    }
+
+    #[test]
+    fn create_index_options_not_supported() {
+        let cases = [
+            (
+                "CREATE UNIQUE INDEX idx ON Foo (id)",
+                CreateIndexOption::Unique,
+            ),
+            (
+                "CREATE INDEX CONCURRENTLY idx ON Foo (id)",
+                CreateIndexOption::Concurrently,
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx ON Foo (id)",
+                CreateIndexOption::IfNotExists,
+            ),
+            (
+                "CREATE INDEX idx ON Foo USING btree (id)",
+                CreateIndexOption::Using,
+            ),
+            (
+                "CREATE INDEX idx ON Foo (id) INCLUDE (name)",
+                CreateIndexOption::Include,
+            ),
+            (
+                "CREATE INDEX idx ON Foo (id) NULLS NOT DISTINCT",
+                CreateIndexOption::NullsDistinct,
+            ),
+            (
+                "CREATE INDEX idx ON Foo (id) WITH (fillfactor = 70)",
+                CreateIndexOption::With,
+            ),
+            (
+                "CREATE INDEX idx ON Foo (id) WHERE id > 0",
+                CreateIndexOption::Where,
+            ),
+        ];
+
+        for (sql, option) in cases {
+            assert_translate_error(sql, TranslateError::UnsupportedCreateIndexOption(option));
         }
     }
 

--- a/core/src/translate/error.rs
+++ b/core/src/translate/error.rs
@@ -20,6 +20,46 @@ pub enum CreateTableOption {
     CloneTable,
 }
 
+/// `CREATE INDEX` clauses that `GlueSQL` does not support yet.
+///
+/// Carried by [`TranslateError::UnsupportedCreateIndexOption`] so callers
+/// can match exhaustively on every currently-rejected clause instead of
+/// inspecting a free-form string.
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateIndexOption {
+    /// `CREATE UNIQUE INDEX ...`
+    #[strum(to_string = "UNIQUE keyword")]
+    Unique,
+
+    /// `CREATE INDEX CONCURRENTLY ...`
+    #[strum(to_string = "CONCURRENTLY keyword")]
+    Concurrently,
+
+    /// `CREATE INDEX IF NOT EXISTS ...`
+    #[strum(to_string = "IF NOT EXISTS clause")]
+    IfNotExists,
+
+    /// `CREATE INDEX ... USING <method> ...`
+    #[strum(to_string = "USING clause")]
+    Using,
+
+    /// `CREATE INDEX ... INCLUDE (...)`
+    #[strum(to_string = "INCLUDE clause")]
+    Include,
+
+    /// `CREATE INDEX ... NULLS [NOT] DISTINCT`
+    #[strum(to_string = "NULLS DISTINCT clause")]
+    NullsDistinct,
+
+    /// `CREATE INDEX ... WITH (...)`
+    #[strum(to_string = "WITH clause")]
+    With,
+
+    /// `CREATE INDEX ... WHERE <predicate>`
+    #[strum(to_string = "WHERE clause")]
+    Where,
+}
+
 /// `INSERT` clauses that `GlueSQL` does not support yet.
 ///
 /// Carried by [`TranslateError::UnsupportedInsertOption`] so callers can
@@ -186,6 +226,7 @@ macro_rules! serialize_via_display {
 }
 
 serialize_via_display!(
+    CreateIndexOption,
     CreateTableOption,
     InsertOption,
     UpdateOption,
@@ -269,6 +310,9 @@ pub enum TranslateError {
 
     #[error("unsupported CREATE TABLE option: {0}")]
     UnsupportedCreateTableOption(CreateTableOption),
+
+    #[error("unsupported CREATE INDEX option: {0}")]
+    UnsupportedCreateIndexOption(CreateIndexOption),
 
     #[error("unsupported UPDATE option: {0}")]
     UnsupportedUpdateOption(UpdateOption),


### PR DESCRIPTION
## Summary

This PR makes `CREATE INDEX` translation reject unsupported index options explicitly instead of silently discarding them.

Previously, options parsed by `sqlparser` such as `UNIQUE`, `CONCURRENTLY`, `IF NOT EXISTS`, `USING`, `INCLUDE`, `NULLS [NOT] DISTINCT`, `WITH`, and `WHERE` were ignored and translated into a regular `Statement::CreateIndex`.

## Problem

For example:

```sql
CREATE TABLE Test (id INTEGER);
INSERT INTO Test VALUES (1);

CREATE UNIQUE INDEX ux_id ON Test (id);

INSERT INTO Test VALUES (1);
SELECT id FROM Test WHERE id = 1;

```

Before this change, `CREATE UNIQUE INDEX` succeeded as a regular index, and duplicate values could still be inserted. **This means the** `UNIQUE` **semantics were silently lost.**

## Changes
- Add `CreateIndexOption` to represent unsupported `CREATE INDEX` options
- Add `TranslateError::UnsupportedCreateIndexOption`
- Explicitly inspect parsed `CREATE INDEX` option fields during translation
- Add regression coverage for each unsupported option
- Preserve existing behavior for plain `CREATE INDEX`

## Verification

Ran:

```bash
cargo test -p gluesql-core create_index_options_not_supported
cargo test -p gluesql-core translate::tests
cargo test -p gluesql-core
cargo test -p gluesql_sled_storage sql_index_basic
cargo clippy --all-targets -- -D warnings
cargo fmt --all
git diff --check

```

Also manually verified the same SQL scenarios with a small SledStorage-based program that executes SQL against the current upstream behavior and this branch through the real `Glue::execute` path.

| Scenario                                     | Before   | After                                      |
| -------------------------------------------- | -------- | ------------------------------------------ |
| Plain `CREATE INDEX`                         | succeeds | succeeds                                   |
| `CREATE UNIQUE INDEX`                        | succeeds | rejected                                   |
| Duplicate insert after `CREATE UNIQUE INDEX` | succeeds | skipped because index creation is rejected |
| `CREATE INDEX CONCURRENTLY`                  | succeeds | rejected                                   |
| `CREATE INDEX IF NOT EXISTS`                 | succeeds | rejected                                   |
| `CREATE INDEX ... USING`                     | succeeds | rejected                                   |
| `CREATE INDEX ... INCLUDE`                   | succeeds | rejected                                   |
| `CREATE INDEX ... NULLS NOT DISTINCT`        | succeeds | rejected                                   |
| `CREATE INDEX ... WITH`                      | succeeds | rejected                                   |
| `CREATE INDEX ... WHERE`                     | succeeds | rejected                                   |


Plain `CREATE INDEX` still succeeds in both cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `CREATE INDEX` statements now clearly reject unsupported options, including unique, concurrent, conditional, access method, included columns, null-distinctness, storage, and predicate clauses.
  * Improved error reporting identifies the specific unsupported index option.
* **Tests**
  * Added coverage for each unsupported `CREATE INDEX` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->