### PR TITLE
Add execution-scoped regex cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default-members = [
 [workspace.package]
 version = "0.19.0"
 edition = "2024"
+rust-version = "1.88"
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
 license = "Apache-2.0"
 repository = "https://github.com/gluesql/gluesql"

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -26,3 +26,5 @@ pub use {
     tribool::Tribool,
     value::{BTreeMapJsonExt, NumericBinaryOperator, Value, ValueError},
 };
+
+pub(crate) use string_ext::{RegexCache, like_with_cache, regex_with_cache};

--- a/core/src/data/string_ext.rs
+++ b/core/src/data/string_ext.rs
@@ -5,6 +5,124 @@ use {
     thiserror::Error,
 };
 
+const REGEX_CACHE_CAPACITY: usize = 32;
+const MAX_CACHED_REGEX_SOURCE_BYTES: usize = 4 * 1024;
+
+#[derive(PartialEq, Eq)]
+struct RegexCacheKey {
+    source: String,
+    case_insensitive: bool,
+}
+
+struct RegexCacheEntry {
+    key: RegexCacheKey,
+    regex: Regex,
+}
+
+pub(crate) struct RegexCache {
+    entries: Vec<RegexCacheEntry>,
+}
+
+impl RegexCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn regex(
+        &mut self,
+        source: String,
+        case_insensitive: bool,
+        error: impl FnOnce(regex::Error) -> StringExtError,
+    ) -> Result<Regex> {
+        let key = RegexCacheKey {
+            source,
+            case_insensitive,
+        };
+
+        if key.source.len() <= MAX_CACHED_REGEX_SOURCE_BYTES
+            && let Some(index) = self.entries.iter().position(|entry| entry.key == key)
+        {
+            let entry = self.entries.remove(index);
+            self.entries.insert(0, entry);
+            return Ok(self.entries[0].regex.clone());
+        }
+
+        let regex = RegexBuilder::new(&key.source)
+            .case_insensitive(key.case_insensitive)
+            .build()
+            .map_err(error)?;
+
+        if key.source.len() <= MAX_CACHED_REGEX_SOURCE_BYTES {
+            if self.entries.len() == REGEX_CACHE_CAPACITY {
+                self.entries.pop();
+            }
+            self.entries.insert(
+                0,
+                RegexCacheEntry {
+                    key,
+                    regex: regex.clone(),
+                },
+            );
+        }
+
+        Ok(regex)
+    }
+}
+
+pub(crate) fn like_with_cache(
+    value: &str,
+    pattern: &str,
+    case_sensitive: bool,
+    cache: &mut RegexCache,
+) -> Result<bool> {
+    let (value, pattern) = if case_sensitive {
+        (value.to_owned(), pattern.to_owned())
+    } else {
+        (value.to_lowercase(), pattern.to_lowercase())
+    };
+    let source = format!(
+        "^{}$",
+        regex::escape(&pattern).replace('%', ".*").replace('_', ".")
+    );
+
+    match_with_cache(&value, &source, false, cache, |_| {
+        StringExtError::UnreachablePatternParsing
+    })
+}
+
+pub(crate) fn regex_with_cache(
+    value: &str,
+    pattern: &str,
+    case_sensitive: bool,
+    cache: &mut RegexCache,
+) -> Result<bool> {
+    match_with_cache(value, pattern, !case_sensitive, cache, |error| {
+        StringExtError::InvalidRegexPattern {
+            pattern: pattern.to_owned(),
+            error: error.to_string(),
+        }
+    })
+}
+
+fn match_with_cache(
+    value: &str,
+    source: &str,
+    case_insensitive: bool,
+    cache: &mut RegexCache,
+    error: impl FnOnce(regex::Error) -> StringExtError,
+) -> Result<bool> {
+    cache
+        .regex(source.to_owned(), case_insensitive, error)
+        .map(|regex| regex.is_match(value))
+}
+
 #[derive(Error, Serialize, Debug, PartialEq, Eq)]
 pub enum StringExtError {
     #[error("unreachable literal unary operation")]
@@ -29,34 +147,120 @@ impl StringExt for str {
             (lowercase_string, lowercase_pattern)
         };
 
-        Ok(Regex::new(&format!(
-            "^{}$",
-            regex::escape(match_pattern.as_str())
-                .replace('%', ".*")
-                .replace('_', ".")
-        ))
-        .map_err(|_| StringExtError::UnreachablePatternParsing)?
-        .is_match(match_string.as_str()))
+        match_with_regex(
+            match_string.as_str(),
+            &format!(
+                "^{}$",
+                regex::escape(match_pattern.as_str())
+                    .replace('%', ".*")
+                    .replace('_', ".")
+            ),
+            false,
+            |_| StringExtError::UnreachablePatternParsing,
+        )
     }
 
     fn regex(&self, pattern: &str, case_sensitive: bool) -> Result<bool> {
-        Ok(RegexBuilder::new(pattern)
-            .case_insensitive(!case_sensitive)
-            .build()
-            .map_err(|error| StringExtError::InvalidRegexPattern {
+        match_with_regex(self, pattern, !case_sensitive, |error| {
+            StringExtError::InvalidRegexPattern {
                 pattern: pattern.to_owned(),
                 error: error.to_string(),
-            })
-            .map(|regex| regex.is_match(self))?)
+            }
+        })
     }
