### PR TITLE
Support RIGHT OUTER JOIN

### DIFF
--- a/core/src/ast/query.rs
+++ b/core/src/ast/query.rs
@@ -97,6 +97,7 @@ pub struct Join {
 pub enum JoinOperator {
     Inner(JoinConstraint),
     LeftOuter(JoinConstraint),
+    RightOuter(JoinConstraint),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -444,6 +445,7 @@ impl Join {
         let (join_operator, join_constraint) = match join_operator {
             JoinOperator::Inner(join_constraint) => ("INNER JOIN", join_constraint),
             JoinOperator::LeftOuter(join_constraint) => ("LEFT OUTER JOIN", join_constraint),
+            JoinOperator::RightOuter(join_constraint) => ("RIGHT OUTER JOIN", join_constraint),
         };
 
         let join_constraint = if quoted {
@@ -1134,6 +1136,30 @@ mod tests {
         }
         .to_sql();
         assert_eq!(actual, expected);
+
+        let actual = r#"RIGHT OUTER JOIN "PlayerItem""#;
+        let expected = Join {
+            relation: TableFactor::Table {
+                name: "PlayerItem".to_owned(),
+                alias: None,
+            },
+            join_operator: JoinOperator::RightOuter(JoinConstraint::None),
+        }
+        .to_sql();
+        assert_eq!(actual, expected);
+
+        let actual = r#"RIGHT OUTER JOIN "PlayerItem" ON "PlayerItem"."user_id" = "Player"."id""#;
+        let expected = Join {
+            relation: TableFactor::Table {
+                name: "PlayerItem".to_owned(),
+                alias: None,
+            },
+            join_operator: JoinOperator::RightOuter(JoinConstraint::On(expr(
+                r#""PlayerItem"."user_id" = "Player"."id""#,
+            ))),
+        }
+        .to_sql();
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -1194,6 +1220,30 @@ mod tests {
             },
             join_operator: JoinOperator::LeftOuter(JoinConstraint::On(expr(
                 "PlayerItem.age > Player.age AND PlayerItem.user_id = Player.id AND PlayerItem.amount > 10 AND PlayerItem.amount * 3 <= 2",
+            ))),
+        }
+        .to_sql_unquoted();
+        assert_eq!(actual, expected);
+
+        let actual = "RIGHT OUTER JOIN PlayerItem";
+        let expected = Join {
+            relation: TableFactor::Table {
+                name: "PlayerItem".to_owned(),
+                alias: None,
+            },
+            join_operator: JoinOperator::RightOuter(JoinConstraint::None),
+        }
+        .to_sql_unquoted();
+        assert_eq!(actual, expected);
+
+        let actual = "RIGHT OUTER JOIN PlayerItem ON PlayerItem.user_id = Player.id";
+        let expected = Join {
+            relation: TableFactor::Table {
+                name: "PlayerItem".to_owned(),
+                alias: None,
+            },
+            join_operator: JoinOperator::RightOuter(JoinConstraint::On(expr(
+                "PlayerItem.user_id = Player.id",
             ))),
         }
         .to_sql_unquoted();

--- a/core/src/executor/alter/table.rs
+++ b/core/src/executor/alter/table.rs
@@ -225,10 +225,15 @@ fn source_for_schema_copy(project: &ProjectPlan) -> Option<&SourcePlan> {
         ProjectInputPlan::Source(relation) => relation,
         ProjectInputPlan::Filter(filter) => match &filter.input {
             FilterInputPlan::Source(relation) => relation,
-            FilterInputPlan::InnerJoin(_) | FilterInputPlan::LeftOuterJoin(_) => return None,
+            FilterInputPlan::InnerJoin(_)
+            | FilterInputPlan::LeftOuterJoin(_)
+            | FilterInputPlan::UnplannedRightOuterJoin(_)
+            | FilterInputPlan::RightOuterJoin(_) => return None,
         },
         ProjectInputPlan::InnerJoin(_)
         | ProjectInputPlan::LeftOuterJoin(_)
+        | ProjectInputPlan::UnplannedRightOuterJoin(_)
+        | ProjectInputPlan::RightOuterJoin(_)
         | ProjectInputPlan::Aggregation(_)
         | ProjectInputPlan::Having(_) => return None,
     };

--- a/core/src/executor/query/aggregation.rs
+++ b/core/src/executor/query/aggregation.rs
@@ -4,7 +4,7 @@ use {
     self::state::State,
     super::{
         SelectedRows, SelectedSources, filter,
-        join::{inner, left_outer},
+        join::{inner, left_outer, reject_unplanned_right_outer, right_outer},
         source,
     },
     crate::{
@@ -45,6 +45,10 @@ where
         AggregationInputPlan::InnerJoin(join) => inner::execute(storage, join, filter_context)?,
         AggregationInputPlan::LeftOuterJoin(join) => {
             left_outer::execute(storage, join, filter_context)?
+        }
+        AggregationInputPlan::UnplannedRightOuterJoin(_) => reject_unplanned_right_outer()?,
+        AggregationInputPlan::RightOuterJoin(join) => {
+            right_outer::execute(storage, join, filter_context)?
         }
         AggregationInputPlan::Filter(filter) => filter::execute(storage, filter, filter_context)?,
     };

--- a/core/src/executor/query/error.rs
+++ b/core/src/executor/query/error.rs
@@ -25,4 +25,10 @@ pub enum QueryError {
 
     #[error("unreachable - table schema missing after source preparation: {0}")]
     UnreachableTableSchemaMissingAfterPreparation(String),
+
+    #[error("unreachable - RIGHT JOIN reached execution without being lowered by the planner")]
+    UnreachableUnplannedRightOuterJoin,
+
+    #[error("unreachable - NULL-extended relations do not match the join sources: {0}")]
+    UnreachableNullExtendRelationMismatch(String),
 }

--- a/core/src/executor/query/filter.rs
+++ b/core/src/executor/query/filter.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         SelectedRows,
-        join::{inner, left_outer},
+        join::{inner, left_outer, reject_unplanned_right_outer, right_outer},
         source,
     },
     crate::{
@@ -28,6 +28,10 @@ where
             .into_selected(None),
         FilterInputPlan::InnerJoin(join) => inner::execute(storage, join, filter_context)?,
         FilterInputPlan::LeftOuterJoin(join) => left_outer::execute(storage, join, filter_context)?,
+        FilterInputPlan::UnplannedRightOuterJoin(_) => reject_unplanned_right_outer()?,
+        FilterInputPlan::RightOuterJoin(join) => {
+            right_outer::execute(storage, join, filter_context)?
+        }
     };
     let filter_context = filter_context.map(Rc::clone);
     let rows = rows.filter_map(move |context| {

--- a/core/src/executor/query/join.rs
+++ b/core/src/executor/query/join.rs
@@ -3,9 +3,10 @@ pub(super) mod hash;
 pub(super) mod inner;
 pub(super) mod left_outer;
 pub(super) mod nested_loop;
+pub(super) mod right_outer;
 
 use {
-    super::{SelectedIter, SelectedSources, SourceColumns},
+    super::{QueryError, SelectedIter, SelectedSources, SourceColumns},
     crate::{executor::context::RowContext, result::Result},
     std::rc::Rc,
 };
@@ -21,4 +22,10 @@ struct JoinCandidates<'a> {
     sources: SelectedSources<'a>,
     right: SourceColumns<'a>,
     groups: JoinCandidateGroupIter<'a>,
+}
+
+/// Reaching here means a custom [`crate::store::Planner`] left
+/// [`crate::planner::plan_right_outer_join`] out of its pipeline.
+pub(super) fn reject_unplanned_right_outer<T>() -> Result<T> {
+    Err(QueryError::UnreachableUnplannedRightOuterJoin.into())
 }

--- a/core/src/executor/query/join/hash.rs
+++ b/core/src/executor/query/join/hash.rs
@@ -1,6 +1,6 @@
 use {
     super::super::{SelectedRows, SourceColumns, source},
-    super::{JoinCandidateGroup, JoinCandidates, inner, left_outer},
+    super::{JoinCandidateGroup, JoinCandidates, inner, left_outer, right_outer},
     crate::{
         data::{Key, Row},
         executor::{context::RowContext, evaluate::evaluate, filter::check_expr},
@@ -31,6 +31,9 @@ pub(super) fn execute<'a, T: GStore>(
         HashJoinInputPlan::InnerJoin(join) => inner::execute(storage, join, filter_context)?,
         HashJoinInputPlan::LeftOuterJoin(join) => {
             left_outer::execute(storage, join, filter_context)?
+        }
+        HashJoinInputPlan::RightOuterJoin(join) => {
+            right_outer::execute(storage, join, filter_context)?
         }
     };
     let right = source::execute(storage, right)?;

--- a/core/src/executor/query/join/nested_loop.rs
+++ b/core/src/executor/query/join/nested_loop.rs
@@ -1,6 +1,9 @@
 use {
     super::super::{SelectedRows, SourceColumns, source},
-    super::{JoinCandidateGroup, JoinCandidates, inner, left_outer},
+    super::{
+        JoinCandidateGroup, JoinCandidates, inner, left_outer, reject_unplanned_right_outer,
+        right_outer,
+    },
     crate::{
         data::Row,
         executor::context::RowContext,
@@ -24,6 +27,10 @@ pub(super) fn execute<'a, T: GStore>(
         NestedLoopJoinInputPlan::InnerJoin(join) => inner::execute(storage, join, filter_context)?,
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
             left_outer::execute(storage, join, filter_context)?
+        }
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(_) => reject_unplanned_right_outer()?,
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+            right_outer::execute(storage, join, filter_context)?
         }
     };
     let right = source::execute(storage, right)?;

--- a/core/src/executor/query/join/right_outer.rs
+++ b/core/src/executor/query/join/right_outer.rs
@@ -1,0 +1,315 @@
+use {
+    super::super::{
+        QueryError, SelectedIter, SelectedRows, SelectedSources, SourceColumns, source,
+    },
+    super::{inner, left_outer, reject_unplanned_right_outer},
+    crate::{
+        data::{Key, Row, Value},
+        executor::{context::RowContext, evaluate::evaluate, filter::check_expr},
+        plan::{
+            ExprPlan, HashJoinInputPlan, HashJoinPlan, JoinConditionInputPlan,
+            NestedLoopJoinInputPlan, NestedLoopJoinPlan, RightOuterJoinInputPlan,
+            RightOuterJoinPlan, SourcePlan,
+        },
+        result::Result,
+        store::GStore,
+    },
+    std::{
+        borrow::Cow,
+        cell::RefCell,
+        collections::{HashMap, HashSet},
+        iter,
+        rc::Rc,
+    },
+};
+
+/// The left-driven [`super::JoinCandidates`] pipeline cannot answer "was this right row matched by
+/// *any* left row?" — its groups are keyed by left row, and the right rows inside a group carry no
+/// stable identity. So this executor drives the join itself, buffering the right relation to use
+/// each row's position as its identity.
+pub(crate) fn execute<'a, T: GStore>(
+    storage: &'a T,
+    plan: &'a RightOuterJoinPlan,
+    filter_context: Option<&Rc<RowContext<'a>>>,
+) -> Result<SelectedRows<'a>> {
+    let (mechanism, condition) = split_input(&plan.input);
+    let SelectedRows {
+        mut sources,
+        rows: left_rows,
+    } = execute_left(storage, mechanism.input(), filter_context)?;
+
+    let right = source::execute(storage, mechanism.right())?;
+    let right_alias = right.output.alias;
+    let right_names = Rc::clone(&right.output.names);
+
+    // The *outer* query's context, not a per-left-row one, matching how `hash::build_rows` prepares
+    // its side: a right-side subquery correlating to the left relation fails to resolve identifiers.
+    let all_rows: Rc<[Row]> = right
+        .rows(filter_context.map(Rc::clone))?
+        .rows
+        .map(|row| {
+            row.map(|mut row| {
+                row.columns = Rc::clone(&right_names);
+                row
+            })
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into();
+
+    let lookup = Lookup::new(storage, mechanism, filter_context, right_alias, &all_rows)?;
+
+    // Must run before the right source joins `sources`: the plan's relations describe the left side
+    // alone, and `null_left_context` pairs them with `sources` by position.
+    let null_left = null_left_context(&sources, &plan.null_extend.relations)?;
+    sources.joined.push(SourceColumns {
+        alias: right_alias,
+        names: Rc::clone(&right_names),
+    });
+
+    let seen: Rc<RefCell<HashSet<usize>>> = Rc::new(RefCell::new(HashSet::new()));
+    let outer_context = filter_context.map(Rc::clone);
+
+    let matched = {
+        let (seen, all_rows) = (Rc::clone(&seen), Rc::clone(&all_rows));
+
+        left_rows.flat_map(move |left| {
+            let left = match left {
+                Ok(left) => left,
+                Err(error) => return Box::new(iter::once(Err(error))) as SelectedIter<'a>,
+            };
+            let evaluation_context = match &outer_context {
+                Some(outer) => Rc::new(RowContext::concat(Rc::clone(&left), Rc::clone(outer))),
+                None => Rc::clone(&left),
+            };
+
+            let candidates = match lookup.candidates(storage, &evaluation_context, all_rows.len()) {
+                Ok(candidates) => candidates,
+                Err(error) => return Box::new(iter::once(Err(error))) as SelectedIter<'a>,
+            };
+
+            let (seen, all_rows) = (Rc::clone(&seen), Rc::clone(&all_rows));
+            let outer_context = outer_context.as_ref().map(Rc::clone);
+
+            Box::new(candidates.into_iter().filter_map(move |index| {
+                let row = all_rows[index].clone();
+                let row_context = Rc::new(RowContext::new(
+                    right_alias,
+                    Cow::Owned(row),
+                    Some(Rc::clone(&left)),
+                ));
+
+                if let Some(expr) = condition {
+                    let context = match &outer_context {
+                        Some(outer) => Rc::new(RowContext::concat(
+                            Rc::clone(&row_context),
+                            Rc::clone(outer),
+                        )),
+                        None => Rc::clone(&row_context),
+                    };
+
+                    match check_expr(storage, Some(&context), None, expr) {
+                        Ok(true) => {}
+                        Ok(false) => return None,
+                        Err(error) => return Some(Err(error)),
+                    }
+                }
+
+                seen.borrow_mut().insert(index);
+
+                Some(Ok(row_context))
+            })) as SelectedIter<'a>
+        })
+    };
+
+    let unmatched = (0..all_rows.len())
+        .filter(move |index| !seen.borrow().contains(index))
+        .map(move |index| {
+            Ok(Rc::new(RowContext::new(
+                right_alias,
+                Cow::Owned(all_rows[index].clone()),
+                null_left.as_ref().map(Rc::clone),
+            )))
+        });
+
+    // `chain` does not touch `unmatched` until `matched` is exhausted, so `seen` is complete
+    // by the time the unmatched pass reads it.
+    Ok(SelectedRows {
+        sources,
+        rows: Box::new(matched.chain(unmatched)),
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Mechanism<'a> {
+    NestedLoop(&'a NestedLoopJoinPlan),
+    Hash(&'a HashJoinPlan),
+}
+
+impl<'a> Mechanism<'a> {
+    fn right(&self) -> &'a SourcePlan {
+        match self {
+            Self::NestedLoop(plan) => &plan.right,
+            Self::Hash(plan) => &plan.right,
+        }
+    }
+
+    fn input(&self) -> LeftInput<'a> {
+        match self {
+            Self::NestedLoop(plan) => LeftInput::NestedLoop(&plan.input),
+            Self::Hash(plan) => LeftInput::Hash(&plan.input),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LeftInput<'a> {
+    NestedLoop(&'a NestedLoopJoinInputPlan),
+    Hash(&'a HashJoinInputPlan),
+}
+
+fn split_input(input: &RightOuterJoinInputPlan) -> (Mechanism<'_>, Option<&ExprPlan>) {
+    match input {
+        RightOuterJoinInputPlan::NestedLoop(plan) => (Mechanism::NestedLoop(plan), None),
+        RightOuterJoinInputPlan::Hash(plan) => (Mechanism::Hash(plan), None),
+        RightOuterJoinInputPlan::Condition(condition) => {
+            let mechanism = match &condition.input {
+                JoinConditionInputPlan::NestedLoop(plan) => Mechanism::NestedLoop(plan),
+                JoinConditionInputPlan::Hash(plan) => Mechanism::Hash(plan),
+            };
+
+            (mechanism, Some(&condition.expr))
+        }
+    }
+}
+
+fn execute_left<'a, T: GStore>(
+    storage: &'a T,
+    input: LeftInput<'a>,
+    filter_context: Option<&Rc<RowContext<'a>>>,
+) -> Result<SelectedRows<'a>> {
+    match input {
+        LeftInput::NestedLoop(NestedLoopJoinInputPlan::Source(source_plan))
+        | LeftInput::Hash(HashJoinInputPlan::Source(source_plan)) => {
+            Ok(source::execute(storage, source_plan)?
+                .rows(None)?
+                .into_selected(None))
+        }
+        LeftInput::NestedLoop(NestedLoopJoinInputPlan::InnerJoin(join))
+        | LeftInput::Hash(HashJoinInputPlan::InnerJoin(join)) => {
+            inner::execute(storage, join, filter_context)
+        }
+        LeftInput::NestedLoop(NestedLoopJoinInputPlan::LeftOuterJoin(join))
+        | LeftInput::Hash(HashJoinInputPlan::LeftOuterJoin(join)) => {
+            left_outer::execute(storage, join, filter_context)
+        }
+        LeftInput::NestedLoop(NestedLoopJoinInputPlan::RightOuterJoin(join))
+        | LeftInput::Hash(HashJoinInputPlan::RightOuterJoin(join)) => {
+            execute(storage, join, filter_context)
+        }
+        LeftInput::NestedLoop(NestedLoopJoinInputPlan::UnplannedRightOuterJoin(_)) => {
+            reject_unplanned_right_outer()
+        }
+    }
+}
+
+enum Lookup<'a> {
+    All,
+    ByKey {
+        index_map: HashMap<Key, Vec<usize>>,
+        input_key: &'a ExprPlan,
+    },
+}
+
+impl<'a> Lookup<'a> {
+    fn new<T: GStore>(
+        storage: &'a T,
+        mechanism: Mechanism<'a>,
+        filter_context: Option<&Rc<RowContext<'a>>>,
+        right_alias: &'a str,
+        all_rows: &[Row],
+    ) -> Result<Self> {
+        let plan = match mechanism {
+            Mechanism::NestedLoop(_) => return Ok(Self::All),
+            Mechanism::Hash(plan) => plan,
+        };
+
+        let mut index_map: HashMap<Key, Vec<usize>> = HashMap::new();
+        for (index, row) in all_rows.iter().enumerate() {
+            let context = Rc::new(RowContext::new(
+                right_alias,
+                Cow::Borrowed(row),
+                filter_context.map(Rc::clone),
+            ));
+
+            let key: Key = evaluate(storage, Some(&context), None, &plan.right_key)?.try_into()?;
+            if matches!(key, Key::None) {
+                continue;
+            }
+            if let Some(expr) = &plan.right_filter
+                && !check_expr(storage, Some(&context), None, expr)?
+            {
+                continue;
+            }
+
+            index_map.entry(key).or_default().push(index);
+        }
+
+        // Rows skipped above stay in `all_rows`, so the unmatched pass still surfaces them.
+        Ok(Self::ByKey {
+            index_map,
+            input_key: &plan.input_key,
+        })
+    }
+
+    fn candidates<T: GStore>(
+        &self,
+        storage: &T,
+        evaluation_context: &Rc<RowContext<'_>>,
+        total: usize,
+    ) -> Result<Vec<usize>> {
+        match self {
+            Self::All => Ok((0..total).collect()),
+            Self::ByKey {
+                index_map,
+                input_key,
+            } => {
+                let key: Key =
+                    evaluate(storage, Some(evaluation_context), None, input_key)?.try_into()?;
+
+                Ok(index_map.get(&key).cloned().unwrap_or_default())
+            }
+        }
+    }
+}
+
+fn null_left_context<'a>(
+    sources: &SelectedSources<'a>,
+    relations: &[String],
+) -> Result<Option<Rc<RowContext<'a>>>> {
+    // `sources` still holds the left side alone, so it lines up positionally with the plan's
+    // relations. Pairing by position keeps duplicate aliases — `A JOIN B AS A` — distinct.
+    let left = iter::once(&sources.base)
+        .chain(sources.joined.iter())
+        .collect::<Vec<_>>();
+    let mismatch = left.len() != relations.len()
+        || left
+            .iter()
+            .zip(relations)
+            .any(|(source, relation)| source.alias != relation);
+    if mismatch {
+        return Err(QueryError::UnreachableNullExtendRelationMismatch(relations.join(", ")).into());
+    }
+
+    Ok(left.into_iter().fold(None, |next, source| {
+        let row = Row {
+            columns: Rc::clone(&source.names),
+            values: source.names.iter().map(|_| Value::Null).collect(),
+        };
+
+        Some(Rc::new(RowContext::new(
+            source.alias,
+            Cow::Owned(row),
+            next,
+        )))
+    }))
+}

--- a/core/src/executor/query/project.rs
+++ b/core/src/executor/query/project.rs
@@ -5,7 +5,7 @@ use {
         SelectedRows, SelectedSources,
         aggregation::{self, AggregatedRows},
         filter, having,
-        join::{inner, left_outer},
+        join::{inner, left_outer, reject_unplanned_right_outer, right_outer},
         source,
     },
     crate::{
@@ -69,6 +69,19 @@ where
         ProjectInputPlan::LeftOuterJoin(join) => {
             let SelectedRows { sources, rows } =
                 left_outer::execute(storage, join, filter_context.as_ref())?;
+            let rows = rows.map(|context| {
+                context.map(|context| AggregateContext {
+                    aggregated: None,
+                    next: Some(context),
+                })
+            });
+
+            (sources, Box::new(rows))
+        }
+        ProjectInputPlan::UnplannedRightOuterJoin(_) => return reject_unplanned_right_outer(),
+        ProjectInputPlan::RightOuterJoin(join) => {
+            let SelectedRows { sources, rows } =
+                right_outer::execute(storage, join, filter_context.as_ref())?;
             let rows = rows.map(|context| {
                 context.map(|context| AggregateContext {
                     aggregated: None,

--- a/core/src/executor/query/source/table.rs
+++ b/core/src/executor/query/source/table.rs
@@ -70,7 +70,7 @@ fn rows<'a, T: GStore>(
 ) -> Result<SourceRows<'a>> {
     let columns = Rc::clone(&source.names);
     let rows = match &table.access {
-        TableAccessPlan::FullScan => {
+        TableAccessPlan::FullScan | TableAccessPlan::FullScanRequired => {
             let rows = storage.scan_data(&table.name)?.map({
                 let columns = Rc::clone(&columns);
 

--- a/core/src/plan/statement.rs
+++ b/core/src/plan/statement.rs
@@ -15,10 +15,12 @@ pub use {
         DistinctInputPlan, DistinctPlan, FilterInputPlan, FilterPlan, HashJoinInputPlan,
         HashJoinPlan, HavingPlan, IndexPredicatePlan, InnerJoinInputPlan, InnerJoinPlan,
         JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
-        LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, OffsetInputPlan,
-        OffsetPlan, OrderByExprPlan, ProjectInputPlan, ProjectPlan, QueryPlan, SelectOrderByPlan,
-        SeriesSourcePlan, SourcePlan, TableAccessPlan, TableAliasPlan, TableSourcePlan,
-        ValuesOrderByPlan, ValuesPlan,
+        LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan, NullExtendPlan,
+        OffsetInputPlan, OffsetPlan, OrderByExprPlan, ProjectInputPlan, ProjectPlan, QueryPlan,
+        RightOuterJoinInputPlan, RightOuterJoinPlan, SelectOrderByPlan, SeriesSourcePlan,
+        SourcePlan, TableAccessPlan, TableAliasPlan, TableSourcePlan,
+        UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan, ValuesOrderByPlan,
+        ValuesPlan,
     },
 };
 

--- a/core/src/plan/statement/query.rs
+++ b/core/src/plan/statement/query.rs
@@ -19,7 +19,8 @@ pub use {
     join::{
         HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan, JoinConditionInputPlan,
         JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan, NestedLoopJoinInputPlan,
-        NestedLoopJoinPlan,
+        NestedLoopJoinPlan, NullExtendPlan, RightOuterJoinInputPlan, RightOuterJoinPlan,
+        UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan,
     },
     limit::{LimitInputPlan, LimitPlan},
     offset::{OffsetInputPlan, OffsetPlan},
@@ -161,6 +162,25 @@ fn joins(from: ast::TableWithJoins) -> NestedLoopJoinInputPlan {
                         }),
                     }))
                 }
+                // A RIGHT JOIN starts out unplanned: the right outer join planner decides which
+                // accumulated left relations an unmatched right row must be NULL-extended with.
+                ast::JoinOperator::RightOuter(ast::JoinConstraint::None) => {
+                    NestedLoopJoinInputPlan::UnplannedRightOuterJoin(Box::new(
+                        UnplannedRightOuterJoinPlan {
+                            input: UnplannedRightOuterJoinInputPlan::NestedLoop(nested_loop),
+                        },
+                    ))
+                }
+                ast::JoinOperator::RightOuter(ast::JoinConstraint::On(expr)) => {
+                    NestedLoopJoinInputPlan::UnplannedRightOuterJoin(Box::new(
+                        UnplannedRightOuterJoinPlan {
+                            input: UnplannedRightOuterJoinInputPlan::Condition(JoinConditionPlan {
+                                input: JoinConditionInputPlan::NestedLoop(nested_loop),
+                                expr: expr.into(),
+                            }),
+                        },
+                    ))
+                }
             }
         },
     )
@@ -175,6 +195,12 @@ fn filter(input: NestedLoopJoinInputPlan, selection: Option<ast::Expr>) -> Aggre
                 NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
                     FilterInputPlan::LeftOuterJoin(join)
                 }
+                NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+                    FilterInputPlan::UnplannedRightOuterJoin(join)
+                }
+                NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+                    FilterInputPlan::RightOuterJoin(join)
+                }
             },
             expr: expr.into(),
         }),
@@ -183,6 +209,12 @@ fn filter(input: NestedLoopJoinInputPlan, selection: Option<ast::Expr>) -> Aggre
             NestedLoopJoinInputPlan::InnerJoin(join) => AggregationInputPlan::InnerJoin(join),
             NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
                 AggregationInputPlan::LeftOuterJoin(join)
+            }
+            NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+                AggregationInputPlan::UnplannedRightOuterJoin(join)
+            }
+            NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+                AggregationInputPlan::RightOuterJoin(join)
             }
         },
     }
