### PR TITLE
Preserve schema engines across storage backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,7 @@ name = "gluesql-composite-storage"
 version = "0.20.0"
 dependencies = [
  "gluesql-core",
+ "gluesql-json-storage",
  "gluesql-redb-storage",
  "gluesql-test-suite",
  "gluesql_memory_storage",

--- a/storages/composite-storage/Cargo.toml
+++ b/storages/composite-storage/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 test-suite.workspace = true
 gluesql_memory_storage.workspace = true
 gluesql-redb-storage.workspace = true
+gluesql-json-storage.workspace = true
 
 [lints]
 workspace = true

--- a/storages/composite-storage/src/store.rs
+++ b/storages/composite-storage/src/store.rs
@@ -1,5 +1,5 @@
 use {
-    super::{CompositeStorage, IStorage},
+    super::CompositeStorage,
     gluesql_core::{
         data::{Key, Schema, Value},
         error::Result,
@@ -7,27 +7,31 @@ use {
     },
 };
 
+fn with_fallback_engine(mut schema: Schema, engine: &str) -> Schema {
+    schema.engine.get_or_insert_with(|| engine.to_owned());
+    schema
+}
+
 impl Store for CompositeStorage {
     fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
-        let schemas = self
-            .storages
-            .values()
-            .map(AsRef::as_ref)
-            .map(<dyn IStorage>::fetch_all_schemas)
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut schemas = Vec::new();
+
+        for (engine, storage) in &self.storages {
+            schemas.extend(
+                storage
+                    .fetch_all_schemas()?
+                    .into_iter()
+                    .map(|schema| with_fallback_engine(schema, engine)),
+            );
+        }
 
         Ok(schemas)
     }
 
     fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
-        for storage in self.storages.values() {
-            let schema = storage.fetch_schema(table_name)?;
-
-            if schema.is_some() {
-                return Ok(schema);
+        for (engine, storage) in &self.storages {
+            if let Some(schema) = storage.fetch_schema(table_name)? {
+                return Ok(Some(with_fallback_engine(schema, engine)));
             }
         }
 

--- a/storages/composite-storage/tests/engine.rs
+++ b/storages/composite-storage/tests/engine.rs
@@ -1,0 +1,55 @@
+use {
+    gluesql_composite_storage::CompositeStorage,
+    gluesql_core::{
+        prelude::{
+            Glue,
+            Value::{I64, Null, Str},
+        },
+        store::Store,
+    },
+    gluesql_memory_storage::MemoryStorage,
+    test_suite::*,
+};
+
+#[test]
+fn engine_less_schema_uses_owning_storage() {
+    let mut legacy = Glue::new(MemoryStorage::default());
+    legacy.execute("CREATE TABLE Legacy (id INTEGER);").unwrap();
+    legacy.execute("INSERT INTO Legacy VALUES (1);").unwrap();
+
+    let mut storage = CompositeStorage::new();
+    storage.push("DEFAULT", MemoryStorage::default());
+    storage.push("LEGACY", legacy.storage);
+    storage.set_default("DEFAULT");
+
+    let mut glue = Glue::new(storage);
+    let schema = glue.storage.fetch_schema("Legacy").unwrap().unwrap();
+    assert_eq!(schema.engine.as_deref(), Some("LEGACY"));
+
+    let schema = glue
+        .storage
+        .fetch_all_schemas()
+        .unwrap()
+        .into_iter()
+        .find(|schema| schema.table_name == "Legacy")
+        .unwrap();
+    assert_eq!(schema.engine.as_deref(), Some("LEGACY"));
+
+    glue.execute("ALTER TABLE Legacy ADD COLUMN name TEXT;")
+        .unwrap();
+    glue.execute("INSERT INTO Legacy VALUES (2, 'two');")
+        .unwrap();
+
+    assert_eq!(
+        glue.execute("SELECT * FROM Legacy;")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap(),
+        select_with_null!(
+            id     | name;
+            I64(1)   Null;
+            I64(2)   Str("two".to_owned())
+        )
+    );
+}

--- a/storages/composite-storage/tests/memory_and_json.rs
+++ b/storages/composite-storage/tests/memory_and_json.rs
@@ -1,0 +1,37 @@
+use {
+    gluesql_composite_storage::CompositeStorage,
+    gluesql_core::prelude::{Glue, Value::I64},
+    gluesql_json_storage::JsonStorage,
+    gluesql_memory_storage::MemoryStorage,
+    std::fs::remove_dir_all,
+    test_suite::*,
+};
+
+#[test]
+fn memory_and_json() {
+    let path = "tmp/memory_and_json";
+    let _ = remove_dir_all(path);
+    let json_storage = JsonStorage::new(path).expect("JsonStorage::new");
+
+    let mut storage = CompositeStorage::new();
+    storage.push("MEMORY", MemoryStorage::default());
+    storage.push("JSON", json_storage);
+    storage.set_default("MEMORY");
+
+    let mut glue = Glue::new(storage);
+    glue.execute("CREATE TABLE Bar (id INTEGER) ENGINE = JSON;")
+        .unwrap();
+    glue.execute("INSERT INTO Bar VALUES (1);").unwrap();
+
+    assert_eq!(
+        glue.execute("SELECT * FROM Bar;")
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap(),
+        select!(id I64; 1),
+    );
+
+    drop(glue);
+    remove_dir_all(path).unwrap();
+}

--- a/storages/json-storage/src/store.rs
+++ b/storages/json-storage/src/store.rs
@@ -31,7 +31,7 @@ impl Store for JsonStorage {
         }
 
         let schema_path = self.schema_path(table_name);
-        let (column_defs, foreign_keys, comment) = if schema_path.exists() {
+        let (column_defs, engine, foreign_keys, comment) = if schema_path.exists() {
             let mut file = File::open(&schema_path).map_storage_err()?;
             let mut ddl = String::new();
             file.read_to_string(&mut ddl).map_storage_err()?;
@@ -43,16 +43,21 @@ impl Store for JsonStorage {
                 ));
             }
 
-            (schema.column_defs, schema.foreign_keys, schema.comment)
+            (
+                schema.column_defs,
+                schema.engine,
+                schema.foreign_keys,
+                schema.comment,
+            )
         } else {
-            (None, Vec::new(), None)
+            (None, None, Vec::new(), None)
         };
 
         Ok(Some(Schema {
             table_name: table_name.to_owned(),
             column_defs,
             indexes: vec![],
-            engine: None,
+            engine,
             foreign_keys,
             comment,
         }))

--- a/storages/json-storage/tests/schema.rs
+++ b/storages/json-storage/tests/schema.rs
@@ -5,10 +5,12 @@ use {
             Glue,
             Value::{self, *},
         },
+        store::Store,
     },
     gluesql_json_storage::JsonStorage,
     std::{
         collections::BTreeMap,
+        fs::remove_dir_all,
         net::{IpAddr, Ipv4Addr},
     },
     test_suite::{concat_with, concat_with_null, row, select, select_with_null, stringify_label},
@@ -176,4 +178,21 @@ fn json_schema() {
     for (actual, expected) in cases {
         assert_eq!(actual.map(|mut payloads| payloads.remove(0)), expected);
     }
+}
+
+#[test]
+fn engine_round_trip() {
+    let path = "tmp/json_engine_round_trip";
+    let _ = remove_dir_all(path);
+    let storage = JsonStorage::new(path).expect("JsonStorage::new");
+    let mut glue = Glue::new(storage);
+
+    glue.execute("CREATE TABLE EngineTable (id INTEGER) ENGINE = JSON;")
+        .unwrap();
+
+    let schema = glue.storage.fetch_schema("EngineTable").unwrap().unwrap();
+    assert_eq!(schema.engine.as_deref(), Some("JSON"));
+
+    drop(glue);
+    remove_dir_all(path).unwrap();
 }

--- a/storages/mongo-storage/src/description.rs
+++ b/storages/mongo-storage/src/description.rs
@@ -7,6 +7,8 @@ use {
 pub struct TableDescription {
     pub foreign_keys: Vec<ForeignKey>,
     pub comment: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/storages/mongo-storage/src/store.rs
+++ b/storages/mongo-storage/src/store.rs
@@ -256,13 +256,14 @@ impl MongoStorage {
             let TableDescription {
                 foreign_keys,
                 comment,
+                engine,
             } = from_str::<TableDescription>(table_description).map_storage_err()?;
 
             let schema = Schema {
                 table_name: collection_name.to_owned(),
                 column_defs,
                 indexes: Vec::new(),
-                engine: None,
+                engine,
                 foreign_keys,
                 comment,
             };

--- a/storages/mongo-storage/src/store_mut.rs
+++ b/storages/mongo-storage/src/store_mut.rs
@@ -119,7 +119,13 @@ impl StoreMut for MongoStorage {
             .unwrap_or_default();
 
         let comment = schema.comment.as_ref().map(ToOwned::to_owned);
-        let validator = Validator::new(labels, column_types, schema.foreign_keys.clone(), comment)?;
+        let validator = Validator::new_with_engine(
+            labels,
+            column_types,
+            schema.foreign_keys.clone(),
+            comment,
+            schema.engine.clone(),
+        )?;
 
         let schema_exists = self
             .fetch_schema(&schema.table_name)

--- a/storages/mongo-storage/src/utils.rs
+++ b/storages/mongo-storage/src/utils.rs
@@ -26,6 +26,16 @@ impl Validator {
         foreign_keys: Vec<ForeignKey>,
         comment: Option<String>,
     ) -> Result<Self> {
+        Self::new_with_engine(labels, column_types, foreign_keys, comment, None)
+    }
+
+    pub(crate) fn new_with_engine(
+        labels: Vec<String>,
+        column_types: Document,
+        foreign_keys: Vec<ForeignKey>,
+        comment: Option<String>,
+        engine: Option<String>,
+    ) -> Result<Self> {
         let mut required = vec!["_id".to_owned()];
         required.extend(labels);
 
@@ -39,6 +49,7 @@ impl Validator {
             &(TableDescription {
                 foreign_keys,
                 comment,
+                engine,
             }),
         )
         .map_storage_err()?;

--- a/storages/mongo-storage/tests/schema.rs
+++ b/storages/mongo-storage/tests/schema.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "test-mongo")]
+
+use {
+    bson::Document,
+    gluesql_core::{prelude::Glue, store::Store},
+    gluesql_mongo_storage::{MongoStorage, utils::Validator},
+};
+
+const CONNECTION_STRING: &str = "mongodb://localhost:27017";
+
+fn storage(database: &str) -> MongoStorage {
+    let storage = MongoStorage::new(CONNECTION_STRING, database).expect("MongoStorage::new");
+    storage.drop_database().expect("database dropped");
+    storage
+}
+
+#[test]
+fn engine_round_trip() {
+    let mut glue = Glue::new(storage("mongo_schema_engine_round_trip"));
+
+    glue.execute("CREATE TABLE EngineTable (id INTEGER) ENGINE = MONGO;")
+        .unwrap();
+
+    let schema = glue.storage.fetch_schema("EngineTable").unwrap().unwrap();
+    assert_eq!(schema.engine.as_deref(), Some("MONGO"));
+
+    glue.storage.drop_database().expect("database dropped");
+}
+
+#[test]
+fn legacy_schema_without_engine_remains_readable() {
+    let storage = storage("mongo_legacy_schema_without_engine");
+    let validator = Validator::new(Vec::new(), Document::new(), Vec::new(), None).unwrap();
+    let description = validator
+        .document
+        .get_document("$jsonSchema")
+        .unwrap()
+        .get_str("description")
+        .unwrap();
+    assert_eq!(description, r#"{"foreign_keys":[],"comment":null}"#);
+
+    storage
+        .db
+        .create_collection("LegacyTable", validator.to_options())
+        .unwrap();
+
+    let schema = storage.fetch_schema("LegacyTable").unwrap().unwrap();
+    assert_eq!(schema.engine, None);
+
+    storage.drop_database().expect("database dropped");
+}

--- a/storages/parquet-storage/src/lib.rs
+++ b/storages/parquet-storage/src/lib.rs
@@ -30,6 +30,7 @@ mod transaction;
 mod value;
 
 type RowIter = Box<dyn Iterator<Item = Result<(Key, Vec<Value>)>>>;
+const ENGINE_METADATA_KEY: &str = "gluesql.engine";
 
 #[derive(Debug, Clone)]
 pub struct ParquetStorage {

--- a/storages/parquet-storage/src/store.rs
+++ b/storages/parquet-storage/src/store.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        ParquetStorage,
+        ENGINE_METADATA_KEY, ParquetStorage,
         column_def::ParquetSchemaType,
         error::{OptionExt, ParquetStorageError, ResultExt},
     },
@@ -36,9 +36,12 @@ impl Store for ParquetStorage {
         let mut is_schemaless = false;
         let mut foreign_keys = Vec::new();
         let mut comment = None;
+        let mut engine = None;
         if let Some(metadata) = key_value_file_metadata {
             for kv in metadata {
-                if kv.key == "schemaless" {
+                if kv.key == ENGINE_METADATA_KEY {
+                    engine.clone_from(&kv.value);
+                } else if kv.key == "schemaless" {
                     is_schemaless = matches!(kv.value.as_deref(), Some("true"));
                 } else if kv.key == "comment" {
                     comment.clone_from(&kv.value);
@@ -78,7 +81,7 @@ impl Store for ParquetStorage {
             table_name: table_name.to_owned(),
             column_defs,
             indexes: vec![],
-            engine: None,
+            engine,
             foreign_keys,
             comment,
         }))

--- a/storages/parquet-storage/src/store_mut.rs
+++ b/storages/parquet-storage/src/store_mut.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{ParquetStorage, ParquetStorageError, error::ResultExt},
+    crate::{ENGINE_METADATA_KEY, ParquetStorage, ParquetStorageError, error::ResultExt},
     gluesql_core::{
         ast::{ColumnDef, ToSql},
         chrono::{NaiveDate, Timelike},
@@ -606,6 +606,12 @@ impl ParquetStorage {
 
     fn gather_metadata_from_glue_schema(schema: &Schema) -> Result<Option<Vec<KeyValue>>> {
         let mut metadata = Vec::new();
+        if let Some(engine) = &schema.engine {
+            metadata.push(KeyValue {
+                key: ENGINE_METADATA_KEY.to_owned(),
+                value: Some(engine.clone()),
+            });
+        }
 
         for foreign_key in &schema.foreign_keys {
             metadata.push(KeyValue {

--- a/storages/parquet-storage/tests/schema.rs
+++ b/storages/parquet-storage/tests/schema.rs
@@ -5,6 +5,7 @@ use {
             Glue, Payload,
             Value::{self, *},
         },
+        store::Store,
     },
     gluesql_parquet_storage::ParquetStorage,
     parquet::data_type::ByteArray,
@@ -171,4 +172,21 @@ fn test_data_modify() {
     for (actual, expected) in cases {
         assert_eq!(actual.map(|mut payloads| payloads.remove(0)), expected);
     }
+}
+
+#[test]
+fn engine_round_trip() {
+    let path = "tmp/parquet_engine_round_trip";
+    let _ = fs::remove_dir_all(path);
+    let storage = ParquetStorage::new(path).expect("ParquetStorage::new");
+    let mut glue = Glue::new(storage);
+
+    glue.execute("CREATE TABLE EngineTable (id INTEGER) ENGINE = PARQUET;")
+        .unwrap();
+
+    let schema = glue.storage.fetch_schema("EngineTable").unwrap().unwrap();
+    assert_eq!(schema.engine.as_deref(), Some("PARQUET"));
+
+    drop(glue);
+    fs::remove_dir_all(path).unwrap();
 }


### PR DESCRIPTION
## Summary
- preserve the engine parsed from JSON schema DDL
- persist schema engines in Parquet file metadata and MongoDB validator descriptions
- make `CompositeStorage` use the owning storage's registered engine only when a fetched schema has no explicit engine
- preserve the existing behavior for explicit engine names, including errors for unregistered engines

## Compatibility
This change does not eagerly migrate or rewrite existing storage data.

- existing JSON schemas already contain the engine in their DDL and are now read correctly
- existing Parquet files without engine metadata remain readable
- existing MongoDB validator descriptions without an engine field remain readable
- MongoDB descriptions omit the engine field when it is `None`, preserving the legacy serialized shape
- engine-less schemas mounted in `CompositeStorage` are associated with the storage that returned them
- explicit persisted engine names are never overwritten

New Parquet files store the engine under the additive `gluesql.engine` metadata key. New or updated MongoDB schemas store it as an optional field in the existing table description.

## Tests

Added regression coverage for:
- engine-less schema routing in `CompositeStorage`
- the reported `MemoryStorage` + `JsonStorage` create/insert/select flow
- JSON schema engine round-tripping
- Parquet schema engine round-tripping
- MongoDB schema engine round-tripping
- reading legacy MongoDB schema metadata without an engine field

Verified with:

```text
cargo test -p gluesql-composite-storage \
-p gluesql-json-storage \
-p gluesql-parquet-storage

cargo test -p gluesql-mongo-storage --features test-mongo

cargo clippy --all-targets -- -D warnings
cargo fmt --all
```

Closes #2023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Storage schemas now preserve and report their configured engine across JSON, MongoDB, Parquet, and composite storage.
  - Composite storage correctly identifies the owning storage for schemas without an explicitly recorded engine.
  - Existing MongoDB schemas without engine metadata remain readable.
  - Tables using multiple storage backends can now be created, altered, inserted into, and queried reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->