+}
+
+fn match_with_regex(
+    value: &str,
+    source: &str,
+    case_insensitive: bool,
+    error: impl FnOnce(regex::Error) -> StringExtError,
+) -> Result<bool> {
+    Ok(RegexBuilder::new(source)
+        .case_insensitive(case_insensitive)
+        .build()
+        .map_err(error)?
+        .is_match(value))
 }
 
 #[cfg(test)]
 mod tests {
     use {
-        super::{StringExt, StringExtError},
+        super::{
+            REGEX_CACHE_CAPACITY, RegexCache, StringExt, StringExtError, like_with_cache,
+            regex_with_cache,
+        },
         crate::result::Error,
     };
+
+    #[test]
+    fn regex_cache_reuses_entries_and_separates_case_options() {
+        let mut cache = RegexCache::new();
+
+        assert_eq!(
+            regex_with_cache("Hello", "^hello$", true, &mut cache),
+            Ok(false)
+        );
+        assert_eq!(
+            regex_with_cache("Hello", "^hello$", false, &mut cache),
+            Ok(true)
+        );
+        assert_eq!(cache.len(), 2);
+        assert_eq!(
+            regex_with_cache("Hello", "^hello$", false, &mut cache),
+            Ok(true)
+        );
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn regex_cache_does_not_store_invalid_or_long_patterns() {
+        let mut cache = RegexCache::new();
+
+        assert!(regex_with_cache("Hello", "[", true, &mut cache).is_err());
+        assert_eq!(cache.len(), 0);
+
+        let long_pattern = "a".repeat(4097);
+        assert_eq!(
+            regex_with_cache("Hello", &long_pattern, true, &mut cache),
+            Ok(false)
+        );
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn like_cache_normalizes_pattern_before_matching() {
+        let mut cache = RegexCache::new();
+
+        assert_eq!(like_with_cache("Hello", "h%", false, &mut cache), Ok(true));
+        assert_eq!(
+            like_with_cache("Hello", "h_llo", false, &mut cache),
+            Ok(true)
+        );
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn like_and_regex_keep_distinct_cache_keys() {
+        let mut cache = RegexCache::new();
+
+        like_with_cache("abc", "a%", true, &mut cache).unwrap();
+        regex_with_cache("abc", "a%", true, &mut cache).unwrap();
+
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn regex_cache_evicts_when_full() {
+        let mut cache = RegexCache::new();
+
+        for index in 0..=REGEX_CACHE_CAPACITY {
+            let pattern = format!("^{index}$");
+            regex_with_cache("0", &pattern, true, &mut cache).unwrap();
+        }
+
+        assert_eq!(cache.len(), REGEX_CACHE_CAPACITY);
+    }
 
     #[test]
     fn regex() {

--- a/core/src/data/string_ext.rs
+++ b/core/src/data/string_ext.rs
@@ -82,19 +82,10 @@ pub(crate) fn like_with_cache(
     case_sensitive: bool,
     cache: &mut RegexCache,
 ) -> Result<bool> {
-    let (value, pattern) = if case_sensitive {
-        (value.to_owned(), pattern.to_owned())
-    } else {
-        (value.to_lowercase(), pattern.to_lowercase())
-    };
-    let source = format!(
-        "^{}$",
-        regex::escape(&pattern).replace('%', ".*").replace('_', ".")
-    );
+    let (value, pattern) = normalize_like(value, pattern, case_sensitive);
+    let source = like_source(&pattern);
 
-    match_with_cache(&value, &source, false, cache, |_| {
-        StringExtError::UnreachablePatternParsing
-    })
+    match_with_cache(&value, &source, false, cache, unreachable_pattern_parsing)
 }
 
 pub(crate) fn regex_with_cache(
@@ -104,10 +95,7 @@ pub(crate) fn regex_with_cache(
     cache: &mut RegexCache,
 ) -> Result<bool> {
     match_with_cache(value, pattern, !case_sensitive, cache, |error| {
-        StringExtError::InvalidRegexPattern {
-            pattern: pattern.to_owned(),
-            error: error.to_string(),
-        }
+        invalid_regex_pattern(pattern, &error)
     })
 }
 
@@ -138,36 +126,47 @@ pub trait StringExt {
 
 impl StringExt for str {
     fn like(&self, pattern: &str, case_sensitive: bool) -> Result<bool> {
-        let (match_string, match_pattern) = if case_sensitive {
-            (self.to_owned(), pattern.to_owned())
-        } else {
-            let lowercase_string = self.to_lowercase();
-            let lowercase_pattern = pattern.to_lowercase();
-
-            (lowercase_string, lowercase_pattern)
-        };
+        let (match_string, match_pattern) = normalize_like(self, pattern, case_sensitive);
 
         match_with_regex(
             match_string.as_str(),
-            &format!(
-                "^{}$",
-                regex::escape(match_pattern.as_str())
-                    .replace('%', ".*")
-                    .replace('_', ".")
-            ),
+            &like_source(&match_pattern),
             false,
-            |_| StringExtError::UnreachablePatternParsing,
+            unreachable_pattern_parsing,
         )
     }
 
     fn regex(&self, pattern: &str, case_sensitive: bool) -> Result<bool> {
         match_with_regex(self, pattern, !case_sensitive, |error| {
-            StringExtError::InvalidRegexPattern {
-                pattern: pattern.to_owned(),
-                error: error.to_string(),
-            }
+            invalid_regex_pattern(pattern, &error)
         })
     }
+}
+
+fn normalize_like(value: &str, pattern: &str, case_sensitive: bool) -> (String, String) {
+    if case_sensitive {
+        (value.to_owned(), pattern.to_owned())
+    } else {
+        (value.to_lowercase(), pattern.to_lowercase())
+    }
+}
+
+fn like_source(pattern: &str) -> String {
+    format!(
+        "^{}$",
+        regex::escape(pattern).replace('%', ".*").replace('_', ".")
+    )
+}
+
+fn invalid_regex_pattern(pattern: &str, error: &regex::Error) -> StringExtError {
+    StringExtError::InvalidRegexPattern {
+        pattern: pattern.to_owned(),
+        error: error.to_string(),
+    }
+}
+
+fn unreachable_pattern_parsing(_: regex::Error) -> StringExtError {
+    StringExtError::UnreachablePatternParsing
 }
 
 fn match_with_regex(
@@ -188,9 +187,10 @@ mod tests {
     use {
         super::{
             REGEX_CACHE_CAPACITY, RegexCache, StringExt, StringExtError, like_with_cache,
-            regex_with_cache,
+            regex_with_cache, unreachable_pattern_parsing,
         },
         crate::result::Error,
+        regex::Regex,
     };
 
     #[test]
@@ -260,6 +260,17 @@ mod tests {
         }
 
         assert_eq!(cache.len(), REGEX_CACHE_CAPACITY);
+    }
+
+    #[test]
+    fn unreachable_pattern_error_is_stable() {
+        let invalid_pattern = "(".to_owned();
+        let error = Regex::new(&invalid_pattern).unwrap_err();
+
+        assert_eq!(
+            unreachable_pattern_parsing(error),
+            StringExtError::UnreachablePatternParsing
+        );
     }
 
     #[test]

--- a/core/src/executor/context.rs
+++ b/core/src/executor/context.rs
@@ -51,6 +51,9 @@ impl ExecutionContext {
         }
     }
 
+    /// Activates this context until the returned scope is dropped.
+    ///
+    /// Nested scopes must be dropped in reverse order of creation.
     pub(crate) fn activate(&self) -> ExecutionScope {
         let previous =
             ACTIVE_REGEX_CACHE.with(|active| active.borrow_mut().replace(Rc::clone(&self.cache)));

--- a/core/src/executor/context.rs
+++ b/core/src/executor/context.rs
@@ -5,3 +5,93 @@ pub use {
     aggregate_context::{AggregateContext, AggregateValues},
     row_context::RowContext,
 };
+
+use {
+    crate::data::RegexCache,
+    std::{cell::RefCell, rc::Rc},
+};
+
+thread_local! {
+    static ACTIVE_REGEX_CACHE: RefCell<Option<Rc<RefCell<RegexCache>>>> = const { RefCell::new(None) };
+}
+
+pub(crate) struct ExecutionContext {
+    cache: Rc<RefCell<RegexCache>>,
+}
+
+impl ExecutionContext {
+    pub(crate) fn new() -> Rc<Self> {
+        Rc::new(Self {
+            cache: Rc::new(RefCell::new(RegexCache::new())),
+        })
+    }
+
+    pub(crate) fn with_regex_cache<T>(operation: impl FnOnce(&mut RegexCache) -> T) -> T {
+        ACTIVE_REGEX_CACHE.with(|active| {
+            let cache = active
+                .borrow()
+                .as_ref()
+                .cloned()
+                .expect("regex cache used outside an execution scope");
+            operation(&mut cache.borrow_mut())
+        })
+    }
+
+    pub(crate) fn is_active() -> bool {
+        ACTIVE_REGEX_CACHE.with(|active| active.borrow().is_some())
+    }
+
+    pub(crate) fn with_scope<T>(operation: impl FnOnce() -> T) -> T {
+        if Self::is_active() {
+            operation()
+        } else {
+            let context = Self::new();
+            let _scope = context.activate();
+            operation()
+        }
+    }
+
+    pub(crate) fn activate(&self) -> ExecutionScope {
+        let previous =
+            ACTIVE_REGEX_CACHE.with(|active| active.borrow_mut().replace(Rc::clone(&self.cache)));
+
+        ExecutionScope { previous }
+    }
+}
+
+pub(crate) struct ExecutionScope {
+    previous: Option<Rc<RefCell<RegexCache>>>,
+}
+
+impl Drop for ExecutionScope {
+    fn drop(&mut self) {
+        ACTIVE_REGEX_CACHE.with(|active| {
+            *active.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::ExecutionContext, crate::data::regex_with_cache};
+
+    #[test]
+    fn nested_execution_context_restores_previous_cache() {
+        let outer = ExecutionContext::new();
+        let outer_scope = outer.activate();
+        ExecutionContext::with_regex_cache(|cache| {
+            regex_with_cache("Hello", "Hello", true, cache).unwrap();
+            assert_eq!(cache.len(), 1);
+        });
+
+        {
+            let inner = ExecutionContext::new();
+            let _inner_scope = inner.activate();
+            ExecutionContext::with_regex_cache(|cache| assert_eq!(cache.len(), 0));
+        }
+
+        ExecutionContext::with_regex_cache(|cache| assert_eq!(cache.len(), 1));
+        drop(outer_scope);
+        drop(outer);
+    }
+}

--- a/core/src/executor/evaluate.rs
+++ b/core/src/executor/evaluate.rs
@@ -6,7 +6,7 @@ mod function;
 use {
     self::function::BreakCase,
     super::{
-        context::{AggregateValues, RowContext},
+        context::{AggregateValues, ExecutionContext, RowContext},
         query,
     },
     crate::{
@@ -32,7 +32,7 @@ where
     'b: 'a,
     T: GStore,
 {
-    evaluate_inner(Some(storage), context, aggregated, expr)
+    ExecutionContext::with_scope(|| evaluate_inner(Some(storage), context, aggregated, expr))
 }
 
 pub fn evaluate_stateless<'a, 'b: 'a>(
@@ -41,8 +41,7 @@ pub fn evaluate_stateless<'a, 'b: 'a>(
 ) -> Result<Evaluated<'a>> {
     let context = context.map(Rc::new);
     let storage: Option<&MockStorage> = None;
-
-    evaluate_inner(storage, context.as_ref(), None, expr)
+    ExecutionContext::with_scope(|| evaluate_inner(storage, context.as_ref(), None, expr))
 }
 
 fn evaluate_inner<'a, 'b, T>(
@@ -213,7 +212,9 @@ where
         } => {
             let target = eval(expr)?;
             let pattern = eval(pattern)?;
-            let evaluated = target.like(pattern, true)?;
+            let evaluated = ExecutionContext::with_regex_cache(|cache| {
+                target.like_with_cache(pattern, true, cache)
+            })?;
 
             Ok(match negated {
                 true => {
@@ -231,7 +232,9 @@ where
         } => {
             let target = eval(expr)?;
             let pattern = eval(pattern)?;
-            let evaluated = target.like(pattern, false)?;
+            let evaluated = ExecutionContext::with_regex_cache(|cache| {
+                target.like_with_cache(pattern, false, cache)
+            })?;
 
             Ok(match negated {
                 true => {
@@ -251,7 +254,9 @@ where
             let target = eval(expr)?;
             let pattern = eval(pattern)?;
 
-            target.regex(pattern, *negated, *case_sensitive)
+            ExecutionContext::with_regex_cache(|cache| {
+                target.regex_with_cache(pattern, *negated, *case_sensitive, cache)
+            })
         }
         ExprPlan::Exists { subquery, negated } => {
             let storage = storage.ok_or(EvaluateError::ExistsSubqueryNotAllowedInStatelessExpr)?;
@@ -750,7 +755,8 @@ mod tests {
         super::{EvaluateError, evaluate, evaluate_stateless},
         crate::{
             ast::{Expr, Projection, SelectItem, SetExpr, Statement},
-            executor::context::AggregateValues,
+            data::Value,
+            executor::context::{AggregateValues, ExecutionContext},
             mock::MockStorage,
             parse_sql::parse,
             plan::{AggregateExprPlan, AggregateFunctionPlan, CountArgExprPlan, ExprPlan},
@@ -815,5 +821,67 @@ mod tests {
                 Box::new(aggregate)
             )))
         );
+    }
+
+    #[test]
+    fn cached_pattern_operators_evaluate_through_execution_cache() {
+        let value = |value: &str| ExprPlan::Value(Value::Str(value.to_owned()));
+        let pattern_match = ExprPlan::Like {
+            expr: Box::new(value("Hello")),
+            negated: false,
+            pattern: Box::new(value("H%")),
+        };
+        let insensitive_match = ExprPlan::ILike {
+            expr: Box::new(value("Hello")),
+            negated: false,
+            pattern: Box::new(value("h%")),
+        };
+        let regex = ExprPlan::Regex {
+            expr: Box::new(value("Hello")),
+            negated: false,
+            pattern: Box::new(value("^hello$")),
+            case_sensitive: false,
+        };
+
+        assert_eq!(
+            evaluate_stateless(None, &pattern_match)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert_eq!(
+            evaluate_stateless(None, &insensitive_match)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert_eq!(
+            evaluate_stateless(None, &regex).unwrap().to_string(),
+            "TRUE"
+        );
+        let context = ExecutionContext::new();
+        let _scope = context.activate();
+        evaluate_stateless(None, &pattern_match).unwrap();
+        evaluate_stateless(None, &pattern_match).unwrap();
+        ExecutionContext::with_regex_cache(|cache| assert_eq!(cache.len(), 1));
+    }
+
+    #[test]
+    fn stateless_pattern_evaluation_creates_a_temporary_scope() {
+        let expression = ExprPlan::Regex {
+            expr: Box::new(ExprPlan::Value(Value::Str("Hello".to_owned()))),
+            negated: false,
+            pattern: Box::new(ExprPlan::Value(Value::Str("Hello".to_owned()))),
+            case_sensitive: true,
+        };
+
+        assert_eq!(
+            evaluate_stateless(None, &expression).unwrap().to_string(),
+            "TRUE"
+        );
+
+        let context = ExecutionContext::new();
+        let _scope = context.activate();
+        ExecutionContext::with_regex_cache(|cache| assert_eq!(cache.len(), 0));
     }
 }

--- a/core/src/executor/evaluate/evaluated.rs
+++ b/core/src/executor/evaluate/evaluated.rs
@@ -37,6 +37,18 @@ pub enum Evaluated<'a> {
     Value(Cow<'a, Value>),
 }
 
+pub(super) fn as_str<'a>(evaluated: &'a Evaluated<'_>) -> Option<&'a str> {
+    match evaluated {
+        Evaluated::Text(value) => Some(value.as_ref()),
+        Evaluated::StrSlice { source, range } => Some(&source[range.clone()]),
+        Evaluated::Value(value) => match value.as_ref() {
+            Value::Str(value) => Some(value.as_str()),
+            _ => None,
+        },
+        Evaluated::Number(_) => None,
+    }
+}
+
 /// Formats the evaluated value as a string.
 /// This is primarily intended for error message generation, not for general-purpose display.
 impl Display for Evaluated<'_> {

--- a/core/src/executor/evaluate/evaluated/like.rs
+++ b/core/src/executor/evaluate/evaluated/like.rs
@@ -1,7 +1,7 @@
 use {
-    super::Evaluated,
+    super::{Evaluated, as_str},
     crate::{
-        data::{StringExt, Value},
+        data::{RegexCache, StringExt, Value, like_with_cache},
         executor::evaluate::error::EvaluateError,
         result::Result,
     },
@@ -9,7 +9,37 @@ use {
 };
 
 impl<'a> Evaluated<'a> {
+    pub(crate) fn like_with_cache(
+        &self,
+        other: Evaluated<'a>,
+        case_sensitive: bool,
+        cache: &mut RegexCache,
+    ) -> Result<Evaluated<'a>> {
+        self.like_inner(other, case_sensitive, Some(cache))
+    }
+
     pub fn like(&self, other: Evaluated<'a>, case_sensitive: bool) -> Result<Evaluated<'a>> {
+        self.like_inner(other, case_sensitive, None)
+    }
+
+    fn like_inner(
+        &self,
+        other: Evaluated<'a>,
+        case_sensitive: bool,
+        mut cache: Option<&mut RegexCache>,
+    ) -> Result<Evaluated<'a>> {
+        if let (Some(left), Some(right)) = (as_str(self), as_str(&other)) {
+            let matched = match cache.as_mut() {
+                Some(cache) => like_with_cache(left, right, case_sensitive, cache)?,
+                None => left.like(right, case_sensitive)?,
+            };
+            return Ok(Evaluated::Value(Cow::Owned(Value::Bool(matched))));
+        }
+
+        self.like_values(other, case_sensitive)
+    }
+
+    fn like_values(&self, other: Evaluated<'a>, case_sensitive: bool) -> Result<Evaluated<'a>> {
         let evaluated = match (self, other) {
             (Evaluated::Text(lhs), Evaluated::Text(rhs)) => Evaluated::Value(Cow::Owned(
                 Value::Bool(lhs.as_ref().like(rhs.as_ref(), case_sensitive)?),
@@ -145,6 +175,61 @@ mod tests {
                 case_sensitive: true,
             }
             .into())
+        );
+    }
+
+    #[test]
+    fn like_with_cache_uses_cache_for_strings_and_falls_back_for_numbers() {
+        let text = |value: &str| Evaluated::Text(Cow::Owned(value.to_owned()));
+        let number = || Evaluated::Number(Cow::Owned(BigDecimal::from(42)));
+        let value = |value: &str| Evaluated::Value(Cow::Owned(Value::Str(value.to_owned())));
+        let boolean = || Evaluated::Value(Cow::Owned(Value::Bool(true)));
+        let slice = |value: &str| Evaluated::StrSlice {
+            source: Cow::Owned(value.to_owned()),
+            range: 0..value.len(),
+        };
+        let mut cache = crate::data::RegexCache::new();
+
+        assert_eq!(
+            text("hello")
+                .like_with_cache(text("h%"), false, &mut cache)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert_eq!(
+            slice("hello")
+                .like_with_cache(slice("h%"), false, &mut cache)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert_eq!(
+            value("hello")
+                .like_with_cache(value("h%"), false, &mut cache)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert!(
+            number()
+                .like_with_cache(text("%"), true, &mut cache)
+                .is_err()
+        );
+        assert!(
+            text("hello")
+                .like_with_cache(number(), true, &mut cache)
+                .is_err()
+        );
+        assert!(
+            boolean()
+                .like_with_cache(text("%"), true, &mut cache)
+                .is_err()
+        );
+        assert!(
+            text("hello")
+                .like_with_cache(boolean(), true, &mut cache)
+                .is_err()
         );
     }
 }

--- a/core/src/executor/evaluate/evaluated/regex.rs
+++ b/core/src/executor/evaluate/evaluated/regex.rs
@@ -1,35 +1,44 @@
 use {
-    super::Evaluated,
+    super::{Evaluated, as_str},
     crate::{
-        data::{StringExt, Value},
+        data::{RegexCache, StringExt, Value, regex_with_cache},
         result::Result,
     },
     std::borrow::Cow,
 };
 
-/// Borrows the text behind an `Evaluated` without allocating, when it holds one.
-fn as_str<'a>(evaluated: &'a Evaluated<'_>) -> Option<&'a str> {
-    match evaluated {
-        Evaluated::Text(value) => Some(value.as_ref()),
-        Evaluated::StrSlice { source, range } => Some(&source[range.clone()]),
-        Evaluated::Value(value) => match value.as_ref() {
-            Value::Str(value) => Some(value.as_str()),
-            _ => None,
-        },
-        Evaluated::Number(_) => None,
-    }
-}
-
 impl<'a> Evaluated<'a> {
+    pub(crate) fn regex_with_cache(
+        &self,
+        other: Evaluated<'a>,
+        negated: bool,
+        case_sensitive: bool,
+        cache: &mut RegexCache,
+    ) -> Result<Evaluated<'a>> {
+        self.regex_inner(other, negated, case_sensitive, Some(cache))
+    }
+
     pub fn regex(
         &self,
         other: Evaluated<'a>,
         negated: bool,
         case_sensitive: bool,
     ) -> Result<Evaluated<'a>> {
-        if let (Some(target), Some(pattern)) = (as_str(self), as_str(&other)) {
-            let matched = target.regex(pattern, case_sensitive)?;
+        self.regex_inner(other, negated, case_sensitive, None)
+    }
 
+    fn regex_inner(
+        &self,
+        other: Evaluated<'a>,
+        negated: bool,
+        case_sensitive: bool,
+        mut cache: Option<&mut RegexCache>,
+    ) -> Result<Evaluated<'a>> {
+        if let (Some(target), Some(pattern)) = (as_str(self), as_str(&other)) {
+            let matched = match cache.as_mut() {
+                Some(cache) => regex_with_cache(target, pattern, case_sensitive, cache)?,
+                None => target.regex(pattern, case_sensitive)?,
+            };
             return Ok(Evaluated::Value(Cow::Owned(Value::Bool(matched ^ negated))));
         }
 
@@ -107,6 +116,43 @@ mod tests {
                 operator: "!~*".to_owned(),
             }
             .into()
+        );
+    }
+
+    #[test]
+    fn regex_with_cache_uses_cache_for_strings_and_falls_back_for_values() {
+        let text = |value: &str| Evaluated::Text(Cow::Owned(value.to_owned()));
+        let slice = |value: &str| Evaluated::StrSlice {
+            source: Cow::Owned(value.to_owned()),
+            range: 0..value.len(),
+        };
+        let number_literal = || Evaluated::Number(Cow::Owned("42".parse().unwrap()));
+        let number = Evaluated::Value(Cow::Owned(Value::I64(42)));
+        let mut cache = crate::data::RegexCache::new();
+
+        assert_eq!(
+            text("Hello")
+                .regex_with_cache(text("^hello$"), false, false, &mut cache)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert_eq!(
+            slice("Hello")
+                .regex_with_cache(slice("^hello$"), false, false, &mut cache)
+                .unwrap()
+                .to_string(),
+            "TRUE"
+        );
+        assert!(
+            number
+                .regex_with_cache(text("."), false, true, &mut cache)
+                .is_err()
+        );
+        assert!(
+            number_literal()
+                .regex_with_cache(text("."), false, true, &mut cache)
+                .is_err()
         );
     }
 }

--- a/core/src/executor/query.rs
+++ b/core/src/executor/query.rs
@@ -16,7 +16,11 @@ pub use error::QueryError;
 pub(super) use output::{OutputBody, body as output_body};
 use {
     crate::{
-        data::Row, executor::context::RowContext, plan::QueryPlan, result::Result, store::GStore,
+        data::Row,
+        executor::context::{ExecutionContext, RowContext},
+        plan::QueryPlan,
+        result::Result,
+        store::GStore,
     },
     std::rc::Rc,
 };
@@ -52,7 +56,14 @@ pub fn execute_with_labels<'a, T>(
 where
     T: GStore,
 {
-    execute_query(storage, query, filter_context).map(|LabeledRows { labels, rows }| (labels, rows))
+    let execution_context = ExecutionContext::new();
+    let result = {
+        let _scope = execution_context.activate();
+        execute_query(storage, query, filter_context)
+    };
+    result.map(|LabeledRows { labels, rows }| {
+        (labels, keep_execution_context(rows, execution_context))
+    })
 }
 
 pub fn execute<'a, T>(
@@ -63,7 +74,36 @@ pub fn execute<'a, T>(
 where
     T: GStore,
 {
-    execute_query(storage, query, filter_context).map(|LabeledRows { rows, .. }| rows)
+    let execution_context = ExecutionContext::new();
+    let result = {
+        let _scope = execution_context.activate();
+        execute_query(storage, query, filter_context)
+    };
+    result.map(|LabeledRows { rows, .. }| keep_execution_context(rows, execution_context))
+}
+
+fn keep_execution_context(
+    rows: QueryIter<'_>,
+    execution_context: Rc<ExecutionContext>,
+) -> QueryIter<'_> {
+    Box::new(ExecutionScopedIter {
+        rows,
+        execution_context,
+    })
+}
+
+struct ExecutionScopedIter<'a> {
+    rows: QueryIter<'a>,
+    execution_context: Rc<ExecutionContext>,
+}
+
+impl Iterator for ExecutionScopedIter<'_> {
+    type Item = Result<Row>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let _scope = self.execution_context.activate();
+        self.rows.next()
+    }
 }
 
 fn execute_query<'a, T>(
@@ -93,5 +133,140 @@ where
         QueryPlan::Distinct(distinct) => distinct::execute(storage, distinct, filter_context),
         QueryPlan::Offset(offset) => offset::execute(storage, offset, filter_context),
         QueryPlan::Limit(limit) => limit::execute(storage, limit, filter_context),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{QueryIter, execute, execute_with_labels, keep_execution_context},
+        crate::{
+            data::{Row, Value, regex_with_cache},
+            mock::MockStorage,
+            plan::{ExprPlan, QueryPlan, ValuesPlan},
+        },
+        std::rc::Rc,
+    };
+
+    #[test]
+    fn execute_keeps_context_alive_until_rows_are_consumed() {
+        let query = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Regex {
+            expr: Box::new(ExprPlan::Value(Value::Str("Hello".to_owned()))),
+            negated: false,
+            pattern: Box::new(ExprPlan::Value(Value::Str("^Hello$".to_owned()))),
+            case_sensitive: true,
+        }]]));
+        let rows = execute(&MockStorage::default(), &query, None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].values, vec![Value::Bool(true)]);
+    }
+
+    #[test]
+    fn execute_with_labels_keeps_context_alive_until_rows_are_consumed() {
+        let query = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Value(Value::Str(
+            "Hello".to_owned(),
+        ))]]));
+        let storage = MockStorage::default();
+        let (labels, rows) = execute_with_labels(&storage, &query, None).unwrap();
+
+        assert_eq!(labels, vec!["column1"]);
+        assert_eq!(rows.count(), 1);
+    }
+
+    #[test]
+    fn interleaved_queries_keep_execution_caches_separate() {
+        let query = QueryPlan::Values(ValuesPlan(vec![vec![ExprPlan::Like {
+            expr: Box::new(ExprPlan::Value(Value::Str("Hello".to_owned()))),
+            negated: false,
+            pattern: Box::new(ExprPlan::Value(Value::Str("H%".to_owned()))),
+        }]]));
+        let storage = MockStorage::default();
+        let mut first = execute(&storage, &query, None).unwrap();
+        let mut second = execute(&storage, &query, None).unwrap();
+
+        assert_eq!(
+            first.next().unwrap().unwrap().values,
+            vec![Value::Bool(true)]
+        );
+        assert_eq!(
+            second.next().unwrap().unwrap().values,
+            vec![Value::Bool(true)]
+        );
+        assert!(first.next().is_none());
+        assert!(second.next().is_none());
+    }
+
+    #[test]
+    fn values_query_reuses_pattern_cache_across_rows() {
+        let value = |value: &str| ExprPlan::Value(Value::Str(value.to_owned()));
+        let pattern = || ExprPlan::Like {
+            expr: Box::new(value("Hello")),
+            negated: false,
+            pattern: Box::new(value("H%")),
+        };
+        let query = QueryPlan::Values(ValuesPlan(vec![
+            vec![pattern()],
+            vec![pattern()],
+            vec![pattern()],
+        ]));
+        let storage = MockStorage::default();
+        let execution_context = super::ExecutionContext::new();
+        let _scope = execution_context.activate();
+
+        let rows = super::execute_query(&storage, &query, None)
+            .unwrap()
+            .rows
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(rows.len(), 3);
+        super::ExecutionContext::with_regex_cache(|cache| assert_eq!(cache.len(), 1));
+    }
+
+    #[test]
+    fn interleaved_iterators_activate_their_own_regex_caches() {
+        let first_context = super::ExecutionContext::new();
+        let second_context = super::ExecutionContext::new();
+        {
+            let _scope = first_context.activate();
+            super::ExecutionContext::with_regex_cache(|cache| {
+                regex_with_cache("first", "first", true, cache).unwrap();
+            });
+        }
+        {
+            let _scope = second_context.activate();
+            super::ExecutionContext::with_regex_cache(|cache| {
+                regex_with_cache("second", "second", true, cache).unwrap();
+                regex_with_cache("other", "other", true, cache).unwrap();
+            });
+        }
+
+        let cache_size_row = || {
+            Box::new(std::iter::from_fn({
+                let mut yielded = false;
+                move || {
+                    if yielded {
+                        return None;
+                    }
+                    yielded = true;
+                    let size = super::ExecutionContext::with_regex_cache(|cache| cache.len());
+                    Some(Ok(Row {
+                        columns: Rc::from(["cache_size".to_owned()]),
+                        values: vec![Value::I64(size as i64)],
+                    }))
+                }
+            })) as QueryIter<'_>
+        };
+        let mut first = keep_execution_context(cache_size_row(), first_context);
+        let mut second = keep_execution_context(cache_size_row(), second_context);
+
+        assert_eq!(first.next().unwrap().unwrap().values, vec![Value::I64(1)]);
+        assert_eq!(second.next().unwrap().unwrap().values, vec![Value::I64(2)]);
+        assert!(first.next().is_none());
+        assert!(second.next().is_none());
     }
 }


### PR DESCRIPTION
# Pull request

## Summary

- add a bounded regex cache owned by `ExecutionContext`
- preserve cache isolation across query iterators, including interleaved execution
- create a temporary scope for direct stateless evaluation outside a query scope
- share LIKE and regex matching internals without propagating cache parameters through every layer
- add tests for cache reuse, key separation, fallback scope creation, iterator scope isolation, and repeated query execution
- limit changes to the data and executor layers

## Performance impact

The cache reduces execution time for repeated constant-pattern queries by avoiding repeated regex compilation within one query execution.

The controlled baseline comparison shows the following changes:

| Rows | Query | Baseline | Cached | Change |
| ---: | --- | ---: | ---: | ---: |
| 1,000 | regex constant | 6.630 ms | 2.027 ms | 69.4% reduced |
| 1,000 | LIKE constant | 17.412 ms | 2.437 ms | 86.0% reduced |
| 1,000 | regex dynamic | 7.029 ms | 7.136 ms | 1.5% increased |
| 100,000 | regex constant | 671.229 ms | 210.741 ms | 68.6% reduced |
| 100,000 | LIKE constant | 1,756.332 ms | 237.803 ms | 86.5% reduced |
| 100,000 | regex dynamic | 715.612 ms | 728.389 ms | 1.8% increased |

## Benchmark

The benchmark has two layers. Micro benchmarks isolate regex compilation, matching, and cache lookup overhead. End-to-end benchmarks measure actual query execution over multiple rows.

The performance-impact table above is the baseline-versus-cached comparison. The end-to-end table below records the standalone cached benchmark run.

Measured with the existing benchmark path:

```text
BENCH_SIZES=1000,100000 MEASURED_RUNS=5 cargo run --release --manifest-path reports/regex-cache-bench/Cargo.toml
```

### Micro benchmark

The `^a|g` pattern is a representative alternation pattern used only to measure regex compilation and matching cost. It is not a production query or a new user-facing behavior.

- `Regex::new("ell")`: 2,734.6 ns/op
- `is_match("ell")`: 7.8 ns/op
- `Regex::new("^a|g")`: 5,282.2 ns/op
- `is_match("^a|g")`: 11.2 ns/op
- complex pattern compilation: 5,717.3 ns/op
- case-insensitive compilation: 5,712.8 ns/op
- thread-local HashMap lookup: 21.7 ns/op

### End-to-end benchmark

| Rows | Query | Median |
| ---: | --- | ---: |
| 1,000 | regex constant | 2.021 ms |
| 1,000 | LIKE constant | 2.270 ms |
| 1,000 | regex dynamic | 7.022 ms |
| 100,000 | regex constant | 211.275 ms |
| 100,000 | LIKE constant | 235.551 ms |
| 100,000 | regex dynamic | 714.360 ms |

Conditions: release build, 3 warm-up runs, 5 measured runs, median values, `MemoryStorage`.
Queries: `name ~ '^match-[0-9]+$'`, `name LIKE 'match-%'`, and `name ~ pattern`.

## Testing

- `cargo test -p gluesql-core`: 607 tests passed
- `cargo fmt --all`: passed
- `git diff --check`: passed
- changed-line and changed-branch coverage

`cargo clippy --all-targets -- -D warnings` is blocked by pre-existing warnings in unrelated files:

- `macros/src/lib.rs`
- `core/src/executor/evaluate/evaluated/eq.rs`
- `core/src/planner/expr/plan_expr/function.rs`

Closes #2005


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved `LIKE`, `ILIKE`, and regular-expression evaluation by reusing compiled patterns during query execution.
  * Added bounded caching with separate handling for case-sensitive patterns and automatic eviction.

* **Reliability**
  * Preserved cache isolation across nested and interleaved query executions.
  * Added safeguards for invalid or excessively long patterns while retaining existing matching behavior.
  * Improved consistency when evaluating text, slices, and string values with matching expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->