@@ -208,6 +240,10 @@ fn group_by_having(
             AggregationInputPlan::Source(source) => ProjectInputPlan::Source(source),
             AggregationInputPlan::InnerJoin(join) => ProjectInputPlan::InnerJoin(join),
             AggregationInputPlan::LeftOuterJoin(join) => ProjectInputPlan::LeftOuterJoin(join),
+            AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+                ProjectInputPlan::UnplannedRightOuterJoin(join)
+            }
+            AggregationInputPlan::RightOuterJoin(join) => ProjectInputPlan::RightOuterJoin(join),
             AggregationInputPlan::Filter(filter) => ProjectInputPlan::Filter(filter),
         },
         None => ProjectInputPlan::Aggregation(AggregationPlan {

--- a/core/src/plan/statement/query/aggregation.rs
+++ b/core/src/plan/statement/query/aggregation.rs
@@ -1,6 +1,9 @@
 use {
     super::FilterPlan,
-    crate::plan::{AggregateExprPlan, ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan},
+    crate::plan::{
+        AggregateExprPlan, ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, RightOuterJoinPlan,
+        SourcePlan, UnplannedRightOuterJoinPlan,
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -9,6 +12,8 @@ pub enum AggregationInputPlan {
     Source(SourcePlan),
     InnerJoin(Box<InnerJoinPlan>),
     LeftOuterJoin(Box<LeftOuterJoinPlan>),
+    UnplannedRightOuterJoin(Box<UnplannedRightOuterJoinPlan>),
+    RightOuterJoin(Box<RightOuterJoinPlan>),
     Filter(FilterPlan),
 }
 
@@ -18,6 +23,8 @@ impl AggregationInputPlan {
             Self::Source(source) => source,
             Self::InnerJoin(join) => join.base_source(),
             Self::LeftOuterJoin(join) => join.base_source(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source(),
+            Self::RightOuterJoin(join) => join.base_source(),
             Self::Filter(filter) => filter.input.base_source(),
         }
     }
@@ -27,6 +34,8 @@ impl AggregationInputPlan {
             Self::Source(_) => Vec::new(),
             Self::InnerJoin(join) => join.joined_sources(),
             Self::LeftOuterJoin(join) => join.joined_sources(),
+            Self::UnplannedRightOuterJoin(join) => join.joined_sources(),
+            Self::RightOuterJoin(join) => join.joined_sources(),
             Self::Filter(filter) => filter.input.joined_sources(),
         }
     }

--- a/core/src/plan/statement/query/filter.rs
+++ b/core/src/plan/statement/query/filter.rs
@@ -1,5 +1,8 @@
 use {
-    crate::plan::{ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, SourcePlan},
+    crate::plan::{
+        ExprPlan, InnerJoinPlan, LeftOuterJoinPlan, RightOuterJoinPlan, SourcePlan,
+        UnplannedRightOuterJoinPlan,
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -8,6 +11,8 @@ pub enum FilterInputPlan {
     Source(SourcePlan),
     InnerJoin(Box<InnerJoinPlan>),
     LeftOuterJoin(Box<LeftOuterJoinPlan>),
+    UnplannedRightOuterJoin(Box<UnplannedRightOuterJoinPlan>),
+    RightOuterJoin(Box<RightOuterJoinPlan>),
 }
 
 impl FilterInputPlan {
@@ -16,6 +21,8 @@ impl FilterInputPlan {
             Self::Source(source) => source,
             Self::InnerJoin(join) => join.base_source(),
             Self::LeftOuterJoin(join) => join.base_source(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source(),
+            Self::RightOuterJoin(join) => join.base_source(),
         }
     }
 
@@ -24,6 +31,8 @@ impl FilterInputPlan {
             Self::Source(source) => source,
             Self::InnerJoin(join) => join.base_source_mut(),
             Self::LeftOuterJoin(join) => join.base_source_mut(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source_mut(),
+            Self::RightOuterJoin(join) => join.base_source_mut(),
         }
     }
 
@@ -32,6 +41,8 @@ impl FilterInputPlan {
             Self::Source(_) => Vec::new(),
             Self::InnerJoin(join) => join.joined_sources(),
             Self::LeftOuterJoin(join) => join.joined_sources(),
+            Self::UnplannedRightOuterJoin(join) => join.joined_sources(),
+            Self::RightOuterJoin(join) => join.joined_sources(),
         }
     }
 }

--- a/core/src/plan/statement/query/join.rs
+++ b/core/src/plan/statement/query/join.rs
@@ -3,6 +3,8 @@ mod hash;
 mod inner;
 mod left_outer;
 mod nested_loop;
+mod right_outer;
+mod unplanned_right_outer;
 
 pub use {
     condition::{JoinConditionInputPlan, JoinConditionPlan},
@@ -10,4 +12,6 @@ pub use {
     inner::{InnerJoinInputPlan, InnerJoinPlan},
     left_outer::{LeftOuterJoinInputPlan, LeftOuterJoinPlan},
     nested_loop::{NestedLoopJoinInputPlan, NestedLoopJoinPlan},
+    right_outer::{NullExtendPlan, RightOuterJoinInputPlan, RightOuterJoinPlan},
+    unplanned_right_outer::{UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan},
 };

--- a/core/src/plan/statement/query/join/hash.rs
+++ b/core/src/plan/statement/query/join/hash.rs
@@ -1,14 +1,46 @@
 use {
-    super::{InnerJoinPlan, LeftOuterJoinPlan},
+    super::{InnerJoinPlan, LeftOuterJoinPlan, RightOuterJoinPlan},
     crate::plan::{ExprPlan, SourcePlan},
     serde::{Deserialize, Serialize},
 };
 
+/// No `UnplannedRightOuterJoin` variant: the hash join planner runs after the right outer join
+/// planner, so a hash mechanism can only sit above an already lowered join.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum HashJoinInputPlan {
     Source(SourcePlan),
     InnerJoin(Box<InnerJoinPlan>),
     LeftOuterJoin(Box<LeftOuterJoinPlan>),
+    RightOuterJoin(Box<RightOuterJoinPlan>),
+}
+
+impl HashJoinInputPlan {
+    pub(crate) fn base_source(&self) -> &SourcePlan {
+        match self {
+            Self::Source(source) => source,
+            Self::InnerJoin(join) => join.base_source(),
+            Self::LeftOuterJoin(join) => join.base_source(),
+            Self::RightOuterJoin(join) => join.base_source(),
+        }
+    }
+
+    pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
+        match self {
+            Self::Source(source) => source,
+            Self::InnerJoin(join) => join.base_source_mut(),
+            Self::LeftOuterJoin(join) => join.base_source_mut(),
+            Self::RightOuterJoin(join) => join.base_source_mut(),
+        }
+    }
+
+    pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
+        match self {
+            Self::Source(_) => Vec::new(),
+            Self::InnerJoin(join) => join.joined_sources(),
+            Self::LeftOuterJoin(join) => join.joined_sources(),
+            Self::RightOuterJoin(join) => join.joined_sources(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -22,27 +54,15 @@ pub struct HashJoinPlan {
 
 impl HashJoinPlan {
     pub(crate) fn base_source(&self) -> &SourcePlan {
-        match &self.input {
-            HashJoinInputPlan::Source(source) => source,
-            HashJoinInputPlan::InnerJoin(join) => join.base_source(),
-            HashJoinInputPlan::LeftOuterJoin(join) => join.base_source(),
-        }
+        self.input.base_source()
     }
 
     pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
-        match &mut self.input {
-            HashJoinInputPlan::Source(source) => source,
-            HashJoinInputPlan::InnerJoin(join) => join.base_source_mut(),
-            HashJoinInputPlan::LeftOuterJoin(join) => join.base_source_mut(),
-        }
+        self.input.base_source_mut()
     }
 
     pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
-        let mut sources = match &self.input {
-            HashJoinInputPlan::Source(_) => Vec::new(),
-            HashJoinInputPlan::InnerJoin(join) => join.joined_sources(),
-            HashJoinInputPlan::LeftOuterJoin(join) => join.joined_sources(),
-        };
+        let mut sources = self.input.joined_sources();
         sources.push(&self.right);
 
         sources

--- a/core/src/plan/statement/query/join/nested_loop.rs
+++ b/core/src/plan/statement/query/join/nested_loop.rs
@@ -1,5 +1,5 @@
 use {
-    super::{InnerJoinPlan, LeftOuterJoinPlan},
+    super::{InnerJoinPlan, LeftOuterJoinPlan, RightOuterJoinPlan, UnplannedRightOuterJoinPlan},
     crate::plan::SourcePlan,
     serde::{Deserialize, Serialize},
 };
@@ -9,6 +9,40 @@ pub enum NestedLoopJoinInputPlan {
     Source(SourcePlan),
     InnerJoin(Box<InnerJoinPlan>),
     LeftOuterJoin(Box<LeftOuterJoinPlan>),
+    UnplannedRightOuterJoin(Box<UnplannedRightOuterJoinPlan>),
+    RightOuterJoin(Box<RightOuterJoinPlan>),
+}
+
+impl NestedLoopJoinInputPlan {
+    pub(crate) fn base_source(&self) -> &SourcePlan {
+        match self {
+            Self::Source(source) => source,
+            Self::InnerJoin(join) => join.base_source(),
+            Self::LeftOuterJoin(join) => join.base_source(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source(),
+            Self::RightOuterJoin(join) => join.base_source(),
+        }
+    }
+
+    pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
+        match self {
+            Self::Source(source) => source,
+            Self::InnerJoin(join) => join.base_source_mut(),
+            Self::LeftOuterJoin(join) => join.base_source_mut(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source_mut(),
+            Self::RightOuterJoin(join) => join.base_source_mut(),
+        }
+    }
+
+    pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
+        match self {
+            Self::Source(_) => Vec::new(),
+            Self::InnerJoin(join) => join.joined_sources(),
+            Self::LeftOuterJoin(join) => join.joined_sources(),
+            Self::UnplannedRightOuterJoin(join) => join.joined_sources(),
+            Self::RightOuterJoin(join) => join.joined_sources(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -19,27 +53,15 @@ pub struct NestedLoopJoinPlan {
 
 impl NestedLoopJoinPlan {
     pub(crate) fn base_source(&self) -> &SourcePlan {
-        match &self.input {
-            NestedLoopJoinInputPlan::Source(source) => source,
-            NestedLoopJoinInputPlan::InnerJoin(join) => join.base_source(),
-            NestedLoopJoinInputPlan::LeftOuterJoin(join) => join.base_source(),
-        }
+        self.input.base_source()
     }
 
     pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
-        match &mut self.input {
-            NestedLoopJoinInputPlan::Source(source) => source,
-            NestedLoopJoinInputPlan::InnerJoin(join) => join.base_source_mut(),
-            NestedLoopJoinInputPlan::LeftOuterJoin(join) => join.base_source_mut(),
-        }
+        self.input.base_source_mut()
     }
 
     pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
-        let mut sources = match &self.input {
-            NestedLoopJoinInputPlan::Source(_) => Vec::new(),
-            NestedLoopJoinInputPlan::InnerJoin(join) => join.joined_sources(),
-            NestedLoopJoinInputPlan::LeftOuterJoin(join) => join.joined_sources(),
-        };
+        let mut sources = self.input.joined_sources();
         sources.push(&self.right);
 
         sources

--- a/core/src/plan/statement/query/join/right_outer.rs
+++ b/core/src/plan/statement/query/join/right_outer.rs
@@ -1,0 +1,202 @@
+use {
+    super::{HashJoinPlan, JoinConditionInputPlan, JoinConditionPlan, NestedLoopJoinPlan},
+    crate::plan::SourcePlan,
+    serde::{Deserialize, Serialize},
+    std::iter,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RightOuterJoinInputPlan {
+    NestedLoop(NestedLoopJoinPlan),
+    Hash(HashJoinPlan),
+    Condition(JoinConditionPlan),
+}
+
+impl RightOuterJoinInputPlan {
+    /// The left input relations, base first and then in join order, without the right relation.
+    pub(crate) fn left_sources(&self) -> Vec<&SourcePlan> {
+        fn sources<'a>(base: &'a SourcePlan, joined: Vec<&'a SourcePlan>) -> Vec<&'a SourcePlan> {
+            iter::once(base).chain(joined).collect()
+        }
+
+        match self {
+            Self::NestedLoop(join) => {
+                sources(join.input.base_source(), join.input.joined_sources())
+            }
+            Self::Hash(join) => sources(join.input.base_source(), join.input.joined_sources()),
+            Self::Condition(condition) => match &condition.input {
+                JoinConditionInputPlan::NestedLoop(join) => {
+                    sources(join.input.base_source(), join.input.joined_sources())
+                }
+                JoinConditionInputPlan::Hash(join) => {
+                    sources(join.input.base_source(), join.input.joined_sources())
+                }
+            },
+        }
+    }
+}
+
+/// The left relations an unmatched right row is NULL-extended with, ordered to line up positionally
+/// with the `SelectedSources` the left pipeline produces at execution time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NullExtendPlan {
+    pub relations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RightOuterJoinPlan {
+    pub input: RightOuterJoinInputPlan,
+    pub null_extend: NullExtendPlan,
+}
+
+impl RightOuterJoinPlan {
+    pub(crate) fn base_source(&self) -> &SourcePlan {
+        match &self.input {
+            RightOuterJoinInputPlan::NestedLoop(join) => join.base_source(),
+            RightOuterJoinInputPlan::Hash(join) => join.base_source(),
+            RightOuterJoinInputPlan::Condition(condition) => condition.base_source(),
+        }
+    }
+
+    pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
+        match &mut self.input {
+            RightOuterJoinInputPlan::NestedLoop(join) => join.base_source_mut(),
+            RightOuterJoinInputPlan::Hash(join) => join.base_source_mut(),
+            RightOuterJoinInputPlan::Condition(condition) => condition.base_source_mut(),
+        }
+    }
+
+    pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
+        match &self.input {
+            RightOuterJoinInputPlan::NestedLoop(join) => join.joined_sources(),
+            RightOuterJoinInputPlan::Hash(join) => join.joined_sources(),
+            RightOuterJoinInputPlan::Condition(condition) => condition.joined_sources(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{NullExtendPlan, RightOuterJoinInputPlan, RightOuterJoinPlan},
+        crate::{
+            data::Value,
+            plan::{
+                ExprPlan, HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan,
+                JoinConditionInputPlan, JoinConditionPlan, NestedLoopJoinInputPlan,
+                NestedLoopJoinPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+            },
+        },
+        pretty_assertions::assert_eq,
+    };
+
+    fn table(name: &str) -> SourcePlan {
+        SourcePlan::Table(TableSourcePlan {
+            name: name.to_owned(),
+            alias: None,
+            access: TableAccessPlan::FullScan,
+        })
+    }
+
+    fn expr() -> ExprPlan {
+        ExprPlan::Value(Value::Bool(true))
+    }
+
+    fn nested_loop() -> NestedLoopJoinPlan {
+        NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::Source(table("A")),
+            right: table("B"),
+        }
+    }
+
+    fn hash() -> HashJoinPlan {
+        HashJoinPlan {
+            input: HashJoinInputPlan::Source(table("A")),
+            right: table("B"),
+            input_key: expr(),
+            right_key: expr(),
+            right_filter: None,
+        }
+    }
+
+    fn condition(input: JoinConditionInputPlan) -> JoinConditionPlan {
+        JoinConditionPlan {
+            input,
+            expr: expr(),
+        }
+    }
+
+    fn null_extend() -> NullExtendPlan {
+        NullExtendPlan {
+            relations: vec!["A".to_owned()],
+        }
+    }
+
+    fn plan(input: RightOuterJoinInputPlan) -> RightOuterJoinPlan {
+        RightOuterJoinPlan {
+            input,
+            null_extend: null_extend(),
+        }
+    }
+
+    #[test]
+    fn accepts_each_input() {
+        for (mut actual, name) in [
+            (
+                plan(RightOuterJoinInputPlan::NestedLoop(nested_loop())),
+                "nested-loop",
+            ),
+            (plan(RightOuterJoinInputPlan::Hash(hash())), "hash"),
+            (
+                plan(RightOuterJoinInputPlan::Condition(condition(
+                    JoinConditionInputPlan::NestedLoop(nested_loop()),
+                ))),
+                "condition",
+            ),
+        ] {
+            assert_eq!(actual.null_extend, null_extend(), "{name}");
+            assert_eq!(actual.base_source(), &table("A"), "{name}");
+            let expected = [table("B")];
+            assert_eq!(
+                actual.joined_sources(),
+                expected.iter().collect::<Vec<_>>(),
+                "{name}"
+            );
+            let expected = [table("A")];
+            assert_eq!(
+                actual.input.left_sources(),
+                expected.iter().collect::<Vec<_>>(),
+                "{name}"
+            );
+            *actual.base_source_mut() = table(name);
+            assert_eq!(actual.base_source(), &table(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn left_sources_accumulate_in_join_order() {
+        let inner_join = InnerJoinPlan {
+            input: InnerJoinInputPlan::NestedLoop(nested_loop()),
+        };
+        let input = RightOuterJoinInputPlan::NestedLoop(NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::InnerJoin(Box::new(inner_join)),
+            right: table("C"),
+        });
+        let expected = [table("A"), table("B")];
+
+        assert_eq!(input.left_sources(), expected.iter().collect::<Vec<_>>());
+
+        let input = RightOuterJoinInputPlan::Condition(condition(JoinConditionInputPlan::Hash(
+            HashJoinPlan {
+                input: HashJoinInputPlan::Source(table("A")),
+                right: table("C"),
+                input_key: expr(),
+                right_key: expr(),
+                right_filter: None,
+            },
+        )));
+        let expected = [table("A")];
+
+        assert_eq!(input.left_sources(), expected.iter().collect::<Vec<_>>());
+    }
+}

--- a/core/src/plan/statement/query/join/unplanned_right_outer.rs
+++ b/core/src/plan/statement/query/join/unplanned_right_outer.rs
@@ -1,0 +1,106 @@
+use {
+    super::{JoinConditionPlan, NestedLoopJoinPlan},
+    crate::plan::SourcePlan,
+    serde::{Deserialize, Serialize},
+};
+
+/// No `Hash` variant: translation only builds nested loop mechanisms, and the hash join planner
+/// runs after this state has already been lowered.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UnplannedRightOuterJoinInputPlan {
+    NestedLoop(NestedLoopJoinPlan),
+    Condition(JoinConditionPlan),
+}
+
+/// Exists only between translation and [`crate::planner::plan_right_outer_join`], which replaces it
+/// with a [`super::RightOuterJoinPlan`]. Later planners pass it through untouched and the executor
+/// rejects it, so reaching execution means a custom [`crate::store::Planner`] skipped that pass.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UnplannedRightOuterJoinPlan {
+    pub input: UnplannedRightOuterJoinInputPlan,
+}
+
+impl UnplannedRightOuterJoinPlan {
+    pub(crate) fn base_source(&self) -> &SourcePlan {
+        match &self.input {
+            UnplannedRightOuterJoinInputPlan::NestedLoop(join) => join.base_source(),
+            UnplannedRightOuterJoinInputPlan::Condition(condition) => condition.base_source(),
+        }
+    }
+
+    pub(crate) fn base_source_mut(&mut self) -> &mut SourcePlan {
+        match &mut self.input {
+            UnplannedRightOuterJoinInputPlan::NestedLoop(join) => join.base_source_mut(),
+            UnplannedRightOuterJoinInputPlan::Condition(condition) => condition.base_source_mut(),
+        }
+    }
+
+    pub(crate) fn joined_sources(&self) -> Vec<&SourcePlan> {
+        match &self.input {
+            UnplannedRightOuterJoinInputPlan::NestedLoop(join) => join.joined_sources(),
+            UnplannedRightOuterJoinInputPlan::Condition(condition) => condition.joined_sources(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan},
+        crate::{
+            data::Value,
+            plan::{
+                ExprPlan, JoinConditionInputPlan, JoinConditionPlan, NestedLoopJoinInputPlan,
+                NestedLoopJoinPlan, SourcePlan, TableAccessPlan, TableSourcePlan,
+            },
+        },
+        pretty_assertions::assert_eq,
+    };
+
+    fn table(name: &str) -> SourcePlan {
+        SourcePlan::Table(TableSourcePlan {
+            name: name.to_owned(),
+            alias: None,
+            access: TableAccessPlan::FullScan,
+        })
+    }
+
+    fn nested_loop() -> NestedLoopJoinPlan {
+        NestedLoopJoinPlan {
+            input: NestedLoopJoinInputPlan::Source(table("A")),
+            right: table("B"),
+        }
+    }
+
+    fn condition() -> JoinConditionPlan {
+        JoinConditionPlan {
+            input: JoinConditionInputPlan::NestedLoop(nested_loop()),
+            expr: ExprPlan::Value(Value::Bool(true)),
+        }
+    }
+
+    #[test]
+    fn accepts_each_input() {
+        let mut actual = UnplannedRightOuterJoinPlan {
+            input: UnplannedRightOuterJoinInputPlan::NestedLoop(nested_loop()),
+        };
+        let expected = UnplannedRightOuterJoinInputPlan::NestedLoop(nested_loop());
+        assert_eq!(actual.input, expected);
+        assert_eq!(actual.base_source(), &table("A"));
+        let expected = [table("B")];
+        assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
+        *actual.base_source_mut() = table("nested-loop");
+        assert_eq!(actual.base_source(), &table("nested-loop"));
+
+        let mut actual = UnplannedRightOuterJoinPlan {
+            input: UnplannedRightOuterJoinInputPlan::Condition(condition()),
+        };
+        let expected = UnplannedRightOuterJoinInputPlan::Condition(condition());
+        assert_eq!(actual.input, expected);
+        assert_eq!(actual.base_source(), &table("A"));
+        let expected = [table("B")];
+        assert_eq!(actual.joined_sources(), expected.iter().collect::<Vec<_>>());
+        *actual.base_source_mut() = table("condition");
+        assert_eq!(actual.base_source(), &table("condition"));
+    }
+}

--- a/core/src/plan/statement/query/project.rs
+++ b/core/src/plan/statement/query/project.rs
@@ -1,6 +1,9 @@
 use {
     super::{AggregationPlan, FilterPlan, HavingPlan},
-    crate::plan::{InnerJoinPlan, LeftOuterJoinPlan, ProjectionPlan, SourcePlan},
+    crate::plan::{
+        InnerJoinPlan, LeftOuterJoinPlan, ProjectionPlan, RightOuterJoinPlan, SourcePlan,
+        UnplannedRightOuterJoinPlan,
+    },
     serde::{Deserialize, Serialize},
 };
 
@@ -9,6 +12,8 @@ pub enum ProjectInputPlan {
     Source(SourcePlan),
     InnerJoin(Box<InnerJoinPlan>),
     LeftOuterJoin(Box<LeftOuterJoinPlan>),
+    UnplannedRightOuterJoin(Box<UnplannedRightOuterJoinPlan>),
+    RightOuterJoin(Box<RightOuterJoinPlan>),
     Filter(FilterPlan),
     Aggregation(AggregationPlan),
     Having(HavingPlan),
@@ -20,6 +25,8 @@ impl ProjectInputPlan {
             Self::Source(source) => source,
             Self::InnerJoin(join) => join.base_source(),
             Self::LeftOuterJoin(join) => join.base_source(),
+            Self::UnplannedRightOuterJoin(join) => join.base_source(),
+            Self::RightOuterJoin(join) => join.base_source(),
             Self::Filter(filter) => filter.input.base_source(),
             Self::Aggregation(aggregation) => aggregation.input.base_source(),
             Self::Having(having) => having.input.input.base_source(),
@@ -31,6 +38,8 @@ impl ProjectInputPlan {
             Self::Source(_) => Vec::new(),
             Self::InnerJoin(join) => join.joined_sources(),
             Self::LeftOuterJoin(join) => join.joined_sources(),
+            Self::UnplannedRightOuterJoin(join) => join.joined_sources(),
+            Self::RightOuterJoin(join) => join.joined_sources(),
             Self::Filter(filter) => filter.input.joined_sources(),
             Self::Aggregation(aggregation) => aggregation.input.joined_sources(),
             Self::Having(having) => having.input.input.joined_sources(),

--- a/core/src/plan/statement/query/source/table_access.rs
+++ b/core/src/plan/statement/query/source/table_access.rs
@@ -10,6 +10,9 @@ use {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TableAccessPlan {
     FullScan,
+    /// A full scan no planner may narrow: a RIGHT JOIN's unmatched pass needs the complete left
+    /// input. Executes exactly like [`Self::FullScan`].
+    FullScanRequired,
     PrimaryKey {
         expr: ExprPlan,
     },

--- a/core/src/planner.rs
+++ b/core/src/planner.rs
@@ -6,6 +6,7 @@ mod hash_join;
 mod index;
 mod primary_key;
 mod query;
+mod right_outer_join;
 mod schema;
 mod schemaless;
 mod validate;
@@ -13,6 +14,6 @@ mod validate;
 pub use {
     self::validate::validate, aggregate::plan as plan_aggregate, error::*,
     hash_join::plan as plan_hash_join, index::plan as plan_index,
-    primary_key::plan as plan_primary_key, schema::fetch_schema_map,
-    schemaless::plan as plan_schemaless,
+    primary_key::plan as plan_primary_key, right_outer_join::plan as plan_right_outer_join,
+    schema::fetch_schema_map, schemaless::plan as plan_schemaless,
 };

--- a/core/src/planner/aggregate.rs
+++ b/core/src/planner/aggregate.rs
@@ -6,8 +6,10 @@ use {
         InnerJoinInputPlan, InnerJoinPlan, JoinConditionInputPlan, JoinConditionPlan,
         LeftOuterJoinInputPlan, LeftOuterJoinPlan, LimitInputPlan, LimitPlan,
         NestedLoopJoinInputPlan, NestedLoopJoinPlan, OffsetInputPlan, OffsetPlan, OrderByExprPlan,
-        ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan, SelectItemPlan,
-        SelectOrderByPlan, SourcePlan, StatementPlan, ValuesOrderByPlan, ValuesPlan,
+        ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan, RightOuterJoinInputPlan,
+        RightOuterJoinPlan, SelectItemPlan, SelectOrderByPlan, SourcePlan, StatementPlan,
+        UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan, ValuesOrderByPlan,
+        ValuesPlan,
     },
     std::collections::HashMap,
 };
@@ -155,6 +157,8 @@ fn plan_project_input(input: &mut ProjectInputPlan) {
         ProjectInputPlan::Source(relation) => plan_source(relation),
         ProjectInputPlan::InnerJoin(join) => plan_inner_join(join),
         ProjectInputPlan::LeftOuterJoin(join) => plan_left_outer_join(join),
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => plan_unplanned_right_outer_join(join),
+        ProjectInputPlan::RightOuterJoin(join) => plan_right_outer_join(join),
         ProjectInputPlan::Filter(filter) => plan_filter(filter),
         ProjectInputPlan::Aggregation(aggregation) => {
             plan_aggregation_input(&mut aggregation.input);
@@ -185,6 +189,8 @@ fn plan_filter(FilterPlan { input, expr }: &mut FilterPlan) {
         FilterInputPlan::Source(relation) => plan_source(relation),
         FilterInputPlan::InnerJoin(join) => plan_inner_join(join),
         FilterInputPlan::LeftOuterJoin(join) => plan_left_outer_join(join),
+        FilterInputPlan::UnplannedRightOuterJoin(join) => plan_unplanned_right_outer_join(join),
+        FilterInputPlan::RightOuterJoin(join) => plan_right_outer_join(join),
     }
     plan_expr(expr);
 }
@@ -194,6 +200,10 @@ fn plan_aggregation_input(input: &mut AggregationInputPlan) {
         AggregationInputPlan::Source(relation) => plan_source(relation),
         AggregationInputPlan::InnerJoin(join) => plan_inner_join(join),
         AggregationInputPlan::LeftOuterJoin(join) => plan_left_outer_join(join),
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            plan_unplanned_right_outer_join(join);
+        }
+        AggregationInputPlan::RightOuterJoin(join) => plan_right_outer_join(join),
         AggregationInputPlan::Filter(filter) => plan_filter(filter),
     }
 }
@@ -227,6 +237,21 @@ fn plan_left_outer_join(join: &mut LeftOuterJoinPlan) {
     }
 }
 
+fn plan_unplanned_right_outer_join(join: &mut UnplannedRightOuterJoinPlan) {
+    match &mut join.input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => plan_nested_loop_join(join),
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => plan_join_condition(condition),
+    }
+}
+
+fn plan_right_outer_join(join: &mut RightOuterJoinPlan) {
+    match &mut join.input {
+        RightOuterJoinInputPlan::NestedLoop(join) => plan_nested_loop_join(join),
+        RightOuterJoinInputPlan::Hash(join) => plan_hash_join(join),
+        RightOuterJoinInputPlan::Condition(condition) => plan_join_condition(condition),
+    }
+}
+
 fn plan_join_condition(condition: &mut JoinConditionPlan) {
     match &mut condition.input {
         JoinConditionInputPlan::NestedLoop(join) => plan_nested_loop_join(join),
@@ -240,6 +265,10 @@ fn plan_nested_loop_join(join: &mut NestedLoopJoinPlan) {
         NestedLoopJoinInputPlan::Source(source) => plan_source(source),
         NestedLoopJoinInputPlan::InnerJoin(join) => plan_inner_join(join),
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => plan_left_outer_join(join),
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            plan_unplanned_right_outer_join(join);
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => plan_right_outer_join(join),
     }
     plan_source(&mut join.right);
 }
@@ -249,6 +278,7 @@ fn plan_hash_join(join: &mut HashJoinPlan) {
         HashJoinInputPlan::Source(source) => plan_source(source),
         HashJoinInputPlan::InnerJoin(join) => plan_inner_join(join),
         HashJoinInputPlan::LeftOuterJoin(join) => plan_left_outer_join(join),
+        HashJoinInputPlan::RightOuterJoin(join) => plan_right_outer_join(join),
     }
     plan_source(&mut join.right);
     plan_expr(&mut join.input_key);
@@ -348,6 +378,20 @@ fn bind_project(
                 aggregate_slots: aggregates,
             });
         }
+        ProjectInputPlan::UnplannedRightOuterJoin(join) if !aggregates.is_empty() => {
+            *input = ProjectInputPlan::Aggregation(AggregationPlan {
+                input: AggregationInputPlan::UnplannedRightOuterJoin(join.clone()),
+                group_by: Vec::new(),
+                aggregate_slots: aggregates,
+            });
+        }
+        ProjectInputPlan::RightOuterJoin(join) if !aggregates.is_empty() => {
+            *input = ProjectInputPlan::Aggregation(AggregationPlan {
+                input: AggregationInputPlan::RightOuterJoin(join.clone()),
+                group_by: Vec::new(),
+                aggregate_slots: aggregates,
+            });
+        }
         ProjectInputPlan::Filter(filter) if !aggregates.is_empty() => {
             *input = ProjectInputPlan::Aggregation(AggregationPlan {
                 input: AggregationInputPlan::Filter(filter.clone()),
@@ -358,6 +402,8 @@ fn bind_project(
         ProjectInputPlan::Source(_)
         | ProjectInputPlan::InnerJoin(_)
         | ProjectInputPlan::LeftOuterJoin(_)
+        | ProjectInputPlan::UnplannedRightOuterJoin(_)
+        | ProjectInputPlan::RightOuterJoin(_)
         | ProjectInputPlan::Filter(_) => {}
         ProjectInputPlan::Aggregation(aggregation) => {
             aggregation.aggregate_slots = aggregates;

--- a/core/src/planner/expr/evaluable.rs
+++ b/core/src/planner/expr/evaluable.rs
@@ -7,8 +7,9 @@ use {
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
             OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan,
-            SelectItemPlan, SelectOrderByPlan, SourcePlan, TableAliasPlan, ValuesOrderByPlan,
-            ValuesPlan,
+            RightOuterJoinInputPlan, RightOuterJoinPlan, SelectItemPlan, SelectOrderByPlan,
+            SourcePlan, TableAliasPlan, UnplannedRightOuterJoinInputPlan,
+            UnplannedRightOuterJoinPlan, ValuesOrderByPlan, ValuesPlan,
         },
         planner::context::Context,
     },
@@ -117,6 +118,10 @@ fn check_project(context: Option<&Rc<Context<'_>>>, project: &ProjectPlan) -> bo
         ProjectInputPlan::Source(relation) => check_source(context, relation),
         ProjectInputPlan::InnerJoin(join) => check_inner_join(context, join),
         ProjectInputPlan::LeftOuterJoin(join) => check_left_outer_join(context, join),
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+            check_unplanned_right_outer_join(context, join)
+        }
+        ProjectInputPlan::RightOuterJoin(join) => check_right_outer_join(context, join),
         ProjectInputPlan::Filter(filter) => check_filter(context, filter),
         ProjectInputPlan::Aggregation(aggregation) => {
             check_aggregation_input(context, &aggregation.input)
@@ -153,6 +158,10 @@ fn check_filter(context: Option<&Rc<Context<'_>>>, filter: &FilterPlan) -> bool 
         FilterInputPlan::Source(relation) => check_source(context, relation),
         FilterInputPlan::InnerJoin(join) => check_inner_join(context, join),
         FilterInputPlan::LeftOuterJoin(join) => check_left_outer_join(context, join),
+        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+            check_unplanned_right_outer_join(context, join)
+        }
+        FilterInputPlan::RightOuterJoin(join) => check_right_outer_join(context, join),
     };
 
     input && check_expr(context.map(Rc::clone), &filter.expr)
@@ -166,6 +175,10 @@ fn check_aggregation_input(
         AggregationInputPlan::Source(relation) => check_source(context, relation),
         AggregationInputPlan::InnerJoin(join) => check_inner_join(context, join),
         AggregationInputPlan::LeftOuterJoin(join) => check_left_outer_join(context, join),
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            check_unplanned_right_outer_join(context, join)
+        }
+        AggregationInputPlan::RightOuterJoin(join) => check_right_outer_join(context, join),
         AggregationInputPlan::Filter(filter) => check_filter(context, filter),
     }
 }
@@ -186,6 +199,26 @@ fn check_left_outer_join(context: Option<&Rc<Context<'_>>>, join: &LeftOuterJoin
     }
 }
 
+fn check_unplanned_right_outer_join(
+    context: Option<&Rc<Context<'_>>>,
+    join: &UnplannedRightOuterJoinPlan,
+) -> bool {
+    match &join.input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => check_nested_loop(context, join),
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+            check_condition(context, condition)
+        }
+    }
+}
+
+fn check_right_outer_join(context: Option<&Rc<Context<'_>>>, join: &RightOuterJoinPlan) -> bool {
+    match &join.input {
+        RightOuterJoinInputPlan::NestedLoop(join) => check_nested_loop(context, join),
+        RightOuterJoinInputPlan::Hash(join) => check_hash(context, join),
+        RightOuterJoinInputPlan::Condition(condition) => check_condition(context, condition),
+    }
+}
+
 fn check_condition(context: Option<&Rc<Context<'_>>>, condition: &JoinConditionPlan) -> bool {
     let input = match &condition.input {
         JoinConditionInputPlan::NestedLoop(join) => check_nested_loop(context, join),
@@ -200,6 +233,10 @@ fn check_nested_loop(context: Option<&Rc<Context<'_>>>, join: &NestedLoopJoinPla
         NestedLoopJoinInputPlan::Source(source) => check_source(context, source),
         NestedLoopJoinInputPlan::InnerJoin(join) => check_inner_join(context, join),
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => check_left_outer_join(context, join),
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            check_unplanned_right_outer_join(context, join)
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => check_right_outer_join(context, join),
     };
 
     input && check_source(context, &join.right)
@@ -210,6 +247,7 @@ fn check_hash(context: Option<&Rc<Context<'_>>>, join: &HashJoinPlan) -> bool {
         HashJoinInputPlan::Source(source) => check_source(context, source),
         HashJoinInputPlan::InnerJoin(join) => check_inner_join(context, join),
         HashJoinInputPlan::LeftOuterJoin(join) => check_left_outer_join(context, join),
+        HashJoinInputPlan::RightOuterJoin(join) => check_right_outer_join(context, join),
     };
 
     input

--- a/core/src/planner/hash_join.rs
+++ b/core/src/planner/hash_join.rs
@@ -8,7 +8,9 @@ use {
             FilterPlan, HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan,
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
-            OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, QueryPlan, StatementPlan,
+            OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, QueryPlan,
+            RightOuterJoinInputPlan, RightOuterJoinPlan, StatementPlan,
+            UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan,
         },
     },
     std::{collections::HashMap, hash::BuildHasher, rc::Rc},
@@ -134,6 +136,14 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
                 let (_, join) = self.left_outer_join(outer_context, *join);
                 ProjectInputPlan::LeftOuterJoin(Box::new(join))
             }
+            ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+                let (_, join) = self.unplanned_right_outer_join(outer_context, *join);
+                ProjectInputPlan::UnplannedRightOuterJoin(Box::new(join))
+            }
+            ProjectInputPlan::RightOuterJoin(join) => {
+                let (_, join) = self.right_outer_join(outer_context, *join);
+                ProjectInputPlan::RightOuterJoin(Box::new(join))
+            }
             ProjectInputPlan::Filter(filter) => {
                 ProjectInputPlan::Filter(self.filter(outer_context.map(Rc::clone), filter))
             }
@@ -185,6 +195,14 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
                 let (_, join) = self.left_outer_join(outer_context.as_ref(), *join);
                 AggregationInputPlan::LeftOuterJoin(Box::new(join))
             }
+            AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+                let (_, join) = self.unplanned_right_outer_join(outer_context.as_ref(), *join);
+                AggregationInputPlan::UnplannedRightOuterJoin(Box::new(join))
+            }
+            AggregationInputPlan::RightOuterJoin(join) => {
+                let (_, join) = self.right_outer_join(outer_context.as_ref(), *join);
+                AggregationInputPlan::RightOuterJoin(Box::new(join))
+            }
             AggregationInputPlan::Filter(filter) => {
                 AggregationInputPlan::Filter(self.filter(outer_context, filter))
             }
@@ -217,6 +235,17 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
             FilterInputPlan::LeftOuterJoin(join) => {
                 let (context, join) = self.left_outer_join(outer_context, *join);
                 (context, FilterInputPlan::LeftOuterJoin(Box::new(join)))
+            }
+            FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                let (context, join) = self.unplanned_right_outer_join(outer_context, *join);
+                (
+                    context,
+                    FilterInputPlan::UnplannedRightOuterJoin(Box::new(join)),
+                )
+            }
+            FilterInputPlan::RightOuterJoin(join) => {
+                let (context, join) = self.right_outer_join(outer_context, *join);
+                (context, FilterInputPlan::RightOuterJoin(Box::new(join)))
             }
         }
     }
@@ -265,6 +294,81 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
         (context, LeftOuterJoinPlan { input })
     }
 
+    /// Reachable only when [`crate::planner::plan_right_outer_join`] was skipped; recursing keeps
+    /// the subtree planned so the executor is the single place that reports the missing pass.
+    fn unplanned_right_outer_join(
+        &self,
+        outer_context: Option<&Rc<Context<'a>>>,
+        plan: UnplannedRightOuterJoinPlan,
+    ) -> (Option<Rc<Context<'a>>>, UnplannedRightOuterJoinPlan) {
+        let (context, input) = match plan.input {
+            UnplannedRightOuterJoinInputPlan::NestedLoop(plan) => {
+                let (context, plan) = self.nested_loop(outer_context, plan);
+                (context, UnplannedRightOuterJoinInputPlan::NestedLoop(plan))
+            }
+            UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+                let (context, condition) = self.join_condition(outer_context, condition);
+                (
+                    context,
+                    UnplannedRightOuterJoinInputPlan::Condition(condition),
+                )
+            }
+        };
+
+        (context, UnplannedRightOuterJoinPlan { input })
+    }
+
+    /// Leaves the join's own `ON` condition as a nested loop: promoting a RIGHT JOIN to a hash
+    /// mechanism is a separate change.
+    fn right_outer_join(
+        &self,
+        outer_context: Option<&Rc<Context<'a>>>,
+        plan: RightOuterJoinPlan,
+    ) -> (Option<Rc<Context<'a>>>, RightOuterJoinPlan) {
+        let RightOuterJoinPlan { input, null_extend } = plan;
+        let (context, input) = match input {
+            RightOuterJoinInputPlan::NestedLoop(plan) => {
+                let (context, plan) = self.nested_loop(outer_context, plan);
+                (context, RightOuterJoinInputPlan::NestedLoop(plan))
+            }
+            RightOuterJoinInputPlan::Hash(plan) => {
+                let (context, plan) = self.hash(outer_context, plan);
+                (context, RightOuterJoinInputPlan::Hash(plan))
+            }
+            RightOuterJoinInputPlan::Condition(condition) => {
+                let (context, condition) = self.join_condition(outer_context, condition);
+                (context, RightOuterJoinInputPlan::Condition(condition))
+            }
+        };
+
+        (context, RightOuterJoinPlan { input, null_extend })
+    }
+
+    fn join_condition(
+        &self,
+        outer_context: Option<&Rc<Context<'a>>>,
+        condition: JoinConditionPlan,
+    ) -> (Option<Rc<Context<'a>>>, JoinConditionPlan) {
+        let JoinConditionPlan { input, expr } = condition;
+        let (context, input) = match input {
+            JoinConditionInputPlan::NestedLoop(plan) => {
+                let (context, plan) = self.nested_loop(outer_context, plan);
+                (context, JoinConditionInputPlan::NestedLoop(plan))
+            }
+            JoinConditionInputPlan::Hash(plan) => {
+                let (context, plan) = self.hash(outer_context, plan);
+                (context, JoinConditionInputPlan::Hash(plan))
+            }
+        };
+        let expr_context = Context::concat(
+            context.as_ref().map(Rc::clone),
+            outer_context.map(Rc::clone),
+        );
+        let expr = self.subquery_expr(expr_context, expr);
+
+        (context, JoinConditionPlan { input, expr })
+    }
+
     fn nested_loop(
         &self,
         outer_context: Option<&Rc<Context<'a>>>,
@@ -296,6 +400,20 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
                 (
                     context,
                     NestedLoopJoinInputPlan::LeftOuterJoin(Box::new(join)),
+                )
+            }
+            NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+                let (context, join) = self.unplanned_right_outer_join(outer_context, *join);
+                (
+                    context,
+                    NestedLoopJoinInputPlan::UnplannedRightOuterJoin(Box::new(join)),
+                )
+            }
+            NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+                let (context, join) = self.right_outer_join(outer_context, *join);
+                (
+                    context,
+                    NestedLoopJoinInputPlan::RightOuterJoin(Box::new(join)),
                 )
             }
         }
@@ -343,6 +461,10 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
             HashJoinInputPlan::LeftOuterJoin(join) => {
                 let (context, join) = self.left_outer_join(outer_context, *join);
                 (context, HashJoinInputPlan::LeftOuterJoin(Box::new(join)))
+            }
+            HashJoinInputPlan::RightOuterJoin(join) => {
+                let (context, join) = self.right_outer_join(outer_context, *join);
+                (context, HashJoinInputPlan::RightOuterJoin(Box::new(join)))
             }
         }
     }
@@ -444,12 +566,24 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
         let input_key = self.subquery_expr(value_context.as_ref().map(Rc::clone), value_expr);
         let right_filter =
             where_clause.map(|expr| self.subquery_expr(key_context.as_ref().map(Rc::clone), expr));
-        let hash = HashJoinPlan {
-            input: nested_loop_to_hash_input(input),
-            right,
-            input_key,
-            right_key,
-            right_filter,
+        let hash = match nested_loop_to_hash_input(input) {
+            HashJoinInputMatch::Hashable(input) => HashJoinPlan {
+                input,
+                right,
+                input_key,
+                right_key,
+                right_filter,
+            },
+            HashJoinInputMatch::Unhashable(input) => {
+                let expr = self.subquery_expr(value_context, original_expr);
+                let context = self.update_context(input_context, &right);
+                let condition = JoinConditionPlan {
+                    input: JoinConditionInputPlan::NestedLoop(NestedLoopJoinPlan { input, right }),
+                    expr,
+                };
+
+                return (context, InnerJoinInputPlan::Condition(condition));
+            }
         };
         let context = self.update_context(input_context, &hash.right);
 
@@ -564,12 +698,24 @@ impl<'a, S: BuildHasher> HashJoinPlanner<'a, S> {
         let input_key = self.subquery_expr(value_context.as_ref().map(Rc::clone), value_expr);
         let right_filter =
             where_clause.map(|expr| self.subquery_expr(key_context.as_ref().map(Rc::clone), expr));
-        let hash = HashJoinPlan {
-            input: nested_loop_to_hash_input(input),
-            right,
-            input_key,
-            right_key,
-            right_filter,
+        let hash = match nested_loop_to_hash_input(input) {
+            HashJoinInputMatch::Hashable(input) => HashJoinPlan {
+                input,
+                right,
+                input_key,
+                right_key,
+                right_filter,
+            },
+            HashJoinInputMatch::Unhashable(input) => {
+                let expr = self.subquery_expr(value_context, original_expr);
+                let context = self.update_context(input_context, &right);
+                let condition = JoinConditionPlan {
+                    input: JoinConditionInputPlan::NestedLoop(NestedLoopJoinPlan { input, right }),
+                    expr,
+                };
+
+                return (context, LeftOuterJoinInputPlan::Condition(condition));
+            }
         };
         let context = self.update_context(input_context, &hash.right);
 
@@ -693,12 +839,24 @@ fn find_evaluable(
     }
 }
 
-fn nested_loop_to_hash_input(input: NestedLoopJoinInputPlan) -> HashJoinInputPlan {
-    match input {
+enum HashJoinInputMatch {
+    Hashable(HashJoinInputPlan),
+    Unhashable(NestedLoopJoinInputPlan),
+}
+
+/// A hash mechanism cannot carry an unplanned join, so that input is handed back untouched.
+fn nested_loop_to_hash_input(input: NestedLoopJoinInputPlan) -> HashJoinInputMatch {
+    let input = match input {
         NestedLoopJoinInputPlan::Source(source) => HashJoinInputPlan::Source(source),
         NestedLoopJoinInputPlan::InnerJoin(join) => HashJoinInputPlan::InnerJoin(join),
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => HashJoinInputPlan::LeftOuterJoin(join),
-    }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => HashJoinInputPlan::RightOuterJoin(join),
+        input @ NestedLoopJoinInputPlan::UnplannedRightOuterJoin(_) => {
+            return HashJoinInputMatch::Unhashable(input);
+        }
+    };
+
+    HashJoinInputMatch::Hashable(input)
 }
 
 #[cfg(test)]

--- a/core/src/planner/index.rs
+++ b/core/src/planner/index.rs
@@ -162,6 +162,18 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
 
                 (ProjectInputPlan::LeftOuterJoin(join), order_by)
             }
+            ProjectInputPlan::UnplannedRightOuterJoin(mut join) => {
+                let (_, order_by) =
+                    self.source(outer_context, join.base_source_mut(), None, order_by);
+
+                (ProjectInputPlan::UnplannedRightOuterJoin(join), order_by)
+            }
+            ProjectInputPlan::RightOuterJoin(mut join) => {
+                let (_, order_by) =
+                    self.source(outer_context, join.base_source_mut(), None, order_by);
+
+                (ProjectInputPlan::RightOuterJoin(join), order_by)
+            }
             ProjectInputPlan::Filter(FilterPlan { mut input, expr }) => {
                 let (expr, order_by) =
                     self.source(outer_context, input.base_source_mut(), Some(expr), order_by);
@@ -172,6 +184,12 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
                         FilterInputPlan::InnerJoin(join) => ProjectInputPlan::InnerJoin(join),
                         FilterInputPlan::LeftOuterJoin(join) => {
                             ProjectInputPlan::LeftOuterJoin(join)
+                        }
+                        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                            ProjectInputPlan::UnplannedRightOuterJoin(join)
+                        }
+                        FilterInputPlan::RightOuterJoin(join) => {
+                            ProjectInputPlan::RightOuterJoin(join)
                         }
                     },
                 };
@@ -242,6 +260,21 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
 
                 (AggregationInputPlan::LeftOuterJoin(join), order_by)
             }
+            AggregationInputPlan::UnplannedRightOuterJoin(mut join) => {
+                let (_, order_by) =
+                    self.source(outer_context, join.base_source_mut(), None, order_by);
+
+                (
+                    AggregationInputPlan::UnplannedRightOuterJoin(join),
+                    order_by,
+                )
+            }
+            AggregationInputPlan::RightOuterJoin(mut join) => {
+                let (_, order_by) =
+                    self.source(outer_context, join.base_source_mut(), None, order_by);
+
+                (AggregationInputPlan::RightOuterJoin(join), order_by)
+            }
             AggregationInputPlan::Filter(FilterPlan { mut input, expr }) => {
                 let (expr, order_by) =
                     self.source(outer_context, input.base_source_mut(), Some(expr), order_by);
@@ -252,6 +285,12 @@ impl<'a, S: BuildHasher> IndexPlanner<'a, S> {
                         FilterInputPlan::InnerJoin(join) => AggregationInputPlan::InnerJoin(join),
                         FilterInputPlan::LeftOuterJoin(join) => {
                             AggregationInputPlan::LeftOuterJoin(join)
+                        }
+                        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                            AggregationInputPlan::UnplannedRightOuterJoin(join)
+                        }
+                        FilterInputPlan::RightOuterJoin(join) => {
+                            AggregationInputPlan::RightOuterJoin(join)
                         }
                     },
                 };

--- a/core/src/planner/primary_key.rs
+++ b/core/src/planner/primary_key.rs
@@ -9,8 +9,9 @@ use {
             FilterPlan, HashJoinInputPlan, HashJoinPlan, InnerJoinInputPlan, InnerJoinPlan,
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
-            OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, QueryPlan, SourcePlan,
-            StatementPlan, TableAccessPlan,
+            OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, QueryPlan,
+            RightOuterJoinInputPlan, RightOuterJoinPlan, SourcePlan, StatementPlan,
+            TableAccessPlan, UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan,
         },
     },
     std::{collections::HashMap, hash::BuildHasher, rc::Rc},
@@ -144,6 +145,14 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
             ProjectInputPlan::LeftOuterJoin(join) => ProjectInputPlan::LeftOuterJoin(Box::new(
                 self.left_outer_join(outer_context, *join),
             )),
+            ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+                ProjectInputPlan::UnplannedRightOuterJoin(Box::new(
+                    self.unplanned_right_outer_join(outer_context, *join),
+                ))
+            }
+            ProjectInputPlan::RightOuterJoin(join) => ProjectInputPlan::RightOuterJoin(Box::new(
+                self.right_outer_join(outer_context, *join),
+            )),
             ProjectInputPlan::Filter(filter) => {
                 let (input, expr) = self.filter(outer_context.map(Rc::clone), filter);
                 match expr {
@@ -153,6 +162,12 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
                         FilterInputPlan::InnerJoin(join) => ProjectInputPlan::InnerJoin(join),
                         FilterInputPlan::LeftOuterJoin(join) => {
                             ProjectInputPlan::LeftOuterJoin(join)
+                        }
+                        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                            ProjectInputPlan::UnplannedRightOuterJoin(join)
+                        }
+                        FilterInputPlan::RightOuterJoin(join) => {
+                            ProjectInputPlan::RightOuterJoin(join)
                         }
                     },
                 }
@@ -203,6 +218,14 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
             AggregationInputPlan::LeftOuterJoin(join) => AggregationInputPlan::LeftOuterJoin(
                 Box::new(self.left_outer_join(outer_context.as_ref(), *join)),
             ),
+            AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+                AggregationInputPlan::UnplannedRightOuterJoin(Box::new(
+                    self.unplanned_right_outer_join(outer_context.as_ref(), *join),
+                ))
+            }
+            AggregationInputPlan::RightOuterJoin(join) => AggregationInputPlan::RightOuterJoin(
+                Box::new(self.right_outer_join(outer_context.as_ref(), *join)),
+            ),
             AggregationInputPlan::Filter(filter) => {
                 let (input, expr) = self.filter(outer_context, filter);
                 match expr {
@@ -212,6 +235,12 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
                         FilterInputPlan::InnerJoin(join) => AggregationInputPlan::InnerJoin(join),
                         FilterInputPlan::LeftOuterJoin(join) => {
                             AggregationInputPlan::LeftOuterJoin(join)
+                        }
+                        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                            AggregationInputPlan::UnplannedRightOuterJoin(join)
+                        }
+                        FilterInputPlan::RightOuterJoin(join) => {
+                            AggregationInputPlan::RightOuterJoin(join)
                         }
                     },
                 }
@@ -232,6 +261,14 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
             }
             FilterInputPlan::LeftOuterJoin(join) => FilterInputPlan::LeftOuterJoin(Box::new(
                 self.left_outer_join(outer_context.as_ref(), *join),
+            )),
+            FilterInputPlan::UnplannedRightOuterJoin(join) => {
+                FilterInputPlan::UnplannedRightOuterJoin(Box::new(
+                    self.unplanned_right_outer_join(outer_context.as_ref(), *join),
+                ))
+            }
+            FilterInputPlan::RightOuterJoin(join) => FilterInputPlan::RightOuterJoin(Box::new(
+                self.right_outer_join(outer_context.as_ref(), *join),
             )),
         };
         let current_context = self.input_context(&input);
@@ -313,6 +350,50 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
         LeftOuterJoinPlan { input }
     }
 
+    /// Reachable only when [`crate::planner::plan_right_outer_join`] was skipped; recursing keeps
+    /// nested subqueries planned so the executor is the single place that reports the missing pass.
+    fn unplanned_right_outer_join(
+        &self,
+        outer_context: Option<&Rc<Context<'a>>>,
+        join: UnplannedRightOuterJoinPlan,
+    ) -> UnplannedRightOuterJoinPlan {
+        let input = match join.input {
+            UnplannedRightOuterJoinInputPlan::NestedLoop(join) => {
+                UnplannedRightOuterJoinInputPlan::NestedLoop(self.nested_loop(outer_context, join))
+            }
+            UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+                UnplannedRightOuterJoinInputPlan::Condition(
+                    self.join_condition(outer_context, condition),
+                )
+            }
+        };
+
+        UnplannedRightOuterJoinPlan { input }
+    }
+
+    /// Recurses for nested subqueries only: the base source is already
+    /// [`TableAccessPlan::FullScanRequired`], so no lookup is installed under a RIGHT JOIN.
+    fn right_outer_join(
+        &self,
+        outer_context: Option<&Rc<Context<'a>>>,
+        join: RightOuterJoinPlan,
+    ) -> RightOuterJoinPlan {
+        let RightOuterJoinPlan { input, null_extend } = join;
+        let input = match input {
+            RightOuterJoinInputPlan::NestedLoop(join) => {
+                RightOuterJoinInputPlan::NestedLoop(self.nested_loop(outer_context, join))
+            }
+            RightOuterJoinInputPlan::Hash(join) => {
+                RightOuterJoinInputPlan::Hash(self.hash(outer_context, join))
+            }
+            RightOuterJoinInputPlan::Condition(condition) => {
+                RightOuterJoinInputPlan::Condition(self.join_condition(outer_context, condition))
+            }
+        };
+
+        RightOuterJoinPlan { input, null_extend }
+    }
+
     fn join_condition(
         &self,
         outer_context: Option<&Rc<Context<'a>>>,
@@ -354,6 +435,16 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
             NestedLoopJoinInputPlan::LeftOuterJoin(join) => NestedLoopJoinInputPlan::LeftOuterJoin(
                 Box::new(self.left_outer_join(outer_context, *join)),
             ),
+            NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+                NestedLoopJoinInputPlan::UnplannedRightOuterJoin(Box::new(
+                    self.unplanned_right_outer_join(outer_context, *join),
+                ))
+            }
+            NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+                NestedLoopJoinInputPlan::RightOuterJoin(Box::new(
+                    self.right_outer_join(outer_context, *join),
+                ))
+            }
         };
 
         NestedLoopJoinPlan {
@@ -378,6 +469,9 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
             HashJoinInputPlan::LeftOuterJoin(join) => HashJoinInputPlan::LeftOuterJoin(Box::new(
                 self.left_outer_join(outer_context, *join),
             )),
+            HashJoinInputPlan::RightOuterJoin(join) => HashJoinInputPlan::RightOuterJoin(Box::new(
+                self.right_outer_join(outer_context, *join),
+            )),
         };
         let input_context = match &input {
             HashJoinInputPlan::Source(source) => self.update_context(None, source),
@@ -385,6 +479,9 @@ impl<'a, S: BuildHasher> PrimaryKeyPlanner<'a, S> {
                 self.source_context(join.base_source(), join.joined_sources())
             }
             HashJoinInputPlan::LeftOuterJoin(join) => {
+                self.source_context(join.base_source(), join.joined_sources())
+            }
+            HashJoinInputPlan::RightOuterJoin(join) => {
                 self.source_context(join.base_source(), join.joined_sources())
             }
         };
@@ -544,7 +641,9 @@ mod tests {
             StatementPlan::Query(QueryPlan::Project(project)) => match &project.input {
                 ProjectInputPlan::Source(_)
                 | ProjectInputPlan::InnerJoin(_)
-                | ProjectInputPlan::LeftOuterJoin(_) => Some(project.input.base_source()),
+                | ProjectInputPlan::LeftOuterJoin(_)
+                | ProjectInputPlan::UnplannedRightOuterJoin(_)
+                | ProjectInputPlan::RightOuterJoin(_) => Some(project.input.base_source()),
                 ProjectInputPlan::Filter(_)
                 | ProjectInputPlan::Aggregation(_)
                 | ProjectInputPlan::Having(_) => None,

--- a/core/src/planner/primary_key/lookup.rs
+++ b/core/src/planner/primary_key/lookup.rs
@@ -196,6 +196,10 @@ mod tests {
             ProjectInputPlan::Source(source) => FilterInputPlan::Source(source),
             ProjectInputPlan::InnerJoin(join) => FilterInputPlan::InnerJoin(join),
             ProjectInputPlan::LeftOuterJoin(join) => FilterInputPlan::LeftOuterJoin(join),
+            ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+                FilterInputPlan::UnplannedRightOuterJoin(join)
+            }
+            ProjectInputPlan::RightOuterJoin(join) => FilterInputPlan::RightOuterJoin(join),
             ProjectInputPlan::Filter(_)
             | ProjectInputPlan::Aggregation(_)
             | ProjectInputPlan::Having(_) => panic!("expected direct source input"),

--- a/core/src/planner/right_outer_join.rs
+++ b/core/src/planner/right_outer_join.rs
@@ -1,0 +1,879 @@
+use {
+    super::expr::visit_mut_expr,
+    crate::plan::{
+        AggregationInputPlan, AggregationPlan, DistinctInputPlan, DistinctPlan, ExprPlan,
+        FilterInputPlan, FilterPlan, HashJoinInputPlan, HashJoinPlan, HavingPlan,
+        InnerJoinInputPlan, InnerJoinPlan, JoinConditionInputPlan, JoinConditionPlan,
+        LeftOuterJoinInputPlan, LeftOuterJoinPlan, LimitInputPlan, LimitPlan,
+        NestedLoopJoinInputPlan, NestedLoopJoinPlan, NullExtendPlan, OffsetInputPlan, OffsetPlan,
+        ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan, RightOuterJoinInputPlan,
+        RightOuterJoinPlan, SelectItemPlan, SelectOrderByPlan, SourcePlan, StatementPlan,
+        TableAccessPlan, UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan,
+        ValuesOrderByPlan, ValuesPlan,
+    },
+    std::mem,
+};
+
+/// Lowers every [`UnplannedRightOuterJoinPlan`] into a [`RightOuterJoinPlan`], deciding which
+/// relations an unmatched right row NULL-extends and marking the left base source
+/// [`TableAccessPlan::FullScanRequired`]. Later passes already gate their rewrites on
+/// [`TableAccessPlan::FullScan`], so the marker disables them without any of them having to
+/// re-interpret RIGHT JOIN syntax.
+///
+/// Missing a nested query here is not a lost optimization but an execution error, so this walks
+/// derived sources and expression subqueries too.
+///
+/// Three expression positions are deliberately *not* walked, because a RIGHT JOIN cannot reach them
+/// at this point in the pipeline — matching what [`super::plan_schemaless`] skips:
+///
+/// - `AggregationPlan::aggregate_slots` is always empty; [`super::plan_aggregate`] fills it last.
+/// - `TableAccessPlan::PrimaryKey` / `Index` expressions cannot exist yet; the primary key and index
+///   planners run later, and `query_builder` (the only other producer) cannot build a RIGHT JOIN.
+///
+/// Should any of those change, the result is an `UnreachableUnplannedRightOuterJoin` error rather
+/// than a wrong answer.
+pub fn plan(statement: StatementPlan) -> StatementPlan {
+    match statement {
+        StatementPlan::Query(query) => StatementPlan::Query(plan_query(query)),
+        StatementPlan::Insert {
+            table_name,
+            columns,
+            source,
+        } => StatementPlan::Insert {
+            table_name,
+            columns,
+            source: plan_query(source),
+        },
+        StatementPlan::CreateTable {
+            if_not_exists,
+            name,
+            columns,
+            source,
+            engine,
+            foreign_keys,
+            comment,
+        } => StatementPlan::CreateTable {
+            if_not_exists,
+            name,
+            columns,
+            source: source.map(|source| Box::new(plan_query(*source))),
+            engine,
+            foreign_keys,
+            comment,
+        },
+        StatementPlan::Update {
+            table_name,
+            assignments,
+            selection,
+        } => StatementPlan::Update {
+            table_name,
+            assignments: assignments
+                .into_iter()
+                .map(|mut assignment| {
+                    plan_expr(&mut assignment.value);
+                    assignment
+                })
+                .collect(),
+            selection: selection.map(plan_owned_expr),
+        },
+        StatementPlan::Delete {
+            table_name,
+            selection,
+        } => StatementPlan::Delete {
+            table_name,
+            selection: selection.map(plan_owned_expr),
+        },
+        _ => statement,
+    }
+}
+
+fn plan_query(query: QueryPlan) -> QueryPlan {
+    match query {
+        QueryPlan::Project(project) => QueryPlan::Project(plan_project(project)),
+        QueryPlan::Values(values) => QueryPlan::Values(plan_values(values)),
+        QueryPlan::SelectOrderBy(order_by) => {
+            QueryPlan::SelectOrderBy(plan_select_order_by(order_by))
+        }
+        QueryPlan::ValuesOrderBy(order_by) => {
+            QueryPlan::ValuesOrderBy(plan_values_order_by(order_by))
+        }
+        QueryPlan::Distinct(distinct) => QueryPlan::Distinct(plan_distinct(distinct)),
+        QueryPlan::Offset(offset) => QueryPlan::Offset(plan_offset(offset)),
+        QueryPlan::Limit(LimitPlan { input, count }) => {
+            let input = match input {
+                LimitInputPlan::Project(project) => LimitInputPlan::Project(plan_project(project)),
+                LimitInputPlan::Values(values) => LimitInputPlan::Values(plan_values(values)),
+                LimitInputPlan::SelectOrderBy(order_by) => {
+                    LimitInputPlan::SelectOrderBy(plan_select_order_by(order_by))
+                }
+                LimitInputPlan::ValuesOrderBy(order_by) => {
+                    LimitInputPlan::ValuesOrderBy(plan_values_order_by(order_by))
+                }
+                LimitInputPlan::Distinct(distinct) => {
+                    LimitInputPlan::Distinct(plan_distinct(distinct))
+                }
+                LimitInputPlan::Offset(offset) => LimitInputPlan::Offset(plan_offset(offset)),
+            };
+
+            QueryPlan::Limit(LimitPlan {
+                input,
+                count: plan_owned_expr(count),
+            })
+        }
+    }
+}
+
+fn plan_offset(OffsetPlan { input, count }: OffsetPlan) -> OffsetPlan {
+    let input = match input {
+        OffsetInputPlan::Project(project) => OffsetInputPlan::Project(plan_project(project)),
+        OffsetInputPlan::Values(values) => OffsetInputPlan::Values(plan_values(values)),
+        OffsetInputPlan::SelectOrderBy(order_by) => {
+            OffsetInputPlan::SelectOrderBy(plan_select_order_by(order_by))
+        }
+        OffsetInputPlan::ValuesOrderBy(order_by) => {
+            OffsetInputPlan::ValuesOrderBy(plan_values_order_by(order_by))
+        }
+        OffsetInputPlan::Distinct(distinct) => OffsetInputPlan::Distinct(plan_distinct(distinct)),
+    };
+
+    OffsetPlan {
+        input,
+        count: plan_owned_expr(count),
+    }
+}
+
+fn plan_distinct(DistinctPlan { input }: DistinctPlan) -> DistinctPlan {
+    let input = match input {
+        DistinctInputPlan::Project(project) => DistinctInputPlan::Project(plan_project(project)),
+        DistinctInputPlan::SelectOrderBy(order_by) => {
+            DistinctInputPlan::SelectOrderBy(plan_select_order_by(order_by))
+        }
+    };
+
+    DistinctPlan { input }
+}
+
+fn plan_select_order_by(
+    SelectOrderByPlan { input, exprs }: SelectOrderByPlan,
+) -> SelectOrderByPlan {
+    SelectOrderByPlan {
+        input: plan_project(input),
+        exprs: exprs
+            .into_iter()
+            .map(|mut order_by| {
+                plan_expr(&mut order_by.expr);
+                order_by
+            })
+            .collect(),
+    }
+}
+
+fn plan_values_order_by(
+    ValuesOrderByPlan { input, exprs }: ValuesOrderByPlan,
+) -> ValuesOrderByPlan {
+    ValuesOrderByPlan {
+        input: plan_values(input),
+        exprs: exprs
+            .into_iter()
+            .map(|mut order_by| {
+                plan_expr(&mut order_by.expr);
+                order_by
+            })
+            .collect(),
+    }
+}
+
+fn plan_values(ValuesPlan(rows): ValuesPlan) -> ValuesPlan {
+    ValuesPlan(
+        rows.into_iter()
+            .map(|row| row.into_iter().map(plan_owned_expr).collect())
+            .collect(),
+    )
+}
+
+fn plan_project(ProjectPlan { input, projection }: ProjectPlan) -> ProjectPlan {
+    let projection = match projection {
+        // A select item can hold a subquery — `SELECT (SELECT … RIGHT JOIN …)` — so the projection
+        // needs the same walk as the input.
+        ProjectionPlan::SelectItems(items) => ProjectionPlan::SelectItems(
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SelectItemPlan::Expr { expr, label } => SelectItemPlan::Expr {
+                        expr: plan_owned_expr(expr),
+                        label,
+                    },
+                    SelectItemPlan::Wildcard | SelectItemPlan::QualifiedWildcard(_) => item,
+                })
+                .collect(),
+        ),
+        ProjectionPlan::SchemalessMap => projection,
+    };
+    let input = match input {
+        ProjectInputPlan::Source(source) => ProjectInputPlan::Source(plan_source(source)),
+        ProjectInputPlan::InnerJoin(join) => {
+            ProjectInputPlan::InnerJoin(Box::new(plan_inner_join(*join)))
+        }
+        ProjectInputPlan::LeftOuterJoin(join) => {
+            ProjectInputPlan::LeftOuterJoin(Box::new(plan_left_outer_join(*join)))
+        }
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+            ProjectInputPlan::RightOuterJoin(Box::new(lower(*join)))
+        }
+        ProjectInputPlan::RightOuterJoin(join) => {
+            ProjectInputPlan::RightOuterJoin(Box::new(plan_right_outer_join(*join)))
+        }
+        ProjectInputPlan::Filter(filter) => ProjectInputPlan::Filter(plan_filter(filter)),
+        ProjectInputPlan::Aggregation(aggregation) => {
+            ProjectInputPlan::Aggregation(plan_aggregation(aggregation))
+        }
+        ProjectInputPlan::Having(HavingPlan { input, expr }) => {
+            ProjectInputPlan::Having(HavingPlan {
+                input: plan_aggregation(input),
+                expr: plan_owned_expr(expr),
+            })
+        }
+    };
+
+    ProjectPlan { input, projection }
+}
+
+fn plan_aggregation(
+    AggregationPlan {
+        input,
+        group_by,
+        aggregate_slots,
+    }: AggregationPlan,
+) -> AggregationPlan {
+    let input = match input {
+        AggregationInputPlan::Source(source) => AggregationInputPlan::Source(plan_source(source)),
+        AggregationInputPlan::InnerJoin(join) => {
+            AggregationInputPlan::InnerJoin(Box::new(plan_inner_join(*join)))
+        }
+        AggregationInputPlan::LeftOuterJoin(join) => {
+            AggregationInputPlan::LeftOuterJoin(Box::new(plan_left_outer_join(*join)))
+        }
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            AggregationInputPlan::RightOuterJoin(Box::new(lower(*join)))
+        }
+        AggregationInputPlan::RightOuterJoin(join) => {
+            AggregationInputPlan::RightOuterJoin(Box::new(plan_right_outer_join(*join)))
+        }
+        AggregationInputPlan::Filter(filter) => AggregationInputPlan::Filter(plan_filter(filter)),
+    };
+
+    AggregationPlan {
+        input,
+        group_by: group_by.into_iter().map(plan_owned_expr).collect(),
+        aggregate_slots,
+    }
+}
+
+fn plan_filter(FilterPlan { input, expr }: FilterPlan) -> FilterPlan {
+    let input = match input {
+        FilterInputPlan::Source(source) => FilterInputPlan::Source(plan_source(source)),
+        FilterInputPlan::InnerJoin(join) => {
+            FilterInputPlan::InnerJoin(Box::new(plan_inner_join(*join)))
+        }
+        FilterInputPlan::LeftOuterJoin(join) => {
+            FilterInputPlan::LeftOuterJoin(Box::new(plan_left_outer_join(*join)))
+        }
+        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+            FilterInputPlan::RightOuterJoin(Box::new(lower(*join)))
+        }
+        FilterInputPlan::RightOuterJoin(join) => {
+            FilterInputPlan::RightOuterJoin(Box::new(plan_right_outer_join(*join)))
+        }
+    };
+
+    FilterPlan {
+        input,
+        expr: plan_owned_expr(expr),
+    }
+}
+
+fn plan_inner_join(InnerJoinPlan { input }: InnerJoinPlan) -> InnerJoinPlan {
+    let input = match input {
+        InnerJoinInputPlan::NestedLoop(join) => {
+            InnerJoinInputPlan::NestedLoop(plan_nested_loop(join))
+        }
+        InnerJoinInputPlan::Hash(join) => InnerJoinInputPlan::Hash(plan_hash(join)),
+        InnerJoinInputPlan::Condition(condition) => {
+            InnerJoinInputPlan::Condition(plan_condition(condition))
+        }
+    };
+
+    InnerJoinPlan { input }
+}
+
+fn plan_left_outer_join(LeftOuterJoinPlan { input }: LeftOuterJoinPlan) -> LeftOuterJoinPlan {
+    let input = match input {
+        LeftOuterJoinInputPlan::NestedLoop(join) => {
+            LeftOuterJoinInputPlan::NestedLoop(plan_nested_loop(join))
+        }
+        LeftOuterJoinInputPlan::Hash(join) => LeftOuterJoinInputPlan::Hash(plan_hash(join)),
+        LeftOuterJoinInputPlan::Condition(condition) => {
+            LeftOuterJoinInputPlan::Condition(plan_condition(condition))
+        }
+    };
+
+    LeftOuterJoinPlan { input }
+}
+
+fn lower(UnplannedRightOuterJoinPlan { input }: UnplannedRightOuterJoinPlan) -> RightOuterJoinPlan {
+    // Lowering the mechanism first means the alias walk below sees only lowered nodes.
+    let input = match input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => {
+            RightOuterJoinInputPlan::NestedLoop(plan_nested_loop(join))
+        }
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+            RightOuterJoinInputPlan::Condition(plan_condition(condition))
+        }
+    };
+    let null_extend = NullExtendPlan {
+        relations: input
+            .left_sources()
+            .into_iter()
+            .map(|source| source.alias_name().to_owned())
+            .collect(),
+    };
+    let mut plan = RightOuterJoinPlan { input, null_extend };
+
+    // Idempotent: chained RIGHT JOINs all resolve to the same leftmost base source. A non-table base
+    // source needs no marker, since only tables carry a narrowable access path.
+    if let SourcePlan::Table(table) = plan.base_source_mut()
+        && table.access == TableAccessPlan::FullScan
+    {
+        table.access = TableAccessPlan::FullScanRequired;
+    }
+
+    plan
+}
+
+/// An already lowered node still needs walking: its subtree can hold further RIGHT JOINs, and a
+/// second run over a planned statement must be a no-op.
+fn plan_right_outer_join(
+    RightOuterJoinPlan { input, null_extend }: RightOuterJoinPlan,
+) -> RightOuterJoinPlan {
+    let input = match input {
+        RightOuterJoinInputPlan::NestedLoop(join) => {
+            RightOuterJoinInputPlan::NestedLoop(plan_nested_loop(join))
+        }
+        RightOuterJoinInputPlan::Hash(join) => RightOuterJoinInputPlan::Hash(plan_hash(join)),
+        RightOuterJoinInputPlan::Condition(condition) => {
+            RightOuterJoinInputPlan::Condition(plan_condition(condition))
+        }
+    };
+
+    RightOuterJoinPlan { input, null_extend }
+}
+
+fn plan_condition(JoinConditionPlan { input, expr }: JoinConditionPlan) -> JoinConditionPlan {
+    let input = match input {
+        JoinConditionInputPlan::NestedLoop(join) => {
+            JoinConditionInputPlan::NestedLoop(plan_nested_loop(join))
+        }
+        JoinConditionInputPlan::Hash(join) => JoinConditionInputPlan::Hash(plan_hash(join)),
+    };
+
+    JoinConditionPlan {
+        input,
+        expr: plan_owned_expr(expr),
+    }
+}
+
+fn plan_nested_loop(NestedLoopJoinPlan { input, right }: NestedLoopJoinPlan) -> NestedLoopJoinPlan {
+    let input = match input {
+        NestedLoopJoinInputPlan::Source(source) => {
+            NestedLoopJoinInputPlan::Source(plan_source(source))
+        }
+        NestedLoopJoinInputPlan::InnerJoin(join) => {
+            NestedLoopJoinInputPlan::InnerJoin(Box::new(plan_inner_join(*join)))
+        }
+        NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
+            NestedLoopJoinInputPlan::LeftOuterJoin(Box::new(plan_left_outer_join(*join)))
+        }
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            NestedLoopJoinInputPlan::RightOuterJoin(Box::new(lower(*join)))
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+            NestedLoopJoinInputPlan::RightOuterJoin(Box::new(plan_right_outer_join(*join)))
+        }
+    };
+
+    NestedLoopJoinPlan {
+        input,
+        right: plan_source(right),
+    }
+}
+
+fn plan_hash(
+    HashJoinPlan {
+        input,
+        right,
+        input_key,
+        right_key,
+        right_filter,
+    }: HashJoinPlan,
+) -> HashJoinPlan {
+    let input = match input {
+        HashJoinInputPlan::Source(source) => HashJoinInputPlan::Source(plan_source(source)),
+        HashJoinInputPlan::InnerJoin(join) => {
+            HashJoinInputPlan::InnerJoin(Box::new(plan_inner_join(*join)))
+        }
+        HashJoinInputPlan::LeftOuterJoin(join) => {
+            HashJoinInputPlan::LeftOuterJoin(Box::new(plan_left_outer_join(*join)))
+        }
+        HashJoinInputPlan::RightOuterJoin(join) => {
+            HashJoinInputPlan::RightOuterJoin(Box::new(plan_right_outer_join(*join)))
+        }
+    };
+
+    HashJoinPlan {
+        input,
+        right: plan_source(right),
+        input_key: plan_owned_expr(input_key),
+        right_key: plan_owned_expr(right_key),
+        right_filter: right_filter.map(plan_owned_expr),
+    }
+}
+
+fn plan_source(source: SourcePlan) -> SourcePlan {
+    match source {
+        SourcePlan::Derived(mut derived) => {
+            *derived.query = plan_query(mem::replace(
+                derived.query.as_mut(),
+                QueryPlan::Values(ValuesPlan(Vec::new())),
+            ));
+
+            SourcePlan::Derived(derived)
+        }
+        SourcePlan::Series(mut series) => {
+            plan_expr(&mut series.size);
+
+            SourcePlan::Series(series)
+        }
+        SourcePlan::Table(_) | SourcePlan::Dictionary(_) => source,
+    }
+}
+
+fn plan_owned_expr(mut expr: ExprPlan) -> ExprPlan {
+    plan_expr(&mut expr);
+
+    expr
+}
+
+fn plan_expr(expr: &mut ExprPlan) {
+    visit_mut_expr(expr, &mut |expr| match expr {
+        ExprPlan::Subquery(query)
+        | ExprPlan::Exists {
+            subquery: query, ..
+        }
+        | ExprPlan::InSubquery {
+            subquery: query, ..
+        } => {
+            // `plan_query` needs ownership, so the subquery is swapped out for an empty
+            // `QueryPlan` and swapped back once it has been planned.
+            **query = plan_query(mem::replace(
+                query.as_mut(),
+                QueryPlan::Values(ValuesPlan(Vec::new())),
+            ));
+        }
+        _ => {}
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::plan,
+        crate::{
+            parse_sql::parse,
+            plan::{
+                AggregationInputPlan, ExprPlan, FilterInputPlan, InnerJoinInputPlan,
+                JoinConditionInputPlan, NestedLoopJoinInputPlan, NullExtendPlan, ProjectInputPlan,
+                QueryPlan, RightOuterJoinInputPlan, RightOuterJoinPlan, SourcePlan, StatementPlan,
+                TableAccessPlan,
+            },
+            translate::translate,
+        },
+        pretty_assertions::assert_eq,
+    };
+
+    fn statement(sql: &str) -> StatementPlan {
+        let parsed = parse(sql).expect(sql).into_iter().next().expect(sql);
+
+        StatementPlan::from(translate(&parsed).expect(sql))
+    }
+
+    fn plan_sql(sql: &str) -> StatementPlan {
+        plan(statement(sql))
+    }
+
+    fn project_input(query: &QueryPlan) -> &ProjectInputPlan {
+        &query.project().expect("expected a project").input
+    }
+
+    fn query_input(statement: &StatementPlan) -> &ProjectInputPlan {
+        let StatementPlan::Query(query) = statement else {
+            panic!("expected a query");
+        };
+
+        project_input(query)
+    }
+
+    fn right_outer(input: &ProjectInputPlan) -> &RightOuterJoinPlan {
+        let ProjectInputPlan::RightOuterJoin(join) = input else {
+            panic!("expected a lowered right outer join");
+        };
+
+        join
+    }
+
+    fn relations(join: &RightOuterJoinPlan) -> &[String] {
+        &join.null_extend.relations
+    }
+
+    fn collect_relations(statement: &StatementPlan, found: &mut Vec<Vec<String>>) {
+        let json = serde_json::to_value(statement).expect("serializable");
+        walk_json(&json, found);
+    }
+
+    fn walk_json(value: &serde_json::Value, found: &mut Vec<Vec<String>>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                assert!(
+                    !map.contains_key("UnplannedRightOuterJoin"),
+                    "an unplanned right outer join survived planning"
+                );
+                if let Some(null_extend) = map.get("null_extend")
+                    && let Some(relations) = null_extend.get("relations")
+                {
+                    found.push(
+                        relations
+                            .as_array()
+                            .expect("relations is an array")
+                            .iter()
+                            .map(|relation| relation.as_str().expect("alias").to_owned())
+                            .collect(),
+                    );
+                }
+                for nested in map.values() {
+                    walk_json(nested, found);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for nested in items {
+                    walk_json(nested, found);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn subquery(expr: &ExprPlan) -> &QueryPlan {
+        match expr {
+            ExprPlan::Subquery(query)
+            | ExprPlan::Exists {
+                subquery: query, ..
+            }
+            | ExprPlan::InSubquery {
+                subquery: query, ..
+            } => query,
+            _ => panic!("expected a subquery"),
+        }
+    }
+
+    #[test]
+    fn lowers_right_outer_join_and_collects_null_extend_relations() {
+        let statement = plan_sql("SELECT * FROM A RIGHT JOIN B ON A.id = B.a_id");
+        let join = right_outer(query_input(&statement));
+
+        assert!(matches!(join.input, RightOuterJoinInputPlan::Condition(_)));
+        assert_eq!(
+            join.null_extend,
+            NullExtendPlan {
+                relations: vec!["A".to_owned()],
+            }
+        );
+
+        let statement = plan_sql("SELECT * FROM A RIGHT JOIN B");
+        let join = right_outer(query_input(&statement));
+
+        assert!(matches!(join.input, RightOuterJoinInputPlan::NestedLoop(_)));
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn null_extend_accumulates_the_whole_left_prefix() {
+        let statement = plan_sql("SELECT * FROM A JOIN B ON A.id = B.a_id RIGHT JOIN C");
+        let join = right_outer(query_input(&statement));
+
+        assert_eq!(relations(join), ["A".to_owned(), "B".to_owned()]);
+
+        let statement = plan_sql("SELECT * FROM A a1 RIGHT JOIN B b1 RIGHT JOIN C c1");
+        let outer = right_outer(query_input(&statement));
+
+        assert_eq!(relations(outer), ["a1".to_owned(), "b1".to_owned()]);
+
+        let RightOuterJoinInputPlan::NestedLoop(nested_loop) = &outer.input else {
+            panic!("expected a nested loop mechanism");
+        };
+        let NestedLoopJoinInputPlan::RightOuterJoin(inner) = &nested_loop.input else {
+            panic!("expected the inner join to be lowered too");
+        };
+
+        assert_eq!(relations(inner), ["a1".to_owned()]);
+    }
+
+    #[test]
+    fn pins_the_left_base_source_to_a_full_scan() {
+        let statement = plan_sql("SELECT * FROM A RIGHT JOIN B RIGHT JOIN C WHERE A.id = 1");
+        let ProjectInputPlan::Filter(filter) = query_input(&statement) else {
+            panic!("expected a filter");
+        };
+        let FilterInputPlan::RightOuterJoin(join) = &filter.input else {
+            panic!("expected a lowered right outer join");
+        };
+        let SourcePlan::Table(table) = join.base_source() else {
+            panic!("expected a table base source");
+        };
+
+        assert_eq!(table.name, "A");
+        assert_eq!(table.access, TableAccessPlan::FullScanRequired);
+    }
+
+    #[test]
+    fn leaves_a_non_table_left_base_source_alone() {
+        let statement = plan_sql("SELECT * FROM (SELECT * FROM A) d RIGHT JOIN B");
+        let join = right_outer(query_input(&statement));
+
+        assert!(matches!(join.base_source(), SourcePlan::Derived(_)));
+        assert_eq!(relations(join), ["d".to_owned()]);
+    }
+
+    #[test]
+    fn lowers_right_outer_joins_inside_derived_sources_and_subqueries() {
+        let statement =
+            plan_sql("SELECT * FROM (SELECT B.id FROM A RIGHT JOIN B ON A.id = B.a_id) d");
+        let SourcePlan::Derived(derived) = query_input(&statement).base_source() else {
+            panic!("expected a derived source");
+        };
+        let join = right_outer(project_input(&derived.query));
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+
+        let statement = plan_sql("SELECT * FROM C WHERE C.id IN (SELECT B.id FROM A RIGHT JOIN B)");
+        let ProjectInputPlan::Filter(filter) = query_input(&statement) else {
+            panic!("expected a filter");
+        };
+        let join = right_outer(project_input(subquery(&filter.expr)));
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn lowers_right_outer_joins_in_every_statement_position() {
+        for sql in [
+            "INSERT INTO C SELECT B.id FROM A RIGHT JOIN B",
+            "CREATE TABLE D AS SELECT B.id FROM A RIGHT JOIN B",
+        ] {
+            let planned = plan_sql(sql);
+            let source = match &planned {
+                StatementPlan::Insert { source, .. } => source,
+                StatementPlan::CreateTable { source, .. } => {
+                    source.as_deref().expect("expected a source")
+                }
+                _ => panic!("unexpected statement: {sql}"),
+            };
+            let join = right_outer(project_input(source));
+
+            assert_eq!(relations(join), ["A".to_owned()], "{sql}");
+        }
+
+        let planned = plan_sql(
+            "UPDATE C SET id = (SELECT B.id FROM A RIGHT JOIN B) WHERE EXISTS (SELECT * FROM A a2 RIGHT JOIN B)",
+        );
+        let StatementPlan::Update {
+            assignments,
+            selection,
+            ..
+        } = &planned
+        else {
+            panic!("expected an update");
+        };
+        let join = right_outer(project_input(subquery(&assignments[0].value)));
+        assert_eq!(relations(join), ["A".to_owned()]);
+
+        let selection = selection.as_ref().expect("expected a selection");
+        let join = right_outer(project_input(subquery(selection)));
+        assert_eq!(relations(join), ["a2".to_owned()]);
+
+        let planned = plan_sql("DELETE FROM C WHERE EXISTS (SELECT * FROM A RIGHT JOIN B)");
+        let StatementPlan::Delete { selection, .. } = &planned else {
+            panic!("expected a delete");
+        };
+        let selection = selection.as_ref().expect("expected a selection");
+        let join = right_outer(project_input(subquery(selection)));
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn lowers_a_right_outer_join_inside_a_select_item() {
+        // A select-item subquery is the one expression position that is not reachable from
+        // `ProjectInputPlan`, so it needs its own walk.
+        for sql in [
+            "SELECT (SELECT B.id FROM A RIGHT JOIN B) AS s FROM C",
+            "SELECT SUM((SELECT B.id FROM A RIGHT JOIN B)) AS s FROM C",
+            "SELECT C.id FROM C WHERE EXISTS (SELECT (SELECT B.id FROM A RIGHT JOIN B) FROM C)",
+        ] {
+            let planned = plan_sql(sql);
+            let mut found = Vec::new();
+            collect_relations(&planned, &mut found);
+
+            assert_eq!(found, vec![vec!["A".to_owned()]], "{sql}");
+        }
+    }
+
+    #[test]
+    fn lowers_a_right_outer_join_in_a_values_expression() {
+        let planned = plan_sql("VALUES ((SELECT B.id FROM A RIGHT JOIN B))");
+        let StatementPlan::Query(QueryPlan::Values(values)) = &planned else {
+            panic!("expected values");
+        };
+        let join = right_outer(project_input(subquery(&values.0[0][0])));
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn no_unplanned_right_outer_join_survives_any_expression_position() {
+        let right_join = "SELECT B.id FROM A RIGHT JOIN B";
+
+        for sql in [
+            format!("SELECT ({right_join}) AS s FROM C"),
+            format!("SELECT SUM(({right_join})) AS s FROM C"),
+            format!("SELECT ABS(({right_join})) AS s FROM C"),
+            format!("SELECT * FROM C WHERE C.id IN ({right_join})"),
+            format!("SELECT * FROM C JOIN D ON D.id = ({right_join})"),
+            format!("SELECT * FROM C LEFT JOIN D ON EXISTS ({right_join})"),
+            format!("SELECT * FROM ({right_join}) d"),
+            format!("SELECT * FROM C ORDER BY ({right_join})"),
+            format!("SELECT * FROM C LIMIT ({right_join})"),
+            format!("SELECT * FROM C OFFSET ({right_join})"),
+            format!("SELECT C.id FROM C GROUP BY C.id HAVING EXISTS ({right_join})"),
+            format!("SELECT C.id FROM C GROUP BY ({right_join})"),
+            format!("SELECT * FROM SERIES(({right_join})) s"),
+            format!("VALUES (({right_join}))"),
+            format!("INSERT INTO C VALUES (({right_join}))"),
+            format!("CREATE TABLE E AS SELECT ({right_join}) AS s FROM C"),
+            format!("UPDATE C SET id = ({right_join})"),
+            format!("UPDATE C SET id = 1 WHERE id = ({right_join})"),
+            format!("DELETE FROM C WHERE id = ({right_join})"),
+        ] {
+            let planned = plan_sql(&sql);
+            let mut found = Vec::new();
+            collect_relations(&planned, &mut found);
+
+            assert_eq!(found, vec![vec!["A".to_owned()]], "{sql}");
+        }
+    }
+
+    #[test]
+    fn planning_an_already_planned_statement_changes_nothing() {
+        let planned = plan_sql("SELECT * FROM A RIGHT JOIN B ON A.id = B.a_id WHERE A.id = 1");
+
+        assert_eq!(plan(planned.clone()), planned);
+    }
+
+    #[test]
+    fn leaves_statements_without_a_right_outer_join_alone() {
+        for sql in [
+            "SELECT * FROM A JOIN B ON A.id = B.a_id LEFT JOIN C",
+            "SELECT * FROM A WHERE id IN (SELECT id FROM B) GROUP BY id HAVING id > 0",
+            "SELECT * FROM SERIES(3) s ORDER BY N LIMIT 1 OFFSET 1",
+            "SELECT * FROM A ORDER BY id OFFSET 1",
+            "VALUES (1), (2)",
+            "VALUES (1) ORDER BY column1 LIMIT 1 OFFSET 1",
+            "SELECT DISTINCT * FROM GLUE_TABLES g",
+            "UPDATE A SET id = 1 WHERE id = 2",
+            "DELETE FROM A WHERE id = 1",
+            "CREATE TABLE B AS SELECT * FROM A",
+            "DROP TABLE A",
+        ] {
+            let statement = statement(sql);
+
+            assert_eq!(plan(statement.clone()), statement, "{sql}");
+        }
+    }
+
+    #[test]
+    fn lowers_a_right_outer_join_under_an_aggregation() {
+        let statement = plan_sql(
+            "SELECT B.id FROM A RIGHT JOIN B ON A.id = B.a_id GROUP BY B.id HAVING B.id > 0",
+        );
+        let ProjectInputPlan::Having(having) = query_input(&statement) else {
+            panic!("expected a having");
+        };
+        let AggregationInputPlan::RightOuterJoin(join) = &having.input.input else {
+            panic!("expected a lowered right outer join");
+        };
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+
+        let statement = plan_sql("SELECT B.id FROM A RIGHT JOIN B GROUP BY B.id");
+        let ProjectInputPlan::Aggregation(aggregation) = query_input(&statement) else {
+            panic!("expected an aggregation");
+        };
+        let AggregationInputPlan::RightOuterJoin(join) = &aggregation.input else {
+            panic!("expected a lowered right outer join");
+        };
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn lowers_a_right_outer_join_feeding_a_later_query_stage() {
+        for sql in [
+            "SELECT * FROM A RIGHT JOIN B ORDER BY B.id",
+            "SELECT DISTINCT * FROM A RIGHT JOIN B",
+            "SELECT * FROM A RIGHT JOIN B OFFSET 1",
+            "SELECT * FROM A RIGHT JOIN B LIMIT 1",
+            "SELECT DISTINCT * FROM A RIGHT JOIN B ORDER BY B.id LIMIT 1 OFFSET 1",
+            "SELECT DISTINCT * FROM A RIGHT JOIN B ORDER BY B.id OFFSET 1",
+        ] {
+            let statement = plan_sql(sql);
+            let join = right_outer(query_input(&statement));
+
+            assert_eq!(relations(join), ["A".to_owned()], "{sql}");
+        }
+    }
+
+    #[test]
+    fn lowers_a_right_outer_join_feeding_a_later_join() {
+        let statement = plan_sql("SELECT * FROM A RIGHT JOIN B JOIN C ON C.id = B.id");
+        let ProjectInputPlan::InnerJoin(inner) = query_input(&statement) else {
+            panic!("expected an inner join");
+        };
+        let InnerJoinInputPlan::Condition(condition) = &inner.input else {
+            panic!("expected a join condition");
+        };
+        let JoinConditionInputPlan::NestedLoop(nested_loop) = &condition.input else {
+            panic!("expected a nested loop mechanism");
+        };
+        let NestedLoopJoinInputPlan::RightOuterJoin(join) = &nested_loop.input else {
+            panic!("expected a lowered right outer join");
+        };
+
+        assert_eq!(relations(join), ["A".to_owned()]);
+    }
+
+    #[test]
+    fn query_plan_keeps_the_right_outer_join_unplanned_before_this_pass() {
+        assert!(matches!(
+            query_input(&statement("SELECT * FROM A RIGHT JOIN B")),
+            ProjectInputPlan::UnplannedRightOuterJoin(_)
+        ));
+    }
+}

--- a/core/src/planner/schema.rs
+++ b/core/src/planner/schema.rs
@@ -8,8 +8,9 @@ use {
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
             OffsetInputPlan, OffsetPlan, OrderByExprPlan, ProjectInputPlan, ProjectPlan,
-            ProjectionPlan, QueryPlan, SelectItemPlan, SelectOrderByPlan, SourcePlan,
-            StatementPlan, ValuesOrderByPlan,
+            ProjectionPlan, QueryPlan, RightOuterJoinInputPlan, RightOuterJoinPlan, SelectItemPlan,
+            SelectOrderByPlan, SourcePlan, StatementPlan, UnplannedRightOuterJoinInputPlan,
+            UnplannedRightOuterJoinPlan, ValuesOrderByPlan,
         },
         result::Result,
         store::Store,
@@ -191,6 +192,10 @@ fn scan_project<T: Store + ?Sized>(
         ProjectInputPlan::Source(relation) => scan_source(storage, relation)?,
         ProjectInputPlan::InnerJoin(join) => scan_inner_join(storage, join)?,
         ProjectInputPlan::LeftOuterJoin(join) => scan_left_outer_join(storage, join)?,
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+            scan_unplanned_right_outer_join(storage, join)?
+        }
+        ProjectInputPlan::RightOuterJoin(join) => scan_right_outer_join(storage, join)?,
         ProjectInputPlan::Filter(filter) => scan_filter(storage, filter)?,
         ProjectInputPlan::Aggregation(aggregation) => {
             let schema_list = scan_aggregation_input(storage, &aggregation.input)?;
@@ -245,6 +250,10 @@ fn scan_filter<T: Store + ?Sized>(
         FilterInputPlan::Source(relation) => scan_source(storage, relation)?,
         FilterInputPlan::InnerJoin(join) => scan_inner_join(storage, join)?,
         FilterInputPlan::LeftOuterJoin(join) => scan_left_outer_join(storage, join)?,
+        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+            scan_unplanned_right_outer_join(storage, join)?
+        }
+        FilterInputPlan::RightOuterJoin(join) => scan_right_outer_join(storage, join)?,
     };
     let expr = scan_expr(storage, expr)?;
 
@@ -259,6 +268,10 @@ fn scan_aggregation_input<T: Store + ?Sized>(
         AggregationInputPlan::Source(relation) => scan_source(storage, relation),
         AggregationInputPlan::InnerJoin(join) => scan_inner_join(storage, join),
         AggregationInputPlan::LeftOuterJoin(join) => scan_left_outer_join(storage, join),
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            scan_unplanned_right_outer_join(storage, join)
+        }
+        AggregationInputPlan::RightOuterJoin(join) => scan_right_outer_join(storage, join),
         AggregationInputPlan::Filter(filter) => scan_filter(storage, filter),
     }
 }
@@ -285,6 +298,29 @@ fn scan_left_outer_join<T: Store + ?Sized>(
     }
 }
 
+fn scan_unplanned_right_outer_join<T: Store + ?Sized>(
+    storage: &T,
+    join: &UnplannedRightOuterJoinPlan,
+) -> Result<HashMap<String, Schema>> {
+    match &join.input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => scan_nested_loop(storage, join),
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+            scan_condition(storage, condition)
+        }
+    }
+}
+
+fn scan_right_outer_join<T: Store + ?Sized>(
+    storage: &T,
+    join: &RightOuterJoinPlan,
+) -> Result<HashMap<String, Schema>> {
+    match &join.input {
+        RightOuterJoinInputPlan::NestedLoop(join) => scan_nested_loop(storage, join),
+        RightOuterJoinInputPlan::Hash(join) => scan_hash(storage, join),
+        RightOuterJoinInputPlan::Condition(condition) => scan_condition(storage, condition),
+    }
+}
+
 fn scan_condition<T: Store + ?Sized>(
     storage: &T,
     condition: &JoinConditionPlan,
@@ -306,6 +342,10 @@ fn scan_nested_loop<T: Store + ?Sized>(
         NestedLoopJoinInputPlan::Source(source) => scan_source(storage, source)?,
         NestedLoopJoinInputPlan::InnerJoin(join) => scan_inner_join(storage, join)?,
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => scan_left_outer_join(storage, join)?,
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            scan_unplanned_right_outer_join(storage, join)?
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => scan_right_outer_join(storage, join)?,
     };
     let right = scan_source(storage, &join.right)?;
 
@@ -320,6 +360,7 @@ fn scan_hash<T: Store + ?Sized>(
         HashJoinInputPlan::Source(source) => scan_source(storage, source)?,
         HashJoinInputPlan::InnerJoin(join) => scan_inner_join(storage, join)?,
         HashJoinInputPlan::LeftOuterJoin(join) => scan_left_outer_join(storage, join)?,
+        HashJoinInputPlan::RightOuterJoin(join) => scan_right_outer_join(storage, join)?,
     };
     let expressions = [&join.input_key, &join.right_key]
         .into_iter()

--- a/core/src/planner/schemaless/query.rs
+++ b/core/src/planner/schemaless/query.rs
@@ -9,7 +9,9 @@ use {
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
             OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan,
-            SelectItemPlan, SelectOrderByPlan, SourcePlan, ValuesOrderByPlan,
+            RightOuterJoinInputPlan, RightOuterJoinPlan, SelectItemPlan, SelectOrderByPlan,
+            SourcePlan, UnplannedRightOuterJoinInputPlan, UnplannedRightOuterJoinPlan,
+            ValuesOrderByPlan,
         },
     },
     std::{
@@ -131,6 +133,10 @@ fn transform_project<S: BuildHasher>(
         ProjectInputPlan::Source(relation) => transform_source(schema_map, relation),
         ProjectInputPlan::InnerJoin(join) => transform_inner_join(schema_map, join),
         ProjectInputPlan::LeftOuterJoin(join) => transform_left_outer_join(schema_map, join),
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+            transform_unplanned_right_outer_join(schema_map, join)
+        }
+        ProjectInputPlan::RightOuterJoin(join) => transform_right_outer_join(schema_map, join),
         ProjectInputPlan::Filter(filter) => transform_filter(schema_map, filter),
         ProjectInputPlan::Aggregation(aggregation) => {
             let state = transform_aggregation_input(schema_map, &mut aggregation.input);
@@ -162,6 +168,10 @@ fn transform_filter<S: BuildHasher>(
         FilterInputPlan::Source(relation) => transform_source(schema_map, relation),
         FilterInputPlan::InnerJoin(join) => transform_inner_join(schema_map, join),
         FilterInputPlan::LeftOuterJoin(join) => transform_left_outer_join(schema_map, join),
+        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+            transform_unplanned_right_outer_join(schema_map, join)
+        }
+        FilterInputPlan::RightOuterJoin(join) => transform_right_outer_join(schema_map, join),
     };
     transform_query_expr(schema_map, expr, &state);
 
@@ -176,6 +186,10 @@ fn transform_aggregation_input<S: BuildHasher>(
         AggregationInputPlan::Source(relation) => transform_source(schema_map, relation),
         AggregationInputPlan::InnerJoin(join) => transform_inner_join(schema_map, join),
         AggregationInputPlan::LeftOuterJoin(join) => transform_left_outer_join(schema_map, join),
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            transform_unplanned_right_outer_join(schema_map, join)
+        }
+        AggregationInputPlan::RightOuterJoin(join) => transform_right_outer_join(schema_map, join),
         AggregationInputPlan::Filter(filter) => transform_filter(schema_map, filter),
     }
 }
@@ -203,22 +217,9 @@ fn transform_inner_join<S: BuildHasher>(
     schema_map: &HashMap<String, Schema, S>,
     join: &mut InnerJoinPlan,
 ) -> QueryRewriteState {
-    let base_source = join.base_source();
-    let rewrite_unqualified_identifiers = matches!(
-        base_source,
-        SourcePlan::Table(table) if is_schemaless_table(schema_map, &table.name)
-    );
-    let mut schemaless_aliases = HashSet::new();
-    collect_schemaless_alias(schema_map, base_source, &mut schemaless_aliases);
-    for source in join.joined_sources() {
-        collect_schemaless_alias(schema_map, source, &mut schemaless_aliases);
-    }
-    let state = QueryRewriteState {
-        rewrite_unqualified_identifiers,
-        schemaless_aliases,
-    };
-
+    let state = join_rewrite_state(schema_map, join.base_source(), join.joined_sources());
     rewrite_inner_join(schema_map, join, &state);
+
     state
 }
 
@@ -226,23 +227,51 @@ fn transform_left_outer_join<S: BuildHasher>(
     schema_map: &HashMap<String, Schema, S>,
     join: &mut LeftOuterJoinPlan,
 ) -> QueryRewriteState {
-    let base_source = join.base_source();
+    let state = join_rewrite_state(schema_map, join.base_source(), join.joined_sources());
+    rewrite_left_outer_join(schema_map, join, &state);
+
+    state
+}
+
+fn transform_unplanned_right_outer_join<S: BuildHasher>(
+    schema_map: &HashMap<String, Schema, S>,
+    join: &mut UnplannedRightOuterJoinPlan,
+) -> QueryRewriteState {
+    let state = join_rewrite_state(schema_map, join.base_source(), join.joined_sources());
+    rewrite_unplanned_right_outer_join(schema_map, join, &state);
+
+    state
+}
+
+fn transform_right_outer_join<S: BuildHasher>(
+    schema_map: &HashMap<String, Schema, S>,
+    join: &mut RightOuterJoinPlan,
+) -> QueryRewriteState {
+    let state = join_rewrite_state(schema_map, join.base_source(), join.joined_sources());
+    rewrite_right_outer_join(schema_map, join, &state);
+
+    state
+}
+
+fn join_rewrite_state<S: BuildHasher>(
+    schema_map: &HashMap<String, Schema, S>,
+    base_source: &SourcePlan,
+    joined_sources: Vec<&SourcePlan>,
+) -> QueryRewriteState {
     let rewrite_unqualified_identifiers = matches!(
         base_source,
         SourcePlan::Table(table) if is_schemaless_table(schema_map, &table.name)
     );
     let mut schemaless_aliases = HashSet::new();
     collect_schemaless_alias(schema_map, base_source, &mut schemaless_aliases);
-    for source in join.joined_sources() {
+    for source in joined_sources {
         collect_schemaless_alias(schema_map, source, &mut schemaless_aliases);
     }
-    let state = QueryRewriteState {
+
+    QueryRewriteState {
         rewrite_unqualified_identifiers,
         schemaless_aliases,
-    };
-
-    rewrite_left_outer_join(schema_map, join, &state);
-    state
+    }
 }
 
 fn collect_schemaless_alias(
@@ -288,6 +317,35 @@ fn rewrite_left_outer_join(
     }
 }
 
+fn rewrite_unplanned_right_outer_join(
+    schema_map: &HashMap<String, Schema, impl BuildHasher>,
+    join: &mut UnplannedRightOuterJoinPlan,
+    state: &QueryRewriteState,
+) {
+    match &mut join.input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => {
+            rewrite_nested_loop(schema_map, join, state);
+        }
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+            rewrite_condition(schema_map, condition, state);
+        }
+    }
+}
+
+fn rewrite_right_outer_join(
+    schema_map: &HashMap<String, Schema, impl BuildHasher>,
+    join: &mut RightOuterJoinPlan,
+    state: &QueryRewriteState,
+) {
+    match &mut join.input {
+        RightOuterJoinInputPlan::NestedLoop(join) => rewrite_nested_loop(schema_map, join, state),
+        RightOuterJoinInputPlan::Hash(join) => rewrite_hash(schema_map, join, state),
+        RightOuterJoinInputPlan::Condition(condition) => {
+            rewrite_condition(schema_map, condition, state);
+        }
+    }
+}
+
 fn rewrite_condition(
     schema_map: &HashMap<String, Schema, impl BuildHasher>,
     condition: &mut JoinConditionPlan,
@@ -311,6 +369,12 @@ fn rewrite_nested_loop(
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
             rewrite_left_outer_join(schema_map, join, state);
         }
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            rewrite_unplanned_right_outer_join(schema_map, join, state);
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+            rewrite_right_outer_join(schema_map, join, state);
+        }
     }
     rewrite_source(schema_map, &mut join.right);
 }
@@ -325,6 +389,9 @@ fn rewrite_hash(
         HashJoinInputPlan::InnerJoin(join) => rewrite_inner_join(schema_map, join, state),
         HashJoinInputPlan::LeftOuterJoin(join) => {
             rewrite_left_outer_join(schema_map, join, state);
+        }
+        HashJoinInputPlan::RightOuterJoin(join) => {
+            rewrite_right_outer_join(schema_map, join, state);
         }
     }
     rewrite_source(schema_map, &mut join.right);

--- a/core/src/planner/schemaless/validate.rs
+++ b/core/src/planner/schemaless/validate.rs
@@ -8,8 +8,9 @@ use {
             JoinConditionInputPlan, JoinConditionPlan, LeftOuterJoinInputPlan, LeftOuterJoinPlan,
             LimitInputPlan, LimitPlan, NestedLoopJoinInputPlan, NestedLoopJoinPlan,
             OffsetInputPlan, OffsetPlan, ProjectInputPlan, ProjectPlan, ProjectionPlan, QueryPlan,
-            SelectItemPlan, SelectOrderByPlan, SourcePlan, StatementPlan, ValuesOrderByPlan,
-            ValuesPlan,
+            RightOuterJoinInputPlan, RightOuterJoinPlan, SelectItemPlan, SelectOrderByPlan,
+            SourcePlan, StatementPlan, UnplannedRightOuterJoinInputPlan,
+            UnplannedRightOuterJoinPlan, ValuesOrderByPlan, ValuesPlan,
         },
         result::Result,
     },
@@ -173,6 +174,10 @@ fn validate_project(
         ProjectInputPlan::Source(relation) => validate_source(schema_map, relation)?,
         ProjectInputPlan::InnerJoin(join) => validate_inner_join(schema_map, join)?,
         ProjectInputPlan::LeftOuterJoin(join) => validate_left_outer_join(schema_map, join)?,
+        ProjectInputPlan::UnplannedRightOuterJoin(join) => {
+            validate_unplanned_right_outer_join(schema_map, join)?;
+        }
+        ProjectInputPlan::RightOuterJoin(join) => validate_right_outer_join(schema_map, join)?,
         ProjectInputPlan::Filter(filter) => validate_filter(schema_map, filter)?,
         ProjectInputPlan::Aggregation(aggregation) => {
             validate_aggregation_input(schema_map, &aggregation.input)?;
@@ -208,6 +213,10 @@ fn validate_filter(
         FilterInputPlan::Source(relation) => validate_source(schema_map, relation)?,
         FilterInputPlan::InnerJoin(join) => validate_inner_join(schema_map, join)?,
         FilterInputPlan::LeftOuterJoin(join) => validate_left_outer_join(schema_map, join)?,
+        FilterInputPlan::UnplannedRightOuterJoin(join) => {
+            validate_unplanned_right_outer_join(schema_map, join)?;
+        }
+        FilterInputPlan::RightOuterJoin(join) => validate_right_outer_join(schema_map, join)?,
     }
     validate_expr(schema_map, expr)
 }
@@ -220,6 +229,10 @@ fn validate_aggregation_input(
         AggregationInputPlan::Source(relation) => validate_source(schema_map, relation),
         AggregationInputPlan::InnerJoin(join) => validate_inner_join(schema_map, join),
         AggregationInputPlan::LeftOuterJoin(join) => validate_left_outer_join(schema_map, join),
+        AggregationInputPlan::UnplannedRightOuterJoin(join) => {
+            validate_unplanned_right_outer_join(schema_map, join)
+        }
+        AggregationInputPlan::RightOuterJoin(join) => validate_right_outer_join(schema_map, join),
         AggregationInputPlan::Filter(filter) => validate_filter(schema_map, filter),
     }
 }
@@ -246,6 +259,31 @@ fn validate_left_outer_join(
     }
 }
 
+fn validate_unplanned_right_outer_join(
+    schema_map: &HashMap<String, Schema, impl BuildHasher>,
+    join: &UnplannedRightOuterJoinPlan,
+) -> ValidateResult {
+    match &join.input {
+        UnplannedRightOuterJoinInputPlan::NestedLoop(join) => {
+            validate_nested_loop(schema_map, join)
+        }
+        UnplannedRightOuterJoinInputPlan::Condition(condition) => {
+            validate_condition(schema_map, condition)
+        }
+    }
+}
+
+fn validate_right_outer_join(
+    schema_map: &HashMap<String, Schema, impl BuildHasher>,
+    join: &RightOuterJoinPlan,
+) -> ValidateResult {
+    match &join.input {
+        RightOuterJoinInputPlan::NestedLoop(join) => validate_nested_loop(schema_map, join),
+        RightOuterJoinInputPlan::Hash(join) => validate_hash(schema_map, join),
+        RightOuterJoinInputPlan::Condition(condition) => validate_condition(schema_map, condition),
+    }
+}
+
 fn validate_condition(
     schema_map: &HashMap<String, Schema, impl BuildHasher>,
     condition: &JoinConditionPlan,
@@ -267,6 +305,12 @@ fn validate_nested_loop(
         NestedLoopJoinInputPlan::LeftOuterJoin(join) => {
             validate_left_outer_join(schema_map, join)?;
         }
+        NestedLoopJoinInputPlan::UnplannedRightOuterJoin(join) => {
+            validate_unplanned_right_outer_join(schema_map, join)?;
+        }
+        NestedLoopJoinInputPlan::RightOuterJoin(join) => {
+            validate_right_outer_join(schema_map, join)?;
+        }
     }
     validate_source(schema_map, &join.right)
 }
@@ -280,6 +324,9 @@ fn validate_hash(
         HashJoinInputPlan::InnerJoin(join) => validate_inner_join(schema_map, join)?,
         HashJoinInputPlan::LeftOuterJoin(join) => {
             validate_left_outer_join(schema_map, join)?;
+        }
+        HashJoinInputPlan::RightOuterJoin(join) => {
+            validate_right_outer_join(schema_map, join)?;
         }
     }
     validate_source(schema_map, &join.right)?;

--- a/core/src/store/planner.rs
+++ b/core/src/store/planner.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         plan::StatementPlan,
         planner::{
-            fetch_schema_map, plan_aggregate, plan_hash_join, plan_primary_key, plan_schemaless,
-            validate,
+            fetch_schema_map, plan_aggregate, plan_hash_join, plan_primary_key,
+            plan_right_outer_join, plan_schemaless, validate,
         },
         result::Result,
     },
@@ -16,6 +16,8 @@ pub trait Planner: Store {
         validate(&schema_map, &statement)?;
 
         let statement = plan_schemaless(&schema_map, statement)?;
+        // Must precede the passes below: it tells them the complete left input is required.
+        let statement = plan_right_outer_join(statement);
         let statement = plan_primary_key(&schema_map, statement);
         let statement = plan_hash_join(&schema_map, statement);
         let statement = plan_aggregate(statement);

--- a/core/src/translate/query.rs
+++ b/core/src/translate/query.rs
@@ -350,6 +350,9 @@ fn translate_join(params: &[ParamLiteral], sql_join: &SqlJoin) -> Result<Join> {
         SqlJoinOperator::LeftOuter(sql_join_constraint) => {
             translate_constraint(sql_join_constraint).map(JoinOperator::LeftOuter)
         }
+        SqlJoinOperator::RightOuter(sql_join_constraint) => {
+            translate_constraint(sql_join_constraint).map(JoinOperator::RightOuter)
+        }
         _ => Err(TranslateError::UnsupportedJoinOperator(format!("{sql_join_operator:?}")).into()),
     }?;
 

--- a/docs/docs/sql-syntax/statements/querying/join.md
+++ b/docs/docs/sql-syntax/statements/querying/join.md
@@ -4,11 +4,12 @@ sidebar_position: 2
 
 # JOIN
 
-GlueSQL supports two types of JOIN operations:
+GlueSQL supports three types of JOIN operations:
 - (INNER) JOIN
 - LEFT (OUTER) JOIN
+- RIGHT (OUTER) JOIN
 
-Please note that `FULL OUTER JOIN` and `RIGHT JOIN` are currently not supported.
+Please note that `FULL OUTER JOIN` is currently not supported.
 
 ## (INNER) JOIN
 
@@ -33,5 +34,38 @@ SELECT * FROM Item LEFT JOIN Player ON Player.id = Item.player_id WHERE quantity
 ```
 
 This query retrieves all rows from the `Item` table and any matching rows from the `Player` table where the `id` in the `Player` table matches the `player_id` in the `Item` table. If there's no match, NULL values are returned for the `Player` table columns. The result is then filtered by the `quantity` column in the `Item` table with a value of 1.
+
+## RIGHT (OUTER) JOIN
+
+A RIGHT JOIN (also known as RIGHT OUTER JOIN) combines rows from two tables based on a specified condition. For each row in the right table (the one named after `RIGHT JOIN`) that does not have a matching row in the left table, the result will contain NULL values for the left table's columns.
+
+Here's an example using the provided test code:
+
+```sql
+SELECT * FROM Item RIGHT JOIN Player ON Player.id = Item.player_id;
+```
+
+This query retrieves all rows from the `Player` table and any matching rows from the `Item` table where the `id` in the `Player` table matches the `player_id` in the `Item` table. If a `Player` row has no matching `Item` row, NULL values are returned for the `Item` table columns.
+
+With two relations, a RIGHT JOIN selects the same rows as a LEFT JOIN with the table order swapped, in a different column order:
+
+```sql
+SELECT * FROM Item RIGHT JOIN Player ON Player.id = Item.player_id;
+-- selects the same rows as:
+SELECT * FROM Player LEFT JOIN Item ON Player.id = Item.player_id;
+```
+
+In a longer chain the equivalence no longer holds by simply swapping two tables, because an unmatched right row is NULL-extended across *every* relation accumulated to its left:
+
+```sql
+SELECT *
+FROM Player
+JOIN Item ON Item.player_id = Player.id
+RIGHT JOIN Trade ON Trade.item_id = Item.id;
+```
+
+A `Trade` row that matches no `Item` comes back with NULL values for both the `Player` and the `Item` columns, and it flows into any later join like any other row.
+
+Rows are not returned in a guaranteed order, so add an `ORDER BY` when the order matters.
 
 Remember to replace the table names, column names, and data types as needed for your specific use case.

--- a/storages/memory-storage/tests/memory_storage.rs
+++ b/storages/memory-storage/tests/memory_storage.rs
@@ -112,3 +112,135 @@ fn schemaless_update_conflict_on_non_map_row() {
         Err(Error::Update(UpdateError::ConflictOnNonMapSchemalessRow))
     );
 }
+
+#[test]
+fn unplanned_right_outer_join_is_rejected_at_execution() {
+    use gluesql_core::{
+        executor::QueryError,
+        parse_sql::parse,
+        plan::StatementPlan,
+        prelude::{Error, Glue},
+        translate::translate,
+    };
+
+    let mut glue = Glue::new(MemoryStorage::default());
+
+    exec!(glue "CREATE TABLE Base (id INTEGER);");
+    exec!(glue "CREATE TABLE Side (base_id INTEGER);");
+
+    // Stands in for a custom `Planner` whose pipeline leaves out `plan_right_outer_join`.
+    let sql = "SELECT * FROM Base RIGHT JOIN Side ON Side.base_id = Base.id";
+    let parsed = parse(sql).unwrap().into_iter().next().unwrap();
+    let unplanned = StatementPlan::from(translate(&parsed).unwrap());
+
+    assert_eq!(
+        glue.execute_stmt(&unplanned),
+        Err(Error::Query(QueryError::UnreachableUnplannedRightOuterJoin)),
+    );
+
+    // The same statement runs once the planner has lowered it.
+    assert!(glue.execute(sql).is_ok());
+}
+
+// `RightOuterJoinInputPlan::Hash` is only reachable by building the plan directly: the hash join
+// planner leaves a RIGHT JOIN's own `ON` as a nested loop. A right row must stay available for the
+// unmatched pass even when it never enters the hash index — NULL key, or excluded by `right_filter`.
+#[test]
+fn right_outer_hash_lookup_keeps_every_right_row_for_the_unmatched_pass() {
+    use gluesql_core::{
+        parse_sql::parse_expr,
+        plan::{
+            ExprPlan, HashJoinInputPlan, HashJoinPlan, NullExtendPlan, ProjectInputPlan,
+            ProjectPlan, ProjectionPlan, QueryPlan, RightOuterJoinInputPlan, RightOuterJoinPlan,
+            SelectItemPlan, SourcePlan, StatementPlan, TableAccessPlan, TableSourcePlan,
+        },
+        prelude::{Glue, Payload, Value},
+        translate::translate_expr,
+    };
+
+    fn expr(sql: &str) -> ExprPlan {
+        ExprPlan::from(translate_expr(&parse_expr(sql).unwrap(), &[]).unwrap())
+    }
+
+    fn table(name: &str) -> SourcePlan {
+        SourcePlan::Table(TableSourcePlan {
+            name: name.to_owned(),
+            alias: None,
+            access: TableAccessPlan::FullScanRequired,
+        })
+    }
+
+    fn select_item(sql: &str, label: &str) -> SelectItemPlan {
+        SelectItemPlan::Expr {
+            expr: expr(sql),
+            label: label.to_owned(),
+        }
+    }
+
+    let mut glue = Glue::new(MemoryStorage::default());
+    exec!(glue "CREATE TABLE Base (id INTEGER);");
+    exec!(glue "INSERT INTO Base VALUES (1), (2);");
+    exec!(glue "CREATE TABLE Side (base_id INTEGER NULL, label TEXT);");
+    exec!(glue "INSERT INTO Side VALUES (1, 'matched'), (NULL, 'null key'), (2, 'filtered out'), (9, 'no match');");
+
+    let statement = StatementPlan::Query(QueryPlan::Project(ProjectPlan {
+        input: ProjectInputPlan::RightOuterJoin(Box::new(RightOuterJoinPlan {
+            input: RightOuterJoinInputPlan::Hash(HashJoinPlan {
+                input: HashJoinInputPlan::Source(table("Base")),
+                right: table("Side"),
+                input_key: expr("Base.id"),
+                right_key: expr("Side.base_id"),
+                right_filter: Some(expr("Side.label != 'filtered out'")),
+            }),
+            null_extend: NullExtendPlan {
+                relations: vec!["Base".to_owned()],
+            },
+        })),
+        projection: ProjectionPlan::SelectItems(vec![
+            select_item("Base.id", "base_id"),
+            select_item("Side.label", "label"),
+        ]),
+    }));
+
+    let expected = Payload::Select {
+        labels: vec!["base_id".to_owned(), "label".to_owned()],
+        rows: vec![
+            vec![Value::I64(1), Value::Str("matched".to_owned())],
+            vec![Value::Null, Value::Str("null key".to_owned())],
+            vec![Value::Null, Value::Str("filtered out".to_owned())],
+            vec![Value::Null, Value::Str("no match".to_owned())],
+        ],
+    };
+
+    assert_eq!(glue.execute_stmt(&statement), Ok(expected));
+}
+
+// Match state is tracked by row position, not by row value, so two identical unmatched right rows
+// must both survive instead of collapsing into one.
+#[test]
+fn right_outer_join_preserves_duplicate_unmatched_rows() {
+    use gluesql_core::prelude::{Glue, Payload, Value};
+
+    let mut glue = Glue::new(MemoryStorage::default());
+    exec!(glue "CREATE TABLE Base (id INTEGER);");
+    exec!(glue "INSERT INTO Base VALUES (1);");
+    exec!(glue "CREATE TABLE Side (base_id INTEGER);");
+    exec!(glue "INSERT INTO Side VALUES (9), (9), (1), (1);");
+
+    let expected = Payload::Select {
+        labels: vec!["id".to_owned(), "base_id".to_owned()],
+        rows: vec![
+            vec![Value::I64(1), Value::I64(1)],
+            vec![Value::I64(1), Value::I64(1)],
+            vec![Value::Null, Value::I64(9)],
+            vec![Value::Null, Value::I64(9)],
+        ],
+    };
+
+    assert_eq!(
+        glue.execute(
+            "SELECT Base.id, Side.base_id FROM Base RIGHT JOIN Side ON Side.base_id = Base.id"
+        ),
+        Ok(vec![expected])
+    );
+}

--- a/storages/sled-storage/src/planner.rs
+++ b/storages/sled-storage/src/planner.rs
@@ -5,7 +5,7 @@ use {
         plan::StatementPlan,
         planner::{
             fetch_schema_map, plan_aggregate, plan_hash_join, plan_index, plan_primary_key,
-            plan_schemaless, validate,
+            plan_right_outer_join, plan_schemaless, validate,
         },
         store::Planner,
     },
@@ -17,6 +17,8 @@ impl Planner for SledStorage {
         validate(&schema_map, &statement)?;
 
         let statement = plan_schemaless(&schema_map, statement)?;
+        // Must precede the passes below: it tells them the complete left input is required.
+        let statement = plan_right_outer_join(statement);
         let statement = plan_primary_key(&schema_map, statement);
         let statement = plan_index(&schema_map, statement);
         let statement = plan_hash_join(&schema_map, statement);

--- a/test-suite/fixtures/index/join.sql
+++ b/test-suite/fixtures/index/join.sql
@@ -1,0 +1,70 @@
+CREATE TABLE Base (
+    id INTEGER,
+    name TEXT
+);
+-- @expect: ok
+
+CREATE TABLE Side (
+    base_id INTEGER,
+    label TEXT
+);
+-- @expect: ok
+
+INSERT INTO Base VALUES (1, 'one'), (2, 'two'), (3, 'three');
+-- @expect: ok
+
+INSERT INTO Side VALUES (1, 'a'), (3, 'b'), (9, 'c');
+-- @expect: ok
+
+CREATE INDEX idx_base_id ON Base (id);
+-- @expect: payload CreateIndex
+
+-- @name: a LEFT JOIN narrows its base source with an index seek
+SELECT id, label FROM Base LEFT JOIN Side ON base_id = id WHERE id = 1;
+-- @expect-index: idx_base_id = 1
+-- @expect:
+-- | id: I64 | label: Str |
+-- | ------- | ---------- |
+-- | 1       | "a"        |
+
+-- @name: a RIGHT JOIN needs the complete left input, so the index seek is off
+SELECT id, label FROM Base RIGHT JOIN Side ON base_id = id WHERE id = 1;
+-- @expect-index: none
+-- @expect:
+-- | id: I64 | label: Str |
+-- | ------- | ---------- |
+-- | 1       | "a"        |
+
+-- @name: a LEFT JOIN reads its base source through an ordered index scan
+SELECT id, label FROM Base LEFT JOIN Side ON base_id = id ORDER BY id;
+-- @expect-index: idx_base_id
+-- @expect:
+-- | id: I64 | label: Str |
+-- | ------- | ---------- |
+-- | 1       | "a"        |
+-- | 2       | NULL       |
+-- | 3       | "b"        |
+
+-- @name: the ordered index scan is off under a RIGHT JOIN too
+SELECT id, label FROM Base RIGHT JOIN Side ON base_id = id ORDER BY id;
+-- @expect-index: none
+-- @expect:
+-- | id: I64 | label: Str |
+-- | ------- | ---------- |
+-- | 1       | "a"        |
+-- | 3       | "b"        |
+-- | NULL    | "c"        |
+
+-- @name: pinning is per-plan, so a later query over the same table still seeks
+SELECT id, name FROM Base WHERE id = 3;
+-- @expect-index: idx_base_id = 3
+-- @expect:
+-- | id: I64 | name: Str |
+-- | ------- | --------- |
+-- | 3       | "three"   |
+
+DROP TABLE Base;
+-- @expect: ok
+
+DROP TABLE Side;
+-- @expect: ok

--- a/test-suite/fixtures/join.sql
+++ b/test-suite/fixtures/join.sql
@@ -265,8 +265,154 @@ SELECT * FROM Player p1 LEFT JOIN Player p2 ON 1 = 1
 SELECT * FROM Item INNER JOIN Item i2 ON i2.id IN (101, 103);
 -- @expect: count 30
 
+CREATE TABLE Trade (id INTEGER, item_id INTEGER, buyer_id INTEGER);
+-- @expect: ok
+
+INSERT INTO Trade VALUES (1, 101, 2), (2, 999, 3), (3, 102, 99), (4, 103, 1);
+-- @expect: ok
+
+-- @name: RIGHT JOIN preserves the right relation
+SELECT * FROM Player RIGHT JOIN Item ON Player.id = Item.player_id;
+-- @expect: count 15
+
+-- @name: RIGHT JOIN keeps right rows that match nothing
+SELECT * FROM Item RIGHT JOIN Player ON Player.id = Item.player_id;
+-- @expect: count 16
+
+-- @name: non-equality condition joins through a nested loop
+SELECT * FROM Item RIGHT JOIN Player ON Player.id != Item.player_id;
+-- @expect: count 60
+
+-- @name: an always-false condition leaves every right row unmatched
+SELECT * FROM Item RIGHT JOIN Player ON Item.quantity > 100;
+-- @expect: count 5
+
+-- @name: an empty left source still yields every right row
+SELECT * FROM (SELECT * FROM Player WHERE FALSE) e RIGHT JOIN Item ON e.id = Item.player_id;
+-- @expect: count 15
+
+-- @name: aggregates count an unmatched right row as zero
+SELECT Player.id, COUNT(Item.id) AS cnt
+FROM Item RIGHT JOIN Player ON Player.id = Item.player_id
+GROUP BY Player.id
+ORDER BY Player.id;
+-- @expect:
+-- | id: I64 | cnt: I64 |
+-- | ------- | -------- |
+-- | 1       | 7        |
+-- | 2       | 2        |
+-- | 3       | 4        |
+-- | 4       | 0        |
+-- | 5       | 2        |
+
+-- @name: WHERE filters the preserved relation after the join
+SELECT * FROM Item RIGHT JOIN Player ON Player.id = Item.player_id WHERE Player.id = 1;
+-- @expect: count 7
+
+-- @name: RIGHT JOIN rejects a derived source correlated to the left relation
+SELECT * FROM Player RIGHT JOIN (SELECT * FROM Item WHERE Item.player_id = Player.id) AS i ON true;
+-- @expect: error Evaluate.CompoundIdentifierNotFound
+
+-- @name: an unmatched right row NULL-extends the whole accumulated prefix
+SELECT *
+FROM Player JOIN Item ON Item.player_id = Player.id
+RIGHT JOIN Trade ON Trade.item_id = Item.id
+WHERE Trade.id IN (1, 2)
+ORDER BY Trade.id;
+-- @expect:
+-- | id: I64 | name: Str | id: I64 | quantity: I64 | player_id: I64 | id: I64 | item_id: I64 | buyer_id: I64 |
+-- | ------- | --------- | ------- | ------------- | -------------- | ------- | ------------ | ------------- |
+-- | 1       | "Taehoon" | 101     | 1             | 1              | 1       | 101          | 2             |
+-- | NULL    | NULL      | NULL    | NULL          | NULL           | 2       | 999          | 3             |
+
+-- @name: a NULL-extended row flows into a later JOIN like any other row
+SELECT Trade.id, buyer.id
+FROM Player JOIN Item ON Item.player_id = Player.id
+RIGHT JOIN Trade ON Trade.item_id = Item.id
+JOIN Player buyer ON buyer.id = Trade.buyer_id
+ORDER BY Trade.id;
+-- @expect:
+-- | id: I64 | id: I64 |
+-- | ------- | ------- |
+-- | 1       | 2       |
+-- | 2       | 3       |
+-- | 4       | 1       |
+
+-- @name: chained RIGHT JOINs treat an already NULL-extended row as matched
+SELECT p.id, Item.id, Trade.id
+FROM (SELECT * FROM Player WHERE id <= 2) p
+RIGHT JOIN Item ON Item.player_id = p.id
+RIGHT JOIN Trade ON Trade.item_id = Item.id
+ORDER BY Trade.id;
+-- @expect:
+-- | id: I64 | id: I64 | id: I64 |
+-- | ------- | ------- | ------- |
+-- | 1       | 101     | 1       |
+-- | NULL    | NULL    | 2       |
+-- | 2       | 102     | 3       |
+-- | NULL    | 103     | 4       |
+
+-- @name: a derived source hides a RIGHT JOIN from the outer query
+SELECT d.pid, d.iid
+FROM (
+    SELECT Player.id AS pid, Item.id AS iid
+    FROM (SELECT * FROM Player WHERE id <= 2) Player
+    RIGHT JOIN Item ON Item.player_id = Player.id
+) d
+WHERE d.iid IN (101, 103)
+ORDER BY d.iid;
+-- @expect:
+-- | pid: I64 | iid: I64 |
+-- | -------- | -------- |
+-- | 1        | 101      |
+-- | NULL     | 103      |
+
+-- @name: an expression subquery hides a RIGHT JOIN from the outer query
+SELECT id FROM Player
+WHERE id IN (
+    SELECT Trade.buyer_id
+    FROM Item RIGHT JOIN Trade ON Trade.item_id = Item.id
+    WHERE Item.id IS NULL
+)
+ORDER BY id;
+-- @expect:
+-- | id: I64 |
+-- | ------- |
+-- | 3       |
+
+-- @name: an alias used twice on the left still NULL-extends both relations
+-- The plan lists the left relations as ["a", "a"], so pairing them with the executor's sources by
+-- alias would resolve both to Player and lose Item's columns. Pairing by position keeps them apart:
+-- every row below must carry 2 NULLs for Player and 3 for Item.
+SELECT * FROM Player a JOIN Item a ON TRUE RIGHT JOIN Trade t ON FALSE ORDER BY t.id;
+-- @expect:
+-- | id: I64 | name: Str | id: I64 | quantity: I64 | player_id: I64 | id: I64 | item_id: I64 | buyer_id: I64 |
+-- | ------- | --------- | ------- | ------------- | -------------- | ------- | ------------ | ------------- |
+-- | NULL    | NULL      | NULL    | NULL          | NULL           | 1       | 101          | 2             |
+-- | NULL    | NULL      | NULL    | NULL          | NULL           | 2       | 999          | 3             |
+-- | NULL    | NULL      | NULL    | NULL          | NULL           | 3       | 102          | 99            |
+-- | NULL    | NULL      | NULL    | NULL          | NULL           | 4       | 103          | 1             |
+
+-- @name: a select-item subquery hides a RIGHT JOIN from the outer query
+SELECT
+    Player.id,
+    (
+        SELECT COUNT(*)
+        FROM Item RIGHT JOIN Trade ON Trade.item_id = Item.id
+        WHERE Item.id IS NULL
+    ) AS orphan_trades
+FROM Player
+WHERE Player.id = 1;
+-- @expect:
+-- | id: I64 | orphan_trades: I64 |
+-- | ------- | ------------------ |
+-- | 1       | 1                  |
+
 DELETE FROM Player
 -- @expect: ok
 
 DELETE FROM Item
+-- @expect: ok
+
+DROP TABLE Trade
 -- @expect: ok

--- a/test-suite/fixtures/join/project.sql
+++ b/test-suite/fixtures/join/project.sql
@@ -77,6 +77,20 @@ LEFT JOIN Item
 -- | 4       | "Berry"   | 103     | 9             | 4              |
 -- | 5       | "Hwan"    | NULL    | NULL          | NULL           |
 
+SELECT p.id, i.id
+FROM Item i
+RIGHT JOIN Player p
+    ON p.id = i.player_id
+ORDER BY p.id
+-- @expect:
+-- | id: I64 | id: I64 |
+-- | ------- | ------- |
+-- | 1       | 101     |
+-- | 2       | 102     |
+-- | 3       | NULL    |
+-- | 4       | 103     |
+-- | 5       | NULL    |
+
 CREATE TABLE Users (id INTEGER, name TEXT);
 -- @expect: ok
 

--- a/test-suite/fixtures/primary_key.sql
+++ b/test-suite/fixtures/primary_key.sql
@@ -43,6 +43,17 @@ WHERE a.id = a2.id;
 -- | 1       |
 -- | 3       |
 
+-- @name: primary key lookup stays disabled when RIGHT JOIN can null-pad the base source
+SELECT a.id, a2.id
+FROM Allegro a
+RIGHT JOIN Allegro a2 ON a.id = a2.id
+WHERE a.id = 3;
+-- @expect-index: none
+-- @expect:
+-- | id: I64 | id: I64 |
+-- | ------- | ------- |
+-- | 3       | 3       |
+
 SELECT id FROM Allegro WHERE id IN (
     SELECT id FROM Allegro WHERE id = id
 );

--- a/test-suite/fixtures/schemaless/basic.sql
+++ b/test-suite/fixtures/schemaless/basic.sql
@@ -101,6 +101,22 @@ WHERE flag IS NOT NULL;
 -- | -------------- | ---------------- | -------------- |
 -- | 1001           | "Beam"           | 3000           |
 
+-- @name: RIGHT JOIN NULL-extends a schemaless left relation through its _doc column
+SELECT * FROM Player RIGHT JOIN Item ON Player.id = Item.id;
+-- @expect:
+-- | _doc: Map | _doc: Map                                                                                  |
+-- | --------- | ------------------------------------------------------------------------------------------ |
+-- | NULL      | {"dex":324,"id":101,"name":"Test 001","new_field":"Hello","obj":{"cost":3000},"rare":true} |
+
+-- @name: the preserved schemaless right relation still resolves its own columns
+SELECT Item.name AS item_name
+FROM Player
+RIGHT JOIN Item ON Player.id = Item.id;
+-- @expect:
+-- | item_name: Str |
+-- | -------------- |
+-- | "Test 001"     |
+
 CREATE TABLE ItemName AS SELECT name, dex FROM Item
 -- @expect: ok
 

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -405,6 +405,7 @@ macro_rules! generate_index_tests {
         sql_case!(index::nested);
         sql_case!(index::null);
         sql_case!(index::expr);
+        sql_case!(index::join);
         sql_case!(index::value);
         sql_case!(index::order_by);
         sql_case!(index::order_by::multi);

--- a/test-suite/src/tester.rs
+++ b/test-suite/src/tester.rs
@@ -49,7 +49,13 @@ fn find_indexes(statement: &StatementPlan) -> Vec<&TableAccessPlan> {
 
     fn find_source_indexes(source: &SourcePlan) -> Vec<&TableAccessPlan> {
         match source {
-            SourcePlan::Table(table) if table.access != TableAccessPlan::FullScan => {
+            // `FullScanRequired` is a planner marker, not an access path, so it is not an index.
+            SourcePlan::Table(table)
+                if !matches!(
+                    table.access,
+                    TableAccessPlan::FullScan | TableAccessPlan::FullScanRequired
+                ) =>
+            {
                 vec![&table.access]
             }
             SourcePlan::Derived(derived) => find_query_indexes(&derived.query),
@@ -75,6 +81,8 @@ fn find_indexes(statement: &StatementPlan) -> Vec<&TableAccessPlan> {
             ProjectInputPlan::Source(_)
             | ProjectInputPlan::InnerJoin(_)
             | ProjectInputPlan::LeftOuterJoin(_)
+            | ProjectInputPlan::UnplannedRightOuterJoin(_)
+            | ProjectInputPlan::RightOuterJoin(_)
             | ProjectInputPlan::Aggregation(_)
             | ProjectInputPlan::Having(_) => None,
         };


### PR DESCRIPTION
Closes #63.

`RIGHT JOIN` / `RIGHT OUTER JOIN` now parses, plans, and executes. An unmatched right row is emitted once with every accumulated left relation NULL-extended.

## Approach

Following the model agreed in #63, a RIGHT JOIN is not executable as translated. It passes through three states:

1. **Translation** produces `UnplannedRightOuterJoinPlan` — a temporary state that carries no NULL-extension decision and therefore cannot execute.
2. **`plan_right_outer_join`** (new pass, runs right after `plan_schemaless`) consumes every temporary node and decides two things:
   - `null_extend` — which accumulated left relations an unmatched right row pads out, as an alias list ordered base-first.
   - `TableAccessPlan::FullScanRequired` on the left base source — the unmatched pass needs the complete left input, so no planner may narrow it.
3. **`RightOuterJoinPlan`** is what every later planner and the executor see. Its `null_extend` field is not an `Option`.

Later planners pass the lowered node through and never re-interpret RIGHT JOIN syntax. The primary key and index planners needed **no logic changes at all**: they already gate on `access == FullScan`, so the new marker excludes them automatically.

The executor drives the join itself rather than reusing the left-driven `JoinCandidates` pipeline, because "was this right row matched by *any* left row?" cannot be answered inside a single left-keyed group. The right relation is read once and each row's **position** is its identity, so duplicate rows keep their multiplicity and rows excluded from a hash candidate index (NULL keys, right-side predicates) still reach the unmatched pass.

## Why not rewrite to LEFT JOIN

Two reasons it is not a translation-level swap:

- `SELECT *` column order would change.
- In `A JOIN B RIGHT JOIN C` the left side is a composite, not a table. Swapping would require putting a join tree on the right of a left-deep plan.

## Limitations

These are intentional in this PR. Happy to fold any of them in if you prefer.

- **The right relation is buffered in memory.** Position-based match tracking needs the right rows available for a second pass, and the storage traits have no rewind. For hash plans this is not new — `hash::build_rows` already materializes the right side — but for nested loop plans it replaces per-left-row rescanning with `O(right)` memory. I could not judge what limit is acceptable here.
- **A RIGHT JOIN's own `ON` is not promoted to a hash mechanism**, so `A RIGHT JOIN B ON A.id = B.k` runs as a nested loop while the LEFT equivalent runs as a hash join. Correctness is unaffected. Doing it properly means generalizing the two existing 104-line `plan_*_nested_loop_condition` functions rather than adding a third near-identical copy, which felt out of scope. Happy to open a follow-up issue, or to fold it into this PR if you prefer.
- **ORDER BY index scans are disabled on the pinned base source.** That optimization only reorders rows and is safe under RIGHT JOIN, but it shares the `access == FullScan` gate with the unsafe ones. Re-enabling is a one-line condition widening; kept conservative here and pinned by a fixture.
- **`query_builder` has no RIGHT JOIN support yet**, per the scope agreed in #63.
- **A right source correlated to the left errors** (`CompoundIdentifierNotFound`). A preserved right relation is undefined if it depends on the left row. Note that INNER/LEFT joins currently *allow* this, which looks unintended rather than RIGHT JOIN specific — raised separately in #1999.

## Notes for review

- `TableAccessPlan` gains a variant and is `Serialize`/`Deserialize`, so this is a public type change. Execution is identical to `FullScan`; the variant only tells planners to leave the source alone. If you would rather not widen that enum, the fallback is a flag on the lowered node plus tree walks in the consumers — which is the "planners re-interpret RIGHT JOIN" shape you asked to avoid, so I went with the variant.
- `null_extend` is an alias list, not aliases plus column names. Column names are computable at plan time, but that would duplicate `output_labels` + `labels::resolve` into the planner and give column naming two sources of truth. The executor pairs the list with its runtime sources **by position**, so a mismatch surfaces as an error rather than mis-named NULL columns. Pairing by alias instead would break when the left prefix reuses one — `Player a JOIN Item a` makes the list `["a", "a"]` — which a fixture now pins.
- **The marker goes on the left base source only.** That is complete today because the only source any planner narrows is the base source — there are three assignments to `.access` in the workspace and all three reach it via `base_source_mut()`. It is an implicit invariant rather than an enforced one though: predicate pushdown to a joined source would bypass the marker and produce phantom NULL-extended rows. Note this is not reachable on `main` today, since LEFT JOIN's base source is its *preserved* side. I can mark every left source instead if you would rather not rely on the invariant — it needs a mutable counterpart to `joined_sources()`, so roughly 40 lines.
- `RightOuterJoinInputPlan::Hash` is not produced by any planner yet, but the executor must handle a hash mechanism regardless: a RIGHT JOIN's `ON` is a `JoinConditionPlan`, whose input enum includes `Hash`. Rather than leave that arm as a landmine for the follow-up, it is implemented and covered by a test that builds the plan directly.

## Tests

- Planner unit tests, including a sweep asserting no temporary node survives in **any** of 19 expression positions — a missed position is an execution error here, not a lost optimization.
- Executor tests for the unmatched pass, duplicate-row multiplicity, and the hash lookup path.
- SQL fixtures: three-table chains, chained RIGHT JOINs, empty left source, aggregate over NULL-extended rows, `WHERE` after the join, derived-source and subquery nesting, schemaless tables, an alias reused across the left prefix, and index/primary-key regressions.
- `cargo fmt --check` clean, `clippy --all-targets --all-features` warning-free, 3174 tests across 95 binaries passing.

## Summary by CodeRabbit

* **New Features**
  * Added support for SQL `RIGHT JOIN` and `RIGHT OUTER JOIN`.
  * Preserves unmatched right-side rows with `NULL` values for missing left-side data.
  * Supports right joins with conditions, filtering, aggregation, subqueries, aliases, chaining, and indexed queries.
* **Bug Fixes**
  * Corrected full-scan handling and index selection for right joins.
* **Documentation**
  * Added RIGHT JOIN syntax guidance, examples, and NULL-propagation details.
* **Tests**
  * Added comprehensive coverage for execution, planning, indexing, schemaless queries, